### PR TITLE
fix(elevation_map_loader): reduce memory consumption

### DIFF
--- a/perception/elevation_map_loader/include/elevation_map_loader/elevation_map_loader_node.hpp
+++ b/perception/elevation_map_loader/include/elevation_map_loader/elevation_map_loader_node.hpp
@@ -49,7 +49,8 @@ public:
       return static_cast<bool>(elevation_map_path_) && static_cast<bool>(map_pcl_ptr_);
     }
   }
-  void reset() {
+  void reset()
+  {
     lanelet_map_ptr_.reset();
     map_pcl_ptr_.reset();
     elevation_map_path_.reset();

--- a/perception/elevation_map_loader/include/elevation_map_loader/elevation_map_loader_node.hpp
+++ b/perception/elevation_map_loader/include/elevation_map_loader/elevation_map_loader_node.hpp
@@ -49,6 +49,11 @@ public:
       return static_cast<bool>(elevation_map_path_) && static_cast<bool>(map_pcl_ptr_);
     }
   }
+  void reset() {
+    lanelet_map_ptr_.reset();
+    map_pcl_ptr_.reset();
+    elevation_map_path_.reset();
+  }
   std::unique_ptr<std::filesystem::path> elevation_map_path_;
   pcl::PointCloud<pcl::PointXYZ>::Ptr map_pcl_ptr_;
   lanelet::LaneletMapPtr lanelet_map_ptr_;

--- a/perception/elevation_map_loader/src/elevation_map_loader_node.cpp
+++ b/perception/elevation_map_loader/src/elevation_map_loader_node.cpp
@@ -128,6 +128,11 @@ void ElevationMapLoaderNode::publish()
     pcl::toROSMsg(*elevation_map_cloud_ptr, elevation_map_cloud_msg);
     pub_elevation_map_cloud_->publish(elevation_map_cloud_msg);
   }
+
+  data_manager_.reset();
+  sub_pointcloud_map_.reset();
+  sub_map_hash_.reset();
+  sub_vector_map_.reset();
 }
 
 void ElevationMapLoaderNode::onMapHash(
@@ -179,6 +184,7 @@ void ElevationMapLoaderNode::createElevationMap()
       pcl::make_shared<grid_map::GridMapPclLoader>(grid_map_logger);
     grid_map_pcl_loader->loadParameters(param_file_path_);
     grid_map_pcl_loader->setInputCloud(data_manager_.map_pcl_ptr_);
+    data_manager_.map_pcl_ptr_.reset();
     createElevationMapFromPointcloud(grid_map_pcl_loader);
     elevation_map_ = grid_map_pcl_loader->getGridMap();
   }


### PR DESCRIPTION
## Description

大規模地図を用いる場合、地図更新後のelevation_mapを作成したあとにもメモリが枯渇してしまうのか、トピック通信が滞ってしまう
そこで、elevation_map自体がメモリを無駄に保持している場所に対する対処を実施する
- elevation_map作成中にGridMapPclLoaderに点群地図をinputする箇所において、input後に点群地図をresetする
  https://github.com/tier4/autoware.universe/pull/562/files#diff-5fad3b90562e1b1e891de04336a5a041e61fce79f7da6ffd854e91a6ea318a07R187
- 作成もしくはelevation_mapのロードが終わったあとは、不要なリソースをすべて初期化する
  https://github.com/tier4/autoware.universe/pull/562/files#diff-5fad3b90562e1b1e891de04336a5a041e61fce79f7da6ffd854e91a6ea318a07R132-R135

## Related links

## Tests performed

ベンチにて、大規模地図のelevation_map作成を実施したあと、FMS Consoleにおいてタスク待ちに遷移すること
以下の手順で実施

1. ベンチ起動
2. FMS Consoleにて、ベンチ車両を「AEAP-576解析用ENEOS」に移動し、「769-20230607064045955111」の地図に更新
3. センサが起動していることを確認
4. ベンチを再起動
5. ベンチにて以下コマンドを実施
```
# elevation_mapがすでに生成されていたら削除
sudo rm -rf $HOME/autoware.proj/install/elevation_map_loader/share/elevation_map_loader/data/elevation_maps

# autoware-launch.serviceを再起動
sudo systemctl restart autoware-launch.service
```
6. しばらく待つ。だいたい15分くらいかかりそう
7. FMS Consoleにおいてタスク待ちに遷移する

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters. -->

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
