### PR TITLE
fix(motion_utils): check if the buffer is empty (#3883)

### DIFF
--- a/common/motion_utils/src/vehicle/vehicle_state_checker.cpp
+++ b/common/motion_utils/src/vehicle/vehicle_state_checker.cpp
@@ -31,7 +31,7 @@ void VehicleStopCheckerBase::addTwist(const TwistStamped & twist)
   twist_buffer_.push_front(twist);
 
   const auto now = clock_->now();
-  while (true) {
+  while (!twist_buffer_.empty()) {
     // Check oldest data time
     const auto time_diff = now - twist_buffer_.back().header.stamp;
 


### PR DESCRIPTION
## Description

Cherry-pick this PR.

- https://github.com/autowarefoundation/autoware.universe/pull/3883

## Related Links
[TIER IV INTERNAL LINK](https://tier4.atlassian.net/browse/RT0-28230)

## Tests performed

Tested with the unit test.
Please see the PR for the details.
https://github.com/autowarefoundation/autoware.universe/pull/3883

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
