### PR TITLE
ci: delete grid_map from build_depends.repos

### DIFF
--- a/build_depends.repos
+++ b/build_depends.repos
@@ -17,10 +17,6 @@ repositories:
     type: git
     url: https://github.com/tier4/tier4_autoware_msgs.git
     version: a624d255107fa724cf90967c5dcc09463b1d1c73
-  universe/vendor/grid_map:
-    type: git
-    url: https://github.com/ANYbotics/grid_map.git
-    version: ba2f9cb6e62f7ee9c5bac7401391a211e442e459
   universe/vendor/mussp:
     type: git
     url: https://github.com/tier4/muSSP.git


### PR DESCRIPTION
## Description

grid_mapはHumbleからaptで取得するので、不要
参照: https://github.com/tier4/pilot-auto.x1.eve/pull/519

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

check-build-dependsは他のパッケージでビルド失敗するため、無視して良い

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
