### PR TITLE
fix(behavior_path_planner): fix pull over deceleration before search area start (#2898)

### DIFF
--- a/planning/behavior_path_planner/src/scene_module/pull_over/pull_over_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/pull_over/pull_over_module.cpp
@@ -470,18 +470,18 @@ BehaviorModuleOutput PullOverModule::plan()
       break;
     }
 
-    // Decelerate before the minimum shift distance from the goal search area.
+    // decelerate before the search area start
     if (status_.is_safe) {
-      auto & first_path = status_.pull_over_path.partial_paths.front();
       const auto search_start_pose = calcLongitudinalOffsetPose(
-        first_path.points, refined_goal_pose_.position,
+        status_.pull_over_path.getFullPath().points, refined_goal_pose_.position,
         -parameters_.backward_goal_search_length - planner_data_->parameters.base_link2front);
-      const Pose deceleration_pose =
-        search_start_pose ? *search_start_pose : first_path.points.front().point.pose;
-      constexpr double deceleration_buffer = 15.0;
-      first_path = util::setDecelerationVelocity(
-        first_path, parameters_.pull_over_velocity, deceleration_pose, -deceleration_buffer,
-        parameters_.deceleration_interval);
+      if (search_start_pose) {
+        auto & first_path = status_.pull_over_path.partial_paths.front();
+        constexpr double deceleration_buffer = 15.0;
+        first_path = util::setDecelerationVelocity(
+          first_path, parameters_.pull_over_velocity, *search_start_pose, -deceleration_buffer,
+          parameters_.deceleration_interval);
+      }
     }
 
     // generate drivable area for each partial path


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

cherry-pick https://github.com/autowarefoundation/autoware.universe/pull/2898 to beta/v0.7

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

https://github.com/autowarefoundation/autoware.universe/pull/2898
https://star4.slack.com/archives/C03QW0GU6P7/p1676600411181709


## Tests performed

<!-- Describe how you have tested this PR. -->
psim, scenario test(main)
build behavior path(v0.7)

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
