### PR TITLE
fix(behavior_velocity_planner): fix detection area being ignored when the ego vehicle stops over the stop line (#3114)

### DIFF
--- a/planning/behavior_velocity_planner/config/detection_area.param.yaml
+++ b/planning/behavior_velocity_planner/config/detection_area.param.yaml
@@ -7,3 +7,4 @@
       use_pass_judge_line: false
       state_clear_time: 2.0
       hold_stop_margin_distance: 0.0
+      distance_to_judge_over_stop_line: 0.5

--- a/planning/behavior_velocity_planner/detection-area-design.md
+++ b/planning/behavior_velocity_planner/detection-area-design.md
@@ -12,14 +12,15 @@ This module is activated when there is a detection area on the target lane.
 
 ### Module Parameters
 
-| Parameter                   | Type   | Description                                                                                        |
-| --------------------------- | ------ | -------------------------------------------------------------------------------------------------- |
-| `use_dead_line`             | bool   | [-] weather to use dead line or not                                                                |
-| `use_pass_judge_line`       | bool   | [-] weather to use pass judge line or not                                                          |
-| `state_clear_time`          | double | [s] when the vehicle is stopping for certain time without incoming obstacle, move to STOPPED state |
-| `stop_margin`               | double | [m] a margin that the vehicle tries to stop before stop_line                                       |
-| `dead_line_margin`          | double | [m] ignore threshold that vehicle behind is collide with ego vehicle or not                        |
-| `hold_stop_margin_distance` | double | [m] parameter for restart prevention (See Algorithm section)                                       |
+| Parameter                          | Type   | Description                                                                                        |
+| ---------------------------------- | ------ | -------------------------------------------------------------------------------------------------- |
+| `use_dead_line`                    | bool   | [-] weather to use dead line or not                                                                |
+| `use_pass_judge_line`              | bool   | [-] weather to use pass judge line or not                                                          |
+| `state_clear_time`                 | double | [s] when the vehicle is stopping for certain time without incoming obstacle, move to STOPPED state |
+| `stop_margin`                      | double | [m] a margin that the vehicle tries to stop before stop_line                                       |
+| `dead_line_margin`                 | double | [m] ignore threshold that vehicle behind is collide with ego vehicle or not                        |
+| `hold_stop_margin_distance`        | double | [m] parameter for restart prevention (See Algorithm section)                                       |
+| `distance_to_judge_over_stop_line` | double | [m] parameter for judging that the stop line has been crossed                                      |
 
 ### Inner-workings / Algorithm
 

--- a/planning/behavior_velocity_planner/include/scene_module/detection_area/scene.hpp
+++ b/planning/behavior_velocity_planner/include/scene_module/detection_area/scene.hpp
@@ -62,6 +62,7 @@ public:
     bool use_pass_judge_line;
     double state_clear_time;
     double hold_stop_margin_distance;
+    double distance_to_judge_over_stop_line;
   };
 
 public:

--- a/planning/behavior_velocity_planner/src/scene_module/detection_area/manager.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/detection_area/manager.cpp
@@ -39,6 +39,8 @@ DetectionAreaModuleManager::DetectionAreaModuleManager(rclcpp::Node & node)
   planner_param_.state_clear_time = node.declare_parameter(ns + ".state_clear_time", 2.0);
   planner_param_.hold_stop_margin_distance =
     node.declare_parameter(ns + ".hold_stop_margin_distance", 0.0);
+  planner_param_.distance_to_judge_over_stop_line =
+    node.declare_parameter(ns + ".distance_to_judge_over_stop_line", 0.5);
 }
 
 void DetectionAreaModuleManager::launchNewModules(

--- a/planning/behavior_velocity_planner/src/scene_module/detection_area/scene.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/detection_area/scene.cpp
@@ -153,7 +153,9 @@ bool DetectionAreaModule::modifyPathVelocity(PathWithLaneId * path, StopReason *
   const double dist_from_ego_to_stop = calcSignedArcLength(
     original_path.points, self_pose.position, current_seg_idx, stop_pose.position,
     stop_line_seg_idx);
-  if (state_ != State::STOP && dist_from_ego_to_stop < 0.0) {
+  if (
+    state_ != State::STOP &&
+    dist_from_ego_to_stop < -planner_param_.distance_to_judge_over_stop_line) {
     setSafe(true);
     return true;
   }
@@ -322,6 +324,12 @@ bool DetectionAreaModule::hasEnoughBrakingDistance(
   const double delay_response_time = planner_data_->delay_response_time;
   const double pass_judge_line_distance =
     planning_utils::calcJudgeLineDistWithAccLimit(current_velocity, max_acc, delay_response_time);
+
+  // prevent from being judged as not having enough distance when the current velocity is zero
+  // and the vehicle crosses the stop line
+  if (current_velocity < 1e-3) {
+    return true;
+  }
 
   return arc_lane_utils::calcSignedDistance(self_pose, line_pose.position) >
          pass_judge_line_distance;


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
cherry-pick https://github.com/autowarefoundation/autoware.universe/pull/3114 for the following scenario.
https://evaluation.tier4.jp/evaluation/scenarios/8c413181-1a5c-4a2e-a926-bb373fdb68a2?project_id=x2_dev

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->
[TIER IV slack](https://star4.slack.com/archives/CRUE57C30/p1678697490241789)

## Tests performed

<!-- Describe how you have tested this PR. -->
https://github.com/autowarefoundation/autoware.universe/pull/3114

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
