### PR TITLE
fix(velodyne_monitor): backport #1623 and #1744 from awf/autoware.universe

### DIFF
--- a/system/velodyne_monitor/Readme.md
+++ b/system/velodyne_monitor/Readme.md
@@ -61,7 +61,8 @@ None
 ### Config files
 
 Config files for several velodyne models are prepared.
-The `temp_**` parameters are set with reference to the operational temperature from each datasheet.
+The `temp_***` parameters are set with reference to the operational temperature from each datasheet.
+Moreover, the `temp_hot_***` of each model are set highly as 20 from operational temperature.
 Now, `VLP-16.param.yaml` is used as default argument because it is lowest spec.
 
 | Model Name     | Config name               | Operational Temperature [℃] |

--- a/system/velodyne_monitor/Readme.md
+++ b/system/velodyne_monitor/Readme.md
@@ -58,6 +58,20 @@ None
 | `rpm_ratio_warn`  | double | 0.80            | If the rpm rate of the motor (= current rpm / default rpm) is lower than this value, the diagnostics status becomes WARN  |
 | `rpm_ratio_error` | double | 0.70            | If the rpm rate of the motor (= current rpm / default rpm) is lower than this value, the diagnostics status becomes ERROR |
 
+### Config files
+
+Config files for several velodyne models are prepared.
+The `temp_**` parameters are set with reference to the operational temperature from each datasheet.
+Now, `VLP-16.param.yaml` is used as default argument because it is lowest spec.
+
+| Model Name     | Config name               | Operational Temperature [℃] |
+| -------------- | ------------------------- | --------------------------- |
+| VLP-16         | VLP-16.param.yaml         | -10 to 60                   |
+| VLP-32C        | VLP-32C.param.yaml        | -20 to 60                   |
+| VLS-128        | VLS-128.param.yaml        | -20 to 60                   |
+| Velarray M1600 | Velarray_M1600.param.yaml | -40 to 85                   |
+| HDL-32E        | HDL-32E.param.yaml        | -10 to 60                   |
+
 ## Assumptions / Known limits
 
 TBD.

--- a/system/velodyne_monitor/config/HDL-32E.param.yaml
+++ b/system/velodyne_monitor/config/HDL-32E.param.yaml
@@ -4,7 +4,7 @@
     timeout: 5.0
     temp_cold_warn: -5.0
     temp_cold_error: -10.0
-    temp_hot_warn: 55.0
-    temp_hot_error: 60.0
+    temp_hot_warn: 75.0
+    temp_hot_error: 80.0
     rpm_ratio_warn: 0.80
     rpm_ratio_error: 0.70

--- a/system/velodyne_monitor/config/HDL-32E.param.yaml
+++ b/system/velodyne_monitor/config/HDL-32E.param.yaml
@@ -4,7 +4,7 @@
     timeout: 5.0
     temp_cold_warn: -5.0
     temp_cold_error: -10.0
-    temp_hot_warn: 75.0
-    temp_hot_error: 80.0
+    temp_hot_warn: 55.0
+    temp_hot_error: 60.0
     rpm_ratio_warn: 0.80
     rpm_ratio_error: 0.70

