### PR TITLE
fix: for pr299 function to work

### DIFF
--- a/planning/motion_velocity_smoother/src/motion_velocity_smoother_node.cpp
+++ b/planning/motion_velocity_smoother/src/motion_velocity_smoother_node.cpp
@@ -284,13 +284,6 @@ void MotionVelocitySmootherNode::onExternalVelocityLimit(const VelocityLimit::Co
   constexpr double eps = 1.0E-04;
   const double margin = node_param_.margin_to_insert_external_velocity_limit;
 
-  // Set distance as zero if ego vehicle is stopped and external velocity limit is zero
-  if (
-    std::fabs(current_odometry_ptr_->twist.twist.linear.x) < eps &&
-    external_velocity_limit_ < eps) {
-    external_velocity_limit_dist_ = 0.0;
-  }
-
   // calculate distance and maximum velocity
   // to decelerate to external velocity limit with jerk and acceleration
   // constraints.
@@ -423,6 +416,14 @@ void MotionVelocitySmootherNode::updateDataForExternalVelocityLimit()
 {
   if (prev_output_.empty()) {
     return;
+  }
+
+  // Set distance as zero if ego vehicle is stopped and external velocity limit is zero
+  constexpr double eps = 1.0E-04;
+  if (
+    std::fabs(current_odometry_ptr_->twist.twist.linear.x) < eps &&
+    external_velocity_limit_ < eps) {
+    external_velocity_limit_dist_ = 0.0;
   }
 
   // calculate distance to insert external velocity limit


### PR DESCRIPTION
## Description

https://github.com/autowarefoundation/autoware.universe/pull/2959 was backported to beta/v0.5.5 by #299 , but it doesn't work.

I have corrected it to work as intended.

Related links:
https://tier4.atlassian.net/browse/T4PB-24713
https://tier4.atlassian.net/browse/T4PB-25293

Before
https://user-images.githubusercontent.com/38061530/222701208-8184f88b-f3fe-4183-98ca-951f975be130.mp4


After
https://user-images.githubusercontent.com/38061530/222700506-19821609-587a-455e-8799-fa99cd2b1630.mp4

<!-- Write a brief description of this PR. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
