### PR TITLE
feat(intersection): remove lanelets on path from detection area (#3655)

### DIFF
--- a/planning/behavior_velocity_planner/include/scene_module/intersection/util.hpp
+++ b/planning/behavior_velocity_planner/include/scene_module/intersection/util.hpp
@@ -57,8 +57,8 @@ std::optional<size_t> getDuplicatedPointIdx(
  */
 IntersectionLanelets getObjectiveLanelets(
   lanelet::LaneletMapConstPtr lanelet_map_ptr, lanelet::routing::RoutingGraphPtr routing_graph_ptr,
-  const int lane_id, const std::set<int> & assoc_ids,
-  const autoware_auto_planning_msgs::msg::PathWithLaneId & path,
+  const int lane_id, const lanelet::ConstLanelets & lanelets_on_path,
+  const std::set<int> & assoc_ids, const autoware_auto_planning_msgs::msg::PathWithLaneId & path,
   const std::pair<size_t, size_t> lane_interval, const double detection_area_length,
   const double occlusion_detection_area_length, const bool tl_arrow_solid_on = false);
 

--- a/planning/behavior_velocity_planner/src/scene_module/intersection/scene_intersection.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/intersection/scene_intersection.cpp
@@ -140,9 +140,11 @@ bool IntersectionModule::modifyPathVelocity(PathWithLaneId * path, StopReason * 
   if (
     !intersection_lanelets_ ||
     intersection_lanelets_.value().tl_arrow_solid_on != tl_arrow_solid_on) {
+    const auto lanelets_on_path = planning_utils::getLaneletsOnPath(
+      *path, lanelet_map_ptr, planner_data_->current_odometry->pose);
     intersection_lanelets_ = util::getObjectiveLanelets(
-      lanelet_map_ptr, routing_graph_ptr, lane_id_, assoc_ids_, path_ip, lane_interval_ip,
-      planner_param_.common.detection_area_length, tl_arrow_solid_on);
+      lanelet_map_ptr, routing_graph_ptr, lane_id_, lanelets_on_path, assoc_ids_, path_ip,
+      lane_interval_ip, planner_param_.common.detection_area_length, tl_arrow_solid_on);
   }
   const auto & detection_lanelets = intersection_lanelets_.value().attention;
   const auto & adjacent_lanelets = intersection_lanelets_.value().adjacent;

--- a/planning/behavior_velocity_planner/src/scene_module/intersection/scene_merge_from_private_road.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/intersection/scene_merge_from_private_road.cpp
@@ -86,7 +86,7 @@ bool MergeFromPrivateRoadModule::modifyPathVelocity(PathWithLaneId * path, StopR
   /* get detection area */
   if (!intersection_lanelets_.has_value()) {
     intersection_lanelets_ = util::getObjectiveLanelets(
-      lanelet_map_ptr, routing_graph_ptr, lane_id_, {} /* not used here */, path_ip,
+      lanelet_map_ptr, routing_graph_ptr, lane_id_, {}, {} /* not used here */, path_ip,
       lane_interval_ip, planner_param_.detection_area_length,
       false /* tl_arrow_solid on does not matter here*/);
   }

--- a/planning/behavior_velocity_planner/src/scene_module/intersection/util.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/intersection/util.cpp
@@ -411,8 +411,8 @@ bool getStopLineIndexFromMap(
 
 IntersectionLanelets getObjectiveLanelets(
   lanelet::LaneletMapConstPtr lanelet_map_ptr, lanelet::routing::RoutingGraphPtr routing_graph_ptr,
-  const int lane_id, const std::set<int> & assoc_ids,
-  const autoware_auto_planning_msgs::msg::PathWithLaneId & path,
+  const int lane_id, const lanelet::ConstLanelets & lanelets_on_path,
+  const std::set<int> & assoc_ids, const autoware_auto_planning_msgs::msg::PathWithLaneId & path,
   const std::pair<size_t, size_t> lane_interval, const double detection_area_length,
   const double occlusion_detection_area_length, const bool tl_arrow_solid_on)
 {
@@ -445,7 +445,7 @@ IntersectionLanelets getObjectiveLanelets(
   }
 
   // get all following lanes of previous lane
-  lanelet::ConstLanelets ego_lanelets{};
+  lanelet::ConstLanelets ego_lanelets = lanelets_on_path;
   for (const auto & previous_lanelet : routing_graph_ptr->previous(assigned_lanelet)) {
     ego_lanelets.push_back(previous_lanelet);
     for (const auto & following_lanelet : routing_graph_ptr->following(previous_lanelet)) {


### PR DESCRIPTION
remove lanelets on path from detection area

## Description

xx1の発着発進のシナリオで交差点死角検知が不要に働いていてfailしていた問題にたいする修正

## Related links

https://github.com/autowarefoundation/autoware.universe/pull/3655 と同じ内容

## Tests performed

<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters. -->

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
