### PR TITLE
fix(behavior_path_planner): consider almost  zero longitudinal start length (#2395)

### DIFF
--- a/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
@@ -2217,7 +2217,9 @@ boost::optional<AvoidPointArray> AvoidanceModule::findNewShiftPoint(
     }
 
     // new shift points must exist in front of Ego
-    if (candidate.start_longitudinal < 0.0) {
+    // this value should be larger than -eps consider path shifter calculation error.
+    const double eps = 0.01;
+    if (candidate.start_longitudinal < -eps) {
       continue;
     }
 


### PR DESCRIPTION
fix(behavior_path_planner): consider almost zero longitudinal start length

## Description

as title says
this is cherry-pick from awf universe

## Related Links
TIER IV INTERNAL LINK: https://tier4.atlassian.net/browse/T4PB-23560

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
