### PR TITLE
fix: performance_monitoring

### DIFF
--- a/system/system_error_monitor/config/diagnostic_aggregator/sensing.param.yaml
+++ b/system/system_error_monitor/config/diagnostic_aggregator/sensing.param.yaml
@@ -14,31 +14,29 @@
               contains: [": sensing_topic_status"]
               timeout: 1.0
 
-        performance_monitoring:
-          type: diagnostic_aggregator/AnalyzerGroup
-          path: performance_monitoring
-          analyzers:
-            concat_status:
-              type: diagnostic_aggregator/GenericAnalyzer
-              path: concat_status
-              contains: [": concat_status"]
-              timeout: 1.0
-
         lidar:
           type: diagnostic_aggregator/AnalyzerGroup
           path: lidar
           analyzers:
-            blockage:
-              type: diagnostic_aggregator/GenericAnalyzer
-              path: blockage
-              contains: [": blockage_validation"]
-              timeout: 1.0
-
-            visibility:
-              type: diagnostic_aggregator/GenericAnalyzer
-              path: visibility
-              contains: [": visibility_validation"]
-              timeout: 1.0
+            performance_monitoring:
+              type: diagnostic_aggregator/AnalyzerGroup
+              path: performance_monitoring
+              analyzers:
+                blockage:
+                  type: diagnostic_aggregator/GenericAnalyzer
+                  path: blockage
+                  contains: [": blockage_validation"]
+                  timeout: 1.0
+                visibility:
+                  type: diagnostic_aggregator/GenericAnalyzer
+                  path: visibility
+                  contains: ["left_upper: visibility_validation"]
+                  timeout: 1.0
+                concat_status:
+                  type: diagnostic_aggregator/GenericAnalyzer
+                  path: concat_status
+                  contains: [": concat_status"]
+                  timeout: 1.0
 
         pyrocan:
           type: diagnostic_aggregator/AnalyzerGroup


### PR DESCRIPTION
## Description
- Fix settings for diagnostics aggregator


## Related Link
- https://github.com/tier4/autoware_launch.x2/pull/281

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Test Result : [link](https://evaluation.tier4.jp/evaluation/reports/b269ea0b-b9f4-5588-8b14-290bfc87e8d2?project_id=x2_dev)

- visibility and blockage values are available as expected on driving log replayer

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
