### PR TITLE
fix(lane_change): fix bug when target reference path is empty (#2752)

### DIFF
--- a/planning/behavior_path_planner/src/scene_module/lane_change/util.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/util.cpp
@@ -374,6 +374,9 @@ LaneChangePaths getLaneChangePaths(
     const auto target_lane_reference_path = getReferencePathFromTargetLane(
       route_handler, target_lanelets, lane_changing_start_pose, target_lane_length, lc_dist,
       required_total_min_distance, forward_path_length, resample_interval, is_goal_in_route);
+    if (target_lane_reference_path.points.empty()) {
+      continue;
+    }
 
     const ShiftLine shift_line = getLaneChangeShiftLine(
       prepare_segment_reference, lane_changing_segment_reference, target_lanelets,


### PR DESCRIPTION
## Description
https://github.com/autowarefoundation/autoware.universe/pull/2752
Hotfix to beta/v0.7.0
> When target_lane_reference_path is empty, behavior_path_planner dies with the following error.
I fixed it.
<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
