### PR TITLE
feat(autoware_auto_perception_rviz_plugin): add simple visualize mode (autowarefoundation#2814)

### DIFF
--- a/common/autoware_auto_perception_rviz_plugin/include/object_detection/object_polygon_detail.hpp
+++ b/common/autoware_auto_perception_rviz_plugin/include/object_detection/object_polygon_detail.hpp
@@ -84,6 +84,12 @@ get_shape_marker_ptr(
   const geometry_msgs::msg::Point & centroid, const geometry_msgs::msg::Quaternion & orientation,
   const std_msgs::msg::ColorRGBA & color_rgba, const double & line_width);
 
+AUTOWARE_AUTO_PERCEPTION_RVIZ_PLUGIN_PUBLIC visualization_msgs::msg::Marker::SharedPtr
+get_2d_shape_marker_ptr(
+  const autoware_auto_perception_msgs::msg::Shape & shape_msg,
+  const geometry_msgs::msg::Point & centroid, const geometry_msgs::msg::Quaternion & orientation,
+  const std_msgs::msg::ColorRGBA & color_rgba, const double & line_width);
+
 /// \brief Convert the given polygon into a marker representing the shape in 3d
 /// \param centroid Centroid position of the shape in Object.header.frame_id frame
 /// \return Marker ptr. Id and header will have to be set by the caller
@@ -131,7 +137,15 @@ AUTOWARE_AUTO_PERCEPTION_RVIZ_PLUGIN_PUBLIC void calc_bounding_box_line_list(
   const autoware_auto_perception_msgs::msg::Shape & shape,
   std::vector<geometry_msgs::msg::Point> & points);
 
+AUTOWARE_AUTO_PERCEPTION_RVIZ_PLUGIN_PUBLIC void calc_2d_bounding_box_bottom_line_list(
+  const autoware_auto_perception_msgs::msg::Shape & shape,
+  std::vector<geometry_msgs::msg::Point> & points);
+
 AUTOWARE_AUTO_PERCEPTION_RVIZ_PLUGIN_PUBLIC void calc_cylinder_line_list(
+  const autoware_auto_perception_msgs::msg::Shape & shape,
+  std::vector<geometry_msgs::msg::Point> & points);
+
+AUTOWARE_AUTO_PERCEPTION_RVIZ_PLUGIN_PUBLIC void calc_2d_cylinder_bottom_line_list(
   const autoware_auto_perception_msgs::msg::Shape & shape,
   std::vector<geometry_msgs::msg::Point> & points);
 
@@ -140,6 +154,10 @@ AUTOWARE_AUTO_PERCEPTION_RVIZ_PLUGIN_PUBLIC void calc_circle_line_list(
   std::vector<geometry_msgs::msg::Point> & points, const int n);
 
 AUTOWARE_AUTO_PERCEPTION_RVIZ_PLUGIN_PUBLIC void calc_polygon_line_list(
+  const autoware_auto_perception_msgs::msg::Shape & shape,
+  std::vector<geometry_msgs::msg::Point> & points);
+
+AUTOWARE_AUTO_PERCEPTION_RVIZ_PLUGIN_PUBLIC void calc_2d_polygon_bottom_line_list(
   const autoware_auto_perception_msgs::msg::Shape & shape,
   std::vector<geometry_msgs::msg::Point> & points);
 

--- a/common/autoware_auto_perception_rviz_plugin/include/object_detection/object_polygon_detail.hpp
+++ b/common/autoware_auto_perception_rviz_plugin/include/object_detection/object_polygon_detail.hpp
@@ -126,7 +126,7 @@ AUTOWARE_AUTO_PERCEPTION_RVIZ_PLUGIN_PUBLIC visualization_msgs::msg::Marker::Sha
 get_predicted_path_marker_ptr(
   const autoware_auto_perception_msgs::msg::Shape & shape,
   const autoware_auto_perception_msgs::msg::PredictedPath & predicted_path,
-  const std_msgs::msg::ColorRGBA & predicted_path_color);
+  const std_msgs::msg::ColorRGBA & predicted_path_color, const bool is_simple = false);
 
 AUTOWARE_AUTO_PERCEPTION_RVIZ_PLUGIN_PUBLIC visualization_msgs::msg::Marker::SharedPtr
 get_path_confidence_marker_ptr(
@@ -163,7 +163,7 @@ AUTOWARE_AUTO_PERCEPTION_RVIZ_PLUGIN_PUBLIC void calc_2d_polygon_bottom_line_lis
 
 AUTOWARE_AUTO_PERCEPTION_RVIZ_PLUGIN_PUBLIC void calc_path_line_list(
   const autoware_auto_perception_msgs::msg::PredictedPath & paths,
-  std::vector<geometry_msgs::msg::Point> & points);
+  std::vector<geometry_msgs::msg::Point> & points, const bool is_simple = false);
 
 /// \brief Convert Point32 to Point
 /// \param val Point32 to be converted

