### PR TITLE
fix building error for cherry-pick

### DIFF
--- a/planning/behavior_path_planner/CMakeLists.txt
+++ b/planning/behavior_path_planner/CMakeLists.txt
@@ -46,6 +46,8 @@ rclcpp_components_register_node(behavior_path_planner_node
 )
 
 if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
   ament_add_ros_isolated_gmock(test_${PROJECT_NAME}_utilities
     test/input.cpp
     test/test_utilities.cpp


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
cherry-pick後にbuildエラーの対策を入れる。
対象のcherry-pickはこちら
https://github.com/autowarefoundation/autoware.universe/pull/1167
https://github.com/autowarefoundation/autoware.universe/pull/1096

autoware_packageを導入していないため、
ament_add_ros_isolated_gmockが見つからないできないことが原因
autoware_pakageのPR→https://github.com/autowarefoundation/autoware.universe/pull/849

本PRを入れることで、ament_add_ros_isolated_gmockが見つかるようになる。

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
