### PR TITLE
feat(perception): use autoware_cmake to avoid Boost warning

### DIFF
--- a/perception/elevation_map_loader/CMakeLists.txt
+++ b/perception/elevation_map_loader/CMakeLists.txt
@@ -1,20 +1,10 @@
 cmake_minimum_required(VERSION 3.5)
 project(elevation_map_loader)
 
-if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 17)
-  set(CMAKE_CXX_STANDARD_REQUIRED ON)
-  set(CMAKE_CXX_EXTENSIONS OFF)
-endif()
-
-if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  add_compile_options(-Wall -Wextra -Wpedantic)
-endif()
+find_package(autoware_cmake REQUIRED)
+autoware_package()
 
 find_package(PCL REQUIRED COMPONENTS io)
-
-find_package(ament_cmake_auto REQUIRED)
-ament_auto_find_build_dependencies()
 
 ament_auto_add_library(elevation_map_loader_node SHARED
   src/elevation_map_loader_node.cpp
@@ -25,11 +15,6 @@ rclcpp_components_register_node(elevation_map_loader_node
   PLUGIN "ElevationMapLoaderNode"
   EXECUTABLE elevation_map_loader
 )
-
-if(BUILD_TESTING)
-  find_package(ament_lint_auto REQUIRED)
-  ament_lint_auto_find_test_dependencies()
-endif()
 
 ament_auto_package(INSTALL_TO_SHARE
   launch

--- a/perception/elevation_map_loader/package.xml
+++ b/perception/elevation_map_loader/package.xml
@@ -7,9 +7,8 @@
   <maintainer email="taichi.higashide@tier4.jp">Taichi Higashide</maintainer>
   <license>Apache License 2.0</license>
 
-  <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
-
+  <build_depend>autoware_cmake</build_depend>
   <depend>autoware_auto_mapping_msgs</depend>
   <depend>grid_map_cv</depend>
   <depend>grid_map_pcl</depend>

--- a/perception/ground_segmentation/CMakeLists.txt
+++ b/perception/ground_segmentation/CMakeLists.txt
@@ -1,34 +1,15 @@
 cmake_minimum_required(VERSION 3.5)
 project(ground_segmentation)
 
-### Compile options
-if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 14)
-  set(CMAKE_CXX_STANDARD_REQUIRED ON)
-  set(CMAKE_CXX_EXTENSIONS OFF)
-endif()
-if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  add_compile_options(-Wall -Wextra -Wpedantic -Werror)
-endif()
+find_package(autoware_cmake REQUIRED)
+autoware_package()
 
-# Ignore PCL errors in Clang
-if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  add_compile_options(-Wno-gnu-anonymous-struct -Wno-nested-anon-types)
-endif()
-
-find_package(ament_cmake_auto REQUIRED)
 find_package(OpenCV REQUIRED)
 find_package(Eigen3 REQUIRED)
 find_package(Boost REQUIRED)
 find_package(PCL REQUIRED)
 find_package(pcl_conversions REQUIRED)
 find_package(OpenMP)
-ament_auto_find_build_dependencies()
-
-
-###########
-## Build ##
-###########
 
 include_directories(
   include
@@ -74,15 +55,6 @@ rclcpp_components_register_node(ground_segmentation
 rclcpp_components_register_node(ground_segmentation
   PLUGIN "ground_segmentation::ScanGroundFilterComponent"
   EXECUTABLE scan_ground_filter_node)
-
-if(BUILD_TESTING)
-  find_package(ament_lint_auto REQUIRED)
-  ament_lint_auto_find_test_dependencies()
-endif()
-
-#############
-## Install ##
-#############
 
 ament_auto_package(INSTALL_TO_SHARE
   launch

--- a/perception/ground_segmentation/package.xml
+++ b/perception/ground_segmentation/package.xml
@@ -16,6 +16,7 @@
   <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
+  <build_depend>autoware_cmake</build_depend>
 
   <depend>libopencv-dev</depend>
   <depend>pcl_conversions</depend>

--- a/perception/occupancy_grid_map_outlier_filter/CMakeLists.txt
+++ b/perception/occupancy_grid_map_outlier_filter/CMakeLists.txt
@@ -1,22 +1,9 @@
 cmake_minimum_required(VERSION 3.5)
 project(occupancy_grid_map_outlier_filter)
 
-### Compile options
-if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 14)
-  set(CMAKE_CXX_STANDARD_REQUIRED ON)
-  set(CMAKE_CXX_EXTENSIONS OFF)
-endif()
-if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  add_compile_options(-Wall -Wextra -Wpedantic -Werror)
-endif()
+find_package(autoware_cmake REQUIRED)
+autoware_package()
 
-# Ignore PCL errors in Clang
-if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  add_compile_options(-Wno-gnu-anonymous-struct -Wno-nested-anon-types)
-endif()
-
-find_package(ament_cmake_auto REQUIRED)
 find_package(OpenCV REQUIRED)
 find_package(Eigen3 REQUIRED)
 find_package(Boost REQUIRED)
@@ -24,11 +11,6 @@ find_package(PCL REQUIRED)
 find_package(pcl_conversions REQUIRED)
 find_package(OpenMP)
 ament_auto_find_build_dependencies()
-
-
-###########
-## Build ##
-###########
 
 include_directories(
   include
@@ -62,15 +44,5 @@ endif()
 rclcpp_components_register_node(occupancy_grid_map_outlier_filter
   PLUGIN "occupancy_grid_map_outlier_filter::OccupancyGridMapOutlierFilterComponent"
   EXECUTABLE occupancy_grid_map_outlier_filter_node)
-
-
-if(BUILD_TESTING)
-  find_package(ament_lint_auto REQUIRED)
-  ament_lint_auto_find_test_dependencies()
-endif()
-
-#############
-## Install ##
-#############
 
 ament_auto_package(INSTALL_TO_SHARE)

--- a/perception/occupancy_grid_map_outlier_filter/package.xml
+++ b/perception/occupancy_grid_map_outlier_filter/package.xml
@@ -16,6 +16,7 @@
   <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
+  <build_depend>autoware_cmake</build_depend>
 
   <depend>autoware_auto_vehicle_msgs</depend>
   <depend>diagnostic_updater</depend>

--- a/perception/shape_estimation/CMakeLists.txt
+++ b/perception/shape_estimation/CMakeLists.txt
@@ -1,17 +1,8 @@
 cmake_minimum_required(VERSION 3.5)
 project(shape_estimation)
 
-if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 14)
-  set(CMAKE_CXX_STANDARD_REQUIRED ON)
-  set(CMAKE_CXX_EXTENSIONS OFF)
-endif()
-if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  add_compile_options(-Wall -Wextra -Wpedantic -Werror)
-endif()
-
-find_package(ament_cmake_auto REQUIRED)
-ament_auto_find_build_dependencies()
+find_package(autoware_cmake REQUIRED)
+autoware_package()
 
 find_package(PCL REQUIRED COMPONENTS common)
 find_package(pcl_conversions REQUIRED)
@@ -72,11 +63,6 @@ rclcpp_components_register_node(shape_estimation_node
   PLUGIN "ShapeEstimationNode"
   EXECUTABLE shape_estimation
 )
-
-if(BUILD_TESTING)
-  find_package(ament_lint_auto REQUIRED)
-  ament_lint_auto_find_test_dependencies()
-endif()
 
 ament_auto_package(INSTALL_TO_SHARE
   launch

--- a/perception/shape_estimation/package.xml
+++ b/perception/shape_estimation/package.xml
@@ -9,6 +9,7 @@
   <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
+  <build_depend>autoware_cmake</build_depend>
 
   <depend>autoware_auto_perception_msgs</depend>
   <depend>builtin_interfaces</depend>


### PR DESCRIPTION
## Description

https://github.com/autowarefoundation/autoware.universe/pull/849 からBoostのwarningが出ているパッケージだけを抜き出して適用

## Related Links
https://tier4.atlassian.net/browse/AEAP-488

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->


下記のコマンドでビルドしてperception以下のパッケージでBoostのwarningが出ないこと
```
colcon build --symlink-install --cmake-args -DCMAKE_BUILD_TYPE=Release --catkin-skip-building-tests --parallel-workers 8 --packages-up-to  $(colcon list --base-path src/autoware/universe/perception | awk '{print $1}')
```

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
