### PR TITLE
fix(accel_brake_map_calibrator): fix usage of transform listener (#2682)

### DIFF
--- a/vehicle/accel_brake_map_calibrator/accel_brake_map_calibrator/package.xml
+++ b/vehicle/accel_brake_map_calibrator/accel_brake_map_calibrator/package.xml
@@ -5,6 +5,9 @@
   <version>0.1.0</version>
   <description>The accel_brake_map_calibrator</description>
   <maintainer email="tomoya.kimura@tier4.jp">Tomoya Kimura</maintainer>
+  <maintainer email="taiki.tanaka@tier4.jp">Taiki Tanaka</maintainer>
+  <maintainer email="takeshi.miura@tier4.jp">Takeshi Miura</maintainer>
+
   <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>

--- a/vehicle/accel_brake_map_calibrator/accel_brake_map_calibrator/src/accel_brake_map_calibrator_node.cpp
+++ b/vehicle/accel_brake_map_calibrator/accel_brake_map_calibrator/src/accel_brake_map_calibrator_node.cpp
@@ -232,15 +232,13 @@ bool AccelBrakeMapCalibrator::getCurrentPitchFromTF(double * pitch)
   }
 
   // get tf
-  geometry_msgs::msg::TransformStamped::ConstSharedPtr transform;
-  try {
-    transform = transform_listener_->getTransform(
-      "map", "base_link", rclcpp::Time(0), rclcpp::Duration::from_seconds(0.5));
-  } catch (tf2::TransformException & ex) {
+  const auto transform = transform_listener_->getTransform(
+    "map", "base_link", rclcpp::Time(0), rclcpp::Duration::from_seconds(0.5));
+  if (!transform) {
     auto & clk = *this->get_clock();
     RCLCPP_WARN_STREAM_THROTTLE(
       rclcpp::get_logger("accel_brake_map_calibrator"), clk, 5000,
-      "cannot get map to base_link transform. " << ex.what());
+      "cannot get map to base_link transform. ");
     return false;
   }
   double roll, raw_pitch, yaw;


### PR DESCRIPTION
## Description
https://github.com/autowarefoundation/autoware.universe/pull/2682
Hotfix to beta/v0.7.0

> Fix usage of transform listener.
transform_listener_->getTransform don't throw an error when getting transform fails. So, in current implementation, accel_brake_map_calibrator dies when there is no available tf. I fixed it.

<!-- Write a brief description of this PR. -->

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed

<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
