### PR TITLE
fix: remove unused check of rviz plugin version (#1474)

### DIFF
--- a/common/polar_grid/CMakeLists.txt
+++ b/common/polar_grid/CMakeLists.txt
@@ -13,7 +13,7 @@ endif()
 find_package(ament_cmake_auto REQUIRED)
 ament_auto_find_build_dependencies()
 
-find_package(Qt5 ${rviz_QT_VERSION} EXACT REQUIRED Core Widgets)
+find_package(Qt5 REQUIRED Core Widgets)
 set(QT_LIBRARIES Qt5::Widgets)
 set(CMAKE_AUTOMOC ON)
 set(CMAKE_INCLUDE_CURRENT_DIR ON)

--- a/common/tier4_calibration_rviz_plugin/CMakeLists.txt
+++ b/common/tier4_calibration_rviz_plugin/CMakeLists.txt
@@ -13,7 +13,7 @@ endif()
 find_package(ament_cmake_auto REQUIRED)
 ament_auto_find_build_dependencies()
 
-find_package(Qt5 ${rviz_QT_VERSION} REQUIRED Core Widgets)
+find_package(Qt5 REQUIRED Core Widgets)
 set(QT_LIBRARIES Qt5::Widgets)
 set(CMAKE_AUTOMOC ON)
 set(CMAKE_INCLUDE_CURRENT_DIR ON)

--- a/common/tier4_datetime_rviz_plugin/CMakeLists.txt
+++ b/common/tier4_datetime_rviz_plugin/CMakeLists.txt
@@ -13,7 +13,7 @@ endif()
 find_package(ament_cmake_auto REQUIRED)
 ament_auto_find_build_dependencies()
 
-find_package(Qt5 ${rviz_QT_VERSION} EXACT REQUIRED Core Widgets)
+find_package(Qt5 REQUIRED Core Widgets)
 set(QT_LIBRARIES Qt5::Widgets)
 set(CMAKE_AUTOMOC ON)
 set(CMAKE_INCLUDE_CURRENT_DIR ON)

--- a/common/tier4_localization_rviz_plugin/CMakeLists.txt
+++ b/common/tier4_localization_rviz_plugin/CMakeLists.txt
@@ -13,7 +13,7 @@ endif()
 find_package(ament_cmake_auto REQUIRED)
 ament_auto_find_build_dependencies()
 
-find_package(Qt5 ${rviz_QT_VERSION} EXACT REQUIRED Core Widgets)
+find_package(Qt5 REQUIRED Core Widgets)
 set(QT_LIBRARIES Qt5::Widgets)
 set(CMAKE_AUTOMOC ON)
 set(CMAKE_INCLUDE_CURRENT_DIR ON)

--- a/common/tier4_perception_rviz_plugin/CMakeLists.txt
+++ b/common/tier4_perception_rviz_plugin/CMakeLists.txt
@@ -13,7 +13,7 @@ endif()
 find_package(ament_cmake_auto REQUIRED)
 ament_auto_find_build_dependencies()
 
-find_package(Qt5 ${rviz_QT_VERSION} EXACT REQUIRED Core Widgets)
+find_package(Qt5 REQUIRED Core Widgets)
 set(QT_LIBRARIES Qt5::Widgets)
 
 set(CMAKE_AUTOMOC ON)

--- a/common/tier4_planning_rviz_plugin/CMakeLists.txt
+++ b/common/tier4_planning_rviz_plugin/CMakeLists.txt
@@ -13,7 +13,7 @@ endif()
 find_package(ament_cmake_auto REQUIRED)
 ament_auto_find_build_dependencies()
 
-find_package(Qt5 ${rviz_QT_VERSION} EXACT REQUIRED Core Widgets)
+find_package(Qt5 REQUIRED Core Widgets)
 set(QT_LIBRARIES Qt5::Widgets)
 set(CMAKE_AUTOMOC ON)
 set(CMAKE_INCLUDE_CURRENT_DIR ON)

--- a/common/tier4_simulated_clock_rviz_plugin/CMakeLists.txt
+++ b/common/tier4_simulated_clock_rviz_plugin/CMakeLists.txt
@@ -13,7 +13,7 @@ endif()
 find_package(ament_cmake_auto REQUIRED)
 ament_auto_find_build_dependencies()
 
-find_package(Qt5 ${rviz_QT_VERSION} EXACT REQUIRED Core Widgets)
+find_package(Qt5 REQUIRED Core Widgets)
 set(QT_LIBRARIES Qt5::Widgets)
 set(CMAKE_AUTOMOC ON)
 set(CMAKE_INCLUDE_CURRENT_DIR ON)

--- a/common/tier4_state_rviz_plugin/CMakeLists.txt
+++ b/common/tier4_state_rviz_plugin/CMakeLists.txt
@@ -13,7 +13,7 @@ endif()
 find_package(ament_cmake_auto REQUIRED)
 ament_auto_find_build_dependencies()
 
-find_package(Qt5 ${rviz_QT_VERSION} EXACT REQUIRED Core Widgets)
+find_package(Qt5 REQUIRED Core Widgets)
 set(QT_LIBRARIES Qt5::Widgets)
 set(CMAKE_AUTOMOC ON)
 set(CMAKE_INCLUDE_CURRENT_DIR ON)

--- a/common/tier4_traffic_light_rviz_plugin/CMakeLists.txt
+++ b/common/tier4_traffic_light_rviz_plugin/CMakeLists.txt
@@ -13,7 +13,7 @@ endif()
 find_package(ament_cmake_auto REQUIRED)
 ament_auto_find_build_dependencies()
 
-find_package(Qt5 ${rviz_QT_VERSION} EXACT REQUIRED Core Widgets)
+find_package(Qt5 REQUIRED Core Widgets)
 set(QT_LIBRARIES Qt5::Widgets)
 set(CMAKE_AUTOMOC ON)
 set(CMAKE_INCLUDE_CURRENT_DIR ON)

--- a/common/tier4_vehicle_rviz_plugin/CMakeLists.txt
+++ b/common/tier4_vehicle_rviz_plugin/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 find_package(ament_cmake_auto REQUIRED)
 ament_auto_find_build_dependencies()
 
-find_package(Qt5 ${rviz_QT_VERSION} EXACT REQUIRED Core Widgets)
+find_package(Qt5 REQUIRED Core Widgets)
 set(QT_LIBRARIES Qt5::Widgets)
 
 set(CMAKE_AUTOMOC ON)

--- a/localization/initial_pose_button_panel/CMakeLists.txt
+++ b/localization/initial_pose_button_panel/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 find_package(ament_cmake_auto REQUIRED)
 ament_auto_find_build_dependencies()
 
-find_package(Qt5 ${rviz_QT_VERSION} EXACT REQUIRED Core Widgets)
+find_package(Qt5 REQUIRED Core Widgets)
 set(QT_LIBRARIES Qt5::Widgets)
 
 add_definitions(-DQT_NO_KEYWORDS -g)


### PR DESCRIPTION
## Description

https://github.com/autowarefoundation/autoware.universe/pull/1474 のbackport

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

下記のコマンドでビルドしてEXACTをignoreするwarningが出ないこと
```
colcon build --symlink-install --cmake-args -DCMAKE_BUILD_TYPE=Release --catkin-skip-building-tests --parallel-workers 8 --packages-up-to  $(colcon list --base-path src/autoware/universe/common/ | awk '{print $1}')
```


## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
