### PR TITLE
fix(bus_stop): create virtual wall at the stop line

### DIFF
--- a/planning/behavior_velocity_planner/src/scene_module/bus_stop/scene.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/bus_stop/scene.cpp
@@ -141,7 +141,7 @@ visualization_msgs::msg::MarkerArray createCorrespondenceMarkerArray(
 std::pair<lanelet::BasicPoint2d, double> calcSmallestEnclosingCircle(
   const lanelet::ConstPolygon2d & poly)
 {
-  // The `eps` is used to avoid precision bugs in circle inclusion checkings.
+  // The `eps` is used to avoid precision bugs in circle inclusion check.
   // If the value of `eps` is too small, this function doesn't work well. More than 1e-10 is
   // recommended.
   const double eps = 1e-5;

--- a/planning/behavior_velocity_planner/src/scene_module/bus_stop/scene.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/bus_stop/scene.cpp
@@ -376,7 +376,8 @@ bool BusStopModule::modifyPathVelocity(
   }
   const auto stop_dist = calcStopDistance(*path, *path_idx_with_pose);
   const auto & stop_pose = path_idx_with_pose->second;
-  const auto & base_link_pose = planner_data_->current_pose.pose;
+  const auto virtual_wall_pose = tier4_autoware_utils::calcOffsetPose(
+    stop_pose, planner_param_.stop_margin_from_stop_line, 0, 0);
 
   if (current_state == State::STOP) {
     // if RTC is activated, do not insert zero velocity and go
@@ -386,8 +387,8 @@ bool BusStopModule::modifyPathVelocity(
 
     planning_utils::insertStopPoint(stop_pose.position, *path);
 
-    // create virtual wall at the head of the ego vehicle
-    debug_data_->stop_poses.push_back(base_link_pose);
+    // create virtual wall at the stop point
+    debug_data_->stop_poses.push_back(virtual_wall_pose);
 
     return true;
   }
@@ -400,8 +401,8 @@ bool BusStopModule::modifyPathVelocity(
 
     planning_utils::insertStopPoint(stop_pose.position, *path);
 
-    // create virtual wall at the head of the ego vehicle
-    debug_data_->stop_poses.push_back(base_link_pose);
+    // create virtual wall at the stop point
+    debug_data_->stop_poses.push_back(virtual_wall_pose);
 
     // Set Turn Indicator
     turn_indicator_->setTurnSignal(TurnIndicatorsCommand::ENABLE_RIGHT, clock_->now());
@@ -418,8 +419,8 @@ bool BusStopModule::modifyPathVelocity(
 
     planning_utils::insertStopPoint(stop_pose.position, *path);
 
-    // create virtual wall at the head of the ego vehicle
-    debug_data_->stop_poses.push_back(base_link_pose);
+    // create virtual wall at the stop point
+    debug_data_->stop_poses.push_back(virtual_wall_pose);
 
     return true;
   }


### PR DESCRIPTION
## Description

Fixed the position of the virtual wall.

### Before
![image](https://github.com/tier4/autoware.universe/assets/11865769/97b7e337-2fca-470f-a77b-4e7227fa21a1)


### After
![image](https://github.com/tier4/autoware.universe/assets/11865769/d38ad3a2-013f-4530-9c5d-40a7212cd773)

## Related Links
(TIER IV Internal Link)
- https://tier4.atlassian.net/browse/RT0-27989

## Tests performed

Tested with simple planning simulator.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
