### PR TITLE
fix(obstacle_avoidance_planner): fix lat_dist_to_front_bound comparison (autowarefoundation#2594)

### DIFF
--- a/planning/obstacle_avoidance_planner/src/utils/utils.cpp
+++ b/planning/obstacle_avoidance_planner/src/utils/utils.cpp
@@ -641,10 +641,10 @@ bool isOutsideDrivableArea(
   const auto left_start_point = getStartPoint(left_bound, right_bound.front());
   const auto right_start_point = getStartPoint(right_bound, left_bound.front());
 
-  // ignore point in front of the front line
+  // ignore point behind of the front line
   const std::vector<geometry_msgs::msg::Point> front_bound = {left_start_point, right_start_point};
   const double lat_dist_to_front_bound = motion_utils::calcLateralOffset(front_bound, point);
-  if (lat_dist_to_front_bound > min_dist) {
+  if (lat_dist_to_front_bound < -min_dist) {
     return false;
   }
 


### PR DESCRIPTION
## Description
https://github.com/autowarefoundation/autoware.universe/pull/2594
hotfix to beta/v0.7.0
> Currently drivable area check for traj footprints in MPT doesn't work. Because lat_dist_to_front_bound (lateral distance of footprint corners to front bound) is always positive.

<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
