### PR TITLE
feat(map): use autoware_cmake to avoid Boost warning

### DIFF
--- a/map/lanelet2_extension/CMakeLists.txt
+++ b/map/lanelet2_extension/CMakeLists.txt
@@ -1,18 +1,8 @@
 cmake_minimum_required(VERSION 3.5)
 project(lanelet2_extension)
 
-if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 14)
-  set(CMAKE_CXX_STANDARD_REQUIRED ON)
-  set(CMAKE_CXX_EXTENSIONS OFF)
-endif()
-
-if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  add_compile_options(-Wall -Wextra -Wpedantic -Werror)
-endif()
-
-find_package(ament_cmake_auto REQUIRED)
-ament_auto_find_build_dependencies()
+find_package(autoware_cmake REQUIRED)
+autoware_package()
 
 find_package(PkgConfig)
 find_path(GeographicLib_INCLUDE_DIR GeographicLib/Config.h
@@ -72,7 +62,6 @@ target_link_libraries(autoware_lanelet2_validation
 )
 
 if(BUILD_TESTING)
-  find_package(ament_cmake_gtest REQUIRED)
   ament_add_gtest(message_conversion-test test/src/test_message_conversion.cpp)
   target_link_libraries(message_conversion-test lanelet2_extension_lib)
   ament_add_gtest(projector-test test/src/test_projector.cpp)
@@ -83,8 +72,6 @@ if(BUILD_TESTING)
   target_link_libraries(regulatory_elements-test lanelet2_extension_lib)
   ament_add_gtest(utilities-test test/src/test_utilities.cpp)
   target_link_libraries(utilities-test lanelet2_extension_lib)
-  find_package(ament_lint_auto REQUIRED)
-  ament_lint_auto_find_test_dependencies()
 endif()
 
 ament_auto_package()

--- a/map/lanelet2_extension/package.xml
+++ b/map/lanelet2_extension/package.xml
@@ -8,8 +8,8 @@
 
   <license>Apache License 2.0</license>
 
-  <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
+  <build_depend>autoware_cmake</build_depend>
 
   <depend>autoware_auto_mapping_msgs</depend>
   <depend>geographiclib</depend>


### PR DESCRIPTION
## Description

https://github.com/autowarefoundation/autoware.universe/pull/849 からBoostのwarningが出ているパッケージだけを抜き出して適用

## Related Links
https://tier4.atlassian.net/browse/AEAP-488

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->


下記のコマンドでビルドしてmap以下のパッケージでBoostのwarningが出ないこと
```
colcon build --symlink-install --cmake-args -DCMAKE_BUILD_TYPE=Release --catkin-skip-building-tests --parallel-workers 8 --packages-up-to  $(colcon list --base-path src/autoware/universe/map/ | awk '{print $1}')
```



## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
