### PR TITLE
fix(tier4_autoware_utils): change the header extension of the included tf2_geometry_msgs from .h to .hpp

### DIFF
--- a/common/tier4_autoware_utils/include/tier4_autoware_utils/geometry/geometry.hpp
+++ b/common/tier4_autoware_utils/include/tier4_autoware_utils/geometry/geometry.hpp
@@ -32,7 +32,7 @@
 #include <geometry_msgs/msg/quaternion.hpp>
 #include <geometry_msgs/msg/transform_stamped.hpp>
 
-#include <tf2_geometry_msgs/tf2_geometry_msgs.h>
+#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
 
 namespace tier4_autoware_utils
 {

--- a/common/tier4_autoware_utils/include/tier4_autoware_utils/geometry/geometry.hpp
+++ b/common/tier4_autoware_utils/include/tier4_autoware_utils/geometry/geometry.hpp
@@ -31,7 +31,6 @@
 #include <geometry_msgs/msg/pose_with_covariance_stamped.hpp>
 #include <geometry_msgs/msg/quaternion.hpp>
 #include <geometry_msgs/msg/transform_stamped.hpp>
-
 #include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
 
 namespace tier4_autoware_utils


### PR DESCRIPTION
## Description

ROS2 Humble環境で、tf2_geometry_msgsのヘッダ拡張子が`.h`だとビルドエラーになるので、拡張子を`.hpp`に変更する。

## Related Links
https://tier4.atlassian.net/browse/AEAP-486

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->


以下の環境下で、tier4_autoware_utilsパッケージのビルド時に、ビルドエラーが出ないことを確認。

- OS
  - Ubuntu22.04
- ROS2 Distribution
  - Humble
- pilot-auto.x1.eveのバージョン
  - [9735f6f69a3a7132a7fa60dea1f30569ebf9b27d](https://github.com/tier4/pilot-auto.x1.eve/tree/9735f6f69a3a7132a7fa60dea1f30569ebf9b27d)

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
