### PR TITLE
chore(imu_monitor): change yaw_rate_diff_threshold from 0.07 to 0.14

### DIFF
--- a/system/imu_monitor/config/imu_monitor.param.yaml
+++ b/system/imu_monitor/config/imu_monitor.param.yaml
@@ -1,4 +1,4 @@
 /**:
   ros__parameters:
-    yaw_rate_diff_threshold: 0.07  # [rad/s]
+    yaw_rate_diff_threshold: 0.14  # [rad/s]
     frame_id: base_link


### PR DESCRIPTION
## Description

Changed yaw_rate_diff_threshold based on experimental data.
[TIER IV INTERNAL LINK](https://tier4.atlassian.net/browse/RT0-28314)

## Related Links
- https://github.com/tier4/autoware.universe/pull/333

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
