### PR TITLE
fix(tier4_debug_tools): fix unnecessary use of map (#1040)

### DIFF
--- a/common/tier4_debug_tools/scripts/stop_reason2pose.py
+++ b/common/tier4_debug_tools/scripts/stop_reason2pose.py
@@ -93,7 +93,7 @@ class StopReason2PoseNode(Node):
         if not poses:
             return None
 
-        distances = map(lambda p: StopReason2PoseNode.calc_distance2d(p, self_pose), poses)
+        distances = [StopReason2PoseNode.calc_distance2d(p, self_pose.pose) for p in poses]
         nearest_idx = np.argmin(distances)
 
         return poses[nearest_idx]


### PR DESCRIPTION
Signed-off-by: Takayuki Murooka <takayuki5168@gmail.com>

## Description

https://github.com/autowarefoundation/autoware.universe/pull/1040 のbackport
上記PRと変更内容が相違ないことが確認できればOKです

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
