### PR TITLE
feat(lane_change): lane change virtual wall marker (#3808)

### DIFF
--- a/planning/behavior_path_planner/include/behavior_path_planner/marker_util/lane_change/debug.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/marker_util/lane_change/debug.hpp
@@ -39,5 +39,8 @@ MarkerArray showPolygon(
   const std::unordered_map<std::string, CollisionCheckDebug> & obj_debug_vec, std::string && ns);
 MarkerArray showPolygonPose(
   const std::unordered_map<std::string, CollisionCheckDebug> & obj_debug_vec, std::string && ns);
+MarkerArray createLaneChangingVirtualWallMarker(
+  const geometry_msgs::msg::Pose & lane_changing_pose, const std::string & module_name,
+  const rclcpp::Time & now, const std::string & ns);
 }  // namespace marker_utils::lane_change_markers
 #endif  // BEHAVIOR_PATH_PLANNER__MARKER_UTIL__LANE_CHANGE__DEBUG_HPP_

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/interface.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/interface.hpp
@@ -91,6 +91,8 @@ public:
 
   void setData(const std::shared_ptr<const PlannerData> & data) override;
 
+  MarkerArray getModuleVirtualWall() override;
+
 protected:
   std::shared_ptr<LaneChangeParameters> parameters_;
 
@@ -105,6 +107,7 @@ protected:
   void updateSteeringFactorPtr(
     const CandidateOutput & output, const LaneChangePath & selected_path) const;
 
+  mutable MarkerArray virtual_wall_marker_;
   mutable LaneChangeDebugMsgArray lane_change_debug_msg_array_;
 
   std::unique_ptr<PathWithLaneId> prev_approved_path_;

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/scene_module_interface.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/scene_module_interface.hpp
@@ -25,11 +25,13 @@
 #include <rclcpp/rclcpp.hpp>
 #include <route_handler/route_handler.hpp>
 #include <rtc_interface/rtc_interface.hpp>
+#include <tier4_autoware_utils/ros/marker_helper.hpp>
 
 #include <autoware_adapi_v1_msgs/msg/steering_factor_array.hpp>
 #include <autoware_auto_planning_msgs/msg/path_with_lane_id.hpp>
 #include <tier4_planning_msgs/msg/avoidance_debug_msg_array.hpp>
 #include <unique_identifier_msgs/msg/uuid.hpp>
+#include <visualization_msgs/msg/detail/marker_array__struct.hpp>
 
 #include <algorithm>
 #include <limits>
@@ -311,6 +313,9 @@ public:
       appendMarkerArray(virtual_wall, &markers);
     }
 
+    const auto module_specific_wall = getModuleVirtualWall();
+    appendMarkerArray(module_specific_wall, &markers);
+
     pub_virtual_wall_->publish(markers);
 
     resetWallPoses();
@@ -332,6 +337,8 @@ public:
   MarkerArray getInfoMarkers() const { return info_marker_; }
 
   MarkerArray getDebugMarkers() const { return debug_marker_; }
+
+  virtual MarkerArray getModuleVirtualWall() { return MarkerArray(); }
 
   ModuleStatus getCurrentStatus() const { return current_state_; }
 

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/scene_module_manager_interface.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/scene_module_manager_interface.hpp
@@ -153,6 +153,9 @@ public:
         appendMarkerArray(virtual_wall, &markers);
       }
 
+      const auto module_specific_wall = m->getModuleVirtualWall();
+      appendMarkerArray(module_specific_wall, &markers);
+
       m->resetWallPoses();
     }
 

--- a/planning/behavior_path_planner/include/behavior_path_planner/utils/lane_change/lane_change_path.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utils/lane_change/lane_change_path.hpp
@@ -32,6 +32,8 @@ struct LaneChangePath
   PathWithLaneId path{};
   lanelet::ConstLanelets reference_lanelets{};
   lanelet::ConstLanelets target_lanelets{};
+  Pose lane_changing_start{};
+  Pose lane_changing_end{};
   ShiftedPath shifted_path{};
   ShiftLine shift_line{};
   double acceleration{0.0};

--- a/planning/behavior_path_planner/src/marker_util/lane_change/debug.cpp
+++ b/planning/behavior_path_planner/src/marker_util/lane_change/debug.cpp
@@ -19,7 +19,9 @@
 
 #include <autoware_auto_perception_msgs/msg/predicted_objects.hpp>
 #include <autoware_auto_planning_msgs/msg/path_with_lane_id.hpp>
+#include <visualization_msgs/msg/detail/marker__struct.hpp>
 
+#include <cstdint>
 #include <cstdlib>
 #include <iomanip>
 #include <string>
@@ -235,4 +237,34 @@ MarkerArray showPolygonPose(
 
   return marker_array;
 }
