### PR TITLE
fix(pose_initializer): fix build warning in Humble

### DIFF
--- a/localization/pose_initializer/src/pose_initializer_core.cpp
+++ b/localization/pose_initializer/src/pose_initializer_core.cpp
@@ -14,8 +14,9 @@
 
 #include "pose_initializer/pose_initializer_core.hpp"
 
-#include <pcl_conversions/pcl_conversions.h>
 #include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
+
+#include <pcl_conversions/pcl_conversions.h>
 
 #include <algorithm>
 #include <chrono>

--- a/localization/pose_initializer/src/pose_initializer_core.cpp
+++ b/localization/pose_initializer/src/pose_initializer_core.cpp
@@ -15,7 +15,7 @@
 #include "pose_initializer/pose_initializer_core.hpp"
 
 #include <pcl_conversions/pcl_conversions.h>
-#include <tf2_geometry_msgs/tf2_geometry_msgs.h>
+#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
 
 #include <algorithm>
 #include <chrono>
@@ -190,7 +190,7 @@ bool PoseInitializer::getHeight(
     input_pose_msg.pose.pose.position.z);
 
   if (map_ptr_) {
-    tf2::Transform transform;
+    tf2::Transform transform{tf2::Quaternion{}, tf2::Vector3{}};
     try {
       const auto stamped = tf2_buffer_.lookupTransform(map_frame_, fixed_frame, tf2::TimePointZero);
       tf2::fromMsg(stamped.transform, transform);


### PR DESCRIPTION
## Description

以下を参考に修正
https://github.com/autowarefoundation/autoware.universe/pull/852/files#diff-076ef3f74b5024fd7148eb1c2b230225b446ca2809ceb717e9e84f9ff25d5561R21

https://github.com/autowarefoundation/autoware.universe/pull/852/files#diff-076ef3f74b5024fd7148eb1c2b230225b446ca2809ceb717e9e84f9ff25d5561R195

## Related Links

https://tier4.atlassian.net/browse/AEAP-488

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

pose_initializerのビルドwarningが出ないこと

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