--- a/common/autoware_auto_perception_rviz_plugin/include/object_detection/object_polygon_display_base.hpp
+++ b/common/autoware_auto_perception_rviz_plugin/include/object_detection/object_polygon_display_base.hpp
@@ -87,6 +87,11 @@ public:
     m_display_type_property->addOption("3d", 0);
     m_display_type_property->addOption("2d", 1);
     m_display_type_property->addOption("Disable", 2);
+    m_simple_visualize_mode_property = new rviz_common::properties::EnumProperty(
+      "Visualization Type", "Normal", "Simplicity of the polygon to display object.", this,
+      SLOT(updatePalette()));
+    m_simple_visualize_mode_property->addOption("Normal", 0);
+    m_simple_visualize_mode_property->addOption("Simple", 1);
     // iterate over default values to create and initialize the properties.
     for (const auto & map_property_it : detail::kDefaultObjectPropertyValues) {
       const auto & class_property_values = map_property_it.second;
@@ -262,7 +267,9 @@ protected:
     if (m_display_predicted_paths_property.getBool()) {
       const std::string uuid_str = uuid_to_string(uuid);
       const std_msgs::msg::ColorRGBA predicted_path_color = get_color_from_uuid(uuid_str);
-      return detail::get_predicted_path_marker_ptr(shape, predicted_path, predicted_path_color);
+      return detail::get_predicted_path_marker_ptr(
+        shape, predicted_path, predicted_path_color,
+        m_simple_visualize_mode_property->getOptionInt() == 1);
     } else {
       return std::nullopt;
     }
@@ -384,6 +391,8 @@ private:
   PolygonPropertyMap m_polygon_properties;
   // Property to choose type of visualization polygon
   rviz_common::properties::EnumProperty * m_display_type_property;
+  // Property to choose simplicity of visualization polygon
+  rviz_common::properties::EnumProperty * m_simple_visualize_mode_property;
   // Property to enable/disable label visualization
   rviz_common::properties::BoolProperty m_display_label_property;
   // Property to enable/disable uuid visualization

--- a/common/autoware_auto_perception_rviz_plugin/package.xml
+++ b/common/autoware_auto_perception_rviz_plugin/package.xml
@@ -7,6 +7,8 @@
   <maintainer email="opensource@apex.ai">Apex.AI, Inc.</maintainer>
   <maintainer email="satoshi.tanaka@tier4.jp">Satoshi Tanaka</maintainer>
   <maintainer email="taiki.tanaka@tier4.jp">Taiki Tanaka</maintainer>
+  <maintainer email="takeshi.miura@tier4.jp">Takeshi Miura</maintainer>
+
   <license>Apache 2.0</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>

--- a/common/autoware_auto_perception_rviz_plugin/src/object_detection/object_polygon_detail.cpp
+++ b/common/autoware_auto_perception_rviz_plugin/src/object_detection/object_polygon_detail.cpp
@@ -276,6 +276,38 @@ visualization_msgs::msg::Marker::SharedPtr get_shape_marker_ptr(
   return marker_ptr;
 }
 
+visualization_msgs::msg::Marker::SharedPtr get_2d_shape_marker_ptr(
+  const autoware_auto_perception_msgs::msg::Shape & shape_msg,
+  const geometry_msgs::msg::Point & centroid, const geometry_msgs::msg::Quaternion & orientation,
+  const std_msgs::msg::ColorRGBA & color_rgba, const double & line_width)
+{
+  auto marker_ptr = std::make_shared<Marker>();
+  marker_ptr->ns = std::string("shape");
+
+  using autoware_auto_perception_msgs::msg::Shape;
+  if (shape_msg.type == Shape::BOUNDING_BOX) {
+    marker_ptr->type = visualization_msgs::msg::Marker::LINE_LIST;
+    calc_2d_bounding_box_bottom_line_list(shape_msg, marker_ptr->points);
+  } else if (shape_msg.type == Shape::CYLINDER) {
+    marker_ptr->type = visualization_msgs::msg::Marker::LINE_LIST;
+    calc_2d_cylinder_bottom_line_list(shape_msg, marker_ptr->points);
+  } else if (shape_msg.type == Shape::POLYGON) {
+    marker_ptr->type = visualization_msgs::msg::Marker::LINE_LIST;
+    calc_2d_polygon_bottom_line_list(shape_msg, marker_ptr->points);
+  } else {
+    marker_ptr->type = visualization_msgs::msg::Marker::LINE_LIST;
+    calc_2d_polygon_bottom_line_list(shape_msg, marker_ptr->points);
+  }
+
+  marker_ptr->action = visualization_msgs::msg::Marker::MODIFY;
+  marker_ptr->pose = to_pose(centroid, orientation);
+  marker_ptr->lifetime = rclcpp::Duration::from_seconds(0.2);
+  marker_ptr->scale.x = line_width;
+  marker_ptr->color = color_rgba;
+
+  return marker_ptr;
+}
+
 void calc_bounding_box_line_list(
   const autoware_auto_perception_msgs::msg::Shape & shape,
   std::vector<geometry_msgs::msg::Point> & points)
@@ -392,6 +424,49 @@ void calc_bounding_box_line_list(
   points.push_back(point);
 }
 
+void calc_2d_bounding_box_bottom_line_list(
+  const autoware_auto_perception_msgs::msg::Shape & shape,
+  std::vector<geometry_msgs::msg::Point> & points)
+{
+  geometry_msgs::msg::Point point;
+  // down surface
+  point.x = shape.dimensions.x / 2.0;
+  point.y = shape.dimensions.y / 2.0;
+  point.z = -shape.dimensions.z / 2.0;
+  points.push_back(point);
+  point.x = -shape.dimensions.x / 2.0;
+  point.y = shape.dimensions.y / 2.0;
+  point.z = -shape.dimensions.z / 2.0;
+  points.push_back(point);
+
+  point.x = shape.dimensions.x / 2.0;
+  point.y = shape.dimensions.y / 2.0;
+  point.z = -shape.dimensions.z / 2.0;
+  points.push_back(point);
+  point.x = shape.dimensions.x / 2.0;
+  point.y = -shape.dimensions.y / 2.0;
+  point.z = -shape.dimensions.z / 2.0;
+  points.push_back(point);
+
+  point.x = -shape.dimensions.x / 2.0;
+  point.y = shape.dimensions.y / 2.0;
+  point.z = -shape.dimensions.z / 2.0;
+  points.push_back(point);
+  point.x = -shape.dimensions.x / 2.0;
+  point.y = -shape.dimensions.y / 2.0;
+  point.z = -shape.dimensions.z / 2.0;
+  points.push_back(point);
+
+  point.x = shape.dimensions.x / 2.0;
+  point.y = -shape.dimensions.y / 2.0;
+  point.z = -shape.dimensions.z / 2.0;
+  points.push_back(point);
+  point.x = -shape.dimensions.x / 2.0;
+  point.y = -shape.dimensions.y / 2.0;
+  point.z = -shape.dimensions.z / 2.0;
+  points.push_back(point);
+}
+
 void calc_cylinder_line_list(
   const autoware_auto_perception_msgs::msg::Shape & shape,
   std::vector<geometry_msgs::msg::Point> & points)
@@ -432,6 +507,21 @@ void calc_cylinder_line_list(
       point.z = -shape.dimensions.z * 0.5;
       points.push_back(point);
     }
+  }
+}
+
+void calc_2d_cylinder_bottom_line_list(
+  const autoware_auto_perception_msgs::msg::Shape & shape,
+  std::vector<geometry_msgs::msg::Point> & points)
+{
+  const double radius = shape.dimensions.x * 0.5;
+  {
+    constexpr int n = 20;
+    geometry_msgs::msg::Point center;
+    center.x = 0.0;
+    center.y = 0.0;
+    center.z = -shape.dimensions.z * 0.5;
+    calc_circle_line_list(center, radius, points, n);
   }
 }
 
