### PR TITLE
fix(system_error_monitor): hold emergency when timeout happens (#2634)

### DIFF
--- a/system/system_error_monitor/include/system_error_monitor/system_error_monitor_core.hpp
+++ b/system/system_error_monitor/include/system_error_monitor/system_error_monitor_core.hpp
@@ -141,6 +141,7 @@ private:
     autoware_auto_system_msgs::msg::HazardStatus * hazard_status) const;
   autoware_auto_system_msgs::msg::HazardStatus judgeHazardStatus() const;
   void updateHazardStatus();
+  void updateTimeoutHazardStatus();
   bool canAutoRecovery() const;
   bool isEmergencyHoldingRequired() const;
 };


### PR DESCRIPTION
## Description

https://github.com/autowarefoundation/autoware.universe/pull/2634 のbackport

TIERIV_INTERNAL_LINK: https://tier4.atlassian.net/browse/T4PB-25040

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
