### PR TITLE
fix(behavior_path_planner): some fixes for lane change

### DIFF
--- a/launch/tier4_planning_launch/launch/scenario_planning/lane_driving/behavior_planning/behavior_planning.launch.py
+++ b/launch/tier4_planning_launch/launch/scenario_planning/lane_driving/behavior_planning/behavior_planning.launch.py
@@ -102,7 +102,7 @@ def launch_setup(context, *args, **kwargs):
             behavior_path_planner_param,
             vehicle_param,
             {
-                "lane_change.enable_abort_lane_change": LaunchConfiguration(
+                "lane_change.cancel.enable_on_lane_changing_phase": LaunchConfiguration(
                     "use_experimental_lane_change_function"
                 ),
                 "lane_change.enable_collision_check_at_prepare_phase": LaunchConfiguration(

--- a/planning/behavior_path_planner/config/lane_change/lane_change.param.yaml
+++ b/planning/behavior_path_planner/config/lane_change/lane_change.param.yaml
@@ -57,6 +57,7 @@
         delta_time: 1.0                     # [s]
         duration: 5.0                       # [s]
         max_lateral_jerk: 1000.0            # [m/s3]
+        overhang_tolerance: 0.0             # [m]
 
       finish_judge_lateral_threshold: 0.2        # [m]
 

--- a/planning/behavior_path_planner/config/lane_change/lane_change.param.yaml
+++ b/planning/behavior_path_planner/config/lane_change/lane_change.param.yaml
@@ -50,13 +50,13 @@
       use_predicted_path_outside_lanelet: true
       use_all_predicted_path: false
 
-      # abort
-      enable_cancel_lane_change: true
-      enable_abort_lane_change: false
-
-      abort_delta_time: 1.0                      # [s]
-      aborting_time: 5.0                         # [s]
-      abort_max_lateral_jerk: 1000.0             # [m/s3]
+      # lane change cancel
+      cancel:
+        enable_on_prepare_phase: true
+        enable_on_lane_changing_phase: true
+        delta_time: 1.0                     # [s]
+        duration: 5.0                       # [s]
+        max_lateral_jerk: 1000.0            # [m/s3]
 
       finish_judge_lateral_threshold: 0.2        # [m]
 

--- a/planning/behavior_path_planner/docs/behavior_path_planner_lane_change_design.md
+++ b/planning/behavior_path_planner/docs/behavior_path_planner_lane_change_design.md
@@ -444,13 +444,14 @@ The following parameters are configurable in `behavior_path_planner.param.yaml`.
 
 The following parameters are configurable in `lane_change.param.yaml`.
 
-| Name                                   | Unit    | Type    | Description                                                    | Default value |
-| :------------------------------------- | ------- | ------- | -------------------------------------------------------------- | ------------- |
-| `cancel.enable_on_prepare_phase`       | [-]     | boolean | Enable cancel lane change                                      | true          |
-| `cancel.enable_on_lane_changing_phase` | [-]     | boolean | Enable abort lane change.                                      | false         |
-| `cancel.delta_time`                    | [s]     | double  | The time taken to start steering to return to the center line. | 3.0           |
-| `cancel.duration`                      | [s]     | double  | The time taken to complete returning to the center line.       | 3.0           |
-| `cancel.max_lateral_jerk`              | [m/sss] | double  | The maximum lateral jerk for abort path                        | 1000.0        |
+| Name                                   | Unit    | Type    | Description                                                                                                      | Default value |
+| :------------------------------------- | ------- | ------- | ---------------------------------------------------------------------------------------------------------------- | ------------- |
+| `cancel.enable_on_prepare_phase`       | [-]     | boolean | Enable cancel lane change                                                                                        | true          |
+| `cancel.enable_on_lane_changing_phase` | [-]     | boolean | Enable abort lane change.                                                                                        | false         |
+| `cancel.delta_time`                    | [s]     | double  | The time taken to start steering to return to the center line.                                                   | 3.0           |
+| `cancel.duration`                      | [s]     | double  | The time taken to complete returning to the center line.                                                         | 3.0           |
+| `cancel.max_lateral_jerk`              | [m/sss] | double  | The maximum lateral jerk for abort path                                                                          | 1000.0        |
+| `cancel.overhang_tolerance`            | [m]     | double  | Lane change cancel is prohibited if the vehicle head exceeds the lane boundary more than this tolerance distance | 0.0           |
 
 ### Debug
 

--- a/planning/behavior_path_planner/docs/behavior_path_planner_lane_change_design.md
+++ b/planning/behavior_path_planner/docs/behavior_path_planner_lane_change_design.md
@@ -386,7 +386,7 @@ detach
 
 Suppose the lane change trajectory is evaluated as unsafe. In that case, if the ego vehicle has not departed from the current lane yet, the trajectory will be reset, and the ego vehicle will resume the lane following the maneuver.
 
-The function can be enabled by setting `enable_cancel_lane_change` to `true`.
+The function can be enabled by setting `enable_on_prepare_phase` to `true`.
 
 The following image illustrates the cancel process.
 
@@ -394,7 +394,7 @@ The following image illustrates the cancel process.
 
 #### Abort
 
-Assume the ego vehicle has already departed from the current lane. In that case, it is dangerous to cancel the path, and it will cause the ego vehicle to change the heading direction abruptly. In this case, planning a trajectory that allows the ego vehicle to return to the current path while minimizing the heading changes is necessary. In this case, the lane change module will generate an abort path. The following images show an example of the abort path. Do note that the function DOESN'T GUARANTEE a safe abort process, as it didn't check the presence of the surrounding objects and/or their reactions. The function can be enable manually by setting both `enable_cancel_lane_change` and `enable_abort_lane_change` to `true`. The parameter `abort_max_lateral_jerk` need to be set to a high value in order for it to work.
+Assume the ego vehicle has already departed from the current lane. In that case, it is dangerous to cancel the path, and it will cause the ego vehicle to change the heading direction abruptly. In this case, planning a trajectory that allows the ego vehicle to return to the current path while minimizing the heading changes is necessary. In this case, the lane change module will generate an abort path. The following images show an example of the abort path. Do note that the function DOESN'T GUARANTEE a safe abort process, as it didn't check the presence of the surrounding objects and/or their reactions. The function can be enable manually by setting both `enable_on_prepare_phase` and `enable_on_lane_changing_phase` to `true`. The parameter `max_lateral_jerk` need to be set to a high value in order for it to work.
 
 ![abort](../image/lane_change/cancel_and_abort/lane_change-abort.png)
 
@@ -444,12 +444,13 @@ The following parameters are configurable in `behavior_path_planner.param.yaml`.
 
 The following parameters are configurable in `lane_change.param.yaml`.
 
-| Name                        | Unit | Type    | Description                             | Default value |
-| :-------------------------- | ---- | ------- | --------------------------------------- | ------------- |
-| `enable_cancel_lane_change` | [-]  | boolean | Enable cancel lane change               | true          |
-| `enable_abort_lane_change`  | [-]  | boolean | Enable abort lane change.               | false         |
-| `abort_delta_time`          | [s]  | double  | The time taken to start aborting.       | 3.0           |
-| `abort_max_lateral_jerk`    | [s]  | double  | The maximum lateral jerk for abort path | 1000.0        |
+| Name                                   | Unit    | Type    | Description                                                    | Default value |
+| :------------------------------------- | ------- | ------- | -------------------------------------------------------------- | ------------- |
+| `cancel.enable_on_prepare_phase`       | [-]     | boolean | Enable cancel lane change                                      | true          |
+| `cancel.enable_on_lane_changing_phase` | [-]     | boolean | Enable abort lane change.                                      | false         |
+| `cancel.delta_time`                    | [s]     | double  | The time taken to start steering to return to the center line. | 3.0           |
+| `cancel.duration`                      | [s]     | double  | The time taken to complete returning to the center line.       | 3.0           |
+| `cancel.max_lateral_jerk`              | [m/sss] | double  | The maximum lateral jerk for abort path                        | 1000.0        |
 
 ### Debug
 

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/base_class.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/base_class.hpp
@@ -143,9 +143,12 @@ public:
 
   LaneChangeParameters getLaneChangeParam() const { return *lane_change_parameters_; }
 
-  bool isCancelEnabled() const { return lane_change_parameters_->enable_cancel_lane_change; }
+  bool isCancelEnabled() const { return lane_change_parameters_->cancel.enable_on_prepare_phase; }
 
-  bool isAbortEnabled() const { return lane_change_parameters_->enable_abort_lane_change; }
+  bool isAbortEnabled() const
+  {
+    return lane_change_parameters_->cancel.enable_on_lane_changing_phase;
+  }
 
   bool isSafe() const { return status_.is_safe; }
 

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/base_class.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/base_class.hpp
@@ -202,8 +202,6 @@ protected:
     const lanelet::ConstLanelets & target_lanelets, Direction direction,
     LaneChangePaths * candidate_paths, const bool check_safety) const = 0;
 
-  virtual std::vector<DrivableLanes> getDrivableLanes() const = 0;
-
   virtual void calcTurnSignalInfo() = 0;
 
   virtual bool isValidPath(const PathWithLaneId & path) const = 0;

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/normal.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/normal.hpp
@@ -102,8 +102,6 @@ protected:
     const lanelet::ConstLanelets & target_lanelets, Direction direction,
     LaneChangePaths * candidate_paths, const bool check_safety = true) const override;
 
-  std::vector<DrivableLanes> getDrivableLanes() const override;
-
   void calcTurnSignalInfo() override;
 
   bool isValidPath(const PathWithLaneId & path) const override;
@@ -134,8 +132,6 @@ protected:
   PathWithLaneId getPrepareSegment(
     const lanelet::ConstLanelets & current_lanes, const double arc_length_from_current,
     const double backward_path_length, const double prepare_length) const override;
-
-  std::vector<DrivableLanes> getDrivableLanes() const override;
 };
 }  // namespace behavior_path_planner
 #endif  // BEHAVIOR_PATH_PLANNER__SCENE_MODULE__LANE_CHANGE__NORMAL_HPP_

