### PR TITLE
feat(system): use autoware_cmake to avoid Boost warning

### DIFF
--- a/system/system_monitor/CMakeLists.txt
+++ b/system/system_monitor/CMakeLists.txt
@@ -1,27 +1,13 @@
 cmake_minimum_required(VERSION 3.5)
 project(system_monitor)
 
-## Compile as C++14, supported in ROS Melodic and newer
-if(NOT CMAKE_CXX_STANDARD)
-  set(CMAKE_CXX_STANDARD 14)
-  set(CMAKE_CXX_STANDARD_REQUIRED ON)
-  set(CMAKE_CXX_EXTENSIONS OFF)
-endif()
-if(CMAKE_COMPILER_IS_GNUCXX OR CMAKE_CXX_COMPILER_ID MATCHES "Clang")
-  add_compile_options(-Wall -Wextra -Wpedantic -Werror -Wno-stringop-truncation)
-endif()
-
-find_package(ament_cmake_auto REQUIRED)
-ament_auto_find_build_dependencies()
+find_package(autoware_cmake REQUIRED)
+autoware_package()
 
 set(CMAKE_MODULE_PATH ${CMAKE_MODULE_PATH} "${CMAKE_CURRENT_SOURCE_DIR}/cmake")
 find_package(NVML)
 find_package(fmt REQUIRED)
 set(LIBRARIES fmt)
-
-###########
-## Build ##
-###########
 
 ## Specify additional locations of header files
 
@@ -191,8 +177,6 @@ rclcpp_components_register_node(gpu_monitor_lib
 
 # TODO(yunus.caliskan): Port the tests to ROS2, robustify the tests.
 if(BUILD_TESTING)
-  find_package(ament_lint_auto REQUIRED)
-  ament_lint_auto_find_test_dependencies()
 
   # ament_add_gtest(test_cpu_monitor
   #   test/src/cpu_monitor/test_${CMAKE_CPU_PLATFORM}_cpu_monitor.cpp
@@ -309,10 +293,6 @@ if(BUILD_TESTING)
   # target_link_libraries(test_gpu_monitor ${GPU_LIBRARY} ${LIBRARIES})
 
 endif()
-
-#############
-## Install ##
-#############
 
 ament_auto_package(INSTALL_TO_SHARE
   launch

--- a/system/system_monitor/package.xml
+++ b/system/system_monitor/package.xml
@@ -9,7 +9,7 @@
   <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
-
+  <build_depend>autoware_cmake</build_depend>
   <depend>diagnostic_msgs</depend>
   <depend>diagnostic_updater</depend>
   <depend>fmt</depend>

--- a/system/system_monitor/reader/hdd_reader/hdd_reader.cpp
+++ b/system/system_monitor/reader/hdd_reader/hdd_reader.cpp
@@ -159,7 +159,7 @@ void usage()
 
 /**
  * @brief exchanges the values of 2 bytes
- * @param [inout] ptr a pointer to ATA string
+ * @param [inout] str a string reference to ATA string
  * @param [in] size size of ATA string
  * @note Each pair of bytes in an ATA string is swapped.
  * FIRMWARE REVISION field example
@@ -170,10 +170,10 @@ void usage()
  * 26   6720h (" g")
  * -> "abcdefg "
  */
-void swap_char(char * ptr, size_t size)
+void swap_char(std::string & str, size_t size)
 {
   for (auto i = 0U; i < size; i += 2U) {
-    std::swap(ptr[i], ptr[i + 1]);
+    std::swap(str[i], str[i + 1]);
   }
 }
 
@@ -219,17 +219,13 @@ int get_ata_identify(int fd, HDDInfo * info)
 
   // IDENTIFY DEVICE
   // Word 10..19 Serial number
-  char serial_number[20 + 1]{};
-  strncpy(serial_number, reinterpret_cast<char *>(data) + 20, 20);
-  swap_char(serial_number, 20);
-  info->serial_ = serial_number;
+  info->serial_ = std::string(reinterpret_cast<char *>(data) + 20, 20);
+  swap_char(info->serial_, 20);
   boost::trim(info->serial_);
 
   // Word 27..46 Model number
-  char model_number[40 + 1]{};
-  strncpy(model_number, reinterpret_cast<char *>(data) + 54, 40);
-  swap_char(model_number, 40);
-  info->model_ = model_number;
+  info->model_ = std::string(reinterpret_cast<char *>(data) + 54, 40);
+  swap_char(info->model_, 40);
   boost::trim(info->model_);
 
   return EXIT_SUCCESS;
@@ -338,15 +334,11 @@ int get_nvme_identify(int fd, HDDInfo * info)
 
   // Identify Controller Data Structure
   // Bytes 23:04 Serial Number (SN)
-  char serial_number[20 + 1]{};
-  strncpy(serial_number, data + 4, 20);
-  info->serial_ = serial_number;
+  info->serial_ = std::string(data + 4, 20);
   boost::trim(info->serial_);
 
   // Bytes 63:24 Model Number (MN)
-  char model_number[40 + 1]{};
-  strncpy(model_number, data + 24, 40);
-  info->model_ = model_number;
+  info->model_ = std::string(data + 24, 40);
   boost::trim(info->model_);
 
   return EXIT_SUCCESS;


### PR DESCRIPTION
## Description

- https://github.com/autowarefoundation/autoware.universe/pull/849 からBoostのwarningが出ているパッケージだけを抜き出して適用
- https://github.com/autowarefoundation/autoware.universe/pull/872 のbackport

## Related Links
https://tier4.atlassian.net/browse/AEAP-488

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->


下記のコマンドでビルドしてsystem以下のパッケージでBoostのwarningが出ないこと
```
colcon build --symlink-install --cmake-args -DCMAKE_BUILD_TYPE=Release --catkin-skip-building-tests --parallel-workers 8 --packages-up-to  $(colcon list --base-path src/autoware/universe/system | awk '{print $1}')
```


## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
