### PR TITLE
fix(probablistic_occupancy_grid_map): fix build warning

### DIFF
--- a/sensing/probabilistic_occupancy_grid_map/src/laserscan_based_occupancy_grid_map/laserscan_based_occupancy_grid_map_node.cpp
+++ b/sensing/probabilistic_occupancy_grid_map/src/laserscan_based_occupancy_grid_map/laserscan_based_occupancy_grid_map_node.cpp
@@ -24,7 +24,7 @@
 
 #include <pcl/point_types.h>
 #include <pcl_conversions/pcl_conversions.h>
-#include <tf2_sensor_msgs/tf2_sensor_msgs.h>
+#include <tf2_sensor_msgs/tf2_sensor_msgs.hpp>
 
 #include <memory>
 #include <string>

--- a/sensing/probabilistic_occupancy_grid_map/src/laserscan_based_occupancy_grid_map/laserscan_based_occupancy_grid_map_node.cpp
+++ b/sensing/probabilistic_occupancy_grid_map/src/laserscan_based_occupancy_grid_map/laserscan_based_occupancy_grid_map_node.cpp
@@ -21,10 +21,10 @@
 #include <tier4_autoware_utils/tier4_autoware_utils.hpp>
 
 #include <nav_msgs/msg/occupancy_grid.hpp>
+#include <tf2_sensor_msgs/tf2_sensor_msgs.hpp>
 
 #include <pcl/point_types.h>
 #include <pcl_conversions/pcl_conversions.h>
-#include <tf2_sensor_msgs/tf2_sensor_msgs.hpp>
 
 #include <memory>
 #include <string>

--- a/sensing/probabilistic_occupancy_grid_map/src/pointcloud_based_occupancy_grid_map/occupancy_grid_map.cpp
+++ b/sensing/probabilistic_occupancy_grid_map/src/pointcloud_based_occupancy_grid_map/occupancy_grid_map.cpp
@@ -59,7 +59,7 @@
 
 #include <sensor_msgs/point_cloud2_iterator.hpp>
 
-#include <tf2_sensor_msgs/tf2_sensor_msgs.h>
+#include <tf2_sensor_msgs/tf2_sensor_msgs.hpp>
 
 #include <algorithm>
 namespace
