### PR TITLE
feat(behavior_velocity_planner): output stop reason of traffic light whenever a stop point is inserted (backport #2323)

### DIFF
--- a/planning/behavior_velocity_planner/src/scene_module/traffic_light/scene.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/traffic_light/scene.cpp
@@ -490,8 +490,9 @@ autoware_auto_planning_msgs::msg::PathWithLaneId TrafficLightModule::insertStopP
   if (debug_data_.highest_confidence_traffic_light_point != std::nullopt) {
     stop_factor.stop_factor_points = std::vector<geometry_msgs::msg::Point>{
       debug_data_.highest_confidence_traffic_light_point.value()};
-    planning_utils::appendStopReason(stop_factor, stop_reason);
   }
+  planning_utils::appendStopReason(stop_factor, stop_reason);
+
   return modified_path;
 }
 


### PR DESCRIPTION
## Description

https://github.com/autowarefoundation/autoware.universe/pull/2323 のbackport

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
