### PR TITLE
perf(behavior_path_planner): simplify calculateDistanceLimit for dynamic drivable area expansion (#4163)

### DIFF
--- a/planning/behavior_path_planner/src/utils/drivable_area_expansion/drivable_area_expansion.cpp
+++ b/planning/behavior_path_planner/src/utils/drivable_area_expansion/drivable_area_expansion.cpp
@@ -32,13 +32,19 @@ void expandDrivableArea(
 {
   const auto uncrossable_lines =
     extractUncrossableLines(*route_handler.getLaneletMapPtr(), params.avoid_linestring_types);
+  multilinestring_t uncrossable_lines_in_range;
+  const auto & p = path.points.front().point.pose.position;
+  for (const auto & line : uncrossable_lines)
+    if (boost::geometry::distance(line, point_t{p.x, p.y}) < params.max_path_arc_length)
+      uncrossable_lines_in_range.push_back(line);
   const auto path_footprints = createPathFootprints(path, params);
   const auto predicted_paths = createObjectFootprints(dynamic_objects, params);
   const auto expansion_polygons =
     params.expansion_method == "lanelet"
       ? createExpansionLaneletPolygons(
           path_lanes, route_handler, path_footprints, predicted_paths, params)
-      : createExpansionPolygons(path, path_footprints, predicted_paths, uncrossable_lines, params);
+      : createExpansionPolygons(
+          path, path_footprints, predicted_paths, uncrossable_lines_in_range, params);
   const auto expanded_drivable_area = createExpandedDrivableAreaPolygon(path, expansion_polygons);
   updateDrivableAreaBounds(path, expanded_drivable_area);
 }

--- a/planning/behavior_path_planner/src/utils/drivable_area_expansion/expansion.cpp
+++ b/planning/behavior_path_planner/src/utils/drivable_area_expansion/expansion.cpp
@@ -25,10 +25,6 @@ double calculateDistanceLimit(
   const multilinestring_t & limit_lines)
 {
   auto dist_limit = std::numeric_limits<double>::max();
-  boost::geometry::for_each_point(limit_lines, [&](const auto & point) {
-    if (boost::geometry::within(point, expansion_polygon))
-      dist_limit = std::min(dist_limit, boost::geometry::distance(point, base_ls));
-  });
   multipoint_t intersections;
   boost::geometry::intersection(expansion_polygon, limit_lines, intersections);
   for (const auto & p : intersections)
@@ -42,16 +38,10 @@ double calculateDistanceLimit(
 {
   auto dist_limit = std::numeric_limits<double>::max();
   for (const auto & polygon : limit_polygons) {
-    for (const auto & p : polygon.outer()) {
-      if (boost::geometry::within(p, expansion_polygon)) {
-        dist_limit = std::min(dist_limit, boost::geometry::distance(p, base_ls));
-      }
-    }
     multipoint_t intersections;
     boost::geometry::intersection(expansion_polygon, polygon, intersections);
-    for (const auto & p : intersections) {
+    for (const auto & p : intersections)
       dist_limit = std::min(dist_limit, boost::geometry::distance(p, base_ls));
-    }
   }
   return dist_limit;
 }


### PR DESCRIPTION
## Description
https://github.com/autowarefoundation/autoware.universe/pull/4163
Hotfix to beta/v0.9.0

> This PR reduces the cost of running the dynamic drivable area expansion.
Currently, the calculations are very heavy and do not scale well with the number of "uncrossable lines".
This PR improves the performances but do not completely solve the scaling issue.

<!-- Write a brief description of this PR. -->

## Related links
https://tier4.atlassian.net/browse/RT0-28451

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed
> I checked the frequency of /planning/scenario_planning/lane_driving/behavior_planning/path_with_lane_id in the curved lane.
( I enabled dynamic_expansion and changed extra_footprint_offset from 0.5 to 3.0. )
On my PC (ThinkPad X1 Extreme Gen4), the frequency was 0.2Hz before PR merge, but it becomes >9.9Hz after PR merge.

<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes
none
<!-- Describe any changed interfaces, such as topics, services, or parameters. -->

## Effects on system behavior
This PR will fix [the issue](https://tier4.atlassian.net/browse/RT0-28451).

<!-- Describe how this PR affects the system behavior. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].
- [x] The PR has been properly tested.
- [x] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.
- [x] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
