### PR TITLE
feat(behavior_path): use multi thread

### DIFF
--- a/planning/behavior_path_planner/include/behavior_path_planner/behavior_path_planner_node.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/behavior_path_planner_node.hpp
@@ -135,22 +135,21 @@ private:
   /**
    * @brief extract path from behavior tree output
    */
-  PathWithLaneId::SharedPtr getPath(const BehaviorModuleOutput & bt_out);
+  PathWithLaneId::SharedPtr getPath(
+    const BehaviorModuleOutput & bt_out, const std::shared_ptr<PlannerData> planner_data);
 
   /**
    * @brief extract path candidate from behavior tree output
    */
-  PathWithLaneId::SharedPtr getPathCandidate(const BehaviorModuleOutput & bt_out);
+  PathWithLaneId::SharedPtr getPathCandidate(
+    const BehaviorModuleOutput & bt_out, const std::shared_ptr<PlannerData> planner_data);
 
   /**
    * @brief publish behavior module status mainly for the user interface
    */
-  void publishModuleStatus(const std::vector<std::shared_ptr<SceneModuleStatus>> & statuses);
-
-  /**
-   * @brief update current pose on the planner_data_
-   */
-  void updateCurrentPose();
+  void publishModuleStatus(
+    const std::vector<std::shared_ptr<SceneModuleStatus>> & statuses,
+    const std::shared_ptr<PlannerData> planner_data);
 
   // debug
 

--- a/planning/behavior_path_planner/include/behavior_path_planner/behavior_path_planner_node.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/behavior_path_planner_node.hpp
@@ -98,6 +98,9 @@ private:
 
   TurnSignalDecider turn_signal_decider_;
 
+  // mutex for planner_data_
+  std::mutex mutex_pd_;
+
   // setup
   void waitForData();
 

--- a/planning/behavior_path_planner/include/behavior_path_planner/behavior_path_planner_node.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/behavior_path_planner_node.hpp
@@ -98,8 +98,8 @@ private:
 
   TurnSignalDecider turn_signal_decider_;
 
-  // mutex for planner_data_
-  std::mutex mutex_pd_;
+  std::mutex mutex_pd_;  // mutex for planner_data_
+  std::mutex mutex_bt_;  // mutex for bt_manager_
 
   // setup
   void waitForData();

--- a/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
+++ b/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
@@ -453,7 +453,7 @@ void BehaviorPathPlannerNode::run()
   RCLCPP_DEBUG(get_logger(), "----- BehaviorPathPlannerNode start -----");
 
   // update planner data
-  updateCurrentPose();
+  planner_data_->self_pose = self_pose_listener_.getCurrentPose();
 
   // NOTE: planner_data must not be referenced for multithreading
   const auto planner_data = planner_data_;
@@ -463,8 +463,8 @@ void BehaviorPathPlannerNode::run()
   const auto output = bt_manager_->run(planner_data);
 
   // path handling
-  const auto path = getPath(output);
-  const auto path_candidate = getPathCandidate(output);
+  const auto path = getPath(output, planner_data);
+  const auto path_candidate = getPathCandidate(output, planner_data);
 
   // update planner data
   mutex_.lock();  // for planner_data_
@@ -504,19 +504,20 @@ void BehaviorPathPlannerNode::run()
   }
 
   // for remote operation
-  publishModuleStatus(bt_manager_->getModulesStatus());
+  publishModuleStatus(bt_manager_->getModulesStatus(), planner_data);
 
   publishDebugMarker(bt_manager_->getDebugMarkers());
 
   RCLCPP_DEBUG(get_logger(), "----- behavior path planner end -----\n\n");
 }
 
