### PR TITLE
fix(dummy_perception_publisher): fix build warning in Humble

### DIFF
--- a/simulator/dummy_perception_publisher/include/dummy_perception_publisher/node.hpp
+++ b/simulator/dummy_perception_publisher/include/dummy_perception_publisher/node.hpp
@@ -21,6 +21,7 @@
 
 #include <autoware_auto_perception_msgs/msg/detected_objects.hpp>
 #include <sensor_msgs/msg/point_cloud2.hpp>
+#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
 #include <tier4_perception_msgs/msg/detected_objects_with_feature.hpp>
 
 #include <pcl/common/distances.h>
@@ -29,7 +30,6 @@
 #include <tf2/LinearMath/Transform.h>
 #include <tf2/convert.h>
 #include <tf2/transform_datatypes.h>
-#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
 #include <tf2_ros/buffer.h>
 #include <tf2_ros/transform_listener.h>
 

--- a/simulator/dummy_perception_publisher/include/dummy_perception_publisher/node.hpp
+++ b/simulator/dummy_perception_publisher/include/dummy_perception_publisher/node.hpp
@@ -29,7 +29,7 @@
 #include <tf2/LinearMath/Transform.h>
 #include <tf2/convert.h>
 #include <tf2/transform_datatypes.h>
-#include <tf2_geometry_msgs/tf2_geometry_msgs.h>
+#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
 #include <tf2_ros/buffer.h>
 #include <tf2_ros/transform_listener.h>
 

--- a/simulator/dummy_perception_publisher/src/node.cpp
+++ b/simulator/dummy_perception_publisher/src/node.cpp
@@ -18,7 +18,7 @@
 #include <tf2/LinearMath/Quaternion.h>
 #include <tf2/LinearMath/Transform.h>
 #include <tf2/LinearMath/Vector3.h>
-#include <tf2_geometry_msgs/tf2_geometry_msgs.h>
+#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
 
 #include <functional>
 #include <limits>

--- a/simulator/dummy_perception_publisher/src/node.cpp
+++ b/simulator/dummy_perception_publisher/src/node.cpp
@@ -14,11 +14,12 @@
 
 #include "dummy_perception_publisher/node.hpp"
 
+#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
+
 #include <pcl/filters/voxel_grid_occlusion_estimation.h>
 #include <tf2/LinearMath/Quaternion.h>
 #include <tf2/LinearMath/Transform.h>
 #include <tf2/LinearMath/Vector3.h>
-#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
 
 #include <functional>
 #include <limits>

--- a/simulator/dummy_perception_publisher/src/signed_distance_function.cpp
+++ b/simulator/dummy_perception_publisher/src/signed_distance_function.cpp
@@ -77,7 +77,7 @@ double CompositeSDF::operator()(double x, double y) const
 size_t CompositeSDF::nearest_sdf_index(double x, double y) const
 {
   double min_value = std::numeric_limits<double>::infinity();
-  size_t idx_min;
+  size_t idx_min{};
   for (size_t i = 0; i < sdf_ptrs_.size(); ++i) {
     const auto value = sdf_ptrs_.at(i)->operator()(x, y);
     if (value < min_value) {


### PR DESCRIPTION
## Description

以下を参考に修正を実施
- https://github.com/autowarefoundation/autoware.universe/pull/852/files#diff-f7025aa1b2846894c7a4a3495b2ff2abefc334d78c350ef4de488373ece32f24R35
- https://github.com/autowarefoundation/autoware.universe/pull/852/files#diff-9e63f577908171e00f9199eac93ea6cddd65ead39b0f83a93123a438a3267ba2R24
- https://github.com/autowarefoundation/autoware.universe/pull/852/files#diff-3290f2cb97b611502587a1421628ad062a0c09a16ab3407fd2e9d572ffae1957R73

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

dummy_perception_publisherがビルドwarningが出ないこと

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
