### PR TITLE
fix(motion_velocity_smoother): insert the point when applying external velocity limit

### DIFF
--- a/planning/motion_velocity_smoother/src/motion_velocity_smoother_node.cpp
+++ b/planning/motion_velocity_smoother/src/motion_velocity_smoother_node.cpp
@@ -827,19 +827,23 @@ void MotionVelocitySmootherNode::applyExternalVelocityLimit(TrajectoryPoints & t
   trajectory_utils::applyMaximumVelocityLimit(
     0, traj.size(), max_velocity_with_deceleration_, traj);
 
-  const size_t closest_idx = findNearestIndexFromEgo(traj);
-
-  double dist = 0.0;
-  for (size_t idx = closest_idx; idx < traj.size() - 1; ++idx) {
-    dist += tier4_autoware_utils::calcDistance2d(traj.at(idx), traj.at(idx + 1));
-    if (dist > external_velocity_limit_.dist) {
-      trajectory_utils::applyMaximumVelocityLimit(
-        idx + 1, traj.size(), external_velocity_limit_.velocity, traj);
-      return;
-    }
+  // insert the point at the distance of external velocity limit
+  const auto & current_pose = current_odometry_ptr_->pose.pose;
+  const size_t closest_seg_idx = motion_utils::findFirstNearestSegmentIndexWithSoftConstraints(
+    traj, current_pose, node_param_.ego_nearest_dist_threshold,
+    node_param_.ego_nearest_yaw_threshold);
+  const auto inserted_index =
+    motion_utils::insertTargetPoint(closest_seg_idx, external_velocity_limit_.dist, traj);
+  if (!inserted_index) {
+    traj.back().longitudinal_velocity_mps = std::min(
+      traj.back().longitudinal_velocity_mps, static_cast<float>(external_velocity_limit_.velocity));
+    return;
   }
-  traj.back().longitudinal_velocity_mps = std::min(
-    traj.back().longitudinal_velocity_mps, static_cast<float>(external_velocity_limit_.velocity));
+
+  // apply external velocity limit from the inserted point
+  trajectory_utils::applyMaximumVelocityLimit(
+    *inserted_index, traj.size(), external_velocity_limit_.velocity, traj);
+
   RCLCPP_DEBUG(
     get_logger(), "externalVelocityLimit : limit_vel = %.3f", external_velocity_limit_.velocity);
 }


### PR DESCRIPTION
## Description

cherry-pick https://github.com/autowarefoundation/autoware.universe/pull/3494 
This solves the problem that the ego vehicle can't stop when external velocity limit is set to 0.

JIRA Ticket
[TIER IV Internal Link](https://tier4.atlassian.net/browse/RT0-27120)

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

- Planning Simulator

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
