### PR TITLE
fix(intersection): do not plan if detection area is not empty and stop line idx is 0 (autowarefoundation#4097)

### DIFF
--- a/planning/behavior_velocity_intersection_module/src/scene_intersection.cpp
+++ b/planning/behavior_velocity_intersection_module/src/scene_intersection.cpp
@@ -694,6 +694,11 @@ IntersectionModule::DecisionResult IntersectionModule::modifyPathVelocityDetail(
     return IntersectionModule::Indecisive{};
   }
 
+  if (default_stop_line_idx == 0) {
+    RCLCPP_DEBUG(logger_, "stop line index is 0");
+    return IntersectionModule::Indecisive{};
+  }
+
   const double baselink2front = planner_data_->vehicle_info_.max_longitudinal_offset_m;
   debug_data_.pass_judge_wall_pose =
     planning_utils::getAheadPose(pass_judge_line_idx, baselink2front, *path);
@@ -774,7 +779,11 @@ IntersectionModule::DecisionResult IntersectionModule::modifyPathVelocityDetail(
       path->points.at(default_stop_line_idx).point.pose.position);
     const bool approached_stop_line =
       (std::fabs(dist_stopline) < planner_param_.common.stop_overshoot_margin);
+    const bool over_stop_line = (dist_stopline < 0.0);
     const bool is_stopped = planner_data_->isVehicleStopped();
+    if (over_stop_line) {
+      before_creep_state_machine_.setState(StateMachine::State::GO);
+    }
     if (before_creep_state_machine_.getState() == StateMachine::State::GO) {
       if (has_collision) {
         return IntersectionModule::OccludedCollisionStop{


### PR DESCRIPTION
## Description

hotfix for https://github.com/autowarefoundation/autoware.universe/pull/4097

## Related links

https://tier4.atlassian.net/browse/RT1-2847?focusedCommentId=128228

## Tests performed

<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters. -->

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].
- [x] The PR has been properly tested.
- [x] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
