### PR TITLE
fix(scenario_selector): fix build warning in Humble

### DIFF
--- a/planning/scenario_selector/include/scenario_selector/scenario_selector_node.hpp
+++ b/planning/scenario_selector/include/scenario_selector/scenario_selector_node.hpp
@@ -27,7 +27,7 @@
 #include <lanelet2_core/LaneletMap.h>
 #include <lanelet2_routing/RoutingGraph.h>
 #include <lanelet2_traffic_rules/TrafficRules.h>
-#include <tf2_geometry_msgs/tf2_geometry_msgs.h>
+#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
 #include <tf2_ros/buffer.h>
 #include <tf2_ros/transform_listener.h>
 

--- a/planning/scenario_selector/include/scenario_selector/scenario_selector_node.hpp
+++ b/planning/scenario_selector/include/scenario_selector/scenario_selector_node.hpp
@@ -22,12 +22,12 @@
 #include <autoware_auto_planning_msgs/msg/trajectory.hpp>
 #include <geometry_msgs/msg/twist_stamped.hpp>
 #include <nav_msgs/msg/odometry.hpp>
+#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
 #include <tier4_planning_msgs/msg/scenario.hpp>
 
 #include <lanelet2_core/LaneletMap.h>
 #include <lanelet2_routing/RoutingGraph.h>
 #include <lanelet2_traffic_rules/TrafficRules.h>
-#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
 #include <tf2_ros/buffer.h>
 #include <tf2_ros/transform_listener.h>
 

--- a/planning/scenario_selector/src/scenario_selector_node/scenario_selector_node.cpp
+++ b/planning/scenario_selector/src/scenario_selector_node/scenario_selector_node.cpp
@@ -186,7 +186,7 @@ std::string ScenarioSelectorNode::selectScenarioByPosition()
   }
 
   if (current_scenario_ == tier4_planning_msgs::msg::Scenario::PARKING) {
-    bool is_parking_completed;
+    bool is_parking_completed{};
     this->get_parameter<bool>("is_parking_completed", is_parking_completed);
     if (is_parking_completed && is_in_lane) {
       this->set_parameter(rclcpp::Parameter("is_parking_completed", false));


### PR DESCRIPTION
## Description

以下を参考に修正を実施
- https://github.com/autowarefoundation/autoware.universe/pull/852/files#diff-eb274b7f1ef24244f52685ea0b593feab249ebe5b4b703dbcd5a57d6588d392dR33
- https://github.com/autowarefoundation/autoware.universe/pull/852/files#diff-2895dbd698a277514b53ced0b819f72662eabcb678f1b37dc8c11efaa74b3d29L189-R189

## Related Links
https://tier4.atlassian.net/browse/AEAP-488

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

scneario_selectorのビルド時にwarningが出ないこと

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
