### PR TITLE
fix(behavior_velocity_planner): fix blind spot over-detection (#2570)

### DIFF
--- a/perception/map_based_prediction/src/path_generator.cpp
+++ b/perception/map_based_prediction/src/path_generator.cpp
@@ -112,6 +112,17 @@ PredictedPath PathGenerator::generatePathForCrosswalkUser(
     }
   }
 
+  // calculate orientation of each point
+  if (predicted_path.path.size() >= 2) {
+    for (size_t i = 0; i < predicted_path.path.size() - 1; i++) {
+      const auto yaw = tier4_autoware_utils::calcAzimuthAngle(
+        predicted_path.path.at(i).position, predicted_path.path.at(i + 1).position);
+      predicted_path.path.at(i).orientation = tier4_autoware_utils::createQuaternionFromYaw(yaw);
+    }
+    predicted_path.path.back().orientation =
+      predicted_path.path.at(predicted_path.path.size() - 2).orientation;
+  }
+
   predicted_path.confidence = 1.0;
   predicted_path.time_step = rclcpp::Duration::from_seconds(sampling_time_interval_);
 

--- a/planning/behavior_velocity_planner/config/blind_spot.param.yaml
+++ b/planning/behavior_velocity_planner/config/blind_spot.param.yaml
@@ -6,3 +6,4 @@
       backward_length: 15.0 # [m]
       ignore_width_from_center_line: 0.7 # [m]
       max_future_movement_time: 10.0 # [second]
+      threshold_yaw_diff: 0.523 # [rad]

--- a/planning/behavior_velocity_planner/include/scene_module/blind_spot/scene.hpp
+++ b/planning/behavior_velocity_planner/include/scene_module/blind_spot/scene.hpp
@@ -65,6 +65,7 @@ public:
     double ignore_width_from_center_line;  //! ignore width from center line from detection_area
     double
       max_future_movement_time;  //! maximum time[second] for considering future movement of object
+    double threshold_yaw_diff;   //! threshold of yaw difference between ego and target object
   };
 
   BlindSpotModule(
@@ -153,7 +154,7 @@ private:
    */
   bool isPredictedPathInArea(
     const autoware_auto_perception_msgs::msg::PredictedObject & object,
-    const lanelet::CompoundPolygon3d & area) const;
+    const lanelet::CompoundPolygon3d & area, geometry_msgs::msg::Pose ego_pose) const;
 
   /**
    * @brief Generate a stop line and insert it into the path.

--- a/planning/behavior_velocity_planner/src/scene_module/blind_spot/manager.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/blind_spot/manager.cpp
@@ -36,6 +36,8 @@ BlindSpotModuleManager::BlindSpotModuleManager(rclcpp::Node & node)
     node.declare_parameter(ns + ".ignore_width_from_center_line", 1.0);
   planner_param_.max_future_movement_time =
     node.declare_parameter(ns + ".max_future_movement_time", 10.0);
+  planner_param_.threshold_yaw_diff =
+    node.declare_parameter(ns + ".threshold_yaw_diff", M_PI / 6.0);
 }
 
 void BlindSpotModuleManager::launchNewModules(


### PR DESCRIPTION
## Description
https://github.com/autowarefoundation/autoware.universe/pull/2570
Hotfix to beta/v0.7.0
> To prevent over-detection of blind_spot, I added yaw difference threshold between ego and target objects as detection conditions.

<!-- Write a brief description of this PR. -->

## Related links
https://github.com/autowarefoundation/autoware.universe/pull/2570

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed
Done (Planning simulator)
<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
