### PR TITLE
fix(tier4_autoware_utils): exception handling in tier4 autoware utils for beta/v0.3.x (backport #1268)

### DIFF
--- a/control/trajectory_follower/src/longitudinal_controller_utils.cpp
+++ b/control/trajectory_follower/src/longitudinal_controller_utils.cpp
@@ -73,6 +73,10 @@ float64_t calcStopDistance(
   const float64_t signed_length_src_offset = tier4_autoware_utils::calcLongitudinalOffsetToSegment(
     traj.points, *seg_idx, current_pose.position);
 
+  if (std::isnan(signed_length_src_offset)) {
+    return 0.0;
+  }
+
   // If no zero velocity point, return the length between current_pose to the end of trajectory.
   if (!stop_idx_opt) {
     float64_t signed_length_on_traj =


### PR DESCRIPTION
## Description

https://github.com/autowarefoundation/autoware.universe/pull/1268 のbackport
cherry-pickではコンフリクトが発生したため、必要な部分を手動でピックアップしている

## Related Links
https://tier4.atlassian.net/browse/T4PB-25358

## 確認事項
- ビルドが問題ないこと
- 元のPRと同じ箇所が編集されていること
- 以下のコードとdiffを取ると見やすいかもしれません
  - [trajectoty.zip](https://github.com/tier4/autoware.universe/files/10837999/trajectoty.zip)

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
