### PR TITLE
chore: fix build_depends.repos for beta/v0.3.x

### DIFF
--- a/build_depends.repos
+++ b/build_depends.repos
@@ -3,7 +3,7 @@ repositories:
   core/autoware_msgs:
     type: git
     url: https://github.com/tier4/autoware_auto_msgs.git # TODO(Tier IV): Move to autowarefoundation/autoware_msgs
-    version: tier4/main
+    version: c8a5d2001da052137c08cdf9e8d75c1975f99b84
   core/common:
     type: git
     url: https://github.com/autowarefoundation/autoware_common.git

--- a/build_depends.repos
+++ b/build_depends.repos
@@ -7,7 +7,7 @@ repositories:
   core/common:
     type: git
     url: https://github.com/autowarefoundation/autoware_common.git
-    version: 1f36fa7579edbe2ed41f745a0ee029a427e468fe
+    version: d95da5d4c3f262259c6e40a0bdc1399c0fdf612f
   core/autoware:
     type: git
     url: https://github.com/autowarefoundation/autoware.core.git

--- a/build_depends.repos
+++ b/build_depends.repos
@@ -7,7 +7,7 @@ repositories:
   core/common:
     type: git
     url: https://github.com/autowarefoundation/autoware_common.git
-    version: main
+    version: 1f36fa7579edbe2ed41f745a0ee029a427e468fe
   core/autoware:
     type: git
     url: https://github.com/autowarefoundation/autoware.core.git


### PR DESCRIPTION
## Description

build_depends.reposのversionがハッシュ固定でないため、pilot-auto.x1.eveのautoware.reposを参考に修正する
- autoware_common: https://github.com/tier4/pilot-auto.x1.eve/blob/beta/v3.3.0/autoware.repos#L10
- autoware_auto_msgs: https://github.com/tier4/pilot-auto.x1.eve/blob/beta/v3.3.0/autoware.repos#L30


## Test performed

check-build-dependsが成功する

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
