### PR TITLE
fix(ground segmentation): correct initial condition of ground grid (#2117)

### DIFF
--- a/perception/ground_segmentation/src/scan_ground_filter_nodelet.cpp
+++ b/perception/ground_segmentation/src/scan_ground_filter_nodelet.cpp
@@ -314,9 +314,7 @@ void ScanGroundFilterComponent::classifyPointCloudGridScan(
         continue;
       }
 
-      if (
-        !initialized_first_gnd_grid && global_slope_p < -global_slope_max_angle_rad_ &&
-        p->orig_point->z < -non_ground_height_threshold_local) {
+      if (!initialized_first_gnd_grid) {
         prev_p = p;
         continue;
       }


### PR DESCRIPTION
## Description

https://github.com/autowarefoundation/autoware.universe/pull/2117
Hotfix to 0.5.2-odaiba

(TierIV Internal Link https://star4.slack.com/archives/C4P0NSMB5/p1666227925545509?thread_ts=1666227340.967779&cid=C4P0NSMB5 )

<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
