### PR TITLE
fix(rtc_interface): fix initial auto mode (#3029)

### DIFF
--- a/planning/rtc_interface/include/rtc_interface/rtc_interface.hpp
+++ b/planning/rtc_interface/include/rtc_interface/rtc_interface.hpp
@@ -81,7 +81,7 @@ private:
   Module module_;
   CooperateStatusArray registered_status_;
   std::vector<CooperateCommand> stored_commands_;
-  bool is_auto_mode_;
+  bool is_auto_mode_init_;
   bool is_locked_;
 
   std::string cooperate_status_namespace_ = "/planning/cooperate_status";

--- a/planning/rtc_interface/src/rtc_interface.cpp
+++ b/planning/rtc_interface/src/rtc_interface.cpp
@@ -70,7 +70,7 @@ namespace rtc_interface
 {
 RTCInterface::RTCInterface(rclcpp::Node * node, const std::string & name)
 : logger_{node->get_logger().get_child("RTCInterface[" + name + "]")},
-  is_auto_mode_{false},
+  is_auto_mode_init_{false},
   is_locked_{false}
 {
   using std::placeholders::_1;
@@ -156,7 +156,6 @@ void RTCInterface::updateCooperateCommandStatus(const std::vector<CooperateComma
     if (itr != registered_status_.statuses.end()) {
       itr->command_status = command.command;
       itr->auto_mode = false;
-      is_auto_mode_ = false;
     }
   }
 }
@@ -165,7 +164,7 @@ void RTCInterface::onAutoModeService(
   const AutoMode::Request::SharedPtr request, const AutoMode::Response::SharedPtr response)
 {
   std::lock_guard<std::mutex> lock(mutex_);
-  is_auto_mode_ = request->enable;
+  is_auto_mode_init_ = request->enable;
   for (auto & status : registered_status_.statuses) {
     status.auto_mode = request->enable;
   }
@@ -192,7 +191,7 @@ void RTCInterface::updateCooperateStatus(
     status.command_status.type = Command::DEACTIVATE;
     status.start_distance = start_distance;
     status.finish_distance = finish_distance;
-    status.auto_mode = is_auto_mode_;
+    status.auto_mode = is_auto_mode_init_;
     registered_status_.statuses.push_back(status);
     return;
   }
@@ -202,7 +201,6 @@ void RTCInterface::updateCooperateStatus(
   itr->safe = safe;
   itr->start_distance = start_distance;
   itr->finish_distance = finish_distance;
-  itr->auto_mode = is_auto_mode_;
 }
 
 void RTCInterface::removeCooperateStatus(const UUID & uuid)


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
cherry-pick https://github.com/autowarefoundation/autoware.universe/pull/3029

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->
https://github.com/autowarefoundation/autoware.universe/pull/3029
https://tier4.atlassian.net/browse/T4PB-26888

## Tests performed

<!-- Describe how you have tested this PR. -->
Confirmed that the rtc approval status changes properly when an  rtc approval instruction is given from the MOT on the planning simulator (see the above Jira ticket).

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