--- a/system/velodyne_monitor/config/VLP-16.param.yaml
+++ b/system/velodyne_monitor/config/VLP-16.param.yaml
@@ -1,0 +1,10 @@
+---
+/**:
+  ros__parameters:
+    timeout: 5.0
+    temp_cold_warn: -5.0
+    temp_cold_error: -10.0
+    temp_hot_warn: 55.0
+    temp_hot_error: 60.0
+    rpm_ratio_warn: 0.80
+    rpm_ratio_error: 0.70

--- a/system/velodyne_monitor/config/VLP-16.param.yaml
+++ b/system/velodyne_monitor/config/VLP-16.param.yaml
@@ -4,7 +4,7 @@
     timeout: 5.0
     temp_cold_warn: -5.0
     temp_cold_error: -10.0
-    temp_hot_warn: 55.0
-    temp_hot_error: 60.0
+    temp_hot_warn: 75.0
+    temp_hot_error: 80.0
     rpm_ratio_warn: 0.80
     rpm_ratio_error: 0.70

--- a/system/velodyne_monitor/config/VLP-32C.param.yaml
+++ b/system/velodyne_monitor/config/VLP-32C.param.yaml
@@ -1,0 +1,10 @@
+---
+/**:
+  ros__parameters:
+    timeout: 5.0
+    temp_cold_warn: -15.0
+    temp_cold_error: -20.0
+    temp_hot_warn: 55.0
+    temp_hot_error: 60.0
+    rpm_ratio_warn: 0.80
+    rpm_ratio_error: 0.70

--- a/system/velodyne_monitor/config/VLP-32C.param.yaml
+++ b/system/velodyne_monitor/config/VLP-32C.param.yaml
@@ -4,7 +4,7 @@
     timeout: 5.0
     temp_cold_warn: -15.0
     temp_cold_error: -20.0
-    temp_hot_warn: 55.0
-    temp_hot_error: 60.0
+    temp_hot_warn: 75.0
+    temp_hot_error: 80.0
     rpm_ratio_warn: 0.80
     rpm_ratio_error: 0.70

--- a/system/velodyne_monitor/config/VLS-128.param.yaml
+++ b/system/velodyne_monitor/config/VLS-128.param.yaml
@@ -1,0 +1,10 @@
+---
+/**:
+  ros__parameters:
+    timeout: 5.0
+    temp_cold_warn: -15.0
+    temp_cold_error: -20.0
+    temp_hot_warn: 55.0
+    temp_hot_error: 60.0
+    rpm_ratio_warn: 0.80
+    rpm_ratio_error: 0.70

--- a/system/velodyne_monitor/config/VLS-128.param.yaml
+++ b/system/velodyne_monitor/config/VLS-128.param.yaml
@@ -4,7 +4,7 @@
     timeout: 5.0
     temp_cold_warn: -15.0
     temp_cold_error: -20.0
-    temp_hot_warn: 55.0
-    temp_hot_error: 60.0
+    temp_hot_warn: 75.0
+    temp_hot_error: 80.0
     rpm_ratio_warn: 0.80
     rpm_ratio_error: 0.70

--- a/system/velodyne_monitor/config/Velarray_M1600.param.yaml
+++ b/system/velodyne_monitor/config/Velarray_M1600.param.yaml
@@ -1,0 +1,10 @@
+---
+/**:
+  ros__parameters:
+    timeout: 5.0
+    temp_cold_warn: -35.0
+    temp_cold_error: -40.0
+    temp_hot_warn: 80.0
+    temp_hot_error: 85.0
+    rpm_ratio_warn: 0.80
+    rpm_ratio_error: 0.70

--- a/system/velodyne_monitor/config/Velarray_M1600.param.yaml
+++ b/system/velodyne_monitor/config/Velarray_M1600.param.yaml
@@ -4,7 +4,7 @@
     timeout: 5.0
     temp_cold_warn: -35.0
     temp_cold_error: -40.0
-    temp_hot_warn: 80.0
-    temp_hot_error: 85.0
+    temp_hot_warn: 100.0
+    temp_hot_error: 105.0
     rpm_ratio_warn: 0.80
     rpm_ratio_error: 0.70

--- a/system/velodyne_monitor/launch/velodyne_monitor.launch.xml
+++ b/system/velodyne_monitor/launch/velodyne_monitor.launch.xml
@@ -1,5 +1,5 @@
 <launch>
-  <arg name="velodyne_monitor_param_file" default="$(find-pkg-share velodyne_monitor)/config/velodyne_monitor.param.yaml"/>
+  <arg name="velodyne_monitor_param_file" default="$(find-pkg-share velodyne_monitor)/config/VLP-16.param.yaml"/>
   <arg name="ip_address" default="192.168.1.201"/>
 
   <node pkg="velodyne_monitor" exec="velodyne_monitor" name="velodyne_monitor" output="log" respawn="true">


### PR DESCRIPTION
## Description

backport two PRs
- https://github.com/autowarefoundation/autoware.universe/pull/1623
- https://github.com/autowarefoundation/autoware.universe/pull/1744

These are merged at https://github.com/tier4/autoware.universe/tree/v0.4.1
- https://github.com/tier4/autoware.universe/pull/95
- https://github.com/tier4/autoware.universe/pull/101

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
