### PR TITLE
fix(obstacle_avoidance_planner): fix drivable area checker (#2639)

### DIFF
--- a/planning/obstacle_avoidance_planner/include/obstacle_avoidance_planner/utils/utils.hpp
+++ b/planning/obstacle_avoidance_planner/include/obstacle_avoidance_planner/utils/utils.hpp
@@ -358,8 +358,8 @@ namespace drivable_area_utils
 {
 bool isOutsideDrivableAreaFromRectangleFootprint(
   const autoware_auto_planning_msgs::msg::TrajectoryPoint & traj_point,
-  const std::vector<geometry_msgs::msg::Point> left_bound,
-  const std::vector<geometry_msgs::msg::Point> right_bound, const VehicleParam & vehicle_param);
+  const std::vector<geometry_msgs::msg::Point> & left_bound,
+  const std::vector<geometry_msgs::msg::Point> & right_bound, const VehicleParam & vehicle_param);
 }
 
 #endif  // OBSTACLE_AVOIDANCE_PLANNER__UTILS__UTILS_HPP_


### PR DESCRIPTION
## Description
https://github.com/autowarefoundation/autoware.universe/pull/2639
Hotfix to beta/v0.7.0

> Currently, the obstacle avoidance planner checks if the footprint of the vehicle is outside of the drivable area by lateral distance from the left and right boundary. However, this method does not work well when the boundary is not straight. In this PR, I use the polygon instead of the line to check if the footprint is outside of the drivable area.
For example, in the following scene, the trajectory point will be judged outside of the drivable area even though it is inside of it. This is because it uses the line created by point0 and point1, so the trajectory point is judged to be located right side of the line.

<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
