### PR TITLE
fix(external_velocity_limit_selector): increase history depth external velocity limit selector

### DIFF
--- a/planning/external_velocity_limit_selector/include/external_velocity_limit_selector/external_velocity_limit_selector_node.hpp
+++ b/planning/external_velocity_limit_selector/include/external_velocity_limit_selector/external_velocity_limit_selector_node.hpp
@@ -17,6 +17,7 @@
 
 #include <rclcpp/rclcpp.hpp>
 
+#include <tier4_debug_msgs/msg/string_stamped.hpp>
 #include <tier4_planning_msgs/msg/velocity_limit.hpp>
 #include <tier4_planning_msgs/msg/velocity_limit_clear_command.hpp>
 
@@ -25,9 +26,12 @@
 #include <string>
 #include <unordered_map>
 
+using tier4_debug_msgs::msg::StringStamped;
 using tier4_planning_msgs::msg::VelocityLimit;
 using tier4_planning_msgs::msg::VelocityLimitClearCommand;
 using tier4_planning_msgs::msg::VelocityLimitConstraints;
+
+using VelocityLimitTable = std::unordered_map<std::string, VelocityLimit>;
 
 class ExternalVelocityLimitSelectorNode : public rclcpp::Node
 {
@@ -58,18 +62,20 @@ private:
   rclcpp::Subscription<VelocityLimit>::SharedPtr sub_external_velocity_limit_from_internal_;
   rclcpp::Subscription<VelocityLimitClearCommand>::SharedPtr sub_velocity_limit_clear_command_;
   rclcpp::Publisher<VelocityLimit>::SharedPtr pub_external_velocity_limit_;
+  rclcpp::Publisher<StringStamped>::SharedPtr pub_debug_string_;
 
   void publishVelocityLimit(const VelocityLimit & velocity_limit);
   void setVelocityLimitFromAPI(const VelocityLimit & velocity_limit);
   void setVelocityLimitFromInternal(const VelocityLimit & velocity_limit);
   void clearVelocityLimit(const std::string & sender);
   void updateVelocityLimit();
+  void publishDebugString();
   VelocityLimit getCurrentVelocityLimit() { return hardest_limit_; }
 
   // Parameters
   NodeParam node_param_{};
   VelocityLimit hardest_limit_{};
-  std::unordered_map<std::string, VelocityLimit> velocity_limit_table_;
+  VelocityLimitTable velocity_limit_table_;
 };
 
 #endif  // EXTERNAL_VELOCITY_LIMIT_SELECTOR__EXTERNAL_VELOCITY_LIMIT_SELECTOR_NODE_HPP_

--- a/planning/external_velocity_limit_selector/launch/external_velocity_limit_selector.launch.xml
+++ b/planning/external_velocity_limit_selector/launch/external_velocity_limit_selector.launch.xml
@@ -8,6 +8,7 @@
   <arg name="input_velocity_limit_from_internal" default="/planning/scenario_planning/max_velocity_candidates"/>
   <arg name="input_velocity_limit_clear_command_from_internal" default="/planning/scenario_planning/clear_velocity_limit"/>
   <arg name="output_velocity_limit_from_selector" default="/planning/scenario_planning/max_velocity"/>
+  <arg name="output_debug_string" default="/planning/scenario_planning/external_velocity_limit_selector/debug"/>
 
   <node pkg="external_velocity_limit_selector" exec="external_velocity_limit_selector" name="external_velocity_limit_selector" output="screen">
     <param from="$(var common_param_path)"/>
@@ -16,5 +17,6 @@
     <remap from="input/velocity_limit_from_internal" to="$(var input_velocity_limit_from_internal)"/>
     <remap from="input/velocity_limit_clear_command_from_internal" to="$(var input_velocity_limit_clear_command_from_internal)"/>
     <remap from="output/external_velocity_limit" to="$(var output_velocity_limit_from_selector)"/>
+    <remap from="output/debug" to="$(var output_debug_string)"/>
   </node>
 </launch>

--- a/planning/external_velocity_limit_selector/package.xml
+++ b/planning/external_velocity_limit_selector/package.xml
@@ -15,6 +15,7 @@
 
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
+  <depend>tier4_debug_msgs</depend>
   <depend>tier4_planning_msgs</depend>
 
   <exec_depend>ros2cli</exec_depend>


### PR DESCRIPTION
Hotfix to beta/v0.7.0
https://github.com/autowarefoundation/autoware.universe/pull/2581

## Description

<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
