### PR TITLE
fix(behavior_path_planner): pull_over far goal bug (#1571)

### DIFF
--- a/planning/behavior_path_planner/src/scene_module/pull_over/pull_over_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/pull_over/pull_over_module.cpp
@@ -157,21 +157,23 @@ bool PullOverModule::isExecutionRequested() const
   if (current_state_ == BT::NodeStatus::RUNNING) {
     return true;
   }
-
-  const auto current_lanes = util::getCurrentLanes(planner_data_);
-  const auto goal_pose = planner_data_->route_handler->getGoalPose();
+  const auto & current_lanes = util::getCurrentLanes(planner_data_);
+  const auto & current_pose = planner_data_->self_pose->pose;
+  const auto & goal_pose = planner_data_->route_handler->getGoalPose();
 
   // check if goal_pose is far
-  const double goal_arc_length = lanelet::utils::getArcCoordinates(current_lanes, goal_pose).length;
-  if (std::abs(goal_arc_length) < std::numeric_limits<double>::epsilon()) {
-    // can not caluculate arc langth correctly, maybe lane loop.
+  const bool is_in_goal_route_section =
+    planner_data_->route_handler->isInGoalRouteSection(current_lanes.back());
+  // current_lanes does not have the goal
+  if (!is_in_goal_route_section) {
     return false;
   }
-
-  const double self_arc_length =
-    lanelet::utils::getArcCoordinates(current_lanes, planner_data_->self_pose->pose).length;
-  const double self_to_goal_arc_length = goal_arc_length - self_arc_length;
-  if (self_to_goal_arc_length > parameters_.request_length) return false;
+  const double self_to_goal_arc_length =
+    util::getSignedDistance(current_pose, goal_pose, current_lanes);
+  // goal is away behind
+  if (self_to_goal_arc_length > parameters_.request_length || self_to_goal_arc_length < 0.0) {
+    return false;
+  }
 
   // check if goal_pose is in shoulder lane
   bool goal_is_in_shoulder_lane = false;


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
cherry-pick 
https://github.com/autowarefoundation/autoware.universe/pull/1571
for v0.5.0

> Solved a problem where setting a goal after a loop pull_over did not work well. Because current_lanes does not contain goal, goal_arc_length cannot be calculated correctly (it becomes 0) and pull_oevr module is invoked. In addition, arc_length could not be calculated properly in the module processing, this caused bug.
In this PR, when a goal is far away and current_lanes does not contain the goal, the module will not be launched.

## Related links

<!-- Write the links related to this PR. -->
https://github.com/autowarefoundation/autoware.universe/pull/1571

## Tests performed

<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
