### PR TITLE
fix(transformPointCloud): use tier4_autoware_utils instead of pcl

### DIFF
--- a/localization/ndt_scan_matcher/src/ndt_scan_matcher_core.cpp
+++ b/localization/ndt_scan_matcher/src/ndt_scan_matcher_core.cpp
@@ -31,6 +31,33 @@
 #include <iomanip>
 #include <thread>
 
+namespace tier4_autoware_utils
+{
+template <typename PointT>
+void transformPointCloud(
+  const pcl::PointCloud<PointT> & cloud_in, pcl::PointCloud<PointT> & cloud_out,
+  const Eigen::Matrix<float, 4, 4> & transform)
+{
+  if (cloud_in.empty() || cloud_in.width == 0) {
+    RCLCPP_WARN(rclcpp::get_logger("transformPointCloud"), "input point cloud is empty!");
+  } else {
+    pcl::transformPointCloud(cloud_in, cloud_out, transform);
+  }
+}
+
+template <typename PointT>
+void transformPointCloud(
+  const pcl::PointCloud<PointT> & cloud_in, pcl::PointCloud<PointT> & cloud_out,
+  const Eigen::Affine3f & transform)
+{
+  if (cloud_in.empty() || cloud_in.width == 0) {
+    RCLCPP_WARN(rclcpp::get_logger("transformPointCloud"), "input point cloud is empty!");
+  } else {
+    pcl::transformPointCloud(cloud_in, cloud_out, transform);
+  }
+}
+}  // namespace tier4_autoware_utils
+
 tier4_debug_msgs::msg::Float32Stamped makeFloat32Stamped(
   const builtin_interfaces::msg::Time & stamp, const float data)
 {
@@ -442,7 +469,7 @@ void NDTScanMatcher::callbackSensorPoints(
   const Eigen::Matrix4f base_to_sensor_matrix = base_to_sensor_affine.matrix().cast<float>();
   pcl::shared_ptr<pcl::PointCloud<PointSource>> sensor_points_baselinkTF_ptr(
     new pcl::PointCloud<PointSource>);
-  pcl::transformPointCloud(
+  tier4_autoware_utils::transformPointCloud(
     *sensor_points_sensorTF_ptr, *sensor_points_baselinkTF_ptr, base_to_sensor_matrix);
   ndt_ptr_->setInputSource(sensor_points_baselinkTF_ptr);
 
@@ -609,7 +636,7 @@ void NDTScanMatcher::callbackSensorPoints(
   publishTF(ndt_base_frame_, result_pose_stamped_msg);
 
   auto sensor_points_mapTF_ptr = std::make_shared<pcl::PointCloud<PointSource>>();
-  pcl::transformPointCloud(
+  tier4_autoware_utils::transformPointCloud(
     *sensor_points_baselinkTF_ptr, *sensor_points_mapTF_ptr, result_pose_matrix);
   sensor_msgs::msg::PointCloud2 sensor_points_mapTF_msg;
   pcl::toROSMsg(*sensor_points_mapTF_ptr, sensor_points_mapTF_msg);
@@ -719,7 +746,7 @@ geometry_msgs::msg::PoseWithCovarianceStamped NDTScanMatcher::alignUsingMonteCar
 
     auto sensor_points_mapTF_ptr = std::make_shared<pcl::PointCloud<PointSource>>();
     const auto sensor_points_baselinkTF_ptr = ndt_ptr->getInputSource();
-    pcl::transformPointCloud(
+    tier4_autoware_utils::transformPointCloud(
       *sensor_points_baselinkTF_ptr, *sensor_points_mapTF_ptr, result_pose_matrix);
     sensor_msgs::msg::PointCloud2 sensor_points_mapTF_msg;
     pcl::toROSMsg(*sensor_points_mapTF_ptr, sensor_points_mapTF_msg);

--- a/localization/ndt_scan_matcher/src/ndt_scan_matcher_core.cpp
+++ b/localization/ndt_scan_matcher/src/ndt_scan_matcher_core.cpp
@@ -39,7 +39,7 @@ void transformPointCloud(
   const Eigen::Matrix<float, 4, 4> & transform)
 {
   if (cloud_in.empty() || cloud_in.width == 0) {
-    RCLCPP_WARN(rclcpp::get_logger("transformPointCloud"), "input point cloud is empty!");
+    // RCLCPP_WARN(rclcpp::get_logger("transformPointCloud"), "input point cloud is empty!");
   } else {
     pcl::transformPointCloud(cloud_in, cloud_out, transform);
   }
@@ -51,7 +51,7 @@ void transformPointCloud(
   const Eigen::Affine3f & transform)
 {
   if (cloud_in.empty() || cloud_in.width == 0) {
-    RCLCPP_WARN(rclcpp::get_logger("transformPointCloud"), "input point cloud is empty!");
+    // RCLCPP_WARN(rclcpp::get_logger("transformPointCloud"), "input point cloud is empty!");
   } else {
     pcl::transformPointCloud(cloud_in, cloud_out, transform);
   }

--- a/planning/behavior_velocity_planner/src/node.cpp
+++ b/planning/behavior_velocity_planner/src/node.cpp
@@ -39,6 +39,33 @@
 #include <scene_module/traffic_light/manager.hpp>
 #include <scene_module/virtual_traffic_light/manager.hpp>
 
+namespace tier4_autoware_utils
+{
+template <typename PointT>
+void transformPointCloud(
+  const pcl::PointCloud<PointT> & cloud_in, pcl::PointCloud<PointT> & cloud_out,
+  const Eigen::Matrix<float, 4, 4> & transform)
+{
+  if (cloud_in.empty() || cloud_in.width == 0) {
+    RCLCPP_WARN(rclcpp::get_logger("transformPointCloud"), "input point cloud is empty!");
+  } else {
+    pcl::transformPointCloud(cloud_in, cloud_out, transform);
+  }
+}
+
+template <typename PointT>
+void transformPointCloud(
+  const pcl::PointCloud<PointT> & cloud_in, pcl::PointCloud<PointT> & cloud_out,
+  const Eigen::Affine3f & transform)
+{
+  if (cloud_in.empty() || cloud_in.width == 0) {
+    RCLCPP_WARN(rclcpp::get_logger("transformPointCloud"), "input point cloud is empty!");
+  } else {
+    pcl::transformPointCloud(cloud_in, cloud_out, transform);
+  }
+}
+}  // namespace tier4_autoware_utils
+
 namespace
 {
 rclcpp::SubscriptionOptions createSubscriptionOptions(rclcpp::Node * node_ptr)
@@ -258,7 +285,7 @@ void BehaviorVelocityPlannerNode::onNoGroundPointCloud(
 
   Eigen::Affine3f affine = tf2::transformToEigen(transform.transform).cast<float>();
   pcl::PointCloud<pcl::PointXYZ>::Ptr pc_transformed(new pcl::PointCloud<pcl::PointXYZ>);
-  pcl::transformPointCloud(pc, *pc_transformed, affine);
+  tier4_autoware_utils::transformPointCloud(pc, *pc_transformed, affine);
 
   {
     std::lock_guard<std::mutex> lock(mutex_);

--- a/planning/behavior_velocity_planner/src/node.cpp
+++ b/planning/behavior_velocity_planner/src/node.cpp
@@ -47,7 +47,7 @@ void transformPointCloud(
   const Eigen::Matrix<float, 4, 4> & transform)
 {
   if (cloud_in.empty() || cloud_in.width == 0) {
-    RCLCPP_WARN(rclcpp::get_logger("transformPointCloud"), "input point cloud is empty!");
+    // RCLCPP_WARN(rclcpp::get_logger("transformPointCloud"), "input point cloud is empty!");
   } else {
     pcl::transformPointCloud(cloud_in, cloud_out, transform);
   }
@@ -59,7 +59,7 @@ void transformPointCloud(
   const Eigen::Affine3f & transform)
 {
   if (cloud_in.empty() || cloud_in.width == 0) {
-    RCLCPP_WARN(rclcpp::get_logger("transformPointCloud"), "input point cloud is empty!");
+    // RCLCPP_WARN(rclcpp::get_logger("transformPointCloud"), "input point cloud is empty!");
   } else {
     pcl::transformPointCloud(cloud_in, cloud_out, transform);
   }

--- a/planning/surround_obstacle_checker/src/node.cpp
+++ b/planning/surround_obstacle_checker/src/node.cpp
@@ -33,6 +33,33 @@
 #include <Eigen/Core>
 #include <Eigen/Geometry>
 
+namespace tier4_autoware_utils
+{
+template <typename PointT>
+void transformPointCloud(
+  const pcl::PointCloud<PointT> & cloud_in, pcl::PointCloud<PointT> & cloud_out,
+  const Eigen::Matrix<float, 4, 4> & transform)
+{
+  if (cloud_in.empty() || cloud_in.width == 0) {
+    RCLCPP_WARN(rclcpp::get_logger("transformPointCloud"), "input point cloud is empty!");
+  } else {
+    pcl::transformPointCloud(cloud_in, cloud_out, transform);
+  }
+}
+
+template <typename PointT>
+void transformPointCloud(
+  const pcl::PointCloud<PointT> & cloud_in, pcl::PointCloud<PointT> & cloud_out,
+  const Eigen::Affine3f & transform)
+{
+  if (cloud_in.empty() || cloud_in.width == 0) {
+    RCLCPP_WARN(rclcpp::get_logger("transformPointCloud"), "input point cloud is empty!");
+  } else {
+    pcl::transformPointCloud(cloud_in, cloud_out, transform);
+  }
+}
+}  // namespace tier4_autoware_utils
+
 SurroundObstacleCheckerNode::SurroundObstacleCheckerNode(const rclcpp::NodeOptions & node_options)
 : Node("surround_obstacle_checker_node", node_options),
   tf_buffer_(this->get_clock()),
@@ -269,7 +296,7 @@ void SurroundObstacleCheckerNode::getNearestObstacleByPointCloud(
   Eigen::Affine3f isometry = tf2::transformToEigen(transform_stamped.transform).cast<float>();
   pcl::PointCloud<pcl::PointXYZ> pcl;
   pcl::fromROSMsg(*pointcloud_ptr_, pcl);
-  pcl::transformPointCloud(pcl, pcl, isometry);
+  tier4_autoware_utils::transformPointCloud(pcl, pcl, isometry);
   for (const auto & p : pcl) {
     // create boost point
     Point2d boost_p(p.x, p.y);

--- a/planning/surround_obstacle_checker/src/node.cpp
+++ b/planning/surround_obstacle_checker/src/node.cpp
@@ -41,7 +41,7 @@ void transformPointCloud(
   const Eigen::Matrix<float, 4, 4> & transform)
 {
   if (cloud_in.empty() || cloud_in.width == 0) {
-    RCLCPP_WARN(rclcpp::get_logger("transformPointCloud"), "input point cloud is empty!");
+    // RCLCPP_WARN(rclcpp::get_logger("transformPointCloud"), "input point cloud is empty!");
   } else {
     pcl::transformPointCloud(cloud_in, cloud_out, transform);
   }
@@ -53,7 +53,7 @@ void transformPointCloud(
   const Eigen::Affine3f & transform)
 {
   if (cloud_in.empty() || cloud_in.width == 0) {
-    RCLCPP_WARN(rclcpp::get_logger("transformPointCloud"), "input point cloud is empty!");
+    // RCLCPP_WARN(rclcpp::get_logger("transformPointCloud"), "input point cloud is empty!");
   } else {
     pcl::transformPointCloud(cloud_in, cloud_out, transform);
   }


### PR DESCRIPTION
## Description

https://github.com/autowarefoundation/autoware.universe/pull/3359 のbackportとして、必要な部分をピックアップして適用する
なお、tier4_autoware_utilsのパッケージに手を加える場合影響範囲が膨大なため、修正が必要な箇所のみの対応とする

## Related Links
https://tier4.atlassian.net/browse/AEAP-517

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

- ビルドが問題ないこと
- コード内に存在している pcl::transformPointCloudが tier4_autoware_utils::transformPointCloudに変更されていること
- planning_simulatorで自己位置およびゴールを設定した際にbehavior_velocity_plannerが強制終了しないこと

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
