### PR TITLE
fix(tier4_vehicle_rviz_plugin): fix build warning in Humble

### DIFF
--- a/common/tier4_vehicle_rviz_plugin/src/tools/steering_angle.cpp
+++ b/common/tier4_vehicle_rviz_plugin/src/tools/steering_angle.cpp
@@ -130,7 +130,7 @@ void SteeringAngleDisplay::update(float wall_dt, float ros_dt)
   // ((property_handle_angle_scale_->getFloat() * (msg_ptr->data / M_PI) * -180.0));
   int handle_image_width = handle_image_.width(), handle_image_height = handle_image_.height();
   QPixmap rotate_handle_image;
-  rotate_handle_image = handle_image_.transformed(rotation_matrix);
+  rotate_handle_image = handle_image_.transformed(QTransform(rotation_matrix));
   rotate_handle_image = rotate_handle_image.copy(
     (rotate_handle_image.width() - handle_image_width) / 2,
     (rotate_handle_image.height() - handle_image_height) / 2, handle_image_width,


### PR DESCRIPTION
## Description

https://github.com/autowarefoundation/autoware.universe/pull/852/files#diff-63a4e57abc1bb5508efbb58428d1a48ec1da6f91318ba8f2c836e2bd7784ec02R133 を参考にwarningを修正

## Related Links
https://tier4.atlassian.net/browse/AEAP-488

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

以下のwarningが出ないこと
```
warning: ‘QPixmap QPixmap::transformed(const QMatrix&, Qt::TransformationMode) const’ is deprecated: Use transformed(const QTransform &, Qt::TransformationMode mode) [-Wdeprecated-declarations]

```

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
