### PR TITLE
fix(intersection): fixed to restart after occlusion is cleared (#3552)

### DIFF
--- a/planning/behavior_velocity_planner/src/scene_module/intersection/scene_intersection.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/intersection/scene_intersection.cpp
@@ -387,7 +387,7 @@ bool IntersectionModule::modifyPathVelocity(PathWithLaneId * path, StopReason * 
       occlusion_first_stop_safety_ = false;
       occlusion_first_stop_distance_ = dist_1st_stopline;
     }
-    occlusion_safety_ = false;
+    occlusion_safety_ = is_occlusion_cleared;
     occlusion_stop_distance_ = dist_2nd_stopline;
   } else {
     /* collision */


### PR DESCRIPTION
## Description

死角がクリアになった後に再発進するように修正

Same as https://github.com/autowarefoundation/autoware.universe/pull/3552

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed

死角クリア後の挙動の確認

https://user-images.githubusercontent.com/28677420/235409008-d2c01f40-163e-4a7f-8925-fef29c5a60f9.mp4


## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters. -->

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
