### PR TITLE
ci: fix build depends

### DIFF
--- a/build_depends.humble.repos
+++ b/build_depends.humble.repos
@@ -3,7 +3,7 @@ repositories:
   core/autoware_common:
     type: git
     url: https://github.com/autowarefoundation/autoware_common.git
-    version: main
+    version: 1f36fa7579edbe2ed41f745a0ee029a427e468fe
   core/autoware.core:
     type: git
     url: https://github.com/autowarefoundation/autoware.core.git

--- a/build_depends.repos
+++ b/build_depends.repos
@@ -3,7 +3,7 @@ repositories:
   core/autoware_common:
     type: git
     url: https://github.com/autowarefoundation/autoware_common.git
-    version: main
+    version: 1f36fa7579edbe2ed41f745a0ee029a427e468fe
   core/autoware.core:
     type: git
     url: https://github.com/autowarefoundation/autoware.core.git


### PR DESCRIPTION
## Description

fix ci build

this PR will back to 1f36fa7579edbe2ed41f745a0ee029a427e468fe which does not include "move lanelet2 packages" commit

![image](https://user-images.githubusercontent.com/65527974/190048507-73dd06c2-a008-4232-b4f4-8e677ac3f53c.png)

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