--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/normal.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/lane_change/normal.hpp
@@ -107,6 +107,8 @@ protected:
   void calcTurnSignalInfo() override;
 
   bool isValidPath(const PathWithLaneId & path) const override;
+
+  rclcpp::Logger logger_ = rclcpp::get_logger("lane_change").get_child(getModuleTypeStr());
 };
 
 class NormalLaneChangeBT : public NormalLaneChange

--- a/planning/behavior_path_planner/include/behavior_path_planner/utils/lane_change/lane_change_module_data.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utils/lane_change/lane_change_module_data.hpp
@@ -34,6 +34,7 @@ struct LaneChangeCancelParameters
   double delta_time{1.0};
   double duration{5.0};
   double max_lateral_jerk{10.0};
+  double overhang_tolerance{0.0};
 };
 struct LaneChangeParameters
 {

--- a/planning/behavior_path_planner/include/behavior_path_planner/utils/lane_change/lane_change_module_data.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utils/lane_change/lane_change_module_data.hpp
@@ -94,6 +94,11 @@ struct LaneChangePhaseInfo
   double lane_changing{0.0};
 
   [[nodiscard]] double sum() const { return prepare + lane_changing; }
+
+  LaneChangePhaseInfo(const double _prepare, const double _lane_changing)
+  : prepare(_prepare), lane_changing(_lane_changing)
+  {
+  }
 };
 
 struct LaneChangeTargetObjectIndices

--- a/planning/behavior_path_planner/include/behavior_path_planner/utils/lane_change/lane_change_module_data.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utils/lane_change/lane_change_module_data.hpp
@@ -26,6 +26,15 @@
 
 namespace behavior_path_planner
 {
+
+struct LaneChangeCancelParameters
+{
+  bool enable_on_prepare_phase{true};
+  bool enable_on_lane_changing_phase{false};
+  double delta_time{1.0};
+  double duration{5.0};
+  double max_lateral_jerk{10.0};
+};
 struct LaneChangeParameters
 {
   // trajectory generation
@@ -63,12 +72,7 @@ struct LaneChangeParameters
   bool check_pedestrian{true};  // check object pedestrian
 
   // abort
-  bool enable_cancel_lane_change{true};
-  bool enable_abort_lane_change{false};
-
-  double abort_delta_time{1.0};
-  double aborting_time{5.0};
-  double abort_max_lateral_jerk{10.0};
+  LaneChangeCancelParameters cancel;
 
   double finish_judge_lateral_threshold{0.2};
 

--- a/planning/behavior_path_planner/include/behavior_path_planner/utils/lane_change/lane_change_path.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utils/lane_change/lane_change_path.hpp
@@ -36,10 +36,13 @@ struct LaneChangePath
   Pose lane_changing_end{};
   ShiftedPath shifted_path{};
   ShiftLine shift_line{};
-  double acceleration{0.0};
-  LaneChangePhaseInfo length{};
-  LaneChangePhaseInfo duration{};
   TurnSignalInfo turn_signal_info{};
+
+  // longitudinal acceleration applied on the prepare and lane-changing phase
+  LaneChangePhaseInfo longitudinal_acceleration{0.0, 0.0};
+
+  LaneChangePhaseInfo length{0.0, 0.0};
+  LaneChangePhaseInfo duration{0.0, 0.0};
   PathWithLaneId prev_path{};
 };
 using LaneChangePaths = std::vector<LaneChangePath>;

--- a/planning/behavior_path_planner/include/behavior_path_planner/utils/lane_change/utils.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utils/lane_change/utils.hpp
@@ -156,12 +156,6 @@ lanelet::ConstLanelets getBackwardLanelets(
   const RouteHandler & route_handler, const lanelet::ConstLanelets & target_lanes,
   const Pose & current_pose, const double backward_length);
 
-LaneChangeTargetObjectIndices filterObjectIndices(
-  const LaneChangePaths & lane_change_paths, const PredictedObjects & objects,
-  const lanelet::ConstLanelets & target_backward_lanes, const Pose & current_pose,
-  const double forward_path_length, const LaneChangeParameters & lane_change_parameter,
-  const double filter_width);
-
 bool isTargetObjectType(const PredictedObject & object, const LaneChangeParameters & parameter);
 
 double calcLateralBufferForFiltering(const double vehicle_width, const double lateral_buffer = 0.0);
@@ -192,5 +186,14 @@ boost::optional<size_t> getLeadingStaticObjectIdx(
   const RouteHandler & route_handler, const LaneChangePath & lane_change_path,
   const PredictedObjects & objects, const std::vector<size_t> & obj_indices,
   const double object_check_min_road_shoulder_width, const double object_shiftable_ratio_threshold);
+
+std::optional<lanelet::BasicPolygon2d> createPolygon(
+  const lanelet::ConstLanelets & lanes, const double start_dist, const double end_dist);
+
+LaneChangeTargetObjectIndices filterObject(
+  const PredictedObjects & objects, const lanelet::ConstLanelets & current_lanes,
+  const lanelet::ConstLanelets & target_lanes, const lanelet::ConstLanelets & target_backward_lanes,
+  const Pose & current_pose, const RouteHandler & route_handler,
+  const LaneChangeParameters & lane_change_parameter);
 }  // namespace behavior_path_planner::utils::lane_change
 #endif  // BEHAVIOR_PATH_PLANNER__UTILS__LANE_CHANGE__UTILS_HPP_

