### PR TITLE
perf(behavior_velocity_planner): remove unnecessary debug data (#2462)

### DIFF
--- a/planning/behavior_velocity_planner/include/scene_module/blind_spot/scene.hpp
+++ b/planning/behavior_velocity_planner/include/scene_module/blind_spot/scene.hpp
@@ -48,13 +48,11 @@ public:
 
   struct DebugData
   {
-    autoware_auto_planning_msgs::msg::PathWithLaneId path_raw;
     geometry_msgs::msg::Pose virtual_wall_pose;
     geometry_msgs::msg::Pose stop_point_pose;
     geometry_msgs::msg::Pose judge_point_pose;
     geometry_msgs::msg::Polygon conflict_area_for_blind_spot;
     geometry_msgs::msg::Polygon detection_area_for_blind_spot;
-    autoware_auto_planning_msgs::msg::PathWithLaneId spline_path;
     autoware_auto_perception_msgs::msg::PredictedObjects conflicting_targets;
   };
 

--- a/planning/behavior_velocity_planner/include/scene_module/intersection/scene_intersection.hpp
+++ b/planning/behavior_velocity_planner/include/scene_module/intersection/scene_intersection.hpp
@@ -46,7 +46,6 @@ public:
   struct DebugData
   {
     bool stop_required;
-    autoware_auto_planning_msgs::msg::PathWithLaneId path_raw;
 
     geometry_msgs::msg::Pose slow_wall_pose;
     geometry_msgs::msg::Pose stop_wall_pose;

--- a/planning/behavior_velocity_planner/include/scene_module/occlusion_spot/occlusion_spot_utils.hpp
+++ b/planning/behavior_velocity_planner/include/scene_module/occlusion_spot/occlusion_spot_utils.hpp
@@ -190,8 +190,6 @@ struct DebugData
   std::vector<geometry_msgs::msg::Point> parked_vehicle_point;
   std::vector<PossibleCollisionInfo> possible_collisions;
   std::vector<geometry_msgs::msg::Point> occlusion_points;
-  PathWithLaneId path_raw;
-  PathWithLaneId path_interpolated;
   void resetData()
   {
     close_partition.clear();

--- a/planning/behavior_velocity_planner/src/scene_module/blind_spot/debug.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/blind_spot/debug.cpp
@@ -93,11 +93,6 @@ visualization_msgs::msg::MarkerArray BlindSpotModule::createDebugMarkerArray()
   const auto now = this->clock_->now();
 
   appendMarkerArray(
-    debug::createPathMarkerArray(
-      debug_data_.path_raw, "path_raw", lane_id_, now, 0.6, 0.3, 0.3, 0.0, 1.0, 1.0),
-    &debug_marker_array, now);
-
-  appendMarkerArray(
     createPoseMarkerArray(
       debug_data_.stop_point_pose, state, "stop_point_pose", module_id_, 1.0, 0.0, 0.0),
     &debug_marker_array, now);
@@ -122,11 +117,6 @@ visualization_msgs::msg::MarkerArray BlindSpotModule::createDebugMarkerArray()
   appendMarkerArray(
     debug::createObjectsMarkerArray(
       debug_data_.conflicting_targets, "conflicting_targets", module_id_, now, 0.99, 0.4, 0.0),
-    &debug_marker_array, now);
-
-  appendMarkerArray(
-    debug::createPathMarkerArray(
-      debug_data_.spline_path, "spline", lane_id_, now, 0.3, 0.1, 0.1, 0.5, 0.5, 0.5),
     &debug_marker_array, now);
 
   return debug_marker_array;

--- a/planning/behavior_velocity_planner/src/scene_module/blind_spot/scene.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/blind_spot/scene.cpp
@@ -85,7 +85,6 @@ bool BlindSpotModule::modifyPathVelocity(
     planning_utils::initializeStopReason(tier4_planning_msgs::msg::StopReason::BLIND_SPOT);
 
   const auto input_path = *path;
-  debug_data_.path_raw = input_path;
 
   StateMachine::State current_state = state_machine_.getState();
   RCLCPP_DEBUG(
@@ -237,7 +236,6 @@ bool BlindSpotModule::generateStopLine(
   if (!splineInterpolate(*path, interval, path_ip, logger_)) {
     return false;
   }
-  debug_data_.spline_path = path_ip;
 
   /* generate stop point */
   int stop_idx_ip = 0;  // stop point index for interpolated path.

--- a/planning/behavior_velocity_planner/src/scene_module/intersection/debug.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/intersection/debug.cpp
@@ -113,11 +113,6 @@ visualization_msgs::msg::MarkerArray IntersectionModule::createDebugMarkerArray(
   const auto now = this->clock_->now();
 
   appendMarkerArray(
-    debug::createPathMarkerArray(
-      debug_data_.path_raw, "path_raw", lane_id_, now, 0.6, 0.3, 0.3, 0.0, 1.0, 1.0),
-    &debug_marker_array, now);
-
-  appendMarkerArray(
     createLaneletPolygonsMarkerArray(
       debug_data_.detection_area, "detection_area", lane_id_, 0.0, 1.0, 0.0),
     &debug_marker_array);

--- a/planning/behavior_velocity_planner/src/scene_module/intersection/scene_intersection.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/intersection/scene_intersection.cpp
@@ -78,7 +78,6 @@ bool IntersectionModule::modifyPathVelocity(
   const StateMachine::State current_state = state_machine_.getState();
 
   debug_data_ = DebugData();
-  debug_data_.path_raw = *path;
 
   *stop_reason =
     planning_utils::initializeStopReason(tier4_planning_msgs::msg::StopReason::INTERSECTION);

--- a/planning/behavior_velocity_planner/src/scene_module/occlusion_spot/debug.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/occlusion_spot/debug.cpp
@@ -204,18 +204,6 @@ MarkerArray OcclusionSpotModule::createDebugMarkerArray()
       makePolygonMarker(debug_data_.close_partition, "close_partition", module_id_, debug_data_.z),
       &debug_marker_array, now);
   }
-  if (!debug_data_.path_interpolated.points.empty()) {
-    const int64_t virtual_lane_id = 0;
-    appendMarkerArray(
-      debug::createPathMarkerArray(
-        debug_data_.path_raw, "path_raw", virtual_lane_id, now, 0.6, 0.3, 0.3, 0.0, 1.0, 1.0),
-      &debug_marker_array, now);
-    appendMarkerArray(
-      debug::createPathMarkerArray(
-        debug_data_.path_interpolated, "path_interpolated", virtual_lane_id, now, 0.6, 0.3, 0.3,
-        0.0, 1.0, 1.0),
-      &debug_marker_array, now);
-  }
   if (!debug_data_.occlusion_points.empty()) {
     appendMarkerArray(
       debug::createPointsMarkerArray(

--- a/planning/behavior_velocity_planner/src/scene_module/occlusion_spot/scene_occlusion_spot.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/occlusion_spot/scene_occlusion_spot.cpp
@@ -186,10 +186,6 @@ bool OcclusionSpotModule::modifyPathVelocity(
   // these debug topics needs computation resource
   debug_data_.z = path->points.front().point.pose.position.z;
   debug_data_.possible_collisions = possible_collisions;
-  if (param_.is_show_occlusion) {
-    debug_data_.path_interpolated = path_interpolated;
-    debug_data_.path_raw.points = clipped_path.points;
-  }
   DEBUG_PRINT(show_time, "total [ms]: ", stop_watch_.toc("total_processing_time", true));
   return true;
 }


### PR DESCRIPTION
Signed-off-by: veqcc <ryuta.kambe@tier4.jp>

## Description
- cherry-pick fix to reduce computation time for blind_spot
  - https://github.com/autowarefoundation/autoware.universe/pull/2462

- Related jira (TIER IV Internal)
  - https://tier4.atlassian.net/browse/T4PB-24132

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
