### PR TITLE
ci(dispatch-release-note): add workflow for release note v0.3.14

### DIFF
--- a/.github/workflows/dispatch-release-note.yaml
+++ b/.github/workflows/dispatch-release-note.yaml
@@ -1,0 +1,39 @@
+name: dispatch-release-note
+on:
+  push:
+    branches:
+      - beta/v*
+      - tier4/main
+    tags:
+      - v*
+  workflow_dispatch:
+    inputs:
+      beta-branch-or-tag-name:
+        description: The name of the beta branch or tag to write release note
+        type: string
+        required: true
+jobs:
+  dispatch-release-note:
+    runs-on: ubuntu-latest
+    name: release-repository-dispatch
+    steps:
+      - name: Set tag name
+        id: set-tag-name
+        run: |
+          if [ "${{ github.event_name }}" = "workflow_dispatch" ]; then
+            REF_NAME="${{ github.event.inputs.beta-branch-or-tag-name }}"
+          else
+            REF_NAME="${{ github.ref_name }}"
+          fi
+          echo ::set-output name=ref-name::"$REF_NAME"
+          echo ::set-output name=tag-name::"${REF_NAME#beta/}"
+
+      - name: Repository dispatch for release note
+        run: |
+          curl \
+          -X POST \
+          -H "Accept: application/vnd.github+json" \
+          -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+          -H "X-GitHub-Api-Version: 2022-11-28" \
+          "https://api.github.com/repos/tier4/update-release-notes/dispatches" \
+          -d '{"event_type":"${{ steps.set-tag-name.outputs.ref-name }}"}'

--- a/.github/workflows/dispatch-release-note.yaml
+++ b/.github/workflows/dispatch-release-note.yaml
@@ -28,12 +28,19 @@ jobs:
           echo ::set-output name=ref-name::"$REF_NAME"
           echo ::set-output name=tag-name::"${REF_NAME#beta/}"
 
+      - name: Generate token
+        id: generate-token
+        uses: tibdex/github-app-token@v1
+        with:
+          app_id: ${{ secrets.APP_ID }}
+          private_key: ${{ secrets.PRIVATE_KEY }}
+
       - name: Repository dispatch for release note
         run: |
           curl \
           -X POST \
           -H "Accept: application/vnd.github+json" \
-          -H "Authorization: Bearer ${{ secrets.GITHUB_TOKEN }}" \
+          -H "Authorization: token ${{ steps.generate-token.outputs.token }}" \
           -H "X-GitHub-Api-Version: 2022-11-28" \
           "https://api.github.com/repos/tier4/update-release-notes/dispatches" \
           -d '{"event_type":"${{ steps.set-tag-name.outputs.ref-name }}"}'


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
- リリースノートを自動的に作成するためのGithub Actionsを追加．
- プロダクトの他のソフトウェアと独立しているため，それらに影響を与えない．
- tier4/mainやv0.6.1ブランチ等でテスト済．
- approve後はsquash mergeします．

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
