### PR TITLE
feat(system_error_monitor): add heartbeat timeout for subscribed data (backport #1501)

### DIFF
--- a/system/system_error_monitor/README.md
+++ b/system/system_error_monitor/README.md
@@ -108,12 +108,13 @@ endif
 
 ### Node Parameters
 
-| Name                         | Type   | Default Value | Explanation                                                                                                                                             |
-| ---------------------------- | ------ | ------------- | ------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `ignore_missing_diagnostics` | bool   | `false`       | If this parameter is turned off, it will be ignored if required modules have not been received.                                                         |
-| `add_leaf_diagnostics`       | bool   | `true`        | Required to use children diagnostics.                                                                                                                   |
-| `diag_timeout_sec`           | double | `1.0` (sec)   | If required diagnostic is not received for a `diag_timeout_sec`, the diagnostic state become STALE state.                                               |
-| `data_ready_timeout`         | double | `30.0`        | If input topics required for system_error_monitor are not available for `data_ready_timeout` seconds, autoware_state will translate to emergency state. |
+| Name                         | Type   | Default Value | Explanation                                                                                                                                                            |
+| ---------------------------- | ------ | ------------- | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `ignore_missing_diagnostics` | bool   | `false`       | If this parameter is turned off, it will be ignored if required modules have not been received.                                                                        |
+| `add_leaf_diagnostics`       | bool   | `true`        | Required to use children diagnostics.                                                                                                                                  |
+| `diag_timeout_sec`           | double | `1.0` (sec)   | If required diagnostic is not received for a `diag_timeout_sec`, the diagnostic state become STALE state.                                                              |
+| `data_ready_timeout`         | double | `30.0`        | If input topics required for system_error_monitor are not available for `data_ready_timeout` seconds, autoware_state will translate to emergency state.                |
+| `data_heartbeat_timeout`     | double | `1.0`         | If input topics required for system_error_monitor are not no longer subscribed for `data_heartbeat_timeout` seconds, autoware_state will translate to emergency state. |
 
 ### Core Parameters
 

--- a/system/system_error_monitor/include/system_error_monitor/system_error_monitor_core.hpp
+++ b/system/system_error_monitor/include/system_error_monitor/system_error_monitor_core.hpp
@@ -71,6 +71,7 @@ private:
     bool ignore_missing_diagnostics;
     bool add_leaf_diagnostics;
     double data_ready_timeout;
+    double data_heartbeat_timeout;
     double diag_timeout_sec;
     double hazard_recovery_timeout;
     int emergency_hazard_level;
@@ -92,6 +93,7 @@ private:
   rclcpp::TimerBase::SharedPtr timer_;
 
   bool isDataReady();
+  bool isDataHeartbeatTimeout();
   void onTimer();
 
   // Subscriber
@@ -124,6 +126,12 @@ private:
   bool onClearEmergencyService(
     [[maybe_unused]] std_srvs::srv::Trigger::Request::SharedPtr request,
     std_srvs::srv::Trigger::Response::SharedPtr response);
+
+  // for Heartbeat
+  rclcpp::Time diag_array_stamp_;
+  rclcpp::Time autoware_state_stamp_;
+  rclcpp::Time current_gate_mode_stamp_;
+  rclcpp::Time control_mode_stamp_;
 
   // Algorithm
   boost::optional<DiagStamped> getLatestDiag(const std::string & diag_name) const;

--- a/system/system_error_monitor/launch/system_error_monitor.launch.xml
+++ b/system/system_error_monitor/launch/system_error_monitor.launch.xml
@@ -3,6 +3,7 @@
   <arg name="ignore_missing_diagnostics" default="false"/>
   <arg name="add_leaf_diagnostics" default="true"/>
   <arg name="data_ready_timeout" default="30.0"/>
+  <arg name="data_heartbeat_timeout" default="1.0"/>
   <arg name="diag_timeout_sec" default="1.0"/>
   <arg name="hazard_recovery_timeout" default="5.0"/>
   <arg name="use_emergency_hold" default="false"/>
@@ -45,6 +46,7 @@
     <arg name="ignore_missing_diagnostics" value="$(var ignore_missing_diagnostics)"/>
     <arg name="add_leaf_diagnostics" value="$(var add_leaf_diagnostics)"/>
     <arg name="data_ready_timeout" value="$(var data_ready_timeout)"/>
+    <arg name="data_heartbeat_timeout" value="$(var data_heartbeat_timeout)"/>
     <arg name="diag_timeout_sec" value="$(var diag_timeout_sec)"/>
     <arg name="hazard_recovery_timeout" value="$(var hazard_recovery_timeout)"/>
     <arg name="use_emergency_hold" value="$(var use_emergency_hold)"/>

--- a/system/system_error_monitor/launch/system_error_monitor_node.launch.xml
+++ b/system/system_error_monitor/launch/system_error_monitor_node.launch.xml
@@ -3,6 +3,7 @@
   <arg name="ignore_missing_diagnostics"/>
   <arg name="add_leaf_diagnostics"/>
   <arg name="data_ready_timeout"/>
+  <arg name="data_heartbeat_timeout"/>
   <arg name="diag_timeout_sec"/>
   <arg name="hazard_recovery_timeout"/>
   <arg name="use_emergency_hold"/>
@@ -23,6 +24,7 @@
     <param name="ignore_missing_diagnostics" value="$(var ignore_missing_diagnostics)"/>
     <param name="add_leaf_diagnostics" value="$(var add_leaf_diagnostics)"/>
     <param name="data_ready_timeout" value="$(var data_ready_timeout)"/>
+    <param name="data_heartbeat_timeout" value="$(var data_heartbeat_timeout)"/>
     <param name="diag_timeout_sec" value="$(var diag_timeout_sec)"/>
     <param name="hazard_recovery_timeout" value="$(var hazard_recovery_timeout)"/>
     <param name="use_emergency_hold" value="$(var use_emergency_hold)"/>


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
This PR is backport from https://github.com/autowarefoundation/autoware.universe/pull/1501

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/