-PathWithLaneId::SharedPtr BehaviorPathPlannerNode::getPath(const BehaviorModuleOutput & bt_output)
+PathWithLaneId::SharedPtr BehaviorPathPlannerNode::getPath(
+  const BehaviorModuleOutput & bt_output, const std::shared_ptr<PlannerData> planner_data)
 {
   // TODO(Horibe) do some error handling when path is not available.
 
-  auto path = bt_output.path ? bt_output.path : planner_data_->prev_output_path;
-  path->header = planner_data_->route_handler->getRouteHeader();
+  auto path = bt_output.path ? bt_output.path : planner_data->prev_output_path;
+  path->header = planner_data->route_handler->getRouteHeader();
   path->header.stamp = this->now();
   RCLCPP_DEBUG(
     get_logger(), "BehaviorTreeManager: output is %s.", bt_output.path ? "FOUND" : "NOT FOUND");
@@ -524,11 +525,11 @@ PathWithLaneId::SharedPtr BehaviorPathPlannerNode::getPath(const BehaviorModuleO
 }
 
 PathWithLaneId::SharedPtr BehaviorPathPlannerNode::getPathCandidate(
-  const BehaviorModuleOutput & bt_output)
+  const BehaviorModuleOutput & bt_output, const std::shared_ptr<PlannerData> planner_data)
 {
   auto path_candidate =
     bt_output.path_candidate ? bt_output.path_candidate : std::make_shared<PathWithLaneId>();
-  path_candidate->header = planner_data_->route_handler->getRouteHeader();
+  path_candidate->header = planner_data->route_handler->getRouteHeader();
   path_candidate->header.stamp = this->now();
   RCLCPP_DEBUG(
     get_logger(), "BehaviorTreeManager: path candidate is %s.",
@@ -537,7 +538,8 @@ PathWithLaneId::SharedPtr BehaviorPathPlannerNode::getPathCandidate(
 }
 
 void BehaviorPathPlannerNode::publishModuleStatus(
-  const std::vector<std::shared_ptr<SceneModuleStatus>> & statuses)
+  const std::vector<std::shared_ptr<SceneModuleStatus>> & statuses,
+  const std::shared_ptr<PlannerData> planner_data)
 {
   auto getModuleType = [](std::string name) {
     if (name == "LaneChange") {
@@ -569,7 +571,7 @@ void BehaviorPathPlannerNode::publishModuleStatus(
       running_modules.modules.push_back(module);
     }
     if (status->module_name == "LaneChange") {
-      const auto force_approval = planner_data_->approval.is_force_approved;
+      const auto force_approval = planner_data->approval.is_force_approved;
       if (
         force_approval.module_name == "ForceLaneChange" &&
         (now - force_approval.stamp).seconds() < 0.5) {
@@ -617,12 +619,6 @@ void BehaviorPathPlannerNode::publishDebugMarker(const std::vector<MarkerArray> 
     tier4_autoware_utils::appendMarkerArray(markers, &msg);
   }
   debug_marker_publisher_->publish(msg);
-}
-
-void BehaviorPathPlannerNode::updateCurrentPose()
-{
-  auto self_pose = self_pose_listener_.getCurrentPose();
-  planner_data_->self_pose = self_pose;
 }
 
 void BehaviorPathPlannerNode::onVelocity(const Odometry::ConstSharedPtr msg)

--- a/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
+++ b/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
@@ -508,7 +508,6 @@ void BehaviorPathPlannerNode::run()
 
   publishDebugMarker(bt_manager_->getDebugMarkers());
 
-  mutex_.unlock();
   RCLCPP_DEBUG(get_logger(), "----- behavior path planner end -----\n\n");
 }
 

--- a/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
+++ b/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
@@ -84,6 +84,8 @@ BehaviorPathPlannerNode::BehaviorPathPlannerNode(const rclcpp::NodeOptions & nod
 
   // behavior tree manager
   {
+    mutex_bt_.lock();
+
     bt_manager_ = std::make_shared<BehaviorTreeManager>(*this, getBehaviorTreeManagerParam());
 
     auto side_shift_module =
@@ -117,6 +119,8 @@ BehaviorPathPlannerNode::BehaviorPathPlannerNode(const rclcpp::NodeOptions & nod
     bt_manager_->registerSceneModule(pull_out_module);
 
     bt_manager_->createBehaviorTree();
+
+    mutex_bt_.unlock();
   }
 
   // turn signal decider
@@ -456,6 +460,7 @@ void BehaviorPathPlannerNode::waitForData()
 void BehaviorPathPlannerNode::run()
 {
   RCLCPP_DEBUG(get_logger(), "----- BehaviorPathPlannerNode start -----");
+  mutex_bt_.lock();  // for bt_manager_
   mutex_pd_.lock();  // for planner_data_
 
   // update planner data
@@ -514,6 +519,7 @@ void BehaviorPathPlannerNode::run()
 
   publishDebugMarker(bt_manager_->getDebugMarkers());
 
+  mutex_bt_.unlock();
   RCLCPP_DEBUG(get_logger(), "----- behavior path planner end -----\n\n");
 }
 

--- a/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
+++ b/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
@@ -455,13 +455,21 @@ void BehaviorPathPlannerNode::run()
   // update planner data
   updateCurrentPose();
 
+  // NOTE: planner_data must not be referenced for multithreading
+  const auto planner_data = planner_data_;
+  mutex_.unlock();
+
   // run behavior planner
-  const auto output = bt_manager_->run(planner_data_);
+  const auto output = bt_manager_->run(planner_data);
 
   // path handling
   const auto path = getPath(output);
   const auto path_candidate = getPathCandidate(output);
+
+  // update planner data
+  mutex_.lock();  // for planner_data_
   planner_data_->prev_output_path = path;
+  mutex_.unlock();
 
   auto clipped_path = modifyPathForSmoothGoalConnection(*path);
   clipPathLength(clipped_path);
@@ -485,7 +493,7 @@ void BehaviorPathPlannerNode::run()
       hazard_signal.command = output.turn_signal_info.hazard_signal.command;
     } else {
       turn_signal = turn_signal_decider_.getTurnSignal(
-        *path, planner_data_->self_pose->pose, *(planner_data_->route_handler),
+        *path, planner_data->self_pose->pose, *(planner_data->route_handler),
         output.turn_signal_info.turn_signal, output.turn_signal_info.signal_distance);
       hazard_signal.command = HazardLightsCommand::DISABLE;
     }
@@ -500,6 +508,7 @@ void BehaviorPathPlannerNode::run()
 
   publishDebugMarker(bt_manager_->getDebugMarkers());
 
+  mutex_.unlock();
   RCLCPP_DEBUG(get_logger(), "----- behavior path planner end -----\n\n");
 }
 


### PR DESCRIPTION
## Description
https://github.com/autowarefoundation/autoware.universe/pull/657
To solve https://github.com/autowarefoundation/autoware.universe/issues/275 in behavior path planner, multi thread is used for callbacks by passing a different callback group, whose type is MutuallyExclusive, to each calback.

Hotfix to v0.2.1

This PR will be merged after confirmation using the actual vehicle.

<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
