### PR TITLE
ci(dispatch-release-note): use PAT instead of GITHUB_TOKEN

### DIFF
--- a/.github/workflows/dispatch-release-note.yaml
+++ b/.github/workflows/dispatch-release-note.yaml
@@ -33,7 +33,7 @@ jobs:
           curl \
           -X POST \
           -H "Accept: application/vnd.github+json" \
-          -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+          -H "Authorization: Bearer ${{ secrets.PAT }}" \
           -H "X-GitHub-Api-Version: 2022-11-28" \
           "https://api.github.com/repos/tier4/update-release-notes/dispatches" \
           -d '{"event_type":"${{ steps.set-tag-name.outputs.ref-name }}"}'


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

We mostly cannot dispatch workflow with GITHUB_TOKEN.
Instead, we often use personal access token (PAT).

Recently, Github announced that we can do it with GITHUB_TOKEN 
https://github.blog/changelog/2022-09-08-github-actions-use-github_token-with-workflow_dispatch-and-repository_dispatch/
However it is limited as I understand.
https://github.com/actions/github-script/issues/351

Thus I want to use PAT now.

If we use PAT, I want reviewer to register PAT as Actions Secrets.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
