### PR TITLE
feat(ekf_localizer): deactivate during the pose initialization for v0.3.x

### DIFF
--- a/localization/ekf_localizer/include/ekf_localizer/ekf_localizer.hpp
+++ b/localization/ekf_localizer/include/ekf_localizer/ekf_localizer.hpp
@@ -18,6 +18,7 @@
 #include <kalman_filter/kalman_filter.hpp>
 #include <kalman_filter/time_delay_kalman_filter.hpp>
 #include <rclcpp/rclcpp.hpp>
+#include <std_srvs/srv/set_bool.hpp>
 #include <tier4_autoware_utils/geometry/geometry.hpp>
 #include <tier4_autoware_utils/system/stop_watch.hpp>
 
@@ -81,6 +82,9 @@ private:
   //!< @brief last predict time
   std::shared_ptr<const rclcpp::Time> last_predict_time_;
 
+  //!< @brief trigger_node service
+  rclcpp::Service<std_srvs::srv::SetBool>::SharedPtr service_trigger_node_;
+
   //!< @brief timer to send transform
   rclcpp::TimerBase::SharedPtr timer_tf_;
   //!< @brief tf broadcaster
@@ -127,6 +131,8 @@ private:
   double proc_cov_yaw_bias_d_;  //!< @brief  discrete yaw bias process noise
   double proc_cov_vx_d_;        //!< @brief  discrete process noise in d_vx=0
   double proc_cov_wz_d_;        //!< @brief  discrete process noise in d_wz=0
+
+  bool is_activated_;
 
   enum IDX {
     X = 0,
@@ -240,6 +246,13 @@ private:
    * @brief for debug
    */
   void showCurrentX();
+
+  /**
+   * @brief trigger node
+   */
+  void serviceTriggerNode(
+    const std_srvs::srv::SetBool::Request::SharedPtr req,
+    std_srvs::srv::SetBool::Response::SharedPtr res);
 
   tier4_autoware_utils::StopWatch<std::chrono::milliseconds> stop_watch_;
 

--- a/localization/ekf_localizer/launch/ekf_localizer.launch.xml
+++ b/localization/ekf_localizer/launch/ekf_localizer.launch.xml
@@ -6,6 +6,7 @@
   <arg name="extend_state_step" default="50"/>
 
   <arg name="input_initial_pose_name" default="initialpose"/>
+  <arg name="input_trigger_node_service_name" default="trigger_node" description="trigger node service"/>
 
   <!-- for Pose measurement -->
   <arg name="input_pose_with_cov_name" default="in_pose_with_covariance"/>
@@ -41,6 +42,7 @@
     <remap from="in_twist_with_covariance" to="$(var input_twist_with_cov_name)"/>
 
     <remap from="initialpose" to="$(var input_initial_pose_name)"/>
+    <remap from="trigger_node_srv" to="$(var input_trigger_node_service_name)"/>
 
     <param name="pose_frame_id" value="map"/>
 

--- a/localization/ekf_localizer/package.xml
+++ b/localization/ekf_localizer/package.xml
@@ -17,6 +17,7 @@
   <depend>rclcpp</depend>
   <depend>sensor_msgs</depend>
   <depend>std_msgs</depend>
+  <depend>std_srvs</depend>
   <depend>tf2</depend>
   <depend>tf2_ros</depend>
   <depend>tier4_autoware_utils</depend>


### PR DESCRIPTION
## Description

大規模地図対応に付随する変更

https://github.com/autowarefoundation/autoware.universe/pull/1873 のv0.3.x向けインテグ



なお、いくつかのPRの上で変更されているため、以下を参考に今の状況に合うように修正した

- https://github.com/autowarefoundation/autoware.universe/pull/1837

  - warningメッセージの置き換え

- https://github.com/autowarefoundation/autoware.universe/commit/6fa5c3f57b00ee9f907cd11819b3887f5d899587

  - activateはinitializeの処理を置き換えている

- https://github.com/autowarefoundation/autoware.universe/pull/1027

  - 観測値をキュー化している

## Related links

TIERIV INTERNAL LINK:
- https://tier4.atlassian.net/browse/T4PB-25485


## Tests performed

<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
