### PR TITLE
chore(system_error_monitor): change the timeout threshold of temperature monitor

### DIFF
--- a/system/system_error_monitor/config/diagnostic_aggregator/sensing.param.yaml
+++ b/system/system_error_monitor/config/diagnostic_aggregator/sensing.param.yaml
@@ -46,7 +46,7 @@
               type: diagnostic_aggregator/GenericAnalyzer
               path: temperature
               contains: [": temperature_monitor"]
-              timeout: 1.0
+              timeout: 2.0
 
         emergency_vehicle:
           type: diagnostic_aggregator/AnalyzerGroup


### PR DESCRIPTION
## Description

Current threshold sometimes cause the STALE error because  the receiving interval of the sensor is 1Hz.
So changed the threshold to 2.0 [sec].

## Tests performed

Tested on an actual vehicle.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
