### PR TITLE
chore: change lifetime of object marker

### DIFF
--- a/common/autoware_auto_perception_rviz_plugin/src/object_detection/object_polygon_detail.cpp
+++ b/common/autoware_auto_perception_rviz_plugin/src/object_detection/object_polygon_detail.cpp
@@ -56,7 +56,7 @@ visualization_msgs::msg::Marker::SharedPtr get_path_confidence_marker_ptr(
   marker_ptr->type = visualization_msgs::msg::Marker::TEXT_VIEW_FACING;
   marker_ptr->ns = std::string("path confidence");
   marker_ptr->action = visualization_msgs::msg::Marker::MODIFY;
-  marker_ptr->lifetime = rclcpp::Duration::from_seconds(0.2);
+  marker_ptr->lifetime = rclcpp::Duration::from_seconds(1.0);
   marker_ptr->scale.x = 0.5;
   marker_ptr->scale.y = 0.5;
   marker_ptr->scale.z = 0.5;
@@ -78,7 +78,7 @@ visualization_msgs::msg::Marker::SharedPtr get_predicted_path_marker_ptr(
   marker_ptr->type = visualization_msgs::msg::Marker::LINE_LIST;
   marker_ptr->ns = std::string("path");
   marker_ptr->action = visualization_msgs::msg::Marker::MODIFY;
-  marker_ptr->lifetime = rclcpp::Duration::from_seconds(0.2);
+  marker_ptr->lifetime = rclcpp::Duration::from_seconds(1.0);
   marker_ptr->pose = initPose();
   marker_ptr->color = predicted_path_color;
   marker_ptr->color.a = std::max(
@@ -114,7 +114,7 @@ visualization_msgs::msg::Marker::SharedPtr get_twist_marker_ptr(
   pt_e.z = twist_with_covariance.twist.linear.z;
   marker_ptr->points.push_back(pt_e);
 
-  marker_ptr->lifetime = rclcpp::Duration::from_seconds(0.2);
+  marker_ptr->lifetime = rclcpp::Duration::from_seconds(1.0);
   marker_ptr->color.a = 0.999;
   marker_ptr->color.r = 1.0;
   marker_ptr->color.g = 0.0;
@@ -139,7 +139,7 @@ visualization_msgs::msg::Marker::SharedPtr get_velocity_text_marker_ptr(
   marker_ptr->text = std::to_string(static_cast<int>(vel * 3.6)) + std::string("[km/h]");
   marker_ptr->action = visualization_msgs::msg::Marker::MODIFY;
   marker_ptr->pose.position = vis_pos;
-  marker_ptr->lifetime = rclcpp::Duration::from_seconds(0.2);
+  marker_ptr->lifetime = rclcpp::Duration::from_seconds(1.0);
   marker_ptr->color = color_rgba;
   return marker_ptr;
 }
@@ -160,7 +160,7 @@ visualization_msgs::msg::Marker::SharedPtr get_acceleration_text_marker_ptr(
   marker_ptr->text = getRoundedDoubleString(acc) + std::string("[m/s^2]");
   marker_ptr->action = visualization_msgs::msg::Marker::MODIFY;
   marker_ptr->pose.position = vis_pos;
-  marker_ptr->lifetime = rclcpp::Duration::from_seconds(0.2);
+  marker_ptr->lifetime = rclcpp::Duration::from_seconds(1.0);
   marker_ptr->color = color_rgba;
   return marker_ptr;
 }
@@ -204,7 +204,7 @@ visualization_msgs::msg::Marker::SharedPtr get_pose_with_covariance_marker_ptr(
   point.y = e2.y() * sigma2;
   point.z = 0;
   marker_ptr->points.push_back(point);
-  marker_ptr->lifetime = rclcpp::Duration::from_seconds(0.2);
+  marker_ptr->lifetime = rclcpp::Duration::from_seconds(1.0);
   marker_ptr->color.a = 0.999;
   marker_ptr->color.r = 1.0;
   marker_ptr->color.g = 1.0;
@@ -239,7 +239,7 @@ visualization_msgs::msg::Marker::SharedPtr get_label_marker_ptr(
   marker_ptr->text = label;
   marker_ptr->action = visualization_msgs::msg::Marker::MODIFY;
   marker_ptr->pose = marker_ptr->pose = to_pose(centroid, orientation);
-  marker_ptr->lifetime = rclcpp::Duration::from_seconds(0.2);
+  marker_ptr->lifetime = rclcpp::Duration::from_seconds(1.0);
   marker_ptr->color = color_rgba;
   return marker_ptr;
 }
@@ -269,7 +269,7 @@ visualization_msgs::msg::Marker::SharedPtr get_shape_marker_ptr(
 
   marker_ptr->action = visualization_msgs::msg::Marker::MODIFY;
   marker_ptr->pose = to_pose(centroid, orientation);
-  marker_ptr->lifetime = rclcpp::Duration::from_seconds(0.2);
+  marker_ptr->lifetime = rclcpp::Duration::from_seconds(1.0);
   marker_ptr->scale.x = line_width;
   marker_ptr->color = color_rgba;
 


### PR DESCRIPTION
Signed-off-by: tomoya.kimura <tomoya.kimura@tier4.jp>

## Description
Currently, the topic Hz of  ```/perception/object_recognition/objects``` drops to about 2-3 Hz due to the excessive computation of map_based_prediction.
This causes the object to blink in Rviz.
 To fix this issue, temporarily increased lifetime from 0.2 to 1.0

<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
