### PR TITLE
ci(pre-commit): update isort version to avoid CI failure (#2777)

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -56,7 +56,7 @@ repos:
         args: [-w, -s, -i=4]
 
   - repo: https://github.com/pycqa/isort
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
       - id: isort
 


### PR DESCRIPTION
ci(pre-commit): update isort version to avoid pre-commit failure

Signed-off-by: Tomohito Ando <tomohito.ando@tier4.jp>

## Description
https://github.com/autowarefoundation/autoware.universe/pull/2777
Hotfix to beta/v0.7.0
> Fixes the pre-commit.ci failure.
https://results.pre-commit.ci/run/github/429651616/1675041634.tp_4EmctSLqQDalbXYYjaw

<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author
https://github.com/autowarefoundation/autoware.universe/pull/2777

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
