### PR TITLE
fix(surround_obstacle_checker): not use boost::assign::list_of

### DIFF
--- a/planning/surround_obstacle_checker/src/node.cpp
+++ b/planning/surround_obstacle_checker/src/node.cpp
@@ -394,7 +394,7 @@ Polygon2d SurroundObstacleCheckerNode::createSelfPolygon()
   poly.outer().push_back(Point2d(front, right));
   poly.outer().push_back(Point2d(rear, right));
   poly.outer().push_back(Point2d(rear, left));
-  bg::correct(ego_polygon);
+  bg::correct(poly);
   return poly;
 }
 

--- a/planning/surround_obstacle_checker/src/node.cpp
+++ b/planning/surround_obstacle_checker/src/node.cpp
@@ -30,6 +30,8 @@
 #include <Eigen/Core>
 #include <Eigen/Geometry>
 
+#include "tier4_autoware_utils/geometry/geometry.hpp"
+
 SurroundObstacleCheckerNode::SurroundObstacleCheckerNode(const rclcpp::NodeOptions & node_options)
 : Node("surround_obstacle_checker_node", node_options),
   tf_buffer_(this->get_clock()),
@@ -388,65 +390,53 @@ Polygon2d SurroundObstacleCheckerNode::createSelfPolygon()
   const double right = vehicle_info_.min_lateral_offset_m;
 
   Polygon2d poly;
