### PR TITLE
fix(behavior_velocity_planner): use only forward path for launching module (#1028)

### DIFF
--- a/map/lanelet2_extension/include/lanelet2_extension/utility/query.hpp
+++ b/map/lanelet2_extension/include/lanelet2_extension/utility/query.hpp
@@ -222,6 +222,10 @@ bool getClosestLanelet(
   const ConstLanelets & lanelets, const geometry_msgs::msg::Pose & search_pose,
   ConstLanelet * closest_lanelet_ptr);
 
+bool getCurrentLanelets(
+  const ConstLanelets & lanelets, const geometry_msgs::msg::Pose & search_pose,
+  ConstLanelets * current_lanelets_ptr);
+
 /**
  * [getSucceedingLaneletSequences retrieves a sequence of lanelets after the given lanelet.
  * The total length of retrieved lanelet sequence at least given length. Returned lanelet sequence

--- a/map/lanelet2_extension/lib/query.cpp
+++ b/map/lanelet2_extension/lib/query.cpp
@@ -741,6 +741,30 @@ bool query::getClosestLanelet(
   return found;
 }
 
+bool query::getCurrentLanelets(
+  const ConstLanelets & lanelets, const geometry_msgs::msg::Pose & search_pose,
+  ConstLanelets * current_lanelets_ptr)
+{
+  if (current_lanelets_ptr == nullptr) {
+    std::cerr << "argument closest_lanelet_ptr is null! Failed to find closest lanelet"
+              << std::endl;
+    return false;
+  }
+
+  if (lanelets.empty()) {
+    return false;
+  }
+
+  lanelet::BasicPoint2d search_point(search_pose.position.x, search_pose.position.y);
+  for (const auto & llt : lanelets) {
+    if (!lanelet::geometry::inside(llt, search_point)) {
+      current_lanelets_ptr->push_back(llt);
+    }
+  }
+
+  return !current_lanelets_ptr->empty();  // return found
+}
+
 std::vector<std::deque<lanelet::ConstLanelet>> getSucceedingLaneletSequencesRecursive(
   const routing::RoutingGraphPtr & graph, const lanelet::ConstLanelet & lanelet,
   const double length)

--- a/planning/behavior_velocity_planner/include/scene_module/crosswalk/manager.hpp
+++ b/planning/behavior_velocity_planner/include/scene_module/crosswalk/manager.hpp
@@ -25,6 +25,8 @@
 
 #include <functional>
 #include <memory>
+#include <set>
+#include <vector>
 
 namespace behavior_velocity_planner
 {
@@ -38,6 +40,17 @@ public:
 private:
   CrosswalkModule::PlannerParam crosswalk_planner_param_;
   WalkwayModule::PlannerParam walkway_planner_param_;
+
+  std::vector<lanelet::ConstLanelet> getCrosswalksOnPath(
+    const autoware_auto_planning_msgs::msg::PathWithLaneId & path,
+    const lanelet::LaneletMapPtr lanelet_map,
+    const std::shared_ptr<const lanelet::routing::RoutingGraphContainer> & overall_graphs);
+
+  std::set<int64_t> getCrosswalkIdSetOnPath(
+    const autoware_auto_planning_msgs::msg::PathWithLaneId & path,
+    const lanelet::LaneletMapPtr lanelet_map,
+    const std::shared_ptr<const lanelet::routing::RoutingGraphContainer> & overall_graphs);
+
   void launchNewModules(const autoware_auto_planning_msgs::msg::PathWithLaneId & path) override;
 
   std::function<bool(const std::shared_ptr<SceneModuleInterface> &)> getModuleExpiredFunction(

--- a/planning/behavior_velocity_planner/include/scene_module/occlusion_spot/occlusion_spot_utils.hpp
+++ b/planning/behavior_velocity_planner/include/scene_module/occlusion_spot/occlusion_spot_utils.hpp
@@ -47,16 +47,6 @@
 #include <utility>
 #include <vector>
 
-namespace tier4_autoware_utils
-{
-template <>
-inline geometry_msgs::msg::Pose getPose(
-  const autoware_auto_planning_msgs::msg::PathPointWithLaneId & p)
-{
-  return p.point.pose;
-}
-}  // namespace tier4_autoware_utils
-
 namespace behavior_velocity_planner
 {
 using autoware_auto_perception_msgs::msg::ObjectClassification;

--- a/planning/behavior_velocity_planner/include/scene_module/scene_module_interface.hpp
+++ b/planning/behavior_velocity_planner/include/scene_module/scene_module_interface.hpp
@@ -17,6 +17,8 @@
 
 #include "behavior_velocity_planner/planner_data.hpp"
 
+#include <utilization/util.hpp>
+
 #include <autoware_auto_planning_msgs/msg/path.hpp>
 #include <autoware_auto_planning_msgs/msg/path_with_lane_id.hpp>
 #include <tier4_planning_msgs/msg/stop_reason.hpp>

--- a/planning/behavior_velocity_planner/include/scene_module/stop_line/manager.hpp
+++ b/planning/behavior_velocity_planner/include/scene_module/stop_line/manager.hpp
@@ -23,9 +23,14 @@
 
 #include <functional>
 #include <memory>
+#include <set>
+#include <utility>
+#include <vector>
 
 namespace behavior_velocity_planner
 {
+using StopLineWithLaneId = std::pair<lanelet::ConstLineString3d, int64_t>;
+
 class StopLineModuleManager : public SceneModuleManagerInterface
 {
 public:
@@ -35,6 +40,15 @@ public:
 
 private:
   StopLineModule::PlannerParam planner_param_;
+
+  std::vector<StopLineWithLaneId> getStopLinesWithLaneIdOnPath(
+    const autoware_auto_planning_msgs::msg::PathWithLaneId & path,
+    const lanelet::LaneletMapPtr lanelet_map);
+
+  std::set<int64_t> getStopLineIdSetOnPath(
+    const autoware_auto_planning_msgs::msg::PathWithLaneId & path,
+    const lanelet::LaneletMapPtr lanelet_map);
+
   void launchNewModules(const autoware_auto_planning_msgs::msg::PathWithLaneId & path) override;
 
   std::function<bool(const std::shared_ptr<SceneModuleInterface> &)> getModuleExpiredFunction(

--- a/planning/behavior_velocity_planner/src/scene_module/blind_spot/manager.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/blind_spot/manager.cpp
@@ -25,36 +25,6 @@
 
 namespace behavior_velocity_planner
 {
-namespace
-{
-std::vector<lanelet::ConstLanelet> getLaneletsOnPath(
-  const autoware_auto_planning_msgs::msg::PathWithLaneId & path,
-  const lanelet::LaneletMapPtr lanelet_map)
-{
-  std::vector<lanelet::ConstLanelet> lanelets;
-
-  for (const auto & p : path.points) {
-    const auto lane_id = p.lane_ids.at(0);
-    lanelets.push_back(lanelet_map->laneletLayer.get(lane_id));
-  }
-
-  return lanelets;
-}
-
-std::set<int64_t> getLaneIdSetOnPath(const autoware_auto_planning_msgs::msg::PathWithLaneId & path)
-{
-  std::set<int64_t> lane_id_set;
-
-  for (const auto & p : path.points) {
-    const auto lane_id = p.lane_ids.at(0);
-    lane_id_set.insert(lane_id);
-  }
-
-  return lane_id_set;
-}
-
-}  // namespace
-
 BlindSpotModuleManager::BlindSpotModuleManager(rclcpp::Node & node)
 : SceneModuleManagerInterface(node, getModuleName())
 {
@@ -71,8 +41,9 @@ BlindSpotModuleManager::BlindSpotModuleManager(rclcpp::Node & node)
 void BlindSpotModuleManager::launchNewModules(
   const autoware_auto_planning_msgs::msg::PathWithLaneId & path)
 {
-  for (const auto & ll :
-       getLaneletsOnPath(path, planner_data_->route_handler_->getLaneletMapPtr())) {
+  for (const auto & ll : planning_utils::getLaneletsOnPath(
+         path, planner_data_->route_handler_->getLaneletMapPtr(),
+         planner_data_->current_pose.pose)) {
     const auto lane_id = ll.id();
     const auto module_id = lane_id;
 
@@ -96,7 +67,8 @@ std::function<bool(const std::shared_ptr<SceneModuleInterface> &)>
 BlindSpotModuleManager::getModuleExpiredFunction(
   const autoware_auto_planning_msgs::msg::PathWithLaneId & path)
 {
-  const auto lane_id_set = getLaneIdSetOnPath(path);
+  const auto lane_id_set = planning_utils::getLaneIdSetOnPath(
+    path, planner_data_->route_handler_->getLaneletMapPtr(), planner_data_->current_pose.pose);
 
   return [lane_id_set](const std::shared_ptr<SceneModuleInterface> & scene_module) {
     return lane_id_set.count(scene_module->getModuleId()) == 0;

--- a/planning/behavior_velocity_planner/src/scene_module/intersection/manager.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/intersection/manager.cpp
@@ -25,40 +25,6 @@
 
 namespace behavior_velocity_planner
 {
-namespace
-{
-std::vector<lanelet::ConstLanelet> getLaneletsOnPath(
-  const autoware_auto_planning_msgs::msg::PathWithLaneId & path,
-  const lanelet::LaneletMapPtr lanelet_map)
-{
-  std::vector<lanelet::ConstLanelet> lanelets;
-
-  for (const auto & p : path.points) {
-    const auto lane_id = p.lane_ids.at(0);
-    const auto lane = lanelet_map->laneletLayer.get(lane_id);
-    if (!lanelet::utils::contains(lanelets, lane)) {
-      lanelets.push_back(lane);
-    }
-  }
-
-  return lanelets;
-}
-
-std::set<int64_t> getLaneIdSetOnPath(const autoware_auto_planning_msgs::msg::PathWithLaneId & path)
-{
-  std::set<int64_t> lane_id_set;
-
-  for (const auto & p : path.points) {
-    for (const auto & lane_id : p.lane_ids) {
-      lane_id_set.insert(lane_id);
-    }
-  }
-
-  return lane_id_set;
-}
-
-}  // namespace
-
 IntersectionModuleManager::IntersectionModuleManager(rclcpp::Node & node)
 : SceneModuleManagerInterface(node, getModuleName())
 {
@@ -100,7 +66,8 @@ MergeFromPrivateModuleManager::MergeFromPrivateModuleManager(rclcpp::Node & node
 void IntersectionModuleManager::launchNewModules(
   const autoware_auto_planning_msgs::msg::PathWithLaneId & path)
 {
-  const auto lanelets = getLaneletsOnPath(path, planner_data_->route_handler_->getLaneletMapPtr());
+  const auto lanelets = planning_utils::getLaneletsOnPath(
+    path, planner_data_->route_handler_->getLaneletMapPtr(), planner_data_->current_pose.pose);
   for (size_t i = 0; i < lanelets.size(); i++) {
     const auto ll = lanelets.at(i);
     const auto lane_id = ll.id();
@@ -126,7 +93,8 @@ void IntersectionModuleManager::launchNewModules(
 void MergeFromPrivateModuleManager::launchNewModules(
   const autoware_auto_planning_msgs::msg::PathWithLaneId & path)
 {
-  const auto lanelets = getLaneletsOnPath(path, planner_data_->route_handler_->getLaneletMapPtr());
+  const auto lanelets = planning_utils::getLaneletsOnPath(
+    path, planner_data_->route_handler_->getLaneletMapPtr(), planner_data_->current_pose.pose);
   for (size_t i = 0; i < lanelets.size(); i++) {
     const auto ll = lanelets.at(i);
     const auto lane_id = ll.id();
@@ -162,7 +130,8 @@ std::function<bool(const std::shared_ptr<SceneModuleInterface> &)>
 IntersectionModuleManager::getModuleExpiredFunction(
   const autoware_auto_planning_msgs::msg::PathWithLaneId & path)
 {
-  const auto lane_id_set = getLaneIdSetOnPath(path);
+  const auto lane_id_set = planning_utils::getLaneIdSetOnPath(
+    path, planner_data_->route_handler_->getLaneletMapPtr(), planner_data_->current_pose.pose);
 
   return [lane_id_set](const std::shared_ptr<SceneModuleInterface> & scene_module) {
     return lane_id_set.count(scene_module->getModuleId()) == 0;
@@ -172,7 +141,8 @@ std::function<bool(const std::shared_ptr<SceneModuleInterface> &)>
 MergeFromPrivateModuleManager::getModuleExpiredFunction(
   const autoware_auto_planning_msgs::msg::PathWithLaneId & path)
 {
-  const auto lane_id_set = getLaneIdSetOnPath(path);
+  const auto lane_id_set = planning_utils::getLaneIdSetOnPath(
+    path, planner_data_->route_handler_->getLaneletMapPtr(), planner_data_->current_pose.pose);
 
   return [lane_id_set](const std::shared_ptr<SceneModuleInterface> & scene_module) {
     return lane_id_set.count(scene_module->getModuleId()) == 0;

--- a/planning/behavior_velocity_planner/src/scene_module/stop_line/manager.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/stop_line/manager.cpp
@@ -21,42 +21,31 @@
 
 namespace behavior_velocity_planner
 {
-namespace
+using lanelet::TrafficSign;
+
+StopLineModuleManager::StopLineModuleManager(rclcpp::Node & node)
+: SceneModuleManagerInterface(node, getModuleName())
 {
-using TrafficSignsWithLaneId = std::vector<std::pair<lanelet::TrafficSignConstPtr, int64_t>>;
-using StopLineWithLaneId = std::pair<lanelet::ConstLineString3d, int64_t>;
-TrafficSignsWithLaneId getTrafficSignRegElemsOnPath(
-  const autoware_auto_planning_msgs::msg::PathWithLaneId & path,
-  const lanelet::LaneletMapPtr lanelet_map)
-{
-  TrafficSignsWithLaneId traffic_signs_reg_elems_with_id;
-  std::set<int64_t> unique_lane_ids;
-  for (const auto & p : path.points) {
-    unique_lane_ids.insert(p.lane_ids.at(0));  // should we iterate ids? keep as it was.
-  }
-
-  for (const auto lane_id : unique_lane_ids) {
-    const auto ll = lanelet_map->laneletLayer.get(lane_id);
-
-    const auto tss = ll.regulatoryElementsAs<const lanelet::TrafficSign>();
-    for (const auto & ts : tss) {
-      traffic_signs_reg_elems_with_id.push_back(std::make_pair(ts, lane_id));
-    }
-  }
-
-  return traffic_signs_reg_elems_with_id;
+  const std::string ns(getModuleName());
+  auto & p = planner_param_;
+  p.stop_margin = node.declare_parameter(ns + ".stop_margin", 0.0);
+  p.stop_check_dist = node.declare_parameter(ns + ".stop_check_dist", 2.0);
+  p.stop_duration_sec = node.declare_parameter(ns + ".stop_duration_sec", 1.0);
+  // debug
+  p.show_stopline_collision_check =
+    node.declare_parameter(ns + ".debug.show_stopline_collision_check", false);
 }
 
-std::vector<StopLineWithLaneId> getStopLinesWithLaneIdOnPath(
+std::vector<StopLineWithLaneId> StopLineModuleManager::getStopLinesWithLaneIdOnPath(
   const autoware_auto_planning_msgs::msg::PathWithLaneId & path,
   const lanelet::LaneletMapPtr lanelet_map)
 {
   std::vector<StopLineWithLaneId> stop_lines_with_lane_id;
 
-  for (const auto & traffic_sign_reg_elem_with_id :
-       getTrafficSignRegElemsOnPath(path, lanelet_map)) {
-    const auto & traffic_sign_reg_elem = traffic_sign_reg_elem_with_id.first;
-    const int64_t lane_id = traffic_sign_reg_elem_with_id.second;
+  for (const auto & m : planning_utils::getRegElemMapOnPath<TrafficSign>(
+         path, lanelet_map, planner_data_->current_pose.pose)) {
+    const auto & traffic_sign_reg_elem = m.first;
+    const int64_t lane_id = m.second.id();
     // Is stop sign?
     if (traffic_sign_reg_elem->type() != "stop_sign") {
       continue;
@@ -70,7 +59,7 @@ std::vector<StopLineWithLaneId> getStopLinesWithLaneIdOnPath(
   return stop_lines_with_lane_id;
 }
 
-std::set<int64_t> getStopLineIdSetOnPath(
+std::set<int64_t> StopLineModuleManager::getStopLineIdSetOnPath(
   const autoware_auto_planning_msgs::msg::PathWithLaneId & path,
   const lanelet::LaneletMapPtr lanelet_map)
 {
@@ -81,21 +70,6 @@ std::set<int64_t> getStopLineIdSetOnPath(
   }
 
   return stop_line_id_set;
-}
-
-}  // namespace
-
-StopLineModuleManager::StopLineModuleManager(rclcpp::Node & node)
-: SceneModuleManagerInterface(node, getModuleName())
-{
-  const std::string ns(getModuleName());
-  auto & p = planner_param_;
-  p.stop_margin = node.declare_parameter(ns + ".stop_margin", 0.0);
-  p.stop_check_dist = node.declare_parameter(ns + ".stop_check_dist", 2.0);
-  p.stop_duration_sec = node.declare_parameter(ns + ".stop_duration_sec", 1.0);
-  // debug
-  p.show_stopline_collision_check =
-    node.declare_parameter(ns + ".debug.show_stopline_collision_check", false);
 }
 
 void StopLineModuleManager::launchNewModules(

--- a/planning/behavior_velocity_planner/src/scene_module/traffic_light/manager.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/traffic_light/manager.cpp
@@ -24,40 +24,7 @@
 
 namespace behavior_velocity_planner
 {
-namespace
-{
-std::unordered_map<lanelet::TrafficLightConstPtr, lanelet::ConstLanelet>
-getTrafficLightRegElemsOnPath(
-  const autoware_auto_planning_msgs::msg::PathWithLaneId & path,
-  const lanelet::LaneletMapPtr lanelet_map)
-{
-  std::unordered_map<lanelet::TrafficLightConstPtr, lanelet::ConstLanelet> traffic_light_reg_elems;
-
-  for (const auto & p : path.points) {
-    const auto lane_id = p.lane_ids.at(0);
-    const auto ll = lanelet_map->laneletLayer.get(lane_id);
-
-    const auto tls = ll.regulatoryElementsAs<const lanelet::TrafficLight>();
-    for (const auto & tl : tls) {
-      traffic_light_reg_elems.insert(std::make_pair(tl, ll));
-    }
-  }
-
-  return traffic_light_reg_elems;
-}
-
-std::set<int64_t> getLaneletIdSetOnPath(
-  const autoware_auto_planning_msgs::msg::PathWithLaneId & path,
-  const lanelet::LaneletMapPtr lanelet_map)
-{
-  std::set<int64_t> lanelet_id_set;
-  for (const auto & traffic_light_reg_elem : getTrafficLightRegElemsOnPath(path, lanelet_map)) {
-    lanelet_id_set.insert(traffic_light_reg_elem.second.id());
-  }
-  return lanelet_id_set;
-}
-
-}  // namespace
+using lanelet::TrafficLight;
 
 TrafficLightModuleManager::TrafficLightModuleManager(rclcpp::Node & node)
 : SceneModuleManagerInterface(node, getModuleName())
@@ -127,8 +94,9 @@ void TrafficLightModuleManager::modifyPathVelocity(
 void TrafficLightModuleManager::launchNewModules(
   const autoware_auto_planning_msgs::msg::PathWithLaneId & path)
 {
-  for (const auto & traffic_light_reg_elem :
-       getTrafficLightRegElemsOnPath(path, planner_data_->route_handler_->getLaneletMapPtr())) {
+  for (const auto & traffic_light_reg_elem : planning_utils::getRegElemMapOnPath<TrafficLight>(
+         path, planner_data_->route_handler_->getLaneletMapPtr(),
+         planner_data_->current_pose.pose)) {
     const auto stop_line = traffic_light_reg_elem.first->stopLine();
 
     if (!stop_line) {
@@ -152,8 +120,8 @@ std::function<bool(const std::shared_ptr<SceneModuleInterface> &)>
 TrafficLightModuleManager::getModuleExpiredFunction(
   const autoware_auto_planning_msgs::msg::PathWithLaneId & path)
 {
-  const auto lanelet_id_set =
-    getLaneletIdSetOnPath(path, planner_data_->route_handler_->getLaneletMapPtr());
+  const auto lanelet_id_set = planning_utils::getLaneletIdSetOnPath<TrafficLight>(
+    path, planner_data_->route_handler_->getLaneletMapPtr(), planner_data_->current_pose.pose);
 
   return [lanelet_id_set](const std::shared_ptr<SceneModuleInterface> & scene_module) {
     return lanelet_id_set.count(scene_module->getModuleId()) == 0;

--- a/planning/behavior_velocity_planner/src/scene_module/virtual_traffic_light/scene.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/virtual_traffic_light/scene.cpp
@@ -23,16 +23,6 @@
 #include <string>
 #include <vector>
 
-namespace tier4_autoware_utils
-{
-template <>
-inline geometry_msgs::msg::Pose getPose(
-  const autoware_auto_planning_msgs::msg::PathPointWithLaneId & p)
-{
-  return p.point.pose;
-}
-}  // namespace tier4_autoware_utils
-
 namespace behavior_velocity_planner
 {
 namespace


### PR DESCRIPTION
## Description

https://github.com/autowarefoundation/autoware.universe/pull/1028 のbackport

<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
