### PR TITLE
feat(hazard_lights_selector): turn on hazard lights from mrm comfortable stop operator

### DIFF
--- a/planning/hazard_lights_selector/CMakeLists.txt
+++ b/planning/hazard_lights_selector/CMakeLists.txt
@@ -1,0 +1,19 @@
+cmake_minimum_required(VERSION 3.14)
+project(hazard_lights_selector)
+
+find_package(autoware_cmake REQUIRED)
+autoware_package()
+
+ament_auto_add_library(hazard_lights_selector_node SHARED
+  src/hazard_lights_selector_node.cpp
+)
+
+rclcpp_components_register_node(hazard_lights_selector_node
+  PLUGIN "hazard_lights_selector::HazardLightsSelectorNode"
+  EXECUTABLE hazard_lights_selector
+)
+
+ament_auto_package(INSTALL_TO_SHARE
+  launch
+  config
+)

--- a/planning/hazard_lights_selector/README.md
+++ b/planning/hazard_lights_selector/README.md
@@ -3,6 +3,7 @@
 ## Purpose
 
 ## Inner-workings / Algorithms
+
 <!-- Write how this package works. Flowcharts and figures are great. Add sub-sections as you like.
 
 Example:

--- a/planning/hazard_lights_selector/README.md
+++ b/planning/hazard_lights_selector/README.md
@@ -1,0 +1,79 @@
+# Hazard lights selector
+
+## Purpose
+
+## Inner-workings / Algorithms
+<!-- Write how this package works. Flowcharts and figures are great. Add sub-sections as you like.
+
+Example:
+  ### Flowcharts
+
+  ...(PlantUML or something)
+
+  ### State Transitions
+
+  ...(PlantUML or something)
+
+  ### How to filter target obstacles
+
+  ...
+
+  ### How to optimize trajectory
+
+  ...
+-->
+
+## Inputs
+
+## Outputs
+
+## Parameters
+
+## Assumptions / Known limits
+
+<!-- Write assumptions and limitations of your implementation.
+
+Example:
+  This algorithm assumes obstacles are not moving, so if they rapidly move after the vehicle started to avoid them, it might collide with them.
+  Also, this algorithm doesn't care about blind spots. In general, since too close obstacles aren't visible due to the sensing performance limit, please take enough margin to obstacles.
+-->
+
+## (Optional) Error detection and handling
+
+<!-- Write how to detect errors and how to recover from them.
+
+Example:
+  This package can handle up to 20 obstacles. If more obstacles found, this node will give up and raise diagnostic errors.
+-->
+
+## (Optional) Performance characterization
+
+<!-- Write performance information like complexity. If it wouldn't be the bottleneck, not necessary.
+
+Example:
+  ### Complexity
+
+  This algorithm is O(N).
+
+  ### Processing time
+
+  ...
+-->
+
+## (Optional) References/External links
+
+<!-- Write links you referred to when you implemented.
+
+Example:
+  [1] {link_to_a_thesis}
+  [2] {link_to_an_issue}
+-->
+
+## (Optional) Future extensions / Unimplemented parts
+
+<!-- Write future extensions of this package.
+
+Example:
+  Currently, this package can't handle the chattering obstacles well. We plan to add some probabilistic filters in the perception layer to improve it.
+  Also, there are some parameters that should be global(e.g. vehicle size, max steering, etc.). These will be refactored and defined as global parameters so that we can share the same parameters between different nodes.
+-->