-  boost::geometry::exterior_ring(poly) = boost::assign::list_of<Point2d>(front, left)(front, right)(
-    rear, right)(rear, left)(front, left);
+  poly.outer().push_back(Point2d(front, left));
+  poly.outer().push_back(Point2d(front, right));
+  poly.outer().push_back(Point2d(rear, right));
+  poly.outer().push_back(Point2d(rear, left));
   return poly;
 }
 
 Polygon2d SurroundObstacleCheckerNode::createObjPolygon(
   const geometry_msgs::msg::Pose & pose, const geometry_msgs::msg::Vector3 & size)
 {
+  auto createPoint32 = [](const double x, const double y, const double z){
+    geometry_msgs::msg::Point32 p;
+    p.x = x;
+    p.y = y;
+    p.z = z;
+    return p;
+  };
+
   // rename
-  const double x = pose.position.x;
-  const double y = pose.position.y;
   const double h = size.x;
   const double w = size.y;
-  const double yaw = tf2::getYaw(pose.orientation);
 
   // create base polygon
-  Polygon2d obj_poly;
-  boost::geometry::exterior_ring(obj_poly) = boost::assign::list_of<Point2d>(h / 2.0, w / 2.0)(
-    -h / 2.0, w / 2.0)(-h / 2.0, -w / 2.0)(h / 2.0, -w / 2.0)(h / 2.0, w / 2.0);
+  geometry_msgs::msg::Polygon polygon{};
+  polygon.points.push_back(createPoint32(h, -w, 0.0));
+  polygon.points.push_back(createPoint32(h, w, 0.0));
+  polygon.points.push_back(createPoint32(-h, w, 0.0));
+  polygon.points.push_back(createPoint32(-h, -w, 0.0));
 
-  // rotate polygon(yaw)
-  boost::geometry::strategy::transform::rotate_transformer<boost::geometry::radian, double, 2, 2>
-    rotate(-yaw);  // anti-clockwise -> :clockwise rotation
-  Polygon2d rotate_obj_poly;
-  boost::geometry::transform(obj_poly, rotate_obj_poly, rotate);
-
-  // translate polygon(x, y)
-  boost::geometry::strategy::transform::translate_transformer<double, 2, 2> translate(x, y);
-  Polygon2d translate_obj_poly;
-  boost::geometry::transform(rotate_obj_poly, translate_obj_poly, translate);
-  return translate_obj_poly;
+  return createObjPolygon(pose, polygon);
 }
 
 Polygon2d SurroundObstacleCheckerNode::createObjPolygon(
   const geometry_msgs::msg::Pose & pose, const geometry_msgs::msg::Polygon & footprint)
 {
-  // rename
-  const double x = pose.position.x;
-  const double y = pose.position.y;
-  const double yaw = tf2::getYaw(pose.orientation);
+  geometry_msgs::msg::Polygon transformed_polygon{};
+  geometry_msgs::msg::TransformStamped geometry_tf{};
+  geometry_tf.transform = tier4_autoware_utils::pose2transform(pose);
+  tf2::doTransform(footprint, transformed_polygon, geometry_tf);
 
-  // create base polygon
-  Polygon2d obj_poly;
-  for (const auto point : footprint.points) {
-    const Point2d point2d(point.x, point.y);
-    obj_poly.outer().push_back(point2d);
+  Polygon2d object_polygon;
+  for (const auto & p : transformed_polygon.points) {
+    object_polygon.outer().push_back(Point2d(p.x, p.y));
   }
 
-  // rotate polygon(yaw)
-  boost::geometry::strategy::transform::rotate_transformer<boost::geometry::radian, double, 2, 2>
-    rotate(-yaw);  // anti-clockwise -> :clockwise rotation
-  Polygon2d rotate_obj_poly;
-  boost::geometry::transform(obj_poly, rotate_obj_poly, rotate);
-
-  // translate polygon(x, y)
-  boost::geometry::strategy::transform::translate_transformer<double, 2, 2> translate(x, y);
-  Polygon2d translate_obj_poly;
-  boost::geometry::transform(rotate_obj_poly, translate_obj_poly, translate);
-  return translate_obj_poly;
+  boost::geometry::correct(object_polygon);
+  return object_polygon;
 }
 
 diagnostic_msgs::msg::DiagnosticStatus SurroundObstacleCheckerNode::makeStopReasonDiag(

--- a/planning/surround_obstacle_checker/src/node.cpp
+++ b/planning/surround_obstacle_checker/src/node.cpp
@@ -394,6 +394,7 @@ Polygon2d SurroundObstacleCheckerNode::createSelfPolygon()
   poly.outer().push_back(Point2d(front, right));
   poly.outer().push_back(Point2d(rear, right));
   poly.outer().push_back(Point2d(rear, left));
+  bg::correct(ego_polygon);
   return poly;
 }
 

--- a/planning/surround_obstacle_checker/src/node.cpp
+++ b/planning/surround_obstacle_checker/src/node.cpp
@@ -27,10 +27,10 @@
 #include <string>
 
 #define EIGEN_MPL2_ONLY
+#include "tier4_autoware_utils/geometry/geometry.hpp"
+
 #include <Eigen/Core>
 #include <Eigen/Geometry>
-
-#include "tier4_autoware_utils/geometry/geometry.hpp"
 
 SurroundObstacleCheckerNode::SurroundObstacleCheckerNode(const rclcpp::NodeOptions & node_options)
 : Node("surround_obstacle_checker_node", node_options),
@@ -400,7 +400,7 @@ Polygon2d SurroundObstacleCheckerNode::createSelfPolygon()
 Polygon2d SurroundObstacleCheckerNode::createObjPolygon(
   const geometry_msgs::msg::Pose & pose, const geometry_msgs::msg::Vector3 & size)
 {
-  auto createPoint32 = [](const double x, const double y, const double z){
+  auto createPoint32 = [](const double x, const double y, const double z) {
     geometry_msgs::msg::Point32 p;
     p.x = x;
     p.y = y;

--- a/planning/surround_obstacle_checker/src/node.cpp
+++ b/planning/surround_obstacle_checker/src/node.cpp
@@ -394,7 +394,7 @@ Polygon2d SurroundObstacleCheckerNode::createSelfPolygon()
   poly.outer().push_back(Point2d(front, right));
   poly.outer().push_back(Point2d(rear, right));
   poly.outer().push_back(Point2d(rear, left));
-  bg::correct(poly);
+  boost::geometry::correct(poly);
   return poly;
 }
 


### PR DESCRIPTION
## Related Link

https://tier4.atlassian.net/browse/T4PB-24283

## Description

boost::assign::list_ofがbad_allocを起こしてそうということがcoredumpを確認してわかったため、それを使わない形にする
最新では使わないようにリファクタリングがはいっているので、それを移植する形で対策を講じる

https://github.com/tier4/autoware.universe/blob/52c7ce377e7504a2223f332e33c93161bd85ae0e/planning/surround_obstacle_checker/src/node.cpp#L89-L140

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
