### PR TITLE
fix: remove unused orocos kdl from dependencies (#848)

### DIFF
--- a/common/autoware_auto_tf2/CMakeLists.txt
+++ b/common/autoware_auto_tf2/CMakeLists.txt
@@ -37,7 +37,6 @@ if(BUILD_TESTING)
     "autoware_auto_system_msgs"
     "autoware_auto_geometry_msgs"
     "geometry_msgs"
-    "orocos_kdl"
     "tf2"
     "tf2_ros"
 )

--- a/common/autoware_auto_tf2/package.xml
+++ b/common/autoware_auto_tf2/package.xml
@@ -17,7 +17,6 @@
     <depend>geometry_msgs</depend>
     <depend>tf2</depend>
     <depend>tf2_ros</depend>
-    <depend>orocos_kdl</depend>
 
     <test_depend>ament_cmake_gtest</test_depend>
     <!-- <test_depend>ament_lint_auto</test_depend> -->


### PR DESCRIPTION
## Description

backport: https://github.com/autowarefoundation/autoware.universe/pull/848

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

I confirmed same changes.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
