### PR TITLE
fix(autoware_auto_common): fix build dependency on geometry_msgs

### DIFF
--- a/common/autoware_auto_common/CMakeLists.txt
+++ b/common/autoware_auto_common/CMakeLists.txt
@@ -66,7 +66,11 @@ if(BUILD_TESTING)
   autoware_set_compile_options(${TEST_COMMON})
   target_compile_options(${TEST_COMMON} PRIVATE -Wno-sign-conversion)
   target_include_directories(${TEST_COMMON} PRIVATE include)
-  ament_target_dependencies(${TEST_COMMON} builtin_interfaces Eigen3)
+  ament_target_dependencies(${TEST_COMMON}
+    builtin_interfaces
+    Eigen3
+    geometry_msgs
+  )
 endif()
 
 # Ament Exporting

--- a/common/autoware_auto_common/package.xml
+++ b/common/autoware_auto_common/package.xml
@@ -16,6 +16,7 @@
     <test_depend>ament_cmake_gtest</test_depend>
     <test_depend>ament_lint_auto</test_depend>
     <test_depend>ament_lint_common</test_depend>
+    <test_depend>geometry_msgs</test_depend>
 
     <export><build_type>ament_cmake</build_type></export>
 </package>


### PR DESCRIPTION
## Description

ROS2 Humble環境でビルドエラーとなるので、`geometry_msgs`パッケージへの依存関係をCMakeLists.txtとpackage.xmlに記述する。

## Related Links
https://tier4.atlassian.net/browse/AEAP-486

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->


以下の環境下で、autoware_auto_commonパッケージのビルド時に、ビルドエラーが出ないことを確認。

- OS
  - Ubuntu22.04
- ROS2 Distribution
  - Humble
- pilot-auto.x1.eveのバージョン
  - [9735f6f69a3a7132a7fa60dea1f30569ebf9b27d](https://github.com/tier4/pilot-auto.x1.eve/tree/9735f6f69a3a7132a7fa60dea1f30569ebf9b27d)

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
