### PR TITLE
feat(behavior_path_planner): error messsage when no pull over/out planners (#2644)

### DIFF
--- a/planning/behavior_path_planner/src/scene_module/pull_out/pull_out_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/pull_out/pull_out_module.cpp
@@ -55,7 +55,7 @@ PullOutModule::PullOutModule(
       std::make_shared<GeometricPullOut>(node, parameters, getGeometricPullOutParameters()));
   }
   if (pull_out_planners_.empty()) {
-    RCLCPP_DEBUG(getLogger(), "Not found enabled planner");
+    RCLCPP_ERROR(getLogger(), "Not found enabled planner");
   }
 }
 

--- a/planning/behavior_path_planner/src/scene_module/pull_over/pull_over_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/pull_over/pull_over_module.cpp
@@ -77,6 +77,9 @@ PullOverModule::PullOverModule(
       node, parameters, getGeometricPullOverParameters(), lane_departure_checker,
       occupancy_grid_map_, is_forward));
   }
+  if (pull_over_planners_.empty()) {
+    RCLCPP_ERROR(getLogger(), "Not found enabled planner");
+  }
 
   // set selected goal searcher
   // currently there is only one goal_searcher_type


### PR DESCRIPTION


feat(behavior_path_planner): error messsage when no pull over/out planner

Signed-off-by: kosuke55 <kosuke.tnp@gmail.com>

Signed-off-by: kosuke55 <kosuke.tnp@gmail.com>

## Description

<!-- Write a brief description of this PR. -->
cherry-pick https://github.com/autowarefoundation/autoware.universe/pull/2644

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
build 

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
