### PR TITLE
fix(pose_initializer): modifying the assignment of covariance variables to output poses

### DIFF
--- a/localization/pose_initializer/src/pose_initializer_core.cpp
+++ b/localization/pose_initializer/src/pose_initializer_core.cpp
@@ -235,12 +235,7 @@ bool PoseInitializer::callAlignServiceAndPublishResult(
   response_id_ = result->seq;
   // NOTE temporary cov
   geometry_msgs::msg::PoseWithCovarianceStamped & pose_with_cov = result->pose_with_covariance;
-  pose_with_cov.pose.covariance[0] = 1.0;
-  pose_with_cov.pose.covariance[1 * 6 + 1] = 1.0;
-  pose_with_cov.pose.covariance[2 * 6 + 2] = 0.01;
-  pose_with_cov.pose.covariance[3 * 6 + 3] = 0.01;
-  pose_with_cov.pose.covariance[4 * 6 + 4] = 0.01;
-  pose_with_cov.pose.covariance[5 * 6 + 5] = 0.2;
+  pose_with_cov.pose.covariance = output_pose_covariance_;
   initial_pose_pub_->publish(pose_with_cov);
   enable_gnss_callback_ = false;
 


### PR DESCRIPTION
## Description
Correction of a problem in which a fixed value was assigned to covariance in the Pose initializer.

[Fixed response of initialize pose API on iv](https://github.com/tier4/autoware.iv/pull/2128/files),  It was not incorporated into the universe version, [so the PR was adapted it. ](https://github.com/autowarefoundation/autoware.universe/pull/1020/files#diff-076ef3f74b5024fd7148eb1c2b230225b446ca2809ceb717e9e84f9ff25d5561R234-R241)
However, It have reverted to assigning a fixed value to covariance.Therefore, there is a problem that the values in the parameter file are not applied.

Adaptation to v0.3.10 is not necessary for tier4/main, since the problem does not exist.
However, v0.4 and v0.5 series have the same problem and need to be adapted.

https://tier4.atlassian.net/browse/EVT4-2065

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
