### PR TITLE
fix(mission_planner): set goal in shoulder lane (#2548)

### DIFF
--- a/planning/mission_planner/src/lanelet2_plugins/default_planner.cpp
+++ b/planning/mission_planner/src/lanelet2_plugins/default_planner.cpp
@@ -272,6 +272,25 @@ bool DefaultPlanner::is_goal_valid(
   const geometry_msgs::msg::Pose & goal, lanelet::ConstLanelets path_lanelets)
 {
   const auto logger = node_->get_logger();
+
+  const auto goal_lanelet_pt = lanelet::utils::conversion::toLaneletPoint(goal.position);
+
+  // check if goal is in shoulder lanelet
+  lanelet::Lanelet closest_shoulder_lanelet;
+  if (lanelet::utils::query::getClosestLanelet(
+        shoulder_lanelets_, goal, &closest_shoulder_lanelet)) {
+    if (is_in_lane(closest_shoulder_lanelet, goal_lanelet_pt)) {
+      const auto lane_yaw =
+        lanelet::utils::getLaneletAngle(closest_shoulder_lanelet, goal.position);
+      const auto goal_yaw = tf2::getYaw(goal.orientation);
+      const auto angle_diff = tier4_autoware_utils::normalizeRadian(lane_yaw - goal_yaw);
+      const double th_angle = tier4_autoware_utils::deg2rad(param_.goal_angle_threshold_deg);
+      if (std::abs(angle_diff) < th_angle) {
+        return true;
+      }
+    }
+  }
+
   lanelet::Lanelet closest_lanelet;
   if (!lanelet::utils::query::getClosestLanelet(road_lanelets_, goal, &closest_lanelet)) {
     return false;
@@ -298,8 +317,6 @@ bool DefaultPlanner::is_goal_valid(
     return false;
   }
 
-  const auto goal_lanelet_pt = lanelet::utils::conversion::toLaneletPoint(goal.position);
-
   if (is_in_lane(closest_lanelet, goal_lanelet_pt)) {
     const auto lane_yaw = lanelet::utils::getLaneletAngle(closest_lanelet, goal.position);
     const auto goal_yaw = tf2::getYaw(goal.orientation);
@@ -323,23 +340,6 @@ bool DefaultPlanner::is_goal_valid(
     return true;
   }
 
-  // check if goal is in shoulder lanelet
-  lanelet::Lanelet closest_shoulder_lanelet;
-  if (!lanelet::utils::query::getClosestLanelet(
-        shoulder_lanelets_, goal, &closest_shoulder_lanelet)) {
-    return false;
-  }
-  // check if goal pose is in shoulder lane
-  if (is_in_lane(closest_shoulder_lanelet, goal_lanelet_pt)) {
-    const auto lane_yaw = lanelet::utils::getLaneletAngle(closest_shoulder_lanelet, goal.position);
-    const auto goal_yaw = tf2::getYaw(goal.orientation);
-    const auto angle_diff = tier4_autoware_utils::normalizeRadian(lane_yaw - goal_yaw);
-
-    const double th_angle = tier4_autoware_utils::deg2rad(param_.goal_angle_threshold_deg);
-    if (std::abs(angle_diff) < th_angle) {
-      return true;
-    }
-  }
   return false;
 }
 


### PR DESCRIPTION
## Description
Hotfix to beta/v0.7.0
https://github.com/autowarefoundation/autoware.universe/pull/2548
> With https://github.com/autowarefoundation/autoware.universe/pull/2088, goal can not be set in shoulder lane.

<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
