### PR TITLE
perf(motion_utils): improve performance of zero_order_hold (#2744)

### DIFF
--- a/common/interpolation/include/interpolation/zero_order_hold.hpp
+++ b/common/interpolation/include/interpolation/zero_order_hold.hpp
@@ -21,36 +21,60 @@
 
 namespace interpolation
 {
-template <class T>
-std::vector<T> zero_order_hold(
-  const std::vector<double> & base_keys, const std::vector<T> & base_values,
-  const std::vector<double> & query_keys, const double overlap_threshold = 1e-3)
+inline std::vector<size_t> calc_closest_segment_indices(
+  const std::vector<double> & base_keys, const std::vector<double> & query_keys,
+  const double overlap_threshold = 1e-3)
 {
   // throw exception for invalid arguments
   const auto validated_query_keys = interpolation_utils::validateKeys(base_keys, query_keys);
-  interpolation_utils::validateKeysAndValues(base_keys, base_values);
 
-  std::vector<T> query_values;
+  std::vector<size_t> closest_segment_indices(validated_query_keys.size());
   size_t closest_segment_idx = 0;
   for (size_t i = 0; i < validated_query_keys.size(); ++i) {
     // Check if query_key is closes to the terminal point of the base keys
     if (base_keys.back() - overlap_threshold < validated_query_keys.at(i)) {
       closest_segment_idx = base_keys.size() - 1;
     } else {
-      for (size_t j = closest_segment_idx; j < base_keys.size() - 1; ++j) {
+      for (size_t j = base_keys.size() - 1; j > closest_segment_idx; --j) {
         if (
-          base_keys.at(j) - overlap_threshold < validated_query_keys.at(i) &&
-          validated_query_keys.at(i) < base_keys.at(j + 1)) {
+          base_keys.at(j - 1) - overlap_threshold < validated_query_keys.at(i) &&
+          validated_query_keys.at(i) < base_keys.at(j)) {
           // find closest segment in base keys
-          closest_segment_idx = j;
+          closest_segment_idx = j - 1;
+          break;
         }
       }
     }
 
-    query_values.push_back(base_values.at(closest_segment_idx));
+    closest_segment_indices.at(i) = closest_segment_idx;
+  }
+
+  return closest_segment_indices;
+}
+
+template <class T>
+std::vector<T> zero_order_hold(
+  const std::vector<double> & base_keys, const std::vector<T> & base_values,
+  const std::vector<size_t> & closest_segment_indices)
+{
+  // throw exception for invalid arguments
+  interpolation_utils::validateKeysAndValues(base_keys, base_values);
+
+  std::vector<T> query_values(closest_segment_indices.size());
+  for (size_t i = 0; i < closest_segment_indices.size(); ++i) {
+    query_values.at(i) = base_values.at(closest_segment_indices.at(i));
   }
 
   return query_values;
+}
+
+template <class T>
+std::vector<T> zero_order_hold(
+  const std::vector<double> & base_keys, const std::vector<T> & base_values,
+  const std::vector<double> & query_keys, const double overlap_threshold = 1e-3)
+{
+  return zero_order_hold(
+    base_keys, base_values, calc_closest_segment_indices(base_keys, query_keys, overlap_threshold));
 }
 }  // namespace interpolation
 

--- a/common/motion_utils/src/resample/resample.cpp
+++ b/common/motion_utils/src/resample/resample.cpp
@@ -240,8 +240,12 @@ autoware_auto_planning_msgs::msg::PathWithLaneId resamplePath(
   const auto lerp = [&](const auto & input) {
     return interpolation::lerp(input_arclength, input, resampled_arclength);
   };
+
+  auto closest_segment_indices =
+    interpolation::calc_closest_segment_indices(input_arclength, resampled_arclength);
+
   const auto zoh = [&](const auto & input) {
-    return interpolation::zero_order_hold(input_arclength, input, resampled_arclength);
+    return interpolation::zero_order_hold(input_arclength, input, closest_segment_indices);
   };
 
   const auto interpolated_pose =
@@ -385,8 +389,14 @@ autoware_auto_planning_msgs::msg::Path resamplePath(
   const auto lerp = [&](const auto & input) {
     return interpolation::lerp(input_arclength, input, resampled_arclength);
   };
+
+  std::vector<size_t> closest_segment_indices;
+  if (use_zero_order_hold_for_v) {
+    closest_segment_indices =
+      interpolation::calc_closest_segment_indices(input_arclength, resampled_arclength);
+  }
   const auto zoh = [&](const auto & input) {
-    return interpolation::zero_order_hold(input_arclength, input, resampled_arclength);
+    return interpolation::zero_order_hold(input_arclength, input, closest_segment_indices);
   };
 
   const auto interpolated_pose =
@@ -537,8 +547,14 @@ autoware_auto_planning_msgs::msg::Trajectory resampleTrajectory(
   const auto lerp = [&](const auto & input) {
     return interpolation::lerp(input_arclength, input, resampled_arclength);
   };
+
+  std::vector<size_t> closest_segment_indices;
+  if (use_zero_order_hold_for_twist) {
+    closest_segment_indices =
+      interpolation::calc_closest_segment_indices(input_arclength, resampled_arclength);
+  }
   const auto zoh = [&](const auto & input) {
-    return interpolation::zero_order_hold(input_arclength, input, resampled_arclength);
+    return interpolation::zero_order_hold(input_arclength, input, closest_segment_indices);
   };
 
   const auto interpolated_pose =


### PR DESCRIPTION
## Description
Hotfix to beta/v0.7.0
https://github.com/autowarefoundation/autoware.universe/pull/2744
> when closest_segment_idx is found in backward loop in zero_order_hold function, immediatly break the loop. The previous implementation was forward and continue updating the idx value, which is unnecessary.
pre-calculate the closest_segment_idx with base and query keys. In the several calls of zero_order_hold from resample.cpp in the form of zoh, the two parameters base_keys and query_keys are the same. Thus the calculation of closest_segment_idx is also the same, which includes double for loops and has a heavy computational cost.

<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
