### PR TITLE
fix(autonomous_emergency_braking): fix build error in Humble

### DIFF
--- a/control/autonomous_emergency_braking/src/node.cpp
+++ b/control/autonomous_emergency_braking/src/node.cpp
@@ -26,36 +26,6 @@
 #include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
 #endif
 
-namespace tf2
-{
-template <>
-inline void doTransform(
-  const geometry_msgs::msg::Pose & t_in, geometry_msgs::msg::Pose & t_out,
-  const geometry_msgs::msg::TransformStamped & transform)
-{
-  KDL::Vector v(t_in.position.x, t_in.position.y, t_in.position.z);
-  KDL::Rotation r = KDL::Rotation::Quaternion(
-    t_in.orientation.x, t_in.orientation.y, t_in.orientation.z, t_in.orientation.w);
-
-  KDL::Frame v_out = gmTransformToKDL(transform) * KDL::Frame(r, v);
-  t_out.position.x = v_out.p[0];
-  t_out.position.y = v_out.p[1];
-  t_out.position.z = v_out.p[2];
-  v_out.M.GetQuaternion(
-    t_out.orientation.x, t_out.orientation.y, t_out.orientation.z, t_out.orientation.w);
-}
-
-template <>
-inline void doTransform(
-  const geometry_msgs::msg::Point & t_in, geometry_msgs::msg::Point & t_out,
-  const geometry_msgs::msg::TransformStamped & transform)
-{
-  KDL::Vector v_out = gmTransformToKDL(transform) * KDL::Vector(t_in.x, t_in.y, t_in.z);
-  t_out.x = v_out[0];
-  t_out.y = v_out[1];
-  t_out.z = v_out[2];
-}
-}  // namespace tf2
 namespace autoware::motion::control::autonomous_emergency_braking
 {
 using diagnostic_msgs::msg::DiagnosticStatus;


### PR DESCRIPTION
## Description

Galactic環境で存在しなかったdoTransform関数を追加していたが、Humble環境ではtf2_geometry_msgs.hppに存在しているため削除する

## Related Links
https://tier4.atlassian.net/browse/AEAP-488

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

autonomous_emergency_brakingがビルドできること

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
