### PR TITLE
ci(sync-upstream): run weekdays except holidays

### DIFF
--- a/.github/workflows/sync-upstream.yaml
+++ b/.github/workflows/sync-upstream.yaml
@@ -2,7 +2,7 @@ name: sync-upstream
 
 on:
   schedule:
-    - cron: 0 0 * * *
+    - cron: 0 1 * * 1-5
   workflow_dispatch:
 
 jobs:
@@ -16,8 +16,21 @@ jobs:
           app_id: ${{ secrets.APP_ID }}
           private_key: ${{ secrets.PRIVATE_KEY }}
 
+      - uses: actions/setup-node@v3
+        with:
+          node-version: 16
+
+      - run: npm install @holiday-jp/holiday_jp
+
+      - uses: actions/github-script@v6
+        id: is-holiday
+        with:
+          script: |
+            const holiday_jp = require(`${process.env.GITHUB_WORKSPACE}/node_modules/@holiday-jp/holiday_jp`)
+            core.setOutput('holiday', holiday_jp.isHoliday(new Date()));
       - name: Run sync-branches
         uses: autowarefoundation/autoware-github-actions/sync-branches@v1
+        if: ${{ steps.is-holiday.outputs.holiday != 'true' || github.event_name == 'workflow_dispatch' }}
         with:
           token: ${{ steps.generate-token.outputs.token }}
           base-branch: tier4/main


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
- Trigger this workflow at 10 a.m. on weekdays
- Judge if national or public holidays (祝日)
- Run this job on workflow dispatch or weekdays except holidays

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not tested this but tested in the related PR: https://github.com/tier4/autoware_launch/pull/51

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