--- a/planning/behavior_path_planner/include/behavior_path_planner/utils/lane_change/utils.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utils/lane_change/utils.hpp
@@ -90,10 +90,10 @@ std::optional<LaneChangePath> constructCandidatePath(
   const PathWithLaneId & prepare_segment, const PathWithLaneId & target_segment,
   const PathWithLaneId & target_lane_reference_path, const ShiftLine & shift_line,
   const lanelet::ConstLanelets & original_lanelets, const lanelet::ConstLanelets & target_lanelets,
-  const std::vector<std::vector<int64_t>> & sorted_lane_ids, const double longitudinal_acceleration,
-  const double lateral_acceleration, const LaneChangePhaseInfo lane_change_length,
-  const LaneChangePhaseInfo lane_change_velocity, const double terminal_lane_changing_velocity,
-  const LaneChangePhaseInfo lane_change_time);
+  const std::vector<std::vector<int64_t>> & sorted_lane_ids,
+  const LaneChangePhaseInfo longitudinal_acceleration, const double lateral_acceleration,
+  const LaneChangePhaseInfo lane_change_length, const LaneChangePhaseInfo lane_change_velocity,
+  const double terminal_lane_changing_velocity, const LaneChangePhaseInfo lane_change_time);
 
 PathSafetyStatus isLaneChangePathSafe(
   const LaneChangePath & lane_change_path, const PredictedObjects::ConstSharedPtr dynamic_objects,
@@ -101,8 +101,8 @@ PathSafetyStatus isLaneChangePathSafe(
   const Twist & current_twist, const BehaviorPathPlannerParameters & common_parameter,
   const behavior_path_planner::LaneChangeParameters & lane_change_parameter,
   const double front_decel, const double rear_decel,
-  std::unordered_map<std::string, CollisionCheckDebug> & debug_data, const double prepare_acc = 0.0,
-  const double lane_changing_acc = 0.0);
+  std::unordered_map<std::string, CollisionCheckDebug> & debug_data, const double prepare_acc,
+  const double lane_changing_acc);
 
 bool isObjectIndexIncluded(
   const size_t & index, const std::vector<size_t> & dynamic_objects_indices);

--- a/planning/behavior_path_planner/include/behavior_path_planner/utils/utils.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utils/utils.hpp
@@ -306,7 +306,7 @@ bool isEgoOutOfRoute(
 
 bool isEgoWithinOriginalLane(
   const lanelet::ConstLanelets & current_lanes, const Pose & current_pose,
-  const BehaviorPathPlannerParameters & common_param);
+  const BehaviorPathPlannerParameters & common_param, const double outer_margin = 0.0);
 
 // path management
 

--- a/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
+++ b/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
@@ -811,6 +811,7 @@ LaneChangeParameters BehaviorPathPlannerNode::getLaneChangeParam()
   p.cancel.delta_time = declare_parameter<double>(parameter("cancel.delta_time"));
   p.cancel.duration = declare_parameter<double>(parameter("cancel.duration"));
   p.cancel.max_lateral_jerk = declare_parameter<double>(parameter("cancel.max_lateral_jerk"));
+  p.cancel.overhang_tolerance = declare_parameter<double>(parameter("cancel.overhang_tolerance"));
 
   p.finish_judge_lateral_threshold =
     declare_parameter<double>("lane_change.finish_judge_lateral_threshold");

--- a/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
+++ b/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
@@ -831,10 +831,9 @@ LaneChangeParameters BehaviorPathPlannerNode::getLaneChangeParam()
   }
 
   if (p.cancel.delta_time < 1.0) {
-    RCLCPP_FATAL_STREAM(
-      get_logger(), "cancel.delta_time: " << p.cancel.delta_time << ", is too short.\n"
-                                          << "Terminating the program...");
-    exit(EXIT_FAILURE);
+    RCLCPP_WARN_STREAM(
+      get_logger(), "cancel.delta_time: " << p.cancel.delta_time
+                                          << ", is too short. This could cause a danger behavior.");
   }
 
   return p;

--- a/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
+++ b/planning/behavior_path_planner/src/behavior_path_planner_node.cpp
@@ -803,13 +803,14 @@ LaneChangeParameters BehaviorPathPlannerNode::getLaneChangeParam()
     p.check_pedestrian = declare_parameter<bool>(ns + "pedestrian");
   }
 
-  // abort
-  p.enable_cancel_lane_change = declare_parameter<bool>(parameter("enable_cancel_lane_change"));
-  p.enable_abort_lane_change = declare_parameter<bool>(parameter("enable_abort_lane_change"));
-
-  p.abort_delta_time = declare_parameter<double>(parameter("abort_delta_time"));
-  p.aborting_time = declare_parameter<double>(parameter("aborting_time"));
-  p.abort_max_lateral_jerk = declare_parameter<double>(parameter("abort_max_lateral_jerk"));
+  // lane change cancel
+  p.cancel.enable_on_prepare_phase =
+    declare_parameter<bool>(parameter("cancel.enable_on_prepare_phase"));
+  p.cancel.enable_on_lane_changing_phase =
+    declare_parameter<bool>(parameter("cancel.enable_on_lane_changing_phase"));
+  p.cancel.delta_time = declare_parameter<double>(parameter("cancel.delta_time"));
+  p.cancel.duration = declare_parameter<double>(parameter("cancel.duration"));
+  p.cancel.max_lateral_jerk = declare_parameter<double>(parameter("cancel.max_lateral_jerk"));
 
   p.finish_judge_lateral_threshold =
     declare_parameter<double>("lane_change.finish_judge_lateral_threshold");
@@ -828,10 +829,10 @@ LaneChangeParameters BehaviorPathPlannerNode::getLaneChangeParam()
     exit(EXIT_FAILURE);
   }
 
-  if (p.abort_delta_time < 1.0) {
+  if (p.cancel.delta_time < 1.0) {
     RCLCPP_FATAL_STREAM(
-      get_logger(), "abort_delta_time: " << p.abort_delta_time << ", is too short.\n"
-                                         << "Terminating the program...");
+      get_logger(), "cancel.delta_time: " << p.cancel.delta_time << ", is too short.\n"
+                                          << "Terminating the program...");
     exit(EXIT_FAILURE);
   }
 

--- a/planning/behavior_path_planner/src/marker_util/lane_change/debug.cpp
+++ b/planning/behavior_path_planner/src/marker_util/lane_change/debug.cpp
@@ -185,11 +185,12 @@ MarkerArray showPolygon(
     }
     const auto & color = colors.at(idx);
     const auto & ego_polygon = info.ego_polygon.outer();
+    const auto poly_z = info.current_pose.position.z;  // temporally
     ego_marker.id = ++id;
     ego_marker.color = createMarkerColor(color[0], color[1], color[2], 0.8);
     ego_marker.points.reserve(ego_polygon.size());
     for (const auto & p : ego_polygon) {
-      ego_marker.points.push_back(tier4_autoware_utils::createPoint(p.x(), p.y(), 0.0));
+      ego_marker.points.push_back(tier4_autoware_utils::createPoint(p.x(), p.y(), poly_z));
     }
     marker_array.markers.push_back(ego_marker);
 
