### PR TITLE
fix(autonomous_emergency_braking): add doTransform to fix undefined symbol

### DIFF
--- a/control/autonomous_emergency_braking/src/node.cpp
+++ b/control/autonomous_emergency_braking/src/node.cpp
@@ -55,6 +55,29 @@ inline void doTransform(
   t_out.y = v_out[1];
   t_out.z = v_out[2];
 }
+
+template<>
+inline
+void doTransform(
+  const geometry_msgs::msg::Vector3 & t_in,
+  geometry_msgs::msg::Vector3 & t_out,
+  const geometry_msgs::msg::TransformStamped & transform)
+{
+  KDL::Vector v_out = gmTransformToKDL(transform).M * KDL::Vector(t_in.x, t_in.y, t_in.z);
+  t_out.x = v_out[0];
+  t_out.y = v_out[1];
+  t_out.z = v_out[2];
+}
+
+inline
+geometry_msgs::msg::Vector3 toMsg(const tf2::Vector3 & in)
+{
+  geometry_msgs::msg::Vector3 out;
+  out.x = in.getX();
+  out.y = in.getY();
+  out.z = in.getZ();
+  return out;
+}
 }  // namespace tf2
 namespace autoware::motion::control::autonomous_emergency_braking
 {

--- a/control/autonomous_emergency_braking/src/node.cpp
+++ b/control/autonomous_emergency_braking/src/node.cpp
@@ -56,11 +56,9 @@ inline void doTransform(
   t_out.z = v_out[2];
 }
 
-template<>
-inline
-void doTransform(
-  const geometry_msgs::msg::Vector3 & t_in,
-  geometry_msgs::msg::Vector3 & t_out,
+template <>
+inline void doTransform(
+  const geometry_msgs::msg::Vector3 & t_in, geometry_msgs::msg::Vector3 & t_out,
   const geometry_msgs::msg::TransformStamped & transform)
 {
   KDL::Vector v_out = gmTransformToKDL(transform).M * KDL::Vector(t_in.x, t_in.y, t_in.z);
@@ -69,8 +67,7 @@ void doTransform(
   t_out.z = v_out[2];
 }
 
-inline
-geometry_msgs::msg::Vector3 toMsg(const tf2::Vector3 & in)
+inline geometry_msgs::msg::Vector3 toMsg(const tf2::Vector3 & in)
 {
   geometry_msgs::msg::Vector3 out;
   out.x = in.getX();


### PR DESCRIPTION
## Description
現在のAEB実装でgalactic環境で動かすと以下のエラーが発生してしまう
```
[component_container-10] /opt/ros/galactic/lib/rclcpp_components/component_container: symbol lookup error: /home/hrkota/pilot-auto.x1.eva/install/autonomous_emergency_braking/lib/libautonomous_emergency_braking_node.so: undefined symbol: _ZN3tf211doTransformIN13geometry_msgs3msg8Vector3_ISaIvEEEEEvRKT_RS6_RKNS2_17TransformStamped_IS4_EE
[INFO] [launch_ros.actions.load_composable_nodes]: Loaded node '/control/trajectory_follower/lane_departure_checker_node' in container '/control/control_container'
[ERROR] [component_container-10]: process has died [pid 28558, exit code 127, cmd '/opt/ros/galactic/lib/rclcpp_components/component_container --ros-args -r __node:=control_container -r __ns:=/control --params-file /tmp/launch_params_ns5yss68'].
```
これは、この関数がHumbleのtf2_geometry_msgs.hppにしか記述されていないために起きる問題
https://github.com/ros2/geometry2/blob/humble/tf2_geometry_msgs/include/tf2_geometry_msgs/tf2_geometry_msgs.hpp#L78-L126
なお、galacticのtf2_geometry_msgs.hは以下
https://github.com/ros2/geometry2/blob/galactic/tf2_geometry_msgs/include/tf2_geometry_msgs/tf2_geometry_msgs.h

これを修正するために、明示的に関数を移植する


## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

https://tier4.atlassian.net/browse/AEAP-557

## Tests performed

以下のrosbagとコマンドを用いて、galactic環境にてAEBが生成する軌道が確認できること

### rosbag
https://drive.google.com/drive/folders/1awJP2EH7RRk1WEsX6LFpriTWDKdAr2jC

### コマンド
```
$ ros2 launch autoware_launch logging_simulator.launch.xml map_path:=/media/hrkota/hrkotaSSD/X1/AEAP-557/map/ pointcloud_map_file:=pointcloud_map.pcd rviz:=true system:=false perception:=true planning:=false control:=true localization:=false vehicle:=true vehicle_id:=eva_j4j1-0009_xt32_2304 sensor_model:=aip_x1_1 vehicle_model:=ymc_golfcart_m0

# 別ターミナルで
$ ros2 bag play *.bag --clock
```

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters. -->

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
