### PR TITLE
ci(dispatch-release-note): use Github Apps instead of GIHUB_TOKEN

### DIFF
--- a/.github/workflows/dispatch-release-note.yaml
+++ b/.github/workflows/dispatch-release-note.yaml
@@ -28,7 +28,6 @@ jobs:
           echo ::set-output name=ref-name::"$REF_NAME"
           echo ::set-output name=tag-name::"${REF_NAME#beta/}"
 
-
       - name: Generate token
         id: generate-token
         uses: tibdex/github-app-token@v1

--- a/.github/workflows/dispatch-release-note.yaml
+++ b/.github/workflows/dispatch-release-note.yaml
@@ -29,7 +29,7 @@ jobs:
           echo ::set-output name=tag-name::"${REF_NAME#beta/}"
 
 
-      - name: Genarate token
+      - name: Generate token
         id: generate-token
         uses: tibdex/github-app-token@v1
         with:

--- a/.github/workflows/dispatch-release-note.yaml
+++ b/.github/workflows/dispatch-release-note.yaml
@@ -28,12 +28,20 @@ jobs:
           echo ::set-output name=ref-name::"$REF_NAME"
           echo ::set-output name=tag-name::"${REF_NAME#beta/}"
 
+
+      - name: Genarate token
+        id: generate-token
+        uses: tibdex/github-app-token@v1
+        with:
+          app_id: ${{ secrets.APP_ID }}
+          private_key: ${{ secrets.PRIVATE_KEY }}
+
       - name: Repository dispatch for release note
         run: |
           curl \
           -X POST \
           -H "Accept: application/vnd.github+json" \
-          -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+          -H "Authorization: token ${{ steps.generate-token.outputs.token }}" \
           -H "X-GitHub-Api-Version: 2022-11-28" \
           "https://api.github.com/repos/tier4/update-release-notes/dispatches" \
           -d '{"event_type":"${{ steps.set-tag-name.outputs.ref-name }}"}'


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
We mostly cannot dispatch workflow with GITHUB_TOKEN.
Instead, we often use Github Apps for organization authorization.
This PR is a substitue for https://github.com/tier4/autoware.universe/pull/314

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
