### PR TITLE
feat: decrease computational cost of external lane change

### DIFF
--- a/planning/behavior_path_planner/src/scene_module/lane_change/external_request_lane_change_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/external_request_lane_change_module.cpp
@@ -373,9 +373,14 @@ std::pair<bool, bool> ExternalRequestLaneChangeModule::getSafePath(
 
   if (!lane_change_lanes.empty()) {
     // find candidate paths
+
+    // in external request lane change,
+    // do not sample trajectories with multiple accelerations to reduce computational cost
+    auto ext_lc_parameters = *parameters_;
+    ext_lc_parameters.lane_change_sampling_num = 1;
     const auto lane_change_paths = lane_change_utils::getLaneChangePaths(
       *route_handler, current_lanes, lane_change_lanes, current_pose, current_twist,
-      common_parameters, *parameters_);
+      common_parameters, ext_lc_parameters);
 
     // get lanes used for detection
     lanelet::ConstLanelets check_lanes;


### PR DESCRIPTION
Signed-off-by: tomoya.kimura <tomoya.kimura@tier4.jp>

## Description
Fixed lane_change_sampling_num of external lane change to 1 for reduction of computational cost

<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