+
+MarkerArray createLaneChangingVirtualWallMarker(
+  const geometry_msgs::msg::Pose & lane_changing_pose, const std::string & module_name,
+  const rclcpp::Time & now, const std::string & ns)
+{
+  int32_t id{0};
+  MarkerArray marker_array{};
+  marker_array.markers.reserve(2);
+  {
+    auto wall_marker = createDefaultMarker(
+      "map", now, ns + "virtual_wall", id, visualization_msgs::msg::Marker::CUBE,
+      createMarkerScale(0.1, 5.0, 2.0), createMarkerColor(0.0, 1.0, 0.0, 0.5));
+    wall_marker.pose = lane_changing_pose;
+    wall_marker.pose.position.z += 1.0;
+    marker_array.markers.push_back(wall_marker);
+  }
+
+  {
+    auto text_marker = createDefaultMarker(
+      "map", now, ns + "_text", id, visualization_msgs::msg::Marker::TEXT_VIEW_FACING,
+      createMarkerScale(0.0, 0.0, 1.0), createMarkerColor(1.0, 1.0, 1.0, 1.0));
+    text_marker.pose = lane_changing_pose;
+    text_marker.pose.position.z += 2.0;
+    text_marker.text = module_name;
+    marker_array.markers.push_back(text_marker);
+  }
+
+  return marker_array;
+}
+
 }  // namespace marker_utils::lane_change_markers

--- a/planning/behavior_path_planner/src/scene_module/lane_change/interface.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/interface.cpp
@@ -14,10 +14,14 @@
 
 #include "behavior_path_planner/scene_module/lane_change/interface.hpp"
 
+#include "behavior_path_planner/marker_util/lane_change/debug.hpp"
 #include "behavior_path_planner/module_status.hpp"
+#include "behavior_path_planner/scene_module/scene_module_interface.hpp"
 #include "behavior_path_planner/scene_module/scene_module_visitor.hpp"
 #include "behavior_path_planner/utils/lane_change/utils.hpp"
 #include "behavior_path_planner/utils/path_utils.hpp"
+
+#include <tier4_autoware_utils/ros/marker_helper.hpp>
 
 #include <algorithm>
 #include <limits>
@@ -313,6 +317,26 @@ std::shared_ptr<LaneChangeDebugMsgArray> LaneChangeInterface::get_debug_msg_arra
 
   lane_change_debug_msg_array_.header.stamp = clock_->now();
   return std::make_shared<LaneChangeDebugMsgArray>(lane_change_debug_msg_array_);
+}
+
+MarkerArray LaneChangeInterface::getModuleVirtualWall()
+{
+  using marker_utils::lane_change_markers::createLaneChangingVirtualWallMarker;
+  MarkerArray marker;
+  if (isWaitingApproval() || current_state_ != ModuleStatus::RUNNING) {
+    return marker;
+  }
+  const auto & start_pose = module_type_->getLaneChangePath().lane_changing_start;
+  const auto start_marker =
+    createLaneChangingVirtualWallMarker(start_pose, name(), clock_->now(), "lane_change_start");
+
+  const auto & end_pose = module_type_->getLaneChangePath().lane_changing_end;
+  const auto end_marker =
+    createLaneChangingVirtualWallMarker(end_pose, name(), clock_->now(), "lane_change_end");
+  marker.markers.reserve(start_marker.markers.size() + end_marker.markers.size());
+  appendMarkerArray(start_marker, &marker);
+  appendMarkerArray(end_marker, &marker);
+  return marker;
 }
 
 void LaneChangeInterface::updateSteeringFactorPtr(const BehaviorModuleOutput & output)

--- a/planning/behavior_path_planner/src/utils/lane_change/utils.cpp
+++ b/planning/behavior_path_planner/src/utils/lane_change/utils.cpp
@@ -152,10 +152,10 @@ std::optional<LaneChangePath> constructCandidatePath(
     "prepare_length: %f, lane_change: %f", prepare_length, lane_changing_length);
 
   const PathPointWithLaneId & lane_changing_start_point = prepare_segment.points.back();
-  const PathPointWithLaneId & lane_changing_end_point = target_segment.points.front();
-  const Pose & lane_changing_end_pose = lane_changing_end_point.point.pose;
+  candidate_path.lane_changing_start = prepare_segment.points.back().point.pose;
+  candidate_path.lane_changing_end = target_segment.points.front().point.pose;
   const auto lane_change_end_idx =
-    motion_utils::findNearestIndex(shifted_path.path.points, lane_changing_end_pose);
+    motion_utils::findNearestIndex(shifted_path.path.points, candidate_path.lane_changing_end);
 
   if (!lane_change_end_idx) {
     RCLCPP_ERROR_STREAM(


### PR DESCRIPTION
* feat(lane_change): lane change virtual wall marker



* virtual wall new architecture



---------

## Description

cherry pick from https://github.com/autowarefoundation/autoware.universe/pull/3808 to `beta/v0.8.0`

With the addition of https://github.com/autowarefoundation/autoware.universe/pull/3566, the flow of lane change states has been changed, and lane changing process will only be cancelled if ego vehicle **is in prepare phase**. 

However, it is difficult to distinguish prepare phase and lane changing phase. Therefore, the aim of this PR is to add virtual marker that will enable see where lane changing is starting.

After PR is merged, we expect the result to be as follows.

![Screenshot from 2023-05-24 14-50-55](https://github.com/autowarefoundation/autoware.universe/assets/93502286/c3bd4337-48c9-41bf-9f4e-c23ee9295027)

![Screenshot from 2023-05-24 14-51-41](https://github.com/autowarefoundation/autoware.universe/assets/93502286/265b6d50-eb20-4be6-9bcc-ff2d917eeb63)

## Related links

https://github.com/autowarefoundation/autoware.universe/pull/3808

## Tests performed

Tested via PSIM

## Notes for reviewers

None

## Interface changes

None

## Effects on system behavior

None

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
