### PR TITLE
feat(obstacle_avoidance_planner): cherry-pick latest changes

### DIFF
--- a/planning/behavior_path_planner/src/utils/utils.cpp
+++ b/planning/behavior_path_planner/src/utils/utils.cpp
@@ -1453,8 +1453,11 @@ void generateDrivableArea(
   }
 
   // make bound longitudinally monotonic
-  makeBoundLongitudinallyMonotonic(path, true);   // for left bound
-  makeBoundLongitudinallyMonotonic(path, false);  // for right bound
+  // TODO(Murooka) Fix makeBoundLongitudinallyMonotonic
+  if (enable_expanding_polygon) {
+    makeBoundLongitudinallyMonotonic(path, true);   // for left bound
+    makeBoundLongitudinallyMonotonic(path, false);  // for right bound
+  }
 }
 
 // calculate bounds from drivable lanes and hatched road markings

--- a/planning/obstacle_avoidance_planner/src/mpt_optimizer.cpp
+++ b/planning/obstacle_avoidance_planner/src/mpt_optimizer.cpp
@@ -921,7 +921,7 @@ void MPTOptimizer::keepMinimumBoundsWidth(std::vector<ReferencePoint> & ref_poin
       // Only the Lower bound is cut out. Widen the bounds towards the lower bound since cut out too
       // much.
       b.lower_bound =
-        std::min(b.lower_bound, original_b.upper_bound + mpt_param_.min_drivable_width);
+        std::min(b.lower_bound, original_b.upper_bound - mpt_param_.min_drivable_width);
       continue;
     }
     // extend longitudinal if it overlaps out_of_upper_bound_sections
@@ -971,7 +971,7 @@ void MPTOptimizer::keepMinimumBoundsWidth(std::vector<ReferencePoint> & ref_poin
       // Only the Upper bound is cut out. Widen the bounds towards the upper bound since cut out too
       // much.
       b.upper_bound =
-        std::max(b.upper_bound, original_b.lower_bound - mpt_param_.min_drivable_width);
+        std::max(b.upper_bound, original_b.lower_bound + mpt_param_.min_drivable_width);
       continue;
     }
     // extend longitudinal if it overlaps out_of_lower_bound_sections


### PR DESCRIPTION
## Description

最新のobstacle avoidance plannerの修正をcherry-pick
バグチケ: https://tier4.atlassian.net/browse/RT1-2343
<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

psim, scenario sim
## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

狭路走行がよりできるようになる

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
