### PR TITLE
fix(behavior_path_planner): do not execute goal_planner when the fixed goal is not in current lanes (#3796)

### DIFF
--- a/planning/behavior_path_planner/src/scene_module/goal_planner/goal_planner_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/goal_planner/goal_planner_module.cpp
@@ -320,16 +320,15 @@ bool GoalPlannerModule::isExecutionRequested() const
     return false;
   }
 
-  // if goal modification is not allowed and goal_pose in current_lanes,
-  // plan path to the original fixed goal
+  // if goal modification is not allowed
+  // 1) goal_pose is in current_lanes, plan path to the original fixed goal
+  // 2) goal_pose is NOT in current_lanes, do not execute goal_planner
   if (!allow_goal_modification_) {
-    if (std::any_of(
-          current_lanes.begin(), current_lanes.end(),
-          [&](const lanelet::ConstLanelet & current_lane) {
-            return lanelet::utils::isInLanelet(goal_pose, current_lane);
-          })) {
-      return true;
-    }
+    // check if goal_pose is in current_lanes.
+    return std::any_of(
+      current_lanes.begin(), current_lanes.end(), [&](const lanelet::ConstLanelet & current_lane) {
+        return lanelet::utils::isInLanelet(goal_pose, current_lane);
+      });
   }
 
   // if (A) or (B) is met execute pull over


### PR DESCRIPTION

## Description

<!-- Write a brief description of this PR. -->
cherry-pick https://github.com/autowarefoundation/autoware.universe/pull/3796 for beta/v0.8.0


## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

https://tier4.atlassian.net/browse/RT1-2382

## Tests performed

<!-- Describe how you have tested this PR. -->

psim

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters. -->

not applicable

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->


not applicable


## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
