### PR TITLE
fix: unlock mutex_pd while running the behavior tree

### DIFF
--- a/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
+++ b/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
@@ -489,7 +489,6 @@ void BehaviorPathPlannerNode::run()
 
   // NOTE: planner_data must not be referenced for multithreading
   const auto planner_data = planner_data_;
-  mutex_pd_.unlock();
 
   // run behavior planner
   const auto output = bt_manager_->run(planner_data);
@@ -499,7 +498,6 @@ void BehaviorPathPlannerNode::run()
   const auto path_candidate = getPathCandidate(output, planner_data);
 
   // update planner data
-  mutex_pd_.lock();  // for planner_data_
   planner_data_->prev_output_path = path;
   mutex_pd_.unlock();
 


### PR DESCRIPTION
Signed-off-by: tomoya.kimura <tomoya.kimura@tier4.jp>

## Description
unlock mutex_pd while running the behavior tree for fixing following problem.
https://github.com/autowarefoundation/autoware.universe/issues/1049

The PR for upstream branch will created by maxime-san.


<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
