### PR TITLE
fix(obstacle_avoidance_planner): fix inf loop in mpt

### DIFF
--- a/planning/obstacle_avoidance_planner/src/node.cpp
+++ b/planning/obstacle_avoidance_planner/src/node.cpp
@@ -1025,6 +1025,19 @@ Trajectories ObstacleAvoidancePlanner::optimizeTrajectory(
     return getPrevTrajs(path.points);
   }
 
+  // NOTE: Elastic band sometimes diverges with status = "OSQP_SOLVED".
+  constexpr double max_path_change_diff = 1.0e4;
+  for (size_t i = 0; i < eb_traj->size(); ++i) {
+    const auto & eb_pos = eb_traj->at(i).pose.position;
+    const auto & path_pos = path.points.at(std::min(i, path.points.size() - 1)).pose.position;
+
+    const double diff_x = eb_pos.x - path_pos.x;
+    const double diff_y = eb_pos.y - path_pos.y;
+    if (max_path_change_diff < std::abs(diff_x) || max_path_change_diff < std::abs(diff_y)) {
+      return getPrevTrajs(path.points);
+    }
+  }
+
   // EB has to be solved twice before solving MPT with fixed points
   // since the result of EB is likely to change with/without fixing (1st/2nd EB)
   // that makes MPT fixing points worse.


### PR DESCRIPTION
## Description

porting https://github.com/autowarefoundation/autoware.universe/pull/1881

不具合により、出力経路と参照経路が1e7レベルのオーダーでずれていたので、それより小さく、また現実的な値 (現状のAutowareでは大きくても1e1)の間を取って1e4としました。かなりテンポラリな値です。

fix inf loop in mpt because of diverged elastic band
<!-- Write a brief description of this PR. -->

## Related Links

https://tier4.atlassian.net/browse/EVT4-2059

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