@@ -198,7 +199,7 @@ MarkerArray showPolygon(
     obj_marker.color = createMarkerColor(color[0], color[1], color[2], 0.8);
     obj_marker.points.reserve(obj_polygon.size());
     for (const auto & p : obj_polygon) {
-      obj_marker.points.push_back(tier4_autoware_utils::createPoint(p.x(), p.y(), 0.0));
+      obj_marker.points.push_back(tier4_autoware_utils::createPoint(p.x(), p.y(), poly_z));
     }
     marker_array.markers.push_back(obj_marker);
     ++idx;

--- a/planning/behavior_path_planner/src/scene_module/lane_change/interface.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/interface.cpp
@@ -413,13 +413,13 @@ void LaneChangeInterface::acceptVisitor(const std::shared_ptr<SceneModuleVisitor
 TurnSignalInfo LaneChangeInterface::getCurrentTurnSignalInfo(
   const PathWithLaneId & path, const TurnSignalInfo & original_turn_signal_info)
 {
-  const auto & target_lanes = module_type_->getLaneChangeStatus().lane_change_lanes;
+  const auto & current_lanes = module_type_->getLaneChangeStatus().current_lanes;
   const auto & is_valid = module_type_->getLaneChangeStatus().is_valid_path;
   const auto & lane_change_path = module_type_->getLaneChangeStatus().lane_change_path;
   const auto & lane_change_param = module_type_->getLaneChangeParam();
 
   if (
-    module_type_->getModuleType() != LaneChangeModuleType::NORMAL || target_lanes.empty() ||
+    module_type_->getModuleType() != LaneChangeModuleType::NORMAL || current_lanes.empty() ||
     !is_valid) {
     return original_turn_signal_info;
   }
@@ -447,13 +447,15 @@ TurnSignalInfo LaneChangeInterface::getCurrentTurnSignalInfo(
   const auto & route_handler = module_type_->getRouteHandler();
   const auto & common_parameter = module_type_->getCommonParam();
   const auto shift_intervals =
-    route_handler->getLateralIntervalsToPreferredLane(target_lanes.back());
+    route_handler->getLateralIntervalsToPreferredLane(current_lanes.back());
   const double next_lane_change_buffer =
     utils::calcMinimumLaneChangeLength(common_parameter, shift_intervals);
   const double & nearest_dist_threshold = common_parameter.ego_nearest_dist_threshold;
   const double & nearest_yaw_threshold = common_parameter.ego_nearest_yaw_threshold;
+  const double & base_to_front = common_parameter.base_link2front;
 
-  const double buffer = next_lane_change_buffer + min_length_for_turn_signal_activation;
+  const double buffer =
+    next_lane_change_buffer + min_length_for_turn_signal_activation + base_to_front;
   const double path_length = motion_utils::calcArcLength(path.points);
   const auto & front_point = path.points.front().point.pose.position;
   const size_t & current_nearest_seg_idx =

--- a/planning/behavior_path_planner/src/scene_module/lane_change/normal.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/normal.cpp
@@ -515,11 +515,13 @@ bool NormalLaneChange::getLaneChangePaths(
       minimum_lane_changing_velocity);
 
     // compute actual longitudinal acceleration
-    const double longitudinal_acc = (prepare_velocity - current_velocity) / prepare_duration;
+    const double longitudinal_acc_on_prepare =
+      (prepare_velocity - current_velocity) / prepare_duration;
 
     // get path on original lanes
     const double prepare_length = std::max(
-      current_velocity * prepare_duration + 0.5 * longitudinal_acc * std::pow(prepare_duration, 2),
+      current_velocity * prepare_duration +
+        0.5 * longitudinal_acc_on_prepare * std::pow(prepare_duration, 2),
       minimum_prepare_length);
 
     if (prepare_length < target_length) {
@@ -566,14 +568,15 @@ bool NormalLaneChange::getLaneChangePaths(
          lateral_acc += lateral_acc_resolution) {
       const auto lane_changing_time = PathShifter::calcShiftTimeFromJerk(
         shift_length, common_parameter.lane_changing_lateral_jerk, lateral_acc);
-      const double lane_changing_lon_acc = utils::lane_change::calcLaneChangingAcceleration(
-        initial_lane_changing_velocity, max_path_velocity, lane_changing_time,
-        sampled_longitudinal_acc);
+      const double longitudinal_acc_on_lane_changing =
+        utils::lane_change::calcLaneChangingAcceleration(
+          initial_lane_changing_velocity, max_path_velocity, lane_changing_time,
+          sampled_longitudinal_acc);
       const auto lane_changing_length =
         initial_lane_changing_velocity * lane_changing_time +
-        0.5 * lane_changing_lon_acc * lane_changing_time * lane_changing_time;
+        0.5 * longitudinal_acc_on_lane_changing * lane_changing_time * lane_changing_time;
       const auto terminal_lane_changing_velocity =
-        initial_lane_changing_velocity + lane_changing_lon_acc * lane_changing_time;
+        initial_lane_changing_velocity + longitudinal_acc_on_lane_changing * lane_changing_time;
       utils::lane_change::setPrepareVelocity(
         prepare_segment, current_velocity, terminal_lane_changing_velocity);
 
@@ -638,7 +641,8 @@ bool NormalLaneChange::getLaneChangePaths(
 
       const auto candidate_path = utils::lane_change::constructCandidatePath(
         prepare_segment, target_segment, target_lane_reference_path, shift_line, original_lanelets,
-        target_lanelets, sorted_lane_ids, lane_changing_lon_acc, lateral_acc, lc_length,
+        target_lanelets, sorted_lane_ids,
+        {longitudinal_acc_on_prepare, longitudinal_acc_on_lane_changing}, lateral_acc, lc_length,
         lc_velocity, terminal_lane_changing_velocity, lc_time);
 
       if (!candidate_path) {
@@ -689,8 +693,8 @@ bool NormalLaneChange::getLaneChangePaths(
       const auto [is_safe, is_object_coming_from_rear] = utils::lane_change::isLaneChangePathSafe(
         *candidate_path, dynamic_objects, dynamic_object_indices, getEgoPose(), getEgoTwist(),
         common_parameter, *lane_change_parameters_, common_parameter.expected_front_deceleration,
-        common_parameter.expected_rear_deceleration, object_debug_, longitudinal_acc,
-        lane_changing_lon_acc);
+        common_parameter.expected_rear_deceleration, object_debug_, longitudinal_acc_on_prepare,
+        longitudinal_acc_on_lane_changing);
 
       if (is_safe) {
         return true;
@@ -727,7 +731,8 @@ PathSafetyStatus NormalLaneChange::isApprovedPathSafe() const
     path, dynamic_objects, dynamic_object_indices, current_pose, current_twist, common_parameters,
     *lane_change_parameters_, common_parameters.expected_front_deceleration_for_abort,
     common_parameters.expected_rear_deceleration_for_abort, debug_data,
-    status_.lane_change_path.acceleration);
+    status_.lane_change_path.longitudinal_acceleration.prepare,
+    status_.lane_change_path.longitudinal_acceleration.lane_changing);
 
   return safety_status;
 }

--- a/planning/behavior_path_planner/src/scene_module/lane_change/normal.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/normal.cpp
@@ -714,7 +714,7 @@ PathSafetyStatus NormalLaneChange::isApprovedPathSafe() const
 
   // get lanes used for detection
   const auto backward_target_lanes_for_object_filtering = utils::lane_change::getBackwardLanelets(
-    route_handler, path.target_lanelets, current_pose, lane_change_parameters.backward_lane_length);
+    route_handler, target_lanes, current_pose, lane_change_parameters.backward_lane_length);
 
   const auto dynamic_object_indices = utils::lane_change::filterObject(
     *dynamic_objects, current_lanes, target_lanes, backward_target_lanes_for_object_filtering,

--- a/planning/behavior_path_planner/src/scene_module/lane_change/normal.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/normal.cpp
@@ -221,7 +221,7 @@ TurnSignalInfo NormalLaneChange::updateOutputTurnSignal()
 
 lanelet::ConstLanelets NormalLaneChange::getCurrentLanes() const
 {
-  return utils::getCurrentLanesFromPath(prev_module_reference_path_, planner_data_);
+  return utils::getCurrentLanesFromPath(prev_module_path_, planner_data_);
 }
 
 lanelet::ConstLanelets NormalLaneChange::getLaneChangeLanes(

--- a/planning/behavior_path_planner/src/scene_module/lane_change/normal.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/normal.cpp
@@ -325,7 +325,7 @@ bool NormalLaneChange::isAbleToReturnCurrentLane() const
 
   const double ego_velocity =
     std::max(getEgoVelocity(), planner_data_->parameters.minimum_lane_changing_velocity);
-  const double estimated_travel_dist = ego_velocity * lane_change_parameters_->abort_delta_time;
+  const double estimated_travel_dist = ego_velocity * lane_change_parameters_->cancel.delta_time;
 
   double dist = 0.0;
   for (size_t idx = nearest_idx; idx < status_.lane_change_path.path.points.size() - 1; ++idx) {
@@ -392,7 +392,7 @@ bool NormalLaneChange::hasFinishedAbort() const
 
 bool NormalLaneChange::isAbortState() const
 {
-  if (!lane_change_parameters_->enable_abort_lane_change) {
+  if (!lane_change_parameters_->cancel.enable_on_lane_changing_phase) {
     return false;
   }
 
@@ -883,9 +883,9 @@ bool NormalLaneChange::getAbortPath()
   };
 
   const auto [abort_start_idx, abort_start_dist] =
-    get_abort_idx_and_distance(lane_change_parameters_->abort_delta_time);
+    get_abort_idx_and_distance(lane_change_parameters_->cancel.delta_time);
   const auto [abort_return_idx, abort_return_dist] = get_abort_idx_and_distance(
-    lane_change_parameters_->abort_delta_time + lane_change_parameters_->aborting_time);
+    lane_change_parameters_->cancel.delta_time + lane_change_parameters_->cancel.delta_time);
 
   if (abort_start_idx >= abort_return_idx) {
     RCLCPP_ERROR(logger_, "abort start idx and return idx is equal. can't compute abort path.");
@@ -921,7 +921,7 @@ bool NormalLaneChange::getAbortPath()
   const double & max_lateral_acc = lateral_acc_range.second;
   path_shifter.setLateralAccelerationLimit(max_lateral_acc);
 
-  if (lateral_jerk > lane_change_parameters_->abort_max_lateral_jerk) {
+  if (lateral_jerk > lane_change_parameters_->cancel.max_lateral_jerk) {
     RCLCPP_ERROR(logger_, "Aborting jerk is too strong. lateral_jerk = %f", lateral_jerk);
     return false;
   }

--- a/planning/behavior_path_planner/src/scene_module/lane_change/normal.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/normal.cpp
@@ -152,7 +152,8 @@ void NormalLaneChange::extendOutputDrivableArea(BehaviorModuleOutput & output)
   const auto & common_parameters = planner_data_->parameters;
   const auto & dp = planner_data_->drivable_area_expansion_parameters;
 
-  const auto drivable_lanes = getDrivableLanes();
+  const auto drivable_lanes = utils::lane_change::generateDrivableLanes(
+    *getRouteHandler(), status_.current_lanes, status_.lane_change_lanes);
   const auto shorten_lanes = utils::cutOverlappedLanes(*output.path, drivable_lanes);
   const auto expanded_lanes = utils::expandLanelets(
     shorten_lanes, dp.drivable_area_left_bound_offset, dp.drivable_area_right_bound_offset,
@@ -700,13 +701,6 @@ bool NormalLaneChange::getLaneChangePaths(
   return false;
 }
 
-std::vector<DrivableLanes> NormalLaneChange::getDrivableLanes() const
-{
-  const auto drivable_lanes = utils::lane_change::generateDrivableLanes(
-    *getRouteHandler(), status_.current_lanes, status_.lane_change_lanes);
-  return utils::combineDrivableLanes(prev_drivable_area_info_.drivable_lanes, drivable_lanes);
-}
-
 PathSafetyStatus NormalLaneChange::isApprovedPathSafe() const
 {
   const auto current_pose = getEgoPose();
@@ -1054,11 +1048,5 @@ PathWithLaneId NormalLaneChangeBT::getPrepareSegment(
     getRouteHandler()->getCenterLinePath(current_lanes, s_start, s_end);
 
   return prepare_segment;
-}
-
-std::vector<DrivableLanes> NormalLaneChangeBT::getDrivableLanes() const
-{
-  return utils::lane_change::generateDrivableLanes(
-    *getRouteHandler(), status_.current_lanes, status_.lane_change_lanes);
 }
 }  // namespace behavior_path_planner

--- a/planning/behavior_path_planner/src/scene_module/lane_change/normal.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/normal.cpp
@@ -333,7 +333,8 @@ bool NormalLaneChange::isAbleToReturnCurrentLane() const
     if (dist > estimated_travel_dist) {
       const auto & estimated_pose = status_.lane_change_path.path.points.at(idx + 1).point.pose;
       return utils::isEgoWithinOriginalLane(
-        status_.current_lanes, estimated_pose, planner_data_->parameters);
+        status_.current_lanes, estimated_pose, planner_data_->parameters,
+        lane_change_parameters_->cancel.overhang_tolerance);
     }
   }
 

--- a/planning/behavior_path_planner/src/scene_module/lane_change/normal.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/normal.cpp
@@ -521,9 +521,7 @@ bool NormalLaneChange::getLaneChangePaths(
       minimum_prepare_length);
 
     if (prepare_length < target_length) {
-      RCLCPP_DEBUG(
-        rclcpp::get_logger("behavior_path_planner").get_child("util").get_child("lane_change"),
-        "prepare length is shorter than distance to target lane!!");
+      RCLCPP_DEBUG(logger_, "prepare length is shorter than distance to target lane!!");
       break;
     }
 
@@ -531,9 +529,7 @@ bool NormalLaneChange::getLaneChangePaths(
       original_lanelets, arc_position_from_current.length, backward_path_length, prepare_length);
 
     if (prepare_segment.points.empty()) {
-      RCLCPP_DEBUG(
-        rclcpp::get_logger("behavior_path_planner").get_child("util").get_child("lane_change"),
-        "prepare segment is empty!!");
+      RCLCPP_DEBUG(logger_, "prepare segment is empty!!");
       continue;
     }
 
@@ -547,8 +543,7 @@ bool NormalLaneChange::getLaneChangePaths(
     // that case, the lane change shouldn't be executed.
     if (target_length_from_lane_change_start_pose > 0.0) {
       RCLCPP_DEBUG(
-        rclcpp::get_logger("behavior_path_planner").get_child("util").get_child("lane_change"),
-        "[only new arch] lane change start getEgoPose() is behind target lanelet!!");
+        logger_, "[only new arch] lane change start getEgoPose() is behind target lanelet!!");
       break;
     }
 
@@ -581,9 +576,7 @@ bool NormalLaneChange::getLaneChangePaths(
         prepare_segment, current_velocity, terminal_lane_changing_velocity);
 
       if (lane_changing_length + prepare_length > dist_to_end_of_current_lanes) {
-        RCLCPP_DEBUG(
-          rclcpp::get_logger("behavior_path_planner").get_child("util").get_child("lane_change"),
-          "length of lane changing path is longer than length to goal!!");
+        RCLCPP_DEBUG(logger_, "length of lane changing path is longer than length to goal!!");
         continue;
       }
 
@@ -596,9 +589,7 @@ bool NormalLaneChange::getLaneChangePaths(
           s_start + lane_changing_length + common_parameter.lane_change_finish_judge_buffer +
             next_lane_change_buffer >
           s_goal) {
-          RCLCPP_DEBUG(
-            rclcpp::get_logger("behavior_path_planner").get_child("util").get_child("lane_change"),
-            "length of lane changing path is longer than length to goal!!");
+          RCLCPP_DEBUG(logger_, "length of lane changing path is longer than length to goal!!");
           continue;
         }
       }
@@ -609,9 +600,7 @@ bool NormalLaneChange::getLaneChangePaths(
         next_lane_change_buffer);
 
       if (target_segment.points.empty()) {
-        RCLCPP_DEBUG(
-          rclcpp::get_logger("behavior_path_planner").get_child("util").get_child("lane_change"),
-          "target segment is empty!! something wrong...");
+        RCLCPP_DEBUG(logger_, "target segment is empty!! something wrong...");
         continue;
       }
 
@@ -633,9 +622,7 @@ bool NormalLaneChange::getLaneChangePaths(
         next_lane_change_buffer);
 
       if (target_lane_reference_path.points.empty()) {
-        RCLCPP_DEBUG(
-          rclcpp::get_logger("behavior_path_planner").get_child("util").get_child("lane_change"),
-          "target_lane_reference_path is empty!!");
+        RCLCPP_DEBUG(logger_, "target_lane_reference_path is empty!!");
         continue;
       }
 
@@ -653,9 +640,7 @@ bool NormalLaneChange::getLaneChangePaths(
         lc_velocity, terminal_lane_changing_velocity, lc_time);
 
       if (!candidate_path) {
-        RCLCPP_DEBUG(
-          rclcpp::get_logger("behavior_path_planner").get_child("util").get_child("lane_change"),
-          "no candidate path!!");
+        RCLCPP_DEBUG(logger_, "no candidate path!!");
         continue;
       }
 
@@ -664,9 +649,7 @@ bool NormalLaneChange::getLaneChangePaths(
         minimum_lane_changing_velocity, common_parameter, direction);
 
       if (!is_valid) {
-        RCLCPP_DEBUG(
-          rclcpp::get_logger("behavior_path_planner").get_child("util").get_child("lane_change"),
-          "invalid candidate path!!");
+        RCLCPP_DEBUG(logger_, "invalid candidate path!!");
         continue;
       }
 
@@ -905,18 +888,14 @@ bool NormalLaneChange::getAbortPath()
     lane_change_parameters_->abort_delta_time + lane_change_parameters_->aborting_time);
 
   if (abort_start_idx >= abort_return_idx) {
-    RCLCPP_ERROR_STREAM(
-      rclcpp::get_logger("behavior_path_planner").get_child("util").get_child("lane_change"),
-      "abort start idx and return idx is equal. can't compute abort path.");
+    RCLCPP_ERROR(logger_, "abort start idx and return idx is equal. can't compute abort path.");
     return false;
   }
 
   if (!utils::lane_change::hasEnoughLengthToLaneChangeAfterAbort(
         *route_handler, reference_lanelets, current_pose, abort_return_dist, common_param,
         direction)) {
-    RCLCPP_ERROR_STREAM(
-      rclcpp::get_logger("behavior_path_planner").get_child("util").get_child("lane_change"),
-      "insufficient distance to abort.");
+    RCLCPP_ERROR(logger_, "insufficient distance to abort.");
     return false;
   }
 
@@ -943,9 +922,7 @@ bool NormalLaneChange::getAbortPath()
   path_shifter.setLateralAccelerationLimit(max_lateral_acc);
 
   if (lateral_jerk > lane_change_parameters_->abort_max_lateral_jerk) {
-    RCLCPP_ERROR_STREAM(
-      rclcpp::get_logger("behavior_path_planner").get_child("util").get_child("lane_change"),
-      "Aborting jerk is too strong. lateral_jerk = " << lateral_jerk);
+    RCLCPP_ERROR(logger_, "Aborting jerk is too strong. lateral_jerk = %f", lateral_jerk);
     return false;
   }
 
@@ -953,9 +930,7 @@ bool NormalLaneChange::getAbortPath()
   // offset front side
   // bool offset_back = false;
   if (!path_shifter.generate(&shifted_path)) {
-    RCLCPP_ERROR_STREAM(
-      rclcpp::get_logger("behavior_path_planner").get_child("util").get_child("lane_change"),
-      "failed to generate abort shifted path.");
+    RCLCPP_ERROR(logger_, "failed to generate abort shifted path.");
   }
 
   const auto arc_position = lanelet::utils::getArcCoordinates(
@@ -1072,12 +1047,7 @@ PathWithLaneId NormalLaneChangeBT::getPrepareSegment(
   const double s_start = arc_length_from_current - backward_path_length;
   const double s_end = arc_length_from_current + prepare_length;
 
-  RCLCPP_DEBUG(
-    rclcpp::get_logger("behavior_path_planner")
-      .get_child("lane_change")
-      .get_child("util")
-      .get_child("getPrepareSegment"),
-    "start: %f, end: %f", s_start, s_end);
+  RCLCPP_DEBUG(logger_, "start: %f, end: %f", s_start, s_end);
 
   PathWithLaneId prepare_segment =
     getRouteHandler()->getCenterLinePath(current_lanes, s_start, s_end);

--- a/planning/behavior_path_planner/src/scene_module/lane_change/normal.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/normal.cpp
@@ -443,6 +443,7 @@ bool NormalLaneChange::getLaneChangePaths(
   const auto & route_handler = *getRouteHandler();
   const auto & dynamic_objects = planner_data_->dynamic_object;
   const auto & common_parameter = planner_data_->parameters;
+  const auto & current_pose = getEgoPose();
 
   const auto backward_path_length = common_parameter.backward_path_length;
   const auto forward_path_length = common_parameter.forward_path_length;
@@ -496,8 +497,6 @@ bool NormalLaneChange::getLaneChangePaths(
 
   const auto sorted_lane_ids = utils::lane_change::getSortedLaneIds(
     route_handler, original_lanelets, target_lanelets, arc_position_from_target.distance);
-  const auto lateral_buffer =
-    utils::lane_change::calcLateralBufferForFiltering(common_parameter.vehicle_width, 0.5);
 
   const auto target_preferred_lanelets = utils::lane_change::getTargetPreferredLanes(
     route_handler, original_lanelets, target_lanelets, direction, type_);
@@ -506,7 +505,13 @@ bool NormalLaneChange::getLaneChangePaths(
   const auto target_preferred_lane_poly_2d =
     lanelet::utils::to2D(target_preferred_lane_poly).basicPolygon();
 
-  LaneChangeTargetObjectIndices dynamic_object_indices;
+  const auto backward_length = lane_change_parameters_->backward_lane_length;
+  const auto backward_target_lanes_for_object_filtering = utils::lane_change::getBackwardLanelets(
+    route_handler, target_lanelets, getEgoPose(), backward_length);
+  const auto dynamic_object_indices = utils::lane_change::filterObject(
+    *dynamic_objects, original_lanelets, target_lanelets,
+    backward_target_lanes_for_object_filtering, current_pose, route_handler,
+    *lane_change_parameters_);
 
   candidate_paths->reserve(longitudinal_acc_sampling_values.size() * lateral_acc_sampling_num);
   for (const auto & sampled_longitudinal_acc : longitudinal_acc_sampling_values) {
@@ -660,16 +665,6 @@ bool NormalLaneChange::getLaneChangePaths(
       }
 
       if (candidate_paths->empty()) {
-        // only compute dynamic object indices once
-        const auto backward_length = lane_change_parameters_->backward_lane_length;
-        const auto backward_target_lanes_for_object_filtering =
-          utils::lane_change::getBackwardLanelets(
-            route_handler, target_lanelets, getEgoPose(), backward_length);
-        dynamic_object_indices = utils::lane_change::filterObjectIndices(
-          {*candidate_path}, *dynamic_objects, backward_target_lanes_for_object_filtering,
-          getEgoPose(), common_parameter.forward_path_length, *lane_change_parameters_,
-          lateral_buffer);
-
         const double object_check_min_road_shoulder_width =
           lane_change_parameters_->object_check_min_road_shoulder_width;
         const double object_shiftable_ratio_threshold =
@@ -712,21 +707,20 @@ PathSafetyStatus NormalLaneChange::isApprovedPathSafe() const
   const auto & dynamic_objects = planner_data_->dynamic_object;
   const auto & common_parameters = getCommonParam();
   const auto & lane_change_parameters = *lane_change_parameters_;
-  const auto & route_handler = getRouteHandler();
+  const auto & route_handler = *getRouteHandler();
   const auto & path = status_.lane_change_path;
+  const auto & current_lanes = status_.current_lanes;
+  const auto & target_lanes = status_.lane_change_lanes;
 
   // get lanes used for detection
   const auto backward_target_lanes_for_object_filtering = utils::lane_change::getBackwardLanelets(
-    *route_handler, path.target_lanelets, current_pose,
-    lane_change_parameters.backward_lane_length);
+    route_handler, path.target_lanelets, current_pose, lane_change_parameters.backward_lane_length);
+
+  const auto dynamic_object_indices = utils::lane_change::filterObject(
+    *dynamic_objects, current_lanes, target_lanes, backward_target_lanes_for_object_filtering,
+    current_pose, route_handler, *lane_change_parameters_);
 
   CollisionCheckDebugMap debug_data;
-  const auto lateral_buffer =
-    utils::lane_change::calcLateralBufferForFiltering(common_parameters.vehicle_width);
-  const auto dynamic_object_indices = utils::lane_change::filterObjectIndices(
-    {path}, *dynamic_objects, backward_target_lanes_for_object_filtering, current_pose,
-    common_parameters.forward_path_length, lane_change_parameters, lateral_buffer);
-
   const auto safety_status = utils::lane_change::isLaneChangePathSafe(
     path, dynamic_objects, dynamic_object_indices, current_pose, current_twist, common_parameters,
     *lane_change_parameters_, common_parameters.expected_front_deceleration_for_abort,

--- a/planning/behavior_path_planner/src/scene_module/lane_change/normal.cpp
+++ b/planning/behavior_path_planner/src/scene_module/lane_change/normal.cpp
@@ -879,7 +879,7 @@ bool NormalLaneChange::getAbortPath()
   const auto [abort_start_idx, abort_start_dist] =
     get_abort_idx_and_distance(lane_change_parameters_->cancel.delta_time);
   const auto [abort_return_idx, abort_return_dist] = get_abort_idx_and_distance(
-    lane_change_parameters_->cancel.delta_time + lane_change_parameters_->cancel.delta_time);
+    lane_change_parameters_->cancel.delta_time + lane_change_parameters_->cancel.duration);
 
   if (abort_start_idx >= abort_return_idx) {
     RCLCPP_ERROR(logger_, "abort start idx and return idx is equal. can't compute abort path.");

--- a/planning/behavior_path_planner/src/utils/lane_change/utils.cpp
+++ b/planning/behavior_path_planner/src/utils/lane_change/utils.cpp
@@ -831,86 +831,6 @@ lanelet::ConstLanelets getBackwardLanelets(
   return backward_lanes;
 }
 
-LaneChangeTargetObjectIndices filterObjectIndices(
-  const LaneChangePaths & lane_change_paths, const PredictedObjects & objects,
-  const lanelet::ConstLanelets & target_backward_lanes, const Pose & current_pose,
-  const double forward_path_length, const LaneChangeParameters & lane_change_parameter,
-  const double filter_width)
-{
-  // Reserve maximum amount possible
-
-  std::vector<size_t> current_lane_obj_indices{};
-  std::vector<size_t> target_lane_obj_indices{};
-  std::vector<size_t> others_obj_indices{};
-  current_lane_obj_indices.reserve(objects.objects.size());
-  target_lane_obj_indices.reserve(objects.objects.size());
-  others_obj_indices.reserve(objects.objects.size());
-
-  const auto & longest_path = lane_change_paths.front();
-  const auto & current_lanes = longest_path.reference_lanelets;
-  const auto & target_lanes = longest_path.target_lanelets;
-  const auto & ego_path = longest_path.path;
-
-  const auto get_basic_polygon =
-    [](const lanelet::ConstLanelets & lanes, const double start_dist, const double end_dist) {
-      const auto polygon_3d = lanelet::utils::getPolygonFromArcLength(lanes, start_dist, end_dist);
-      return lanelet::utils::to2D(polygon_3d).basicPolygon();
-    };
-  const auto arc = lanelet::utils::getArcCoordinates(current_lanes, current_pose);
-  const auto current_polygon =
-    get_basic_polygon(current_lanes, arc.length, arc.length + forward_path_length);
-  const auto target_polygon =
-    get_basic_polygon(target_lanes, 0.0, std::numeric_limits<double>::max());
-  LineString2d ego_path_linestring;
-  ego_path_linestring.reserve(ego_path.points.size());
-  for (const auto & pt : ego_path.points) {
-    const auto & position = pt.point.pose.position;
-    boost::geometry::append(ego_path_linestring, Point2d(position.x, position.y));
-  }
-
-  for (size_t i = 0; i < objects.objects.size(); ++i) {
-    const auto & obj = objects.objects.at(i);
-
-    if (!isTargetObjectType(obj, lane_change_parameter)) {
-      continue;
-    }
-
-    const auto obj_polygon = tier4_autoware_utils::toPolygon2d(obj);
-    if (boost::geometry::intersects(current_polygon, obj_polygon)) {
-      const double distance = boost::geometry::distance(obj_polygon, ego_path_linestring);
-
-      if (distance < filter_width) {
-        current_lane_obj_indices.push_back(i);
-        continue;
-      }
-    }
-
-    const bool is_intersect_with_target = boost::geometry::intersects(target_polygon, obj_polygon);
-    if (is_intersect_with_target) {
-      target_lane_obj_indices.push_back(i);
-      continue;
-    }
-
-    const bool is_intersect_with_backward = std::invoke([&]() {
-      for (const auto & ll : target_backward_lanes) {
-        const bool is_intersect_with_backward =
-          boost::geometry::intersects(ll.polygon2d().basicPolygon(), obj_polygon);
-        if (is_intersect_with_backward) {
-          target_lane_obj_indices.push_back(i);
-          return true;
-        }
-      }
-      return false;
-    });
-
-    if (!is_intersect_with_backward) {
-      others_obj_indices.push_back(i);
-    }
-  }
-
-  return {current_lane_obj_indices, target_lane_obj_indices, others_obj_indices};
-}
-
 bool isTargetObjectType(const PredictedObject & object, const LaneChangeParameters & parameter)
 {
   using autoware_auto_perception_msgs::msg::ObjectClassification;
@@ -1171,5 +1091,88 @@ boost::optional<size_t> getLeadingStaticObjectIdx(
   }
 
   return leading_obj_idx;
+}
+
+std::optional<lanelet::BasicPolygon2d> createPolygon(
+  const lanelet::ConstLanelets & lanes, const double start_dist, const double end_dist)
+{
+  if (lanes.empty()) {
+    return {};
+  }
+  const auto polygon_3d = lanelet::utils::getPolygonFromArcLength(lanes, start_dist, end_dist);
+  return lanelet::utils::to2D(polygon_3d).basicPolygon();
+}
+
+LaneChangeTargetObjectIndices filterObject(
+  const PredictedObjects & objects, const lanelet::ConstLanelets & current_lanes,
+  const lanelet::ConstLanelets & target_lanes, const lanelet::ConstLanelets & target_backward_lanes,
+  const Pose & current_pose, const RouteHandler & route_handler,
+  const LaneChangeParameters & lane_change_parameter)
+{
+  // Guard
+  if (objects.objects.empty()) {
+    return {};
+  }
+
+  // Get path
+  const auto path =
+    route_handler.getCenterLinePath(current_lanes, 0.0, std::numeric_limits<double>::max());
+
+  const auto current_polygon =
+    createPolygon(current_lanes, 0.0, std::numeric_limits<double>::max());
+  const auto target_polygon = createPolygon(target_lanes, 0.0, std::numeric_limits<double>::max());
+  const auto target_backward_polygon =
+    createPolygon(target_backward_lanes, 0.0, std::numeric_limits<double>::max());
+
+  LaneChangeTargetObjectIndices filtered_obj_indices;
+  for (size_t i = 0; i < objects.objects.size(); ++i) {
+    const auto & object = objects.objects.at(i);
+    const auto & obj_velocity = object.kinematics.initial_twist_with_covariance.twist.linear.x;
+
+    // ignore specific object types
+    if (!isTargetObjectType(object, lane_change_parameter)) {
+      continue;
+    }
+
+    const auto obj_polygon = tier4_autoware_utils::toPolygon2d(object);
+
+    // calc distance from the current ego position
+    double max_dist_ego_to_obj = std::numeric_limits<double>::lowest();
+    for (const auto & polygon_p : obj_polygon.outer()) {
+      const auto obj_p = tier4_autoware_utils::createPoint(polygon_p.x(), polygon_p.y(), 0.0);
+      const double dist_ego_to_obj =
+        motion_utils::calcSignedArcLength(path.points, current_pose.position, obj_p);
+      max_dist_ego_to_obj = std::max(dist_ego_to_obj, max_dist_ego_to_obj);
+    }
+
+    // ignore static object that are behind the ego vehicle
+    if (obj_velocity < 1.0 && max_dist_ego_to_obj < 0.0) {
+      continue;
+    }
+
+    // check if the object intersects with target lanes
+    if (target_polygon && boost::geometry::intersects(target_polygon.value(), obj_polygon)) {
+      filtered_obj_indices.target_lane.push_back(i);
+      continue;
+    }
+
+    // check if the object intersects with target backward lanes
+    if (
+      target_backward_polygon &&
+      boost::geometry::intersects(target_backward_polygon.value(), obj_polygon)) {
+      filtered_obj_indices.target_lane.push_back(i);
+      continue;
+    }
+
+    // check if the object intersects with current lanes
+    if (current_polygon && boost::geometry::intersects(current_polygon.value(), obj_polygon)) {
+      filtered_obj_indices.current_lane.push_back(i);
+      continue;
+    }
+
+    filtered_obj_indices.other_lane.push_back(i);
+  }
+
+  return filtered_obj_indices;
 }
 }  // namespace behavior_path_planner::utils::lane_change

--- a/planning/behavior_path_planner/src/utils/lane_change/utils.cpp
+++ b/planning/behavior_path_planner/src/utils/lane_change/utils.cpp
@@ -210,15 +210,15 @@ std::optional<LaneChangePath> constructCandidatePath(
   const PathWithLaneId & prepare_segment, const PathWithLaneId & target_segment,
   const PathWithLaneId & target_lane_reference_path, const ShiftLine & shift_line,
   const lanelet::ConstLanelets & original_lanelets, const lanelet::ConstLanelets & target_lanelets,
-  const std::vector<std::vector<int64_t>> & sorted_lane_ids, const double longitudinal_acceleration,
-  const double lateral_acceleration, const LaneChangePhaseInfo lane_change_length,
-  const LaneChangePhaseInfo lane_change_velocity, const double terminal_lane_changing_velocity,
-  const LaneChangePhaseInfo lane_change_time)
+  const std::vector<std::vector<int64_t>> & sorted_lane_ids,
+  const LaneChangePhaseInfo longitudinal_acceleration, const double lateral_acceleration,
+  const LaneChangePhaseInfo lane_change_length, const LaneChangePhaseInfo lane_change_velocity,
+  const double terminal_lane_changing_velocity, const LaneChangePhaseInfo lane_change_time)
 {
   PathShifter path_shifter;
   path_shifter.setPath(target_lane_reference_path);
   path_shifter.addShiftLine(shift_line);
-  path_shifter.setLongitudinalAcceleration(longitudinal_acceleration);
+  path_shifter.setLongitudinalAcceleration(longitudinal_acceleration.lane_changing);
   ShiftedPath shifted_path;
 
   // offset front side
@@ -238,7 +238,7 @@ std::optional<LaneChangePath> constructCandidatePath(
   const auto & lane_changing_length = lane_change_length.lane_changing;
 
   LaneChangePath candidate_path;
-  candidate_path.acceleration = longitudinal_acceleration;
+  candidate_path.longitudinal_acceleration = longitudinal_acceleration;
   candidate_path.length.prepare = prepare_length;
   candidate_path.length.lane_changing = lane_changing_length;
   candidate_path.duration.prepare = lane_change_time.prepare;

--- a/planning/behavior_path_planner/src/utils/lane_change/utils.cpp
+++ b/planning/behavior_path_planner/src/utils/lane_change/utils.cpp
@@ -1165,8 +1165,17 @@ LaneChangeTargetObjectIndices filterObject(
     }
 
     // check if the object intersects with current lanes
-    if (current_polygon && boost::geometry::intersects(current_polygon.value(), obj_polygon)) {
+    if (
+      current_polygon && boost::geometry::intersects(current_polygon.value(), obj_polygon) &&
+      max_dist_ego_to_obj >= 0.0) {
+      // check only the objects that are in front of the ego vehicle
       filtered_obj_indices.current_lane.push_back(i);
+      continue;
+    }
+
+    // ignore all objects that are behind the ego vehicle and not on the current and target
+    // lanes
+    if (max_dist_ego_to_obj < 0.0) {
       continue;
     }
 

--- a/planning/behavior_path_planner/src/utils/utils.cpp
+++ b/planning/behavior_path_planner/src/utils/utils.cpp
@@ -1101,7 +1101,7 @@ bool isEgoOutOfRoute(
 
 bool isEgoWithinOriginalLane(
   const lanelet::ConstLanelets & current_lanes, const Pose & current_pose,
-  const BehaviorPathPlannerParameters & common_param)
+  const BehaviorPathPlannerParameters & common_param, const double outer_margin)
 {
   const auto lane_length = lanelet::utils::getLaneletLength2d(current_lanes);
   const auto lane_poly = lanelet::utils::getPolygonFromArcLength(current_lanes, 0, lane_length);
@@ -1111,9 +1111,17 @@ bool isEgoWithinOriginalLane(
   const auto vehicle_poly =
     tier4_autoware_utils::toFootprint(current_pose, base_link2front, base_link2rear, vehicle_width);
 
-  // Check if the ego vehicle is entirely within the lane by checking if the vehicle's polygon
-  // is within the lane's polygon
-  return boost::geometry::within(vehicle_poly, lanelet::utils::to2D(lane_poly).basicPolygon());
+  // Check if the ego vehicle is entirely within the lane with a given outer margin.
+  for (const auto & p : vehicle_poly.outer()) {
+    // When the point is in the polygon, the distance is 0. When it is out of the polygon, return a
+    // positive value.
+    const auto dist = boost::geometry::distance(p, lanelet::utils::to2D(lane_poly).basicPolygon());
+    if (dist > std::max(outer_margin, 0.0)) {
+      return false;  // out of polygon
+    }
+  }
+
+  return true;  // inside polygon
 }
 
 lanelet::ConstLanelets transformToLanelets(const DrivableLanes & drivable_lanes)


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
Fix and refactor of lane change functions.

- Safety check chattering
- Abort condition
- Object filtering
- Turn signal

## Related links

launch PR:
https://github.com/tier4/autoware_launch.xx1/pull/540
<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed

Tested in real vehicle and planning simulator.
<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters. -->

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
