### PR TITLE
feat(behavior_path_planner): ignore pull out start near lane end (#2675)

### DIFF
--- a/planning/behavior_path_planner/README.md
+++ b/planning/behavior_path_planner/README.md
@@ -440,6 +440,7 @@ If a safe path cannot be generated from the current position, search backwards f
 | max_back_distance                                                          | [m]            | double | maximum back distance                                                                                                 | 15.0          |
 | backward_search_resolution                                                 | [m]            | double | distance interval for searching backward pull out start point                                                         | 2.0           |
 | backward_path_update_duration                                              | [s]            | double | time interval for searching backward pull out start point. this prevents chattering between back driving and pull_out | 3.0           |
+| ignore_distance_from_lane_end                                              | [m]            | double | distance from end of pull out lanes for ignoring start candidates                                                     | 15.0          |
 
 #### Unimplemented parts / limitations for pull put
 

--- a/planning/behavior_path_planner/config/pull_out/pull_out.param.yaml
+++ b/planning/behavior_path_planner/config/pull_out/pull_out.param.yaml
@@ -28,3 +28,4 @@
       max_back_distance: 15.0
       backward_search_resolution: 2.0
       backward_path_update_duration: 3.0
+      ignore_distance_from_lane_end: 15.0

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/pull_out/pull_out_parameters.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/pull_out/pull_out_parameters.hpp
@@ -49,6 +49,7 @@ struct PullOutParameters
   double max_back_distance;
   double backward_search_resolution;
   double backward_path_update_duration;
+  double ignore_distance_from_lane_end;
   // drivable area expansion
   double drivable_area_right_bound_offset;
   double drivable_area_left_bound_offset;

--- a/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
+++ b/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
@@ -537,6 +537,7 @@ PullOutParameters BehaviorPathPlannerNode::getPullOutParam()
   p.max_back_distance = dp("max_back_distance", 15.0);
   p.backward_search_resolution = dp("backward_search_resolution", 2.0);
   p.backward_path_update_duration = dp("backward_path_update_duration", 3.0);
+  p.ignore_distance_from_lane_end = dp("ignore_distance_from_lane_end", 15.0);
   // drivable area
   p.drivable_area_right_bound_offset = dp("drivable_area_right_bound_offset", 0.0);
   p.drivable_area_left_bound_offset = dp("drivable_area_left_bound_offset", 0.0);


### PR DESCRIPTION
## Description
https://github.com/autowarefoundation/autoware.universe/pull/2675
Hotfix to beta/v0.7.0
> Same to pull_over https://github.com/autowarefoundation/autoware.universe/pull/2667,
ignore pull_out start candidate near the lane end to prevent distortion with the path generated close to the drivable area.

<!-- Write a brief description of this PR. -->

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed

<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
