### PR TITLE
fix(behavior_path_planner): fix geometric pull out lane id for overlapping (#2828)

### DIFF
--- a/planning/behavior_path_planner/src/scene_module/utils/geometric_parallel_parking.cpp
+++ b/planning/behavior_path_planner/src/scene_module/utils/geometric_parallel_parking.cpp
@@ -361,7 +361,16 @@ std::vector<PathWithLaneId> GeometricParallelParking::planOneTrial(
   }
 
   // combine road and shoulder lanes
-  lanelet::ConstLanelets lanes = road_lanes;
+  // cut the road lanes up to start_pose to prevent unintended processing for overlapped lane
+  lanelet::ConstLanelets lanes{};
+  tier4_autoware_utils::Point2d start_point2d(start_pose.position.x, start_pose.position.y);
+  for (const auto & lane : road_lanes) {
+    if (boost::geometry::within(start_point2d, lane.polygon2d().basicPolygon())) {
+      lanes.push_back(lane);
+      break;
+    }
+    lanes.push_back(lane);
+  }
   lanes.insert(lanes.end(), shoulder_lanes.begin(), shoulder_lanes.end());
 
   // If start_pose is parallel to goal_pose, we can know lateral deviation of edges of vehicle,


### PR DESCRIPTION

## Description

<!-- Write a brief description of this PR. -->
cherry-pick
https://github.com/autowarefoundation/autoware.universe/pull/2828

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed

<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
