### PR TITLE
fix(behavior_velocity_planner): do not consider stop_line_margin when a stop line is defined at map in crosswalk module

### DIFF
--- a/planning/behavior_velocity_planner/include/scene_module/crosswalk/scene_crosswalk.hpp
+++ b/planning/behavior_velocity_planner/include/scene_module/crosswalk/scene_crosswalk.hpp
@@ -113,7 +113,7 @@ private:
     const PathWithLaneId & ego_path, StopFactor & stop_factor);
 
   boost::optional<std::pair<double, geometry_msgs::msg::Point>> getStopLine(
-    const PathWithLaneId & ego_path) const;
+    const PathWithLaneId & ego_path, bool & exist_stopline_in_map) const;
 
   std::vector<CollisionPoint> getCollisionPoints(
     const PathWithLaneId & ego_path, const PredictedObject & object,


### PR DESCRIPTION
Signed-off-by: tomoya.kimura <tomoya.kimura@tier4.jp>

## Related Links
https://github.com/autowarefoundation/autoware.universe/pull/1978
(TIERIV Internal: https://star4.slack.com/archives/CEV8XMJBV/p1664358448041849?thread_ts=1664323130.934649&cid=CEV8XMJBV )

## Description
https://github.com/autowarefoundation/autoware.universe/pull/1978

> In crosswalk module, the parameter stop_line_distance should be considered only when the explicit stop_line is not defined in lanelet. But, in the current implementation, stop_line_distance is always considered. I fixed it.

Hotfix to beta/v0.5.2.



## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
