### PR TITLE
fix(behavior_path_planner): set shuolder goal after loop

### DIFF
--- a/planning/behavior_path_planner/src/scene_module/pull_over/pull_over_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/pull_over/pull_over_module.cpp
@@ -163,6 +163,11 @@ bool PullOverModule::isExecutionRequested() const
 
   // check if goal_pose is far
   const double goal_arc_length = lanelet::utils::getArcCoordinates(current_lanes, goal_pose).length;
+  if (std::abs(goal_arc_length) < std::numeric_limits<double>::epsilon()) {
+    // can not caluculate arc langth correctly, maybe lane loop.
+    return false;
+  }
+
   const double self_arc_length =
     lanelet::utils::getArcCoordinates(current_lanes, planner_data_->self_pose->pose).length;
   const double self_to_goal_arc_length = goal_arc_length - self_arc_length;


### PR DESCRIPTION
Signed-off-by: kosuke55 <kosuke.tnp@gmail.com>

## Description

<!-- Write a brief description of this PR. -->
Fixed a problem with pull over mosule not working when goal is placed on shoulder lane after loop. This is just a workaround.
The problem is that the arc length cannot be calculated correctly, so this workaround will be considered in the lanelet function.

## Related links

<!-- Write the links related to this PR. -->
https://star4.slack.com/archives/CEV8XMJBV/p1659608990931289?thread_ts=1659523164.728609&cid=CEV8XMJBV

## Tests performed

<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
