### PR TITLE
fix: set callback group to timer (#516)

### DIFF
--- a/control/external_cmd_selector/src/external_cmd_selector/external_cmd_selector_node.cpp
+++ b/control/external_cmd_selector/src/external_cmd_selector/external_cmd_selector_node.cpp
@@ -103,7 +103,8 @@ ExternalCmdSelector::ExternalCmdSelector(const rclcpp::NodeOptions & node_option
   // Timer
   const auto period_ns = rclcpp::Rate(update_rate).period();
   timer_ = rclcpp::create_timer(
-    this, get_clock(), period_ns, std::bind(&ExternalCmdSelector::onTimer, this));
+    this, get_clock(), period_ns, std::bind(&ExternalCmdSelector::onTimer, this),
+    callback_group_subscribers_);
 }
 
 void ExternalCmdSelector::onLocalControlCmd(const ExternalControlCommand::ConstSharedPtr msg)

--- a/system/ad_service_state_monitor/src/ad_service_state_monitor_node/ad_service_state_monitor_node.cpp
+++ b/system/ad_service_state_monitor/src/ad_service_state_monitor_node/ad_service_state_monitor_node.cpp
@@ -462,5 +462,6 @@ AutowareStateMonitorNode::AutowareStateMonitorNode()
   // Timer
   const auto period_ns = rclcpp::Rate(update_rate_).period();
   timer_ = rclcpp::create_timer(
-    this, get_clock(), period_ns, std::bind(&AutowareStateMonitorNode::onTimer, this));
+    this, get_clock(), period_ns, std::bind(&AutowareStateMonitorNode::onTimer, this),
+    callback_group_subscribers_);
 }


### PR DESCRIPTION
## Related Issue(required)
<!-- Link related issue -->

## Description(required)
 - Cherry-pick
   - https://github.com/autowarefoundation/autoware.universe/pull/516
 - Restore callback group settings for external_cmd_selector and ad_service_state_monitor_node 
<!-- Describe what this PR changes. -->

## Review Procedure(required)

<!-- Explain how to review this PR. -->

## Related PR(optional)

<!-- Link related PR -->

## Pre-Review Checklist for the PR Author

**PR Author should check the checkboxes below when creating the PR.**

- [x] Read [commit-guidelines][commit-guidelines]
- [x] Assign PR to reviewer

If you are adding new package following items are required:

- [ ] Documentation with description of the package is available
- [ ] A sample launch file and parameter file are available if the package contains executable nodes

## Checklist for the PR Reviewer

**Reviewers should check the checkboxes below before approval.**

- [ ] Commits are properly organized and messages are according to the guideline
- [ ] PR title describes the changes

## Post-Review Checklist for the PR Author

**PR Author should check the checkboxes below before merging.**

- [ ] All open points are addressed and tracked via issues or tickets

## CI Checks

- **Build and test for PR / build-and-test-pr**: Required to pass before the merge.
- **Build and test for PR / clang-tidy-pr**: NOT required to pass before the merge. It is up to the reviewer(s). Found false positives? See the [guidelines][clang-tidy-guidelines].
- **Check spelling**: NOT required to pass before the merge. It is up to the reviewer(s). See [here][spell-check-dict] if you want to add some words to the spell check dictionary.

[commit-guidelines]: https://www.conventionalcommits.org/en/v1.0.0/
[spell-check-dict]: https://github.com/tier4/autoware-spell-check-dict#how-to-contribute