@@ -516,6 +606,33 @@ void calc_polygon_line_list(
     points.push_back(point);
     point.x = shape.footprint.points.at(i).x;
     point.y = shape.footprint.points.at(i).y;
+    point.z = -shape.dimensions.z / 2.0;
+    points.push_back(point);
+  }
+}
+
+void calc_2d_polygon_bottom_line_list(
+  const autoware_auto_perception_msgs::msg::Shape & shape,
+  std::vector<geometry_msgs::msg::Point> & points)
+{
+  if (shape.footprint.points.size() < 2) {
+    RCLCPP_WARN(
+      rclcpp::get_logger("ObjectPolygonDisplayBase"),
+      "there are no enough footprint to visualize polygon");
+    return;
+  }
+  for (size_t i = 0; i < shape.footprint.points.size(); ++i) {
+    geometry_msgs::msg::Point point;
+    point.x = shape.footprint.points.at(i).x;
+    point.y = shape.footprint.points.at(i).y;
+    point.z = -shape.dimensions.z / 2.0;
+    points.push_back(point);
+    point.x = shape.footprint.points
+                .at(static_cast<int>(i + 1) % static_cast<int>(shape.footprint.points.size()))
+                .x;
+    point.y = shape.footprint.points
+                .at(static_cast<int>(i + 1) % static_cast<int>(shape.footprint.points.size()))
+                .y;
     point.z = -shape.dimensions.z / 2.0;
     points.push_back(point);
   }


### PR DESCRIPTION
## Description
Hotfix to beta/v0.7.0. Improve performance of rviz.

https://github.com/autowarefoundation/autoware.universe/pull/2780
https://github.com/autowarefoundation/autoware.universe/pull/2814

> Add simple visualization mode to autoware_auto_perception_rviz_plugin for reduction of visualization cost.
Compared to before the PR merge, there is no change when using default parameters.

<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
