### PR TITLE
feat(sensing): use autoware_cmake to avoid Boost warning

### DIFF
--- a/sensing/pointcloud_preprocessor/CMakeLists.txt
+++ b/sensing/pointcloud_preprocessor/CMakeLists.txt
@@ -1,34 +1,14 @@
 cmake_minimum_required(VERSION 3.5)
 project(pointcloud_preprocessor)
 
-### Compile options
-if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 14)
-  set(CMAKE_CXX_STANDARD_REQUIRED ON)
-  set(CMAKE_CXX_EXTENSIONS OFF)
-endif()
-if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  add_compile_options(-Wall -Wextra -Wpedantic -Werror)
-endif()
+find_package(autoware_cmake REQUIRED)
+autoware_package()
 
-# Ignore PCL errors in Clang
-if(CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  add_compile_options(-Wno-gnu-anonymous-struct -Wno-nested-anon-types)
-endif()
-
-find_package(ament_cmake_auto REQUIRED)
 find_package(OpenCV REQUIRED)
 find_package(Eigen3 REQUIRED)
 find_package(Boost REQUIRED)
 find_package(PCL REQUIRED)
-find_package(pcl_conversions REQUIRED)
 find_package(OpenMP)
-ament_auto_find_build_dependencies()
-
-
-###########
-## Build ##
-###########
 
 include_directories(
   include
@@ -154,15 +134,6 @@ rclcpp_components_register_node(pointcloud_preprocessor_filter
 rclcpp_components_register_node(pointcloud_preprocessor_filter
   PLUGIN "pointcloud_preprocessor::BlockageDiagComponent"
   EXECUTABLE blockage_diag_node)
-
-if(BUILD_TESTING)
-  find_package(ament_lint_auto REQUIRED)
-  ament_lint_auto_find_test_dependencies()
-endif()
-
-#############
-## Install ##
-#############
 
 ament_auto_package(INSTALL_TO_SHARE
   launch

--- a/sensing/pointcloud_preprocessor/package.xml
+++ b/sensing/pointcloud_preprocessor/package.xml
@@ -16,6 +16,7 @@
   <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
+  <build_depend>autoware_cmake</build_depend>
 
   <depend>autoware_auto_vehicle_msgs</depend>
   <depend>autoware_point_types</depend>

--- a/sensing/probabilistic_occupancy_grid_map/CMakeLists.txt
+++ b/sensing/probabilistic_occupancy_grid_map/CMakeLists.txt
@@ -1,20 +1,12 @@
 cmake_minimum_required(VERSION 3.5)
 project(probabilistic_occupancy_grid_map)
 
-if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 14)
-  set(CMAKE_CXX_STANDARD_REQUIRED ON)
-  set(CMAKE_CXX_EXTENSIONS OFF)
-endif()
-if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  add_compile_options(-Wall -Wextra -Wpedantic)
-endif()
+find_package(autoware_cmake REQUIRED)
+autoware_package()
 
-find_package(ament_cmake_auto REQUIRED)
 find_package(eigen3_cmake_module REQUIRED)
 find_package(Eigen3 REQUIRED)
 find_package(PCL REQUIRED)
-ament_auto_find_build_dependencies()
 
 # PointcloudBasedOccupancyGridMap
 ament_auto_add_library(pointcloud_based_occupancy_grid_map SHARED
@@ -47,16 +39,6 @@ rclcpp_components_register_node(laserscan_based_occupancy_grid_map
   PLUGIN "occupancy_grid_map::LaserscanBasedOccupancyGridMapNode"
   EXECUTABLE laserscan_based_occupancy_grid_map_node
 )
-
-
-if(BUILD_TESTING)
-  find_package(ament_lint_auto REQUIRED)
-  list(APPEND AMENT_LINT_AUTO_EXCLUDE
-    # To avoid conflicts between cpplint and uncrustify w.r.t. inclusion guards
-    ament_cmake_uncrustify
-  )
-  ament_lint_auto_find_test_dependencies()
-endif()
 
 ament_auto_package(
   INSTALL_TO_SHARE

--- a/sensing/probabilistic_occupancy_grid_map/package.xml
+++ b/sensing/probabilistic_occupancy_grid_map/package.xml
@@ -8,6 +8,7 @@
   <author email="yukihiro.saito@tier4.jp">Yukihiro Saito</author>
   <license>Apache License 2.0</license>
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
+  <build_depend>autoware_cmake</build_depend>
 
   <depend>eigen3_cmake_module</depend>
   <depend>laser_geometry</depend>


### PR DESCRIPTION
## Description

https://github.com/autowarefoundation/autoware.universe/pull/849 からBoostのwarningが出ているパッケージだけを抜き出して適用

## Related Links
https://tier4.atlassian.net/browse/AEAP-488

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->


下記のコマンドでビルドしてsensing以下のパッケージでBoostのwarningが出ないこと
```
colcon build --symlink-install --cmake-args -DCMAKE_BUILD_TYPE=Release --catkin-skip-building-tests --parallel-workers 8 --packages-up-to  $(colcon list --base-path src/autoware/universe/sensing | awk '{print $1}')
```


## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
