### PR TITLE
fix: pre-commit settings for beta/v0.3.x

### DIFF
--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -5,12 +5,28 @@ on:
 
 jobs:
   pre-commit:
+    if: ${{ github.event.repository.private }} # Use pre-commit.ci for public repositories
     runs-on: ubuntu-latest
     steps:
+      - name: Generate token
+        id: generate-token
+        uses: tibdex/github-app-token@v1
+        with:
+          app_id: ${{ secrets.APP_ID }}
+          private_key: ${{ secrets.PRIVATE_KEY }}
+
       - name: Check out repository
         uses: actions/checkout@v3
+        with:
+          ref: ${{ github.event.pull_request.head.ref }}
+
+      - name: Set git config
+        uses: autowarefoundation/autoware-github-actions/set-git-config@v1
+        with:
+          token: ${{ steps.generate-token.outputs.token }}
 
       - name: Run pre-commit
         uses: autowarefoundation/autoware-github-actions/pre-commit@v1
         with:
           pre-commit-config: .pre-commit-config.yaml
+          token: ${{ steps.generate-token.outputs.token }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -55,7 +55,7 @@ repos:
         args: [-w, -s, -i=4]
 
   - repo: https://github.com/pycqa/isort
-    rev: 5.10.1
+    rev: 5.12.0
     hooks:
       - id: isort
 


### PR DESCRIPTION
## Description

以下PRにて、pre-commitでエラーが発生しているので修正
https://github.com/tier4/autoware.universe/pull/281

isortのバージョンが古い様子のため、tier4/mainから変更をpickした
https://github.com/tier4/autoware.universe/blob/tier4/main/.pre-commit-config.yaml#L57-L60

また、workflowに関しても、tier4/mainから変更をpick
https://github.com/tier4/autoware.universe/blob/tier4/main/.github/workflows/pre-commit.yaml

## 確認事項
- pre-commitが成功すること
- pre-commitはスキップされて、pre-commit.ciのみが実施されていること

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