--- a/planning/hazard_lights_selector/config/hazard_lights_selector.param.yaml
+++ b/planning/hazard_lights_selector/config/hazard_lights_selector.param.yaml
@@ -1,0 +1,3 @@
+/**:
+  ros__parameters:
+    update_rate: 10  # hazard lights command publish rate [Hz]

--- a/planning/hazard_lights_selector/include/hazard_lights_selector/hazard_lights_selector_node.hpp
+++ b/planning/hazard_lights_selector/include/hazard_lights_selector/hazard_lights_selector_node.hpp
@@ -33,7 +33,6 @@ struct Parameters
 public:
   explicit HazardLightsSelectorNode(const rclcpp::NodeOptions & node_options);
 
-
 private:
   // Parameter
   Parameters params_;

--- a/planning/hazard_lights_selector/include/hazard_lights_selector/hazard_lights_selector_node.hpp
+++ b/planning/hazard_lights_selector/include/hazard_lights_selector/hazard_lights_selector_node.hpp
@@ -25,10 +25,10 @@ using autoware_auto_vehicle_msgs::msg::HazardLightsCommand;
 
 class HazardLightsSelectorNode : public rclcpp::Node
 {
-struct Parameters
-{
-  int update_rate;  // [Hz]
-};
+  struct Parameters
+  {
+    int update_rate;  // [Hz]
+  };
 
 public:
   explicit HazardLightsSelectorNode(const rclcpp::NodeOptions & node_options);

--- a/planning/hazard_lights_selector/include/hazard_lights_selector/hazard_lights_selector_node.hpp
+++ b/planning/hazard_lights_selector/include/hazard_lights_selector/hazard_lights_selector_node.hpp
@@ -25,11 +25,19 @@ using autoware_auto_vehicle_msgs::msg::HazardLightsCommand;
 
 class HazardLightsSelectorNode : public rclcpp::Node
 {
+struct Parameters
+{
+  int update_rate;  // [Hz]
+};
+
 public:
   explicit HazardLightsSelectorNode(const rclcpp::NodeOptions & node_options);
 
 
 private:
+  // Parameter
+  Parameters params_;
+
   // Subscriber
   rclcpp::Subscription<HazardLightsCommand>::SharedPtr sub_hazard_lights_cmd_from_path_planner_;
   rclcpp::Subscription<HazardLightsCommand>::SharedPtr sub_hazard_lights_cmd_from_mrm_operator_;
@@ -44,6 +52,13 @@ private:
 
   // Timer
   rclcpp::TimerBase::SharedPtr timer_;
+
+  void onTimer();
+
+  // State
+  HazardLightsCommand current_hazard_lights_cmd_;
+  HazardLightsCommand::ConstSharedPtr hazard_lights_command_from_path_planner_;
+  HazardLightsCommand::ConstSharedPtr hazard_lights_command_from_mrm_operator_;
 
 };
 }  // namespace hazard_lights_selector

--- a/planning/hazard_lights_selector/include/hazard_lights_selector/hazard_lights_selector_node.hpp
+++ b/planning/hazard_lights_selector/include/hazard_lights_selector/hazard_lights_selector_node.hpp
@@ -19,6 +19,8 @@
 
 #include <autoware_auto_vehicle_msgs/msg/hazard_lights_command.hpp>
 
+namespace hazard_lights_selector
+{
 using autoware_auto_vehicle_msgs::msg::HazardLightsCommand;
 
 class HazardLightsSelectorNode : public rclcpp::Node
@@ -26,14 +28,24 @@ class HazardLightsSelectorNode : public rclcpp::Node
 public:
   explicit HazardLightsSelectorNode(const rclcpp::NodeOptions & node_options);
 
-  struct NodeParam
-  {
-  };
 
 private:
+  // Subscriber
+  rclcpp::Subscription<HazardLightsCommand>::SharedPtr sub_hazard_lights_cmd_from_path_planner_;
+  rclcpp::Subscription<HazardLightsCommand>::SharedPtr sub_hazard_lights_cmd_from_mrm_operator_;
 
-  // Parameters
-  NodeParam node_param_{};
+  void onHazardLightsCommandFromPathPlanner(HazardLightsCommand::ConstSharedPtr msg);
+  void onHazardLightsCommandFromMrmOperator(HazardLightsCommand::ConstSharedPtr msg);
+
+  // Publisher
+  rclcpp::Publisher<HazardLightsCommand>::SharedPtr pub_hazard_lights_cmd_;
+
+  void publishHazardLightsCommand() const;
+
+  // Timer
+  rclcpp::TimerBase::SharedPtr timer_;
+
 };
+}  // namespace hazard_lights_selector
 
 #endif  // HAZARD_LIGHTS_SELECTOR__HAZARD_LIGHTS_SELECTOR_NODE_HPP_

--- a/planning/hazard_lights_selector/include/hazard_lights_selector/hazard_lights_selector_node.hpp
+++ b/planning/hazard_lights_selector/include/hazard_lights_selector/hazard_lights_selector_node.hpp
@@ -1,0 +1,39 @@
+// Copyright 2021 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef HAZARD_LIGHTS_SELECTOR__HAZARD_LIGHTS_SELECTOR_NODE_HPP_
+#define HAZARD_LIGHTS_SELECTOR__HAZARD_LIGHTS_SELECTOR_NODE_HPP_
+
+#include <rclcpp/rclcpp.hpp>
+
+#include <autoware_auto_vehicle_msgs/msg/hazard_lights_command.hpp>
+
+using autoware_auto_vehicle_msgs::msg::HazardLightsCommand;
+
+class HazardLightsSelectorNode : public rclcpp::Node
+{
+public:
+  explicit HazardLightsSelectorNode(const rclcpp::NodeOptions & node_options);
+
+  struct NodeParam
+  {
+  };
+
+private:
+
+  // Parameters
+  NodeParam node_param_{};
+};
+
+#endif  // HAZARD_LIGHTS_SELECTOR__HAZARD_LIGHTS_SELECTOR_NODE_HPP_

--- a/planning/hazard_lights_selector/include/hazard_lights_selector/hazard_lights_selector_node.hpp
+++ b/planning/hazard_lights_selector/include/hazard_lights_selector/hazard_lights_selector_node.hpp
@@ -56,10 +56,8 @@ private:
   void onTimer();
 
   // State
-  HazardLightsCommand current_hazard_lights_cmd_;
   HazardLightsCommand::ConstSharedPtr hazard_lights_command_from_path_planner_;
   HazardLightsCommand::ConstSharedPtr hazard_lights_command_from_mrm_operator_;
-
 };
 }  // namespace hazard_lights_selector
 

--- a/planning/hazard_lights_selector/launch/hazard_lights_selector.launch.xml
+++ b/planning/hazard_lights_selector/launch/hazard_lights_selector.launch.xml
@@ -1,0 +1,16 @@
+<launch>
+  <!-- common param -->
+  <arg name="param_path" default="$(find-pkg-share hazard_lights_selector)/config/hazard_lights_selector.param.yaml"/>
+
+  <!-- input/output -->
+  <arg name="input_hazard_lights_cmd_from_path_planner" default="/planning/behavior_path_planner/hazard_lights_cmd"/>
+  <arg name="input_hazard_lights_cmd_from_mrm_operator" default="/system/mrm_comfortable_stop_operator/hazard_lights_cmd"/>
+  <arg name="output_hazard_lights_cmd" default="/planning/hazard_lights_cmd"/>
+
+  <node pkg="hazard_lights_selector" exec="hazard_lights_selector" name="hazard_lights_selector" output="screen">
+    <param from="$(var param_path)"/>
+    <remap from="~/input/behavior_path_planner/hazard_lights_cmd" to="$(var input_hazard_lights_cmd_from_path_planner)"/>
+    <remap from="~/input/behavior_mrm_operator/hazard_lights_cmd" to="$(var input_hazard_lights_cmd_from_mrm_operator)"/>
+    <remap from="~/output/hazard_lights_cmd" to="$(var output_hazard_lights_cmd)"/>
+  </node>
+</launch>

--- a/planning/hazard_lights_selector/package.xml
+++ b/planning/hazard_lights_selector/package.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>hazard_lights_selector</name>
+  <version>0.1.0</version>
+  <description>The hazard_lights_selector ROS2 package</description>
+  <maintainer email="makoto.kurihara@tier4.jp">Makoto Kurihara</maintainer>
+  <license>Apache License 2.0</license>
+
+  <author email="makoto.kurihara@tier4.jp">Makoto Kurihara</author>
+
+  <buildtool_depend>ament_cmake_auto</buildtool_depend>
+
+  <build_depend>autoware_cmake</build_depend>
+
+  <depend>rclcpp</depend>
+  <depend>rclcpp_components</depend>
+  <depend>autoware_auto_vehicle_msgs</depend>
+
+  <exec_depend>ros2cli</exec_depend>
+  <exec_depend>topic_tools</exec_depend>
+
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>autoware_lint_common</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/planning/hazard_lights_selector/package.xml
+++ b/planning/hazard_lights_selector/package.xml
@@ -5,6 +5,7 @@
   <version>0.1.0</version>
   <description>The hazard_lights_selector ROS2 package</description>
   <maintainer email="makoto.kurihara@tier4.jp">Makoto Kurihara</maintainer>
+  <maintainer email="tomohito.ando@tier4.jp">Tomohito Ando</maintainer>
   <license>Apache License 2.0</license>
 
   <author email="makoto.kurihara@tier4.jp">Makoto Kurihara</author>

--- a/planning/hazard_lights_selector/package.xml
+++ b/planning/hazard_lights_selector/package.xml
@@ -14,9 +14,9 @@
 
   <build_depend>autoware_cmake</build_depend>
 
+  <depend>autoware_auto_vehicle_msgs</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
-  <depend>autoware_auto_vehicle_msgs</depend>
 
   <exec_depend>ros2cli</exec_depend>
   <exec_depend>topic_tools</exec_depend>

--- a/planning/hazard_lights_selector/src/hazard_lights_selector_node.cpp
+++ b/planning/hazard_lights_selector/src/hazard_lights_selector_node.cpp
@@ -40,9 +40,6 @@ HazardLightsSelectorNode::HazardLightsSelectorNode(const rclcpp::NodeOptions & n
   const auto update_period_ns = rclcpp::Rate(params_.update_rate).period();
   timer_ = rclcpp::create_timer(
     this, get_clock(), update_period_ns, std::bind(&HazardLightsSelectorNode::onTimer, this));
-
-  // State
-  current_hazard_lights_cmd_.command = HazardLightsCommand::DISABLE;
 }
 
 void HazardLightsSelectorNode::onHazardLightsCommandFromPathPlanner(HazardLightsCommand::ConstSharedPtr msg)

--- a/planning/hazard_lights_selector/src/hazard_lights_selector_node.cpp
+++ b/planning/hazard_lights_selector/src/hazard_lights_selector_node.cpp
@@ -33,8 +33,8 @@ HazardLightsSelectorNode::HazardLightsSelectorNode(const rclcpp::NodeOptions & n
     std::bind(&HazardLightsSelectorNode::onHazardLightsCommandFromMrmOperator, this, _1));
 
   // Publisher
-  pub_hazard_lights_cmd_ = this->create_publisher<HazardLightsCommand>(
-    "~/output/hazard_lights_cmd", 1);
+  pub_hazard_lights_cmd_ =
+    this->create_publisher<HazardLightsCommand>("~/output/hazard_lights_cmd", 1);
 
   // Timer
   const auto update_period_ns = rclcpp::Rate(params_.update_rate).period();
@@ -42,12 +42,14 @@ HazardLightsSelectorNode::HazardLightsSelectorNode(const rclcpp::NodeOptions & n
     this, get_clock(), update_period_ns, std::bind(&HazardLightsSelectorNode::onTimer, this));
 }
 
-void HazardLightsSelectorNode::onHazardLightsCommandFromPathPlanner(HazardLightsCommand::ConstSharedPtr msg)
+void HazardLightsSelectorNode::onHazardLightsCommandFromPathPlanner(
+  HazardLightsCommand::ConstSharedPtr msg)
 {
   hazard_lights_command_from_path_planner_ = msg;
 }
 
-void HazardLightsSelectorNode::onHazardLightsCommandFromMrmOperator(HazardLightsCommand::ConstSharedPtr msg)
+void HazardLightsSelectorNode::onHazardLightsCommandFromMrmOperator(
+  HazardLightsCommand::ConstSharedPtr msg)
 {
   hazard_lights_command_from_mrm_operator_ = msg;
 }

--- a/planning/hazard_lights_selector/src/hazard_lights_selector_node.cpp
+++ b/planning/hazard_lights_selector/src/hazard_lights_selector_node.cpp
@@ -1,0 +1,81 @@
+// Copyright 2021 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <hazard_lights_selector/hazard_lights_selector_node.hpp>
+
+namespace hazard_lights_selector
+{
+HazardLightsSelectorNode::HazardLightsSelectorNode(const rclcpp::NodeOptions & node_options)
+: Node("hazard_lights_selector", node_options)
+{
+  using std::placeholders::_1;
+
+  // Parameter
+  params_.update_rate = static_cast<int>(declare_parameter<int>("update_rate", 10));
+
+  // Subscriber
+  sub_hazard_lights_cmd_from_path_planner_ = this->create_subscription<HazardLightsCommand>(
+    "~/input/behavior_path_planner/hazard_lights_cmd", 1,
+    std::bind(&HazardLightsSelectorNode::onHazardLightsCommandFromPathPlanner, this, _1));
+  sub_hazard_lights_cmd_from_mrm_operator_ = this->create_subscription<HazardLightsCommand>(
+    "~/input/behavior_mrm_operator/hazard_lights_cmd", 1,
+    std::bind(&HazardLightsSelectorNode::onHazardLightsCommandFromMrmOperator, this, _1));
+
+  // Publisher
+  pub_hazard_lights_cmd_ = this->create_publisher<HazardLightsCommand>(
+    "~/output/hazard_lights_cmd", 1);
+
+  // Timer
+  const auto update_period_ns = rclcpp::Rate(params_.update_rate).period();
+  timer_ = rclcpp::create_timer(
+    this, get_clock(), update_period_ns, std::bind(&HazardLightsSelectorNode::onTimer, this));
+
+  // State
+  current_hazard_lights_cmd_.command = HazardLightsCommand::DISABLE;
+}
+
+void HazardLightsSelectorNode::onHazardLightsCommandFromPathPlanner(HazardLightsCommand::ConstSharedPtr msg)
+{
+  hazard_lights_command_from_path_planner_ = msg;
+}
+
+void HazardLightsSelectorNode::onHazardLightsCommandFromMrmOperator(HazardLightsCommand::ConstSharedPtr msg)
+{
+  hazard_lights_command_from_mrm_operator_ = msg;
+}
+
+void HazardLightsSelectorNode::onTimer()
+{
+  auto hazard_lights_cmd = HazardLightsCommand();
+  hazard_lights_cmd.stamp = this->now();
+  hazard_lights_cmd.command = HazardLightsCommand::DISABLE;
+
+  if (hazard_lights_command_from_path_planner_ != nullptr) {
+    if (hazard_lights_command_from_path_planner_->command == HazardLightsCommand::ENABLE) {
+      hazard_lights_cmd.command = HazardLightsCommand::ENABLE;
+    }
+  }
+  if (hazard_lights_command_from_mrm_operator_ != nullptr) {
+    if (hazard_lights_command_from_mrm_operator_->command == HazardLightsCommand::ENABLE) {
+      hazard_lights_cmd.command = HazardLightsCommand::ENABLE;
+    }
+  }
+
+  pub_hazard_lights_cmd_->publish(hazard_lights_cmd);
+}
+
+}  // namespace hazard_lights_selector
+
+#include "rclcpp_components/register_node_macro.hpp"
+RCLCPP_COMPONENTS_REGISTER_NODE(hazard_lights_selector::HazardLightsSelectorNode)

--- a/system/mrm_comfortable_stop_operator/include/mrm_comfortable_stop_operator/mrm_comfortable_stop_operator_core.hpp
+++ b/system/mrm_comfortable_stop_operator/include/mrm_comfortable_stop_operator/mrm_comfortable_stop_operator_core.hpp
@@ -19,6 +19,7 @@
 #include <memory>
 
 // Autoware
+#include <autoware_auto_vehicle_msgs/msg/hazard_lights_command.hpp>
 #include <tier4_planning_msgs/msg/velocity_limit.hpp>
 #include <tier4_planning_msgs/msg/velocity_limit_clear_command.hpp>
 #include <tier4_planning_msgs/msg/velocity_limit_constraints.hpp>
@@ -30,6 +31,7 @@
 
 namespace mrm_comfortable_stop_operator
 {
+using autoware_auto_vehicle_msgs::msg::HazardLightsCommand;
 
 struct Parameters
 {
@@ -60,10 +62,12 @@ private:
   rclcpp::Publisher<tier4_planning_msgs::msg::VelocityLimit>::SharedPtr pub_velocity_limit_;
   rclcpp::Publisher<tier4_planning_msgs::msg::VelocityLimitClearCommand>::SharedPtr
     pub_velocity_limit_clear_command_;
+  rclcpp::Publisher<HazardLightsCommand>::SharedPtr pub_hazard_lights_cmd_;
 
   void publishStatus() const;
   void publishVelocityLimit() const;
   void publishVelocityLimitClearCommand() const;
+  void publishHazardLightsCommand() const;
 
   // Timer
   rclcpp::TimerBase::SharedPtr timer_;

--- a/system/mrm_comfortable_stop_operator/launch/mrm_comfortable_stop_operator.launch.py
+++ b/system/mrm_comfortable_stop_operator/launch/mrm_comfortable_stop_operator.launch.py
@@ -39,6 +39,7 @@ def launch_setup(context, *args, **kwargs):
             ("~/output/mrm/comfortable_stop/status", "/system/mrm/comfortable_stop/status"),
             ("~/output/velocity_limit", "/planning/scenario_planning/max_velocity_candidates"),
             ("~/output/velocity_limit/clear", "/planning/scenario_planning/clear_velocity_limit"),
+            ("~/output/hazard_lights_cmd", "~/hazard_lights_cmd"),
         ],
     )
 

--- a/system/mrm_comfortable_stop_operator/package.xml
+++ b/system/mrm_comfortable_stop_operator/package.xml
@@ -12,6 +12,7 @@
   <build_depend>autoware_cmake</build_depend>
 
   <depend>autoware_adapi_v1_msgs</depend>
+  <depend>autoware_auto_vehicle_msgs</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
   <depend>std_msgs</depend>

--- a/system/mrm_comfortable_stop_operator/src/mrm_comfortable_stop_operator/mrm_comfortable_stop_operator_core.cpp
+++ b/system/mrm_comfortable_stop_operator/src/mrm_comfortable_stop_operator/mrm_comfortable_stop_operator_core.cpp
@@ -40,8 +40,7 @@ MrmComfortableStopOperator::MrmComfortableStopOperator(const rclcpp::NodeOptions
   pub_velocity_limit_clear_command_ =
     create_publisher<tier4_planning_msgs::msg::VelocityLimitClearCommand>(
       "~/output/velocity_limit/clear", rclcpp::QoS{1}.transient_local());
-  pub_hazard_lights_cmd_ = create_publisher<HazardLightsCommand>(
-    "~/output/hazard_lights_cmd", 1);
+  pub_hazard_lights_cmd_ = create_publisher<HazardLightsCommand>("~/output/hazard_lights_cmd", 1);
 
   // Timer
   const auto update_period_ns = rclcpp::Rate(params_.update_rate).period();

--- a/system/mrm_comfortable_stop_operator/src/mrm_comfortable_stop_operator/mrm_comfortable_stop_operator_core.cpp
+++ b/system/mrm_comfortable_stop_operator/src/mrm_comfortable_stop_operator/mrm_comfortable_stop_operator_core.cpp
@@ -40,6 +40,8 @@ MrmComfortableStopOperator::MrmComfortableStopOperator(const rclcpp::NodeOptions
   pub_velocity_limit_clear_command_ =
     create_publisher<tier4_planning_msgs::msg::VelocityLimitClearCommand>(
       "~/output/velocity_limit/clear", rclcpp::QoS{1}.transient_local());
+  pub_hazard_lights_cmd_ = create_publisher<HazardLightsCommand>(
+    "~/output/hazard_lights_cmd", 1);
 
   // Timer
   const auto update_period_ns = rclcpp::Rate(params_.update_rate).period();
@@ -96,7 +98,24 @@ void MrmComfortableStopOperator::publishVelocityLimitClearCommand() const
   pub_velocity_limit_clear_command_->publish(velocity_limit_clear_command);
 }
 
-void MrmComfortableStopOperator::onTimer() const { publishStatus(); }
+void MrmComfortableStopOperator::publishHazardLightsCommand() const
+{
+  auto hazard_lights_cmd = HazardLightsCommand();
+  hazard_lights_cmd.stamp = this->now();
+  hazard_lights_cmd.command = HazardLightsCommand::DISABLE;
+
+  if (status_.state == tier4_system_msgs::msg::MrmBehaviorStatus::OPERATING) {
+    hazard_lights_cmd.command = HazardLightsCommand::ENABLE;
+  }
+
+  pub_hazard_lights_cmd_->publish(hazard_lights_cmd);
+}
+
+void MrmComfortableStopOperator::onTimer() const
+{
+  publishStatus();
+  publishHazardLightsCommand();
+}
 
 }  // namespace mrm_comfortable_stop_operator
 


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
https://tier4.atlassian.net/browse/T4PB-22513

Add hazard_lights_selector so that hazard lights can be directed from nodes other than behavior_path_planner

**Related PR**
- https://github.com/tier4/autoware_launch.x2/pull/258

**Before**
![hazard_light_cmd-Before drawio](https://user-images.githubusercontent.com/876355/225598884-6777c21f-5f3f-4236-b9d9-48b0a9719b91.png)

**After**
![hazard_light_cmd-After drawio](https://user-images.githubusercontent.com/876355/225598592-946bc87e-3336-444a-8205-06d654721134.png)

**Test**
緩停止MRMを発動させて`/planning/hazard_lights_cmd`のcommandが2 (=ENABLE)をpublishすること

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
