### PR TITLE
fix(dummy_perception_publisher): use rosidl_get_typesupport_target instead of rosidl_target_interfaces

### DIFF
--- a/simulator/dummy_perception_publisher/CMakeLists.txt
+++ b/simulator/dummy_perception_publisher/CMakeLists.txt
@@ -65,8 +65,8 @@ target_include_directories(dummy_perception_publisher_node
     $<INSTALL_INTERFACE:include>)
 
 # For using message definitions from the same package
-rosidl_target_interfaces(dummy_perception_publisher_node
-  ${PROJECT_NAME} "rosidl_typesupport_cpp")
+rosidl_get_typesupport_target(cpp_typesupport_target ${PROJECT_NAME} "rosidl_typesupport_cpp")
+target_link_libraries(dummy_perception_publisher_node "${cpp_typesupport_target}")
 
 # PCL dependencies – `ament_target_dependencies` doesn't respect the
 # components/modules selected above and only links in `common` ,so we need


### PR DESCRIPTION
## Description

https://docs.ros.org/en/humble/Releases/Release-Humble-Hawksbill.html#rosidl-cmake
Humbleではrosidl_target_interfaces()が非推奨となったので、https://github.com/ros2/demos/pull/529 を参考に修正します。

Related Links: https://tier4.atlassian.net/browse/AEAP-550

## Tests performed

colconでdummy_perception_publisherをビルドし、Error/Warningが出力されないこと。

Note: 修正前は次のWarningが出力される。

```sh
CMake Deprecation Warning at /opt/ros/humble/share/rosidl_cmake/cmake/rosidl_target_interfaces.cmake:32 (message):
  Use rosidl_get_typesupport_target() and target_link_libraries() instead of
  rosidl_target_interfaces()
Call Stack (most recent call first):
  CMakeLists.txt:68 (rosidl_target_interfaces)
```

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
