### PR TITLE
fix: add check for external_emergency_stop_heartbeat_received_time to isDataReady (autowarefoundation#2155)

### DIFF
--- a/control/vehicle_cmd_gate/README.md
+++ b/control/vehicle_cmd_gate/README.md
@@ -66,4 +66,6 @@
 
 ## Assumptions / Known limits
 
-TBD.
+The parameter `use_external_emergency_stop` (true by default) enables an emergency stop request from external modules.
+This feature requires a `~/input/external_emergency_stop_heartbeat` topic for health monitoring of the external module, and the vehicle_cmd_gate module will not start without the topic.
+The `use_external_emergency_stop` parameter must be false when the "external emergency stop" function is not used.

--- a/control/vehicle_cmd_gate/src/vehicle_cmd_gate.cpp
+++ b/control/vehicle_cmd_gate/src/vehicle_cmd_gate.cpp
@@ -227,6 +227,13 @@ bool VehicleCmdGate::isDataReady()
     }
   }
 
+  if (use_external_emergency_stop_) {
+    if (!external_emergency_stop_heartbeat_received_time_) {
+      RCLCPP_WARN(get_logger(), "external_emergency_stop_heartbeat_received_time_ is false");
+      return false;
+    }
+  }
+
   return true;
 }
 


### PR DESCRIPTION
* fix: add check for external_emergency_stop_heartbeat_received_time to isDataReady

Signed-off-by: Azumi Suzuki <azumi.suzuki@tier4.jp>

* feat: add README about `use_external_emergency_stop` parameter

Signed-off-by: Azumi Suzuki <azumi.suzuki@tier4.jp>

* fix: update README as recommended

Signed-off-by: Azumi Suzuki <azumi.suzuki@tier4.jp>

Signed-off-by: Azumi Suzuki <azumi.suzuki@tier4.jp>

## Description

Backport https://github.com/autowarefoundation/autoware.universe/pull/2155 to beta/v0.5.4

TIER IV ticket link : https://tier4.atlassian.net/browse/T4PB-20370

<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
