### PR TITLE
feat: change timeout in approval handler 

### DIFF
--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/approval_handler.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/approval_handler.hpp
@@ -35,7 +35,7 @@ public:
   bool isApproved() const
   {
     const auto now = clock_.now();
-    const auto thresh_sec = 0.5;
+    const auto thresh_sec = 5.0;
     if (approval_.data && (now - approval_.stamp).seconds() < thresh_sec) {
       if ((now - last_clear_time_).seconds() > thresh_sec) {
         return true;


### PR DESCRIPTION
## Description


In some cases, even if the lane change is approved, it will time out in the approval_handler and the lane change will not be executed.
It is a temporary fix for that

<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