@@ -158,7 +158,6 @@ void OccupancyGridMap::updateWithPointCloud(
   const PointCloud2 & raw_pointcloud, const PointCloud2 & obstacle_pointcloud,
   const Pose & robot_pose)
 {
-  constexpr double ep = 0.001;
   constexpr double min_angle = tier4_autoware_utils::deg2rad(-180.0);
   constexpr double max_angle = tier4_autoware_utils::deg2rad(180.0);
   constexpr double angle_increment = tier4_autoware_utils::deg2rad(0.1);
@@ -302,7 +301,6 @@ void OccupancyGridMap::updateWithPointCloud(
   for (size_t bin_index = 0; bin_index < obstacle_pointcloud_angle_bins.size(); ++bin_index) {
     auto & obstacle_pointcloud_angle_bin = obstacle_pointcloud_angle_bins.at(bin_index);
     auto & raw_pointcloud_angle_bin = raw_pointcloud_angle_bins.at(bin_index);
-    auto raw_distance_iter = raw_pointcloud_angle_bin.begin();
     for (size_t dist_index = 0; dist_index < obstacle_pointcloud_angle_bin.size(); ++dist_index) {
       const auto & source = obstacle_pointcloud_angle_bin.at(dist_index);
       setCellValue(source.wx, source.wy, occupancy_cost_value::LETHAL_OBSTACLE);

--- a/sensing/probabilistic_occupancy_grid_map/src/pointcloud_based_occupancy_grid_map/occupancy_grid_map.cpp
+++ b/sensing/probabilistic_occupancy_grid_map/src/pointcloud_based_occupancy_grid_map/occupancy_grid_map.cpp
@@ -299,7 +299,6 @@ void OccupancyGridMap::updateWithPointCloud(
   // Third step: Overwrite occupied cell
   for (size_t bin_index = 0; bin_index < obstacle_pointcloud_angle_bins.size(); ++bin_index) {
     auto & obstacle_pointcloud_angle_bin = obstacle_pointcloud_angle_bins.at(bin_index);
-    auto & raw_pointcloud_angle_bin = raw_pointcloud_angle_bins.at(bin_index);
     for (size_t dist_index = 0; dist_index < obstacle_pointcloud_angle_bin.size(); ++dist_index) {
       const auto & source = obstacle_pointcloud_angle_bin.at(dist_index);
       setCellValue(source.wx, source.wy, occupancy_cost_value::LETHAL_OBSTACLE);

--- a/sensing/probabilistic_occupancy_grid_map/src/pointcloud_based_occupancy_grid_map/occupancy_grid_map.cpp
+++ b/sensing/probabilistic_occupancy_grid_map/src/pointcloud_based_occupancy_grid_map/occupancy_grid_map.cpp
@@ -58,7 +58,6 @@
 #include <tier4_autoware_utils/tier4_autoware_utils.hpp>
 
 #include <sensor_msgs/point_cloud2_iterator.hpp>
-
 #include <tf2_sensor_msgs/tf2_sensor_msgs.hpp>
 
 #include <algorithm>

--- a/sensing/probabilistic_occupancy_grid_map/src/pointcloud_based_occupancy_grid_map/pointcloud_based_occupancy_grid_map_node.cpp
+++ b/sensing/probabilistic_occupancy_grid_map/src/pointcloud_based_occupancy_grid_map/pointcloud_based_occupancy_grid_map_node.cpp
@@ -24,7 +24,7 @@
 
 #include <pcl/point_types.h>
 #include <pcl_conversions/pcl_conversions.h>
-#include <tf2_sensor_msgs/tf2_sensor_msgs.h>
+#include <tf2_sensor_msgs/tf2_sensor_msgs.hpp>
 
 #include <memory>
 #include <string>

--- a/sensing/probabilistic_occupancy_grid_map/src/pointcloud_based_occupancy_grid_map/pointcloud_based_occupancy_grid_map_node.cpp
+++ b/sensing/probabilistic_occupancy_grid_map/src/pointcloud_based_occupancy_grid_map/pointcloud_based_occupancy_grid_map_node.cpp
@@ -21,10 +21,10 @@
 #include <tier4_autoware_utils/tier4_autoware_utils.hpp>
 
 #include <nav_msgs/msg/occupancy_grid.hpp>
+#include <tf2_sensor_msgs/tf2_sensor_msgs.hpp>
 
 #include <pcl/point_types.h>
 #include <pcl_conversions/pcl_conversions.h>
-#include <tf2_sensor_msgs/tf2_sensor_msgs.hpp>
 
 #include <memory>
 #include <string>


### PR DESCRIPTION
## Description

以下のwarningを修正
```
--- stderr: probabilistic_occupancy_grid_map                                                                                                         
** WARNING ** io features related to pcap will be disabled
In file included from /home/hrkota/pilot-auto.x1.eve/src/autoware/universe/sensing/probabilistic_occupancy_grid_map/src/pointcloud_based_occupancy_grid_map/occupancy_grid_map.cpp:62:
/opt/ros/humble/include/tf2_sensor_msgs/tf2_sensor_msgs.h:32:2: warning: #warning This header is obsolete, please include tf2_sensor_msgs/tf2_sensor_msgs.hpp instead [-Wcpp]
   32 | #warning This header is obsolete, please include tf2_sensor_msgs/tf2_sensor_msgs.hpp instead
      |  ^~~~~~~
In file included from /home/hrkota/pilot-auto.x1.eve/src/autoware/universe/sensing/probabilistic_occupancy_grid_map/src/pointcloud_based_occupancy_grid_map/pointcloud_based_occupancy_grid_map_node.cpp:27:
/opt/ros/humble/include/tf2_sensor_msgs/tf2_sensor_msgs.h:32:2: warning: #warning This header is obsolete, please include tf2_sensor_msgs/tf2_sensor_msgs.hpp instead [-Wcpp]
   32 | #warning This header is obsolete, please include tf2_sensor_msgs/tf2_sensor_msgs.hpp instead
/home/hrkota/pilot-auto.x1.eve/src/autoware/universe/sensing/probabilistic_occupancy_grid_map/src/pointcloud_based_occupancy_grid_map/occupancy_grid_map.cpp:305:10: warning: variable ‘raw_distance_iter’ set but not used [-Wunused-but-set-variable]
  305 |     auto raw_distance_iter = raw_pointcloud_angle_bin.begin();
      |          ^~~~~~~~~~~~~~~~~
/home/hrkota/pilot-auto.x1.eve/src/autoware/universe/sensing/probabilistic_occupancy_grid_map/src/pointcloud_based_occupancy_grid_map/occupancy_grid_map.cpp:161:20: warning: unused variable ‘ep’ [-Wunused-variable]
  161 |   constexpr double ep = 0.001;
      |                    ^~
In file included from /home/hrkota/pilot-auto.x1.eve/src/autoware/universe/sensing/probabilistic_occupancy_grid_map/src/laserscan_based_occupancy_grid_map/laserscan_based_occupancy_grid_map_node.cpp:27:
/opt/ros/humble/include/tf2_sensor_msgs/tf2_sensor_msgs.h:32:2: warning: #warning This header is obsolete, please include tf2_sensor_msgs/tf2_sensor_msgs.hpp instead [-Wcpp]
   32 | #warning This header is obsolete, please include tf2_sensor_msgs/tf2_sensor_msgs.hpp instead
      |  ^~~~~~~
/home/hrkota/pilot-auto.x1.eve/src/autoware/universe/sensing/probabilistic_occupancy_grid_map/src/pointcloud_based_occupancy_grid_map/occupancy_grid_map.cpp:303:12: warning: unused variable ‘raw_pointcloud_angle_bin’ [-Wunused-variable]
  303 |     auto & raw_pointcloud_angle_bin = raw_pointcloud_angle_bins.at(bin_index);
      |            ^~~~~~~~~~~~~~~~~~~~~~~~


```

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Description に記載のwarningが出ないこと

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
