### PR TITLE
chore: fix MRM diag are tf_status and external_cmd_converter #278

### DIFF
--- a/system/system_error_monitor/config/diagnostic_aggregator/control.param.yaml
+++ b/system/system_error_monitor/config/diagnostic_aggregator/control.param.yaml
@@ -76,6 +76,6 @@
                   analyzers:
                     heartbeat:
                       type: diagnostic_aggregator/GenericAnalyzer
-                      path: heartbeat
-                      contains: ["external_cmd_converter: heartbeat"]
+                      path: remote_control_topic_status
+                      contains: [": remote_control_topic_status"]
                       timeout: 1.0

--- a/system/system_error_monitor/config/diagnostic_aggregator/localization.param.yaml
+++ b/system/system_error_monitor/config/diagnostic_aggregator/localization.param.yaml
@@ -13,11 +13,6 @@
               path: topic_status
               contains: [": localization_topic_status"]
               timeout: 1.0
-            tf_status:
-              type: diagnostic_aggregator/GenericAnalyzer
-              path: tf_status
-              contains: [": localization_tf_status"]
-              timeout: 1.0
 
         performance_monitoring:
           type: diagnostic_aggregator/AnalyzerGroup


### PR DESCRIPTION
## Description

It has occurred a Stale error in both tf_status and external_cmd_converter.
This PR fixes the issues.

- tf_status
  - It has already been contained in ocalization_topic_status
- external_cmd_converter
  - changed the aggregator key which was checked on the bench system.

### Related
- https://github.com/tier4/autoware_launch.x2/pull/278
- https://tier4.atlassian.net/browse/RT0-28037
- https://tier4.atlassian.net/browse/RT0-28038

## Tests performed

Tested on the X2 bench system

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->
Affects for diag behaviour.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
