### PR TITLE
feat(planning): use autoware_cmake to avoid Boost warning

### DIFF
--- a/planning/behavior_path_planner/CMakeLists.txt
+++ b/planning/behavior_path_planner/CMakeLists.txt
@@ -1,17 +1,9 @@
 cmake_minimum_required(VERSION 3.5)
 project(behavior_path_planner)
 
-if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 14)
-  set(CMAKE_CXX_STANDARD_REQUIRED ON)
-  set(CMAKE_CXX_EXTENSIONS OFF)
-endif()
-if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  add_compile_options(-Wall -Wextra -Wpedantic -Werror)
-endif()
+find_package(autoware_cmake REQUIRED)
+autoware_package()
 
-find_package(ament_cmake_auto REQUIRED)
-ament_auto_find_build_dependencies()
 find_package(OpenCV REQUIRED)
 
 ament_auto_add_library(behavior_path_planner_node SHARED
@@ -46,8 +38,6 @@ rclcpp_components_register_node(behavior_path_planner_node
 )
 
 if(BUILD_TESTING)
-  find_package(ament_lint_auto REQUIRED)
-  ament_lint_auto_find_test_dependencies()
   ament_add_ros_isolated_gmock(test_${PROJECT_NAME}_utilities
     test/input.cpp
     test/test_utilities.cpp

--- a/planning/behavior_path_planner/package.xml
+++ b/planning/behavior_path_planner/package.xml
@@ -13,6 +13,7 @@
   <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
+  <build_depend>autoware_cmake</build_depend>
 
   <depend>autoware_auto_perception_msgs</depend>
   <depend>autoware_auto_planning_msgs</depend>

--- a/planning/behavior_velocity_planner/CMakeLists.txt
+++ b/planning/behavior_velocity_planner/CMakeLists.txt
@@ -1,26 +1,15 @@
 cmake_minimum_required(VERSION 3.5)
 project(behavior_velocity_planner)
 
-### Compile options
-if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 14)
-  set(CMAKE_CXX_STANDARD_REQUIRED ON)
-  set(CMAKE_CXX_EXTENSIONS OFF)
-endif()
-if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  add_compile_options(-Wall -Wextra -Wpedantic -Werror)
-endif()
+find_package(autoware_cmake REQUIRED)
+autoware_package()
 
 # Find the non-obvious packages manually
-find_package(ament_cmake REQUIRED)
 find_package(Boost REQUIRED)
 find_package(eigen3_cmake_module REQUIRED)
 find_package(Eigen3 REQUIRED)
 find_package(PCL REQUIRED COMPONENTS common)
 find_package(OpenCV REQUIRED)
-
-find_package(ament_cmake_auto REQUIRED)
-ament_auto_find_build_dependencies()
 
 set(BEHAVIOR_VELOCITY_PLANNER_DEPENDENCIES
   tier4_api_msgs
@@ -312,8 +301,6 @@ rclcpp_components_register_node(behavior_velocity_planner
 
 
 if(BUILD_TESTING)
-  find_package(ament_lint_auto REQUIRED)
-  ament_lint_auto_find_test_dependencies()
 
   # utils for test
   ament_auto_add_library(utilization SHARED

--- a/planning/behavior_velocity_planner/package.xml
+++ b/planning/behavior_velocity_planner/package.xml
@@ -10,6 +10,7 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>eigen3_cmake_module</buildtool_depend>
+  <build_depend>autoware_cmake</build_depend>
 
   <depend>autoware_auto_mapping_msgs</depend>
   <depend>autoware_auto_perception_msgs</depend>

--- a/planning/mission_planner/CMakeLists.txt
+++ b/planning/mission_planner/CMakeLists.txt
@@ -1,18 +1,8 @@
 cmake_minimum_required(VERSION 3.5)
 project(mission_planner)
 
-### Compile options
-if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 14)
-  set(CMAKE_CXX_STANDARD_REQUIRED ON)
-  set(CMAKE_CXX_EXTENSIONS OFF)
-endif()
-if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  add_compile_options(-Wall -Wextra -Wpedantic)
-endif()
-
-find_package(ament_cmake_auto REQUIRED)
-ament_auto_find_build_dependencies()
+find_package(autoware_cmake REQUIRED)
+autoware_package()
 
 ament_auto_add_library(mission_planner_node SHARED
   lib/mission_planner_base.cpp
@@ -33,11 +23,6 @@ rclcpp_components_register_node(goal_pose_visualizer_node
   PLUGIN "mission_planner::GoalPoseVisualizer"
   EXECUTABLE goal_pose_visualizer
 )
-
-if(BUILD_TESTING)
-  find_package(ament_lint_auto REQUIRED)
-  ament_lint_auto_find_test_dependencies()
-endif()
 
 ament_auto_package(INSTALL_TO_SHARE
   launch

--- a/planning/mission_planner/package.xml
+++ b/planning/mission_planner/package.xml
@@ -9,6 +9,7 @@
   <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
+  <build_depend>autoware_cmake</build_depend>
 
   <depend>autoware_auto_planning_msgs</depend>
   <depend>geometry_msgs</depend>

--- a/planning/obstacle_avoidance_planner/CMakeLists.txt
+++ b/planning/obstacle_avoidance_planner/CMakeLists.txt
@@ -1,17 +1,8 @@
 cmake_minimum_required(VERSION 3.5)
 project(obstacle_avoidance_planner)
 
-if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 14)
-  set(CMAKE_CXX_STANDARD_REQUIRED ON)
-  set(CMAKE_CXX_EXTENSIONS OFF)
-endif()
-if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  add_compile_options(-Wall -Wextra -Wpedantic -Werror)
-endif()
-
-find_package(ament_cmake_auto REQUIRED)
-ament_auto_find_build_dependencies()
+find_package(autoware_cmake REQUIRED)
+autoware_package()
 
 find_package(Eigen3 REQUIRED)
 find_package(OpenCV REQUIRED)
@@ -41,11 +32,6 @@ rclcpp_components_register_node(obstacle_avoidance_planner
   PLUGIN "ObstacleAvoidancePlanner"
   EXECUTABLE obstacle_avoidance_planner_node
 )
-
-if(BUILD_TESTING)
-  find_package(ament_lint_auto REQUIRED)
-  ament_lint_auto_find_test_dependencies()
-endif()
 
 ament_auto_package(
   INSTALL_TO_SHARE

--- a/planning/obstacle_avoidance_planner/package.xml
+++ b/planning/obstacle_avoidance_planner/package.xml
@@ -9,6 +9,7 @@
   <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
+  <build_depend>autoware_cmake</build_depend>
 
   <depend>autoware_auto_perception_msgs</depend>
   <depend>autoware_auto_planning_msgs</depend>

--- a/planning/obstacle_stop_planner/CMakeLists.txt
+++ b/planning/obstacle_stop_planner/CMakeLists.txt
@@ -1,17 +1,8 @@
 cmake_minimum_required(VERSION 3.5)
 project(obstacle_stop_planner)
 
-if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 14)
-  set(CMAKE_CXX_STANDARD_REQUIRED ON)
-  set(CMAKE_CXX_EXTENSIONS OFF)
-endif()
-if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  add_compile_options(-Wall -Wextra -Wpedantic -Werror)
-endif()
-
-find_package(ament_cmake_auto REQUIRED)
-ament_auto_find_build_dependencies()
+find_package(autoware_cmake REQUIRED)
+autoware_package()
 
 find_package(Eigen3 REQUIRED)
 find_package(OpenCV REQUIRED)
@@ -38,11 +29,6 @@ rclcpp_components_register_node(obstacle_stop_planner
   PLUGIN "motion_planning::ObstacleStopPlannerNode"
   EXECUTABLE obstacle_stop_planner_node
 )
-
-if(BUILD_TESTING)
-  find_package(ament_lint_auto REQUIRED)
-  ament_lint_auto_find_test_dependencies()
-endif()
 
 ament_auto_package(
   INSTALL_TO_SHARE

--- a/planning/obstacle_stop_planner/package.xml
+++ b/planning/obstacle_stop_planner/package.xml
@@ -9,6 +9,7 @@
   <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
+  <build_depend>autoware_cmake</build_depend>
 
   <depend>autoware_auto_perception_msgs</depend>
   <depend>autoware_auto_planning_msgs</depend>

--- a/planning/planning_error_monitor/CMakeLists.txt
+++ b/planning/planning_error_monitor/CMakeLists.txt
@@ -1,17 +1,8 @@
 cmake_minimum_required(VERSION 3.5)
 project(planning_error_monitor)
 
-if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 14)
-  set(CMAKE_CXX_STANDARD_REQUIRED ON)
-  set(CMAKE_CXX_EXTENSIONS OFF)
-endif()
-if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  add_compile_options(-Wall -Wextra -Wpedantic)
-endif()
-
-find_package(ament_cmake_auto REQUIRED)
-ament_auto_find_build_dependencies()
+find_package(autoware_cmake REQUIRED)
+autoware_package()
 
 ament_auto_add_library(planning_error_monitor_node SHARED
   src/planning_error_monitor_node.cpp
@@ -31,8 +22,6 @@ rclcpp_components_register_node(invalid_trajectory_publisher_node
 )
 
 if(BUILD_TESTING)
-  find_package(ament_lint_auto REQUIRED)
-  ament_lint_auto_find_test_dependencies()
   ament_add_gtest(test_planning_error_monitor
     test/src/test_main.cpp
     test/src/test_planning_error_monitor_functions.cpp

--- a/planning/planning_error_monitor/package.xml
+++ b/planning/planning_error_monitor/package.xml
@@ -9,6 +9,7 @@
   <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
+  <build_depend>autoware_cmake</build_depend>
 
   <depend>autoware_auto_planning_msgs</depend>
   <depend>diagnostic_updater</depend>

--- a/planning/route_handler/CMakeLists.txt
+++ b/planning/route_handler/CMakeLists.txt
@@ -1,25 +1,11 @@
 cmake_minimum_required(VERSION 3.5)
 project(route_handler)
 
-### Compile options
-if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 17)
-endif()
-if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  add_compile_options(-Wall -Wextra -Wpedantic -Werror)
-endif()
-
-find_package(ament_cmake_auto REQUIRED)
-ament_auto_find_build_dependencies()
+find_package(autoware_cmake REQUIRED)
+autoware_package()
 
 ament_auto_add_library(route_handler SHARED
   src/route_handler.cpp
 )
-
-# Test
-if(BUILD_TESTING)
-  find_package(ament_lint_auto REQUIRED)
-  ament_lint_auto_find_test_dependencies()
-endif()
 
 ament_auto_package()

--- a/planning/route_handler/package.xml
+++ b/planning/route_handler/package.xml
@@ -7,6 +7,7 @@
   <maintainer email="fumiya.watanabe@tier4.jp">Fumiya Watanabe</maintainer>
   <license>Apache License 2.0</license>
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
+  <build_depend>autoware_cmake</build_depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>autoware_lint_common</test_depend>

--- a/planning/scenario_selector/CMakeLists.txt
+++ b/planning/scenario_selector/CMakeLists.txt
@@ -1,19 +1,8 @@
 cmake_minimum_required(VERSION 3.5)
 project(scenario_selector)
 
-### Compile options
-if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 14)
-  set(CMAKE_CXX_STANDARD_REQUIRED ON)
-  set(CMAKE_CXX_EXTENSIONS OFF)
-endif()
-if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  add_compile_options(-Wall -Wextra -Wpedantic)
-endif()
-
-## Dependencies
-find_package(ament_cmake_auto REQUIRED)
-ament_auto_find_build_dependencies()
+find_package(autoware_cmake REQUIRED)
+autoware_package()
 
 # Target
 
@@ -31,11 +20,6 @@ rclcpp_components_register_node(scenario_selector_node
   PLUGIN "ScenarioSelectorNode"
   EXECUTABLE scenario_selector
 )
-
-if(BUILD_TESTING)
-  find_package(ament_lint_auto REQUIRED)
-  ament_lint_auto_find_test_dependencies()
-endif()
 
 ament_auto_package(INSTALL_TO_SHARE
   launch

--- a/planning/scenario_selector/package.xml
+++ b/planning/scenario_selector/package.xml
@@ -8,6 +8,7 @@
   <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
+  <build_depend>autoware_cmake</build_depend>
 
   <depend>autoware_auto_mapping_msgs</depend>
   <depend>autoware_auto_planning_msgs</depend>

--- a/planning/surround_obstacle_checker/CMakeLists.txt
+++ b/planning/surround_obstacle_checker/CMakeLists.txt
@@ -1,22 +1,12 @@
 cmake_minimum_required(VERSION 3.5)
 project(surround_obstacle_checker)
 
-### Compile options
-if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 14)
-  set(CMAKE_CXX_STANDARD_REQUIRED ON)
-  set(CMAKE_CXX_EXTENSIONS OFF)
-endif()
-if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  add_compile_options(-Wall -Wextra -Wpedantic)
-endif()
+find_package(autoware_cmake REQUIRED)
+autoware_package()
 
-find_package(ament_cmake REQUIRED)
 find_package(eigen3_cmake_module REQUIRED)
 find_package(Eigen3 REQUIRED)
 find_package(PCL REQUIRED COMPONENTS common)
-find_package(ament_cmake_auto REQUIRED)
-ament_auto_find_build_dependencies()
 
 ament_auto_add_library(${PROJECT_NAME} SHARED
   src/debug_marker.cpp
@@ -31,11 +21,6 @@ rclcpp_components_register_node(${PROJECT_NAME}
   PLUGIN "SurroundObstacleCheckerNode"
   EXECUTABLE ${PROJECT_NAME}_node
 )
-
-if(BUILD_TESTING)
-  find_package(ament_lint_auto REQUIRED)
-  ament_lint_auto_find_test_dependencies()
-endif()
 
 ament_auto_package(
   INSTALL_TO_SHARE

--- a/planning/surround_obstacle_checker/package.xml
+++ b/planning/surround_obstacle_checker/package.xml
@@ -11,6 +11,8 @@
 
   <buildtool_depend>ament_cmake</buildtool_depend>
   <buildtool_depend>eigen3_cmake_module</buildtool_depend>
+  <build_depend>autoware_cmake</build_depend>
+
   <depend>autoware_auto_perception_msgs</depend>
   <depend>autoware_auto_planning_msgs</depend>
   <depend>diagnostic_msgs</depend>


### PR DESCRIPTION
## Description

https://github.com/autowarefoundation/autoware.universe/pull/849 からBoostのwarningが出ているパッケージだけを抜き出して適用

## Related Links
https://tier4.atlassian.net/browse/AEAP-488

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->


下記のコマンドでビルドしてplanning以下のパッケージでBoostのwarningが出ないこと
```
colcon build --symlink-install --cmake-args -DCMAKE_BUILD_TYPE=Release --catkin-skip-building-tests --parallel-workers 8 --packages-up-to  $(colcon list --base-path src/autoware/universe/planning | awk '{print $1}')
```



## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
