### PR TITLE
feat(trajecotry_follower,trajecotry_follower_nodes): add constant acc

### DIFF
--- a/control/trajectory_follower/CMakeLists.txt
+++ b/control/trajectory_follower/CMakeLists.txt
@@ -51,6 +51,7 @@ target_compile_options(${LATERAL_CONTROLLER_LIB} PRIVATE -Wno-error=old-style-ca
 set(LONGITUDINAL_CONTROLLER_LIB longitudinal_controller_lib)
 set(LONGITUDINAL_CONTROLLER_LIB_SRC
   src/pid_longitudinal_controller.cpp
+  src/constant_velocity_controller.cpp
   src/pid.cpp
   src/smooth_stop.cpp
   src/longitudinal_controller_utils.cpp
@@ -59,6 +60,7 @@ set(LONGITUDINAL_CONTROLLER_LIB_SRC
 set(LONGITUDINAL_CONTROLLER_LIB_HEADERS
   include/trajectory_follower/longitudinal_controller_base.hpp
   include/trajectory_follower/pid_longitudinal_controller.hpp
+  include/trajectory_follower/constant_velocity_controller.hpp
   include/trajectory_follower/sync_data.hpp
   include/trajectory_follower/input_data.hpp
   include/trajectory_follower/debug_values.hpp

--- a/control/trajectory_follower/include/trajectory_follower/constant_velocity_controller.hpp
+++ b/control/trajectory_follower/include/trajectory_follower/constant_velocity_controller.hpp
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef TRAJECTORY_FOLLOWER_NODES__CONTROLLER_NODE_HPP_
-#define TRAJECTORY_FOLLOWER_NODES__CONTROLLER_NODE_HPP_
+#ifndef TRAJECTORY_FOLLOWER__CONSTANT_VELOCITY_CONTROLLER_HPP_
+#define TRAJECTORY_FOLLOWER__CONSTANT_VELOCITY_CONTROLLER_HPP_
 
 #include "eigen3/Eigen/Core"
 #include "eigen3/Eigen/Geometry"
@@ -24,7 +24,6 @@
 #include "tf2_ros/buffer.h"
 #include "tf2_ros/transform_listener.h"
 #include "trajectory_follower/debug_values.hpp"
-#include "trajectory_follower/lateral_controller_base.hpp"
 #include "trajectory_follower/longitudinal_controller_base.hpp"
 #include "trajectory_follower/longitudinal_controller_utils.hpp"
 #include "trajectory_follower/lowpass_filter.hpp"
@@ -32,7 +31,6 @@
 #include "trajectory_follower/smooth_stop.hpp"
 #include "vehicle_info_util/vehicle_info_util.hpp"
 
-#include "autoware_auto_control_msgs/msg/ackermann_control_command.hpp"
 #include "autoware_auto_control_msgs/msg/longitudinal_command.hpp"
 #include "autoware_auto_planning_msgs/msg/trajectory.hpp"
 #include "autoware_auto_system_msgs/msg/float32_multi_array_diagnostic.hpp"
@@ -41,6 +39,7 @@
 #include "nav_msgs/msg/odometry.hpp"
 #include "tf2_msgs/msg/tf_message.hpp"
 
+#include <deque>
 #include <memory>
 #include <string>
 #include <utility>
@@ -52,65 +51,49 @@ namespace motion
 {
 namespace control
 {
-using trajectory_follower::LateralOutput;
-using trajectory_follower::LongitudinalOutput;
-namespace trajectory_follower_nodes
+namespace trajectory_follower
 {
 using autoware::common::types::bool8_t;
 using autoware::common::types::float64_t;
 namespace trajectory_follower = ::autoware::motion::control::trajectory_follower;
 namespace motion_common = ::autoware::motion::motion_common;
 
-/// \classController
+/// \class ConstantVelocityController
 /// \brief The node class used for generating longitudinal control commands (velocity/acceleration)
-class TRAJECTORY_FOLLOWER_PUBLIC Controller : public rclcpp::Node
+class TRAJECTORY_FOLLOWER_PUBLIC ConstantVelocityController : public LongitudinalControllerBase
 {
 public:
-  explicit Controller(const rclcpp::NodeOptions & node_options);
-  virtual ~Controller() {}
+  explicit ConstantVelocityController(rclcpp::Node & node);
 
 private:
-  rclcpp::TimerBase::SharedPtr timer_control_;
-  trajectory_follower::InputData input_data_;
-  double timeout_thr_sec_;
-  boost::optional<LongitudinalOutput> longitudinal_output_{boost::none};
-  boost::optional<LateralOutput> lateral_output_{boost::none};
+  rclcpp::Node * node_;
+  // ros variables
+  rclcpp::Publisher<autoware_auto_system_msgs::msg::Float32MultiArrayDiagnostic>::SharedPtr
+    m_pub_slope;
+  rclcpp::Publisher<autoware_auto_system_msgs::msg::Float32MultiArrayDiagnostic>::SharedPtr
+    m_pub_debug;
 
-  std::shared_ptr<trajectory_follower::LongitudinalControllerBase> longitudinal_controller_;
-  std::shared_ptr<trajectory_follower::LateralControllerBase> lateral_controller_;
+  // control state
+  enum class ControlState { DRIVE = 0, STOPPING, STOPPED, EMERGENCY };
+  ControlState m_control_state{ControlState::STOPPED};
 
-  rclcpp::Subscription<autoware_auto_planning_msgs::msg::Trajectory>::SharedPtr sub_ref_path_;
-  rclcpp::Subscription<nav_msgs::msg::Odometry>::SharedPtr sub_odometry_;
-  rclcpp::Subscription<autoware_auto_vehicle_msgs::msg::SteeringReport>::SharedPtr sub_steering_;
-  rclcpp::Publisher<autoware_auto_control_msgs::msg::AckermannControlCommand>::SharedPtr
-    control_cmd_pub_;
-
-  enum class LateralControllerMode {
-    INVALID = 0,
-    MPC = 1,
-    PURE_PURSUIT = 2,
-  };
-  enum class LongitudinalControllerMode {
-    INVALID = 0,
-    PID = 1,
-    CONSTANT = 2,
-  };
+  // control period
+  float64_t m_longitudinal_ctrl_period;
 
   /**
    * @brief compute control command, and publish periodically
    */
-  void callbackTimerControl();
-  void onTrajectory(const autoware_auto_planning_msgs::msg::Trajectory::SharedPtr);
-  void onOdometry(const nav_msgs::msg::Odometry::SharedPtr msg);
-  void onSteering(const autoware_auto_vehicle_msgs::msg::SteeringReport::SharedPtr msg);
-  bool isTimeOut();
-  LateralControllerMode getLateralControllerMode(const std::string & algorithm_name) const;
-  LongitudinalControllerMode getLongitudinalControllerMode(
-    const std::string & algorithm_name) const;
+  boost::optional<LongitudinalOutput> run() override;
+
+  /**
+   * @brief set input data like current odometry and trajectory.
+   */
+  void setInputData([[maybe_unused]]InputData const & input_data) {};
+
 };
-}  // namespace trajectory_follower_nodes
+}  // namespace trajectory_follower
 }  // namespace control
 }  // namespace motion
 }  // namespace autoware
 
-#endif  // TRAJECTORY_FOLLOWER_NODES__CONTROLLER_NODE_HPP_
+#endif  // TRAJECTORY_FOLLOWER__CONSTANT_VELOCITY_CONTROLLER_HPP_

--- a/control/trajectory_follower/src/constant_velocity_controller.cpp
+++ b/control/trajectory_follower/src/constant_velocity_controller.cpp
@@ -1,0 +1,72 @@
+// Copyright 2021 Tier IV, Inc. All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "trajectory_follower/constant_velocity_controller.hpp"
+
+#include "motion_common/motion_common.hpp"
+#include "motion_common/trajectory_common.hpp"
+#include "tier4_autoware_utils/tier4_autoware_utils.hpp"
+#include "time_utils/time_utils.hpp"
+
+#include <algorithm>
+#include <limits>
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace autoware
+{
+namespace motion
+{
+namespace control
+{
+namespace trajectory_follower
+{
+ConstantVelocityController::ConstantVelocityController(rclcpp::Node & node) : node_{&node}
+{
+  using std::placeholders::_1;
+
+  // parameters timer
+  m_longitudinal_ctrl_period = node_->get_parameter("ctrl_period").as_double();
+
+  // subscriber, publisher
+  m_pub_slope =
+    node_->create_publisher<autoware_auto_system_msgs::msg::Float32MultiArrayDiagnostic>(
+      "~/output/slope_angle", rclcpp::QoS{1});
+  m_pub_debug =
+    node_->create_publisher<autoware_auto_system_msgs::msg::Float32MultiArrayDiagnostic>(
+      "~/output/longitudinal_diagnostic", rclcpp::QoS{1});
+
+}
+
+boost::optional<LongitudinalOutput> ConstantVelocityController::run(){
+
+  autoware_auto_control_msgs::msg::LongitudinalCommand cmd{};
+  {
+    cmd.stamp = node_->now();
+    cmd.speed = 5.0;
+    cmd.acceleration = 1.0;
+  }
+  LongitudinalOutput output;
+  {
+    output.control_cmd = cmd;
+  }
+  return output;
+}
+
+}  // namespace trajectory_follower
+}  // namespace control
+}  // namespace motion
+}  // namespace autoware

--- a/control/trajectory_follower_nodes/src/controller_node.cpp
+++ b/control/trajectory_follower_nodes/src/controller_node.cpp
@@ -18,6 +18,7 @@
 #include "motion_common/trajectory_common.hpp"
 #include "pure_pursuit/pure_pursuit_lateral_controller.hpp"
 #include "time_utils/time_utils.hpp"
+#include "trajectory_follower/constant_velocity_controller.hpp"
 #include "trajectory_follower/mpc_lateral_controller.hpp"
 #include "trajectory_follower/pid_longitudinal_controller.hpp"
 
@@ -66,6 +67,11 @@ Controller::Controller(const rclcpp::NodeOptions & node_options) : Node("control
         std::make_shared<trajectory_follower::PidLongitudinalController>(*this);
       break;
     }
+    case LongitudinalControllerMode::CONSTANT: {
+      longitudinal_controller_ =
+        std::make_shared<trajectory_follower::ConstantVelocityController>(*this);
+      break;
+    }
     default:
       throw std::domain_error("[LongitudinalController] invalid algorithm");
   }
@@ -101,6 +107,7 @@ Controller::LongitudinalControllerMode Controller::getLongitudinalControllerMode
   const std::string & controller_mode) const
 {
   if (controller_mode == "pid") return LongitudinalControllerMode::PID;
+  if (controller_mode == "constant") return LongitudinalControllerMode::CONSTANT;
 
   return LongitudinalControllerMode::INVALID;
 }


### PR DESCRIPTION
## Description

- add contant velocity controller for psim testing

## Related links


https://user-images.githubusercontent.com/65527974/196928801-407f4735-88ea-4a7e-8f42-ec9bd9b0257d.mp4



## Tests performed

by psim

because psim doesn't have any limitation for velocity or acceleration this will keeps accelerating
https://user-images.githubusercontent.com/65527974/195523927-aff283ed-2659-43cb-991b-3c69839a796b.mp4



## Notes for reviewers

Dont merge this


this PR needs this change and set option constant
https://github.com/tier4/autoware_launch/pull/514
```
    # longitudinal controller mode
    add_launch_arg(
        "longitudinal_controller_mode",
        "constant",
        "longitudinal controller mode: `pid` or `constant`",
    )
```

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
