### PR TITLE
fix(behavior_path_planner): return default value if no registered module exists (#3843)

### DIFF
--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/scene_module_manager_interface.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/scene_module_manager_interface.hpp
@@ -205,6 +205,10 @@ public:
 
   bool isSimultaneousExecutableAsApprovedModule() const
   {
+    if (registered_modules_.empty()) {
+      return enable_simultaneous_execution_as_approved_module_;
+    }
+
     return std::all_of(
       registered_modules_.begin(), registered_modules_.end(), [](const SceneModulePtr & module) {
         return module->isSimultaneousExecutableAsApprovedModule();
@@ -213,6 +217,10 @@ public:
 
   bool isSimultaneousExecutableAsCandidateModule() const
   {
+    if (registered_modules_.empty()) {
+      return enable_simultaneous_execution_as_candidate_module_;
+    }
+
     return std::all_of(
       registered_modules_.begin(), registered_modules_.end(), [](const SceneModulePtr & module) {
         return module->isSimultaneousExecutableAsCandidateModule();


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

cherry-pick
https://github.com/autowarefoundation/autoware.universe/pull/3843

https://tier4.atlassian.net/browse/RT1-2532
LCとexternal LCのチャタリングが治る

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed

<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters. -->

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].
- [x] The PR has been properly tested.
- [x] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.
- [x] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
