### PR TITLE
fix(tier4_autoware_utils): add ignore boost deprecated

### DIFF
--- a/common/tier4_autoware_utils/CMakeLists.txt
+++ b/common/tier4_autoware_utils/CMakeLists.txt
@@ -9,6 +9,9 @@ if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
   add_compile_options(-Wall -Wextra -Wpedantic -Werror)
 endif()
 
+# Ignore Boost deprecated messages
+add_compile_definitions(BOOST_ALLOW_DEPRECATED_HEADERS)
+
 find_package(ament_cmake_auto REQUIRED)
 ament_auto_find_build_dependencies()
 


### PR DESCRIPTION
## Description

Boostのwarningが出ないようにignoreする

## Related Links

https://tier4.atlassian.net/browse/AEAP-488

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

tier4_autowrare_utilsでBoostのwarningが出ないことを確認

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
