### PR TITLE
fix: sync stored_commands to cooperate status (#2223)

### DIFF
--- a/planning/rtc_interface/include/rtc_interface/rtc_interface.hpp
+++ b/planning/rtc_interface/include/rtc_interface/rtc_interface.hpp
@@ -62,6 +62,7 @@ private:
   std::vector<CooperateResponse> validateCooperateCommands(
     const std::vector<CooperateCommand> & commands);
   void updateCooperateCommandStatus(const std::vector<CooperateCommand> & commands);
+  void removeStoredCommand(const UUID & uuid);
   rclcpp::Logger getLogger() const;
   bool isLocked() const;
 

--- a/planning/rtc_interface/src/rtc_interface.cpp
+++ b/planning/rtc_interface/src/rtc_interface.cpp
@@ -187,6 +187,7 @@ void RTCInterface::updateCooperateStatus(
 void RTCInterface::removeCooperateStatus(const UUID & uuid)
 {
   std::lock_guard<std::mutex> lock(mutex_);
+  removeStoredCommand(uuid);
   // Find registered status which has same uuid and erase it
   const auto itr = std::find_if(
     registered_status_.statuses.begin(), registered_status_.statuses.end(),
@@ -202,10 +203,23 @@ void RTCInterface::removeCooperateStatus(const UUID & uuid)
     "[removeCooperateStatus] uuid : " << to_string(uuid) << " is not found." << std::endl);
 }
 
+void RTCInterface::removeStoredCommand(const UUID & uuid)
+{
+  // Find stored command which has same uuid and erase it
+  const auto itr = std::find_if(
+    stored_commands_.begin(), stored_commands_.end(), [uuid](auto & s) { return s.uuid == uuid; });
+
+  if (itr != stored_commands_.end()) {
+    stored_commands_.erase(itr);
+    return;
+  }
+}
+
 void RTCInterface::clearCooperateStatus()
 {
   std::lock_guard<std::mutex> lock(mutex_);
   registered_status_.statuses.clear();
+  stored_commands_.clear();
 }
 
 bool RTCInterface::isActivated(const UUID & uuid)


### PR DESCRIPTION
## Description
https://github.com/autowarefoundation/autoware.universe/pull/2223
Hotfix to beta/v0.5.2-odaiba3

> In rtc_interface, stored_commands is updated only when onCooperateCommandService() is called and is_locked_ is true.
However, the stored_commands are copied to the cooperate command status every time unlockCommandUpdate() is called.
As a result, the cooperate commands that are cleared once may be re-registered through stored_commands_.
I fixed this by properly clearing the stored_command.
Note: This bug is caused by performing lane-change in the same direction more than once.



<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
