### PR TITLE
fix(multi_object_tracker): fix unintended perturbation in tracking estimation via non initialized eigen vector (#3651)

### DIFF
--- a/perception/multi_object_tracker/src/tracker/model/big_vehicle_tracker.cpp
+++ b/perception/multi_object_tracker/src/tracker/model/big_vehicle_tracker.cpp
@@ -44,7 +44,8 @@ BigVehicleTracker::BigVehicleTracker(
 : Tracker(time, object.classification),
   logger_(rclcpp::get_logger("BigVehicleTracker")),
   last_update_time_(time),
-  z_(object.kinematics.pose_with_covariance.pose.position.z)
+  z_(object.kinematics.pose_with_covariance.pose.position.z),
+  tracking_offset_(Eigen::Vector2d::Zero())
 {
   object_ = object;
 

--- a/perception/multi_object_tracker/src/tracker/model/normal_vehicle_tracker.cpp
+++ b/perception/multi_object_tracker/src/tracker/model/normal_vehicle_tracker.cpp
@@ -44,7 +44,8 @@ NormalVehicleTracker::NormalVehicleTracker(
 : Tracker(time, object.classification),
   logger_(rclcpp::get_logger("NormalVehicleTracker")),
   last_update_time_(time),
-  z_(object.kinematics.pose_with_covariance.pose.position.z)
+  z_(object.kinematics.pose_with_covariance.pose.position.z),
+  tracking_offset_(Eigen::Vector2d::Zero())
 {
   object_ = object;
 


### PR DESCRIPTION
add initialize for anchor point vector

## Description

trackerで初期値が未初期化されていた問題の修正

https://github.com/autowarefoundation/autoware.universe/pull/3651 と同じ内容

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed

<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters. -->

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
