### PR TITLE
feat(elevation_map_loader): add error handling for std::runtime_error (backport #4187)

### DIFF
--- a/perception/elevation_map_loader/src/elevation_map_loader_node.cpp
+++ b/perception/elevation_map_loader/src/elevation_map_loader_node.cpp
@@ -102,7 +102,8 @@ void ElevationMapLoaderNode::publish()
     try {
       is_bag_loaded = grid_map::GridMapRosConverter::loadFromBag(
         *data_manager_.elevation_map_path_, "elevation_map", elevation_map_);
-    } catch (rosbag2_storage_plugins::SqliteException & e) {
+    } catch (const std::runtime_error & e) {
+      RCLCPP_ERROR(this->get_logger(), e.what());
       is_bag_loaded = false;
     }
     if (!is_bag_loaded) {


### PR DESCRIPTION
## Description

https://github.com/autowarefoundation/autoware.universe/pull/4187 のbackport

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

以下の通りbackportが適用されていることを確認した

### db3が削除されている場合( std::runtime_errorが出る場合）
```
[component_container_mt-1] [INFO 1689293078.412637383] [perception.obstacle_segmentation.elevation_map.elevation_map_loader] onPointcloudMap(): subscribe pointcloud_map
[component_container_mt-1] [INFO 1689293078.460765760] [perception.obstacle_segmentation.elevation_map.elevation_map_loader] onVectorMap(): subscribe vector_map
[component_container_mt-1] [INFO 1689293078.477021059] 
[component_container_mt-1] [INFO 1689292962.307476140] [perception.obstacle_segmentation.elevation_map.elevation_map_loader] publish(): Load elevation map from: /home/hrkota/pilot-auto.x1.eve/install/elevation_map_loader/share/elevation_map_loader/data/elevation_maps/2da791365627241513c56a88a78baaf17d86b5e90febcb8987ec92c9e99ad2c6
[component_container_mt-1] [ERROR 1689292962.320853720] [rosbag2_storage] get_interface_instance(): Could not open '/home/hrkota/pilot-auto.x1.eve/install/elevation_map_loader/share/elevation_map_loader/data/elevation_maps/2da791365627241513c56a88a78baaf17d86b5e90febcb8987ec92c9e99ad2c6/2da791365627241513c56a88a78baaf17d86b5e90febcb8987ec92c9e99ad2c6_0.db3' with 'sqlite3'. Error: Failed to read from bag: File '/home/hrkota/pilot-auto.x1.eve/install/elevation_map_loader/share/elevation_map_loader/data/elevation_maps/2da791365627241513c56a88a78baaf17d86b5e90febcb8987ec92c9e99ad2c6/2da791365627241513c56a88a78baaf17d86b5e90febcb8987ec92c9e99ad2c6_0.db3' does not exist!
[component_container_mt-1] [ERROR 1689292962.320874686] [rosbag2_storage] open_read_only(): Could not load/open plugin with storage id 'sqlite3'
[component_container_mt-1] [ERROR 1689292962.320942977] [perception.obstacle_segmentation.elevation_map.elevation_map_loader] publish(): No storage could be initialized. Abort
[component_container_mt-1] [ERROR 1689292962.320965319] [perception.obstacle_segmentation.elevation_map.elevation_map_loader] publish(): Try to loading bag, but bag is broken. Remove /home/hrkota/pilot-auto.x1.eve/install/elevation_map_loader/share/elevation_map_loader/data/elevation_maps/2da791365627241513c56a88a78baaf17d86b5e90febcb8987ec92c9e99ad2c6
[component_container_mt-1] [INFO 1689292962.321324607] [perception.obstacle_segmentation.elevation_map.elevation_map_loader] publish(): Create elevation map from pointcloud map 
[component_container_mt-1] [INFO 1689292963.566615735] [perception.obstacle_segmentation.elevation_map.elevation_map_loader] printTimeElapsedToRosInfoStream(): Finish creating elevation map. Total time: 1.222 sec
[component_container_mt-1] [INFO 1689292967.571208632] [rosbag2_storage] open(): Opened database '/home/hrkota/pilot-auto.x1.eve/install/elevation_map_loader/share/elevation_map_loader/data/elevation_maps/2da791365627241513c56a88a78baaf17d86b5e90febcb8987ec92c9e99ad2c6/2da791365627241513c56a88a78baaf17d86b5e90febcb8987ec92c9e99ad2c6_0.db3' for READ_WRITE.
[component_container_mt-1] [INFO 1689292967.578154028] [perception.obstacle_segmentation.elevation_map.elevation_map_loader] saveElevationMap(): Saving elevation map successful: true
```

### db3が壊れている場合（rosbag2_storage_plugins::SqliteExceptionが出る場合）
```
[component_container_mt-1] [INFO 1689293078.412637383] [perception.obstacle_segmentation.elevation_map.elevation_map_loader] onPointcloudMap(): subscribe pointcloud_map
[component_container_mt-1] [INFO 1689293078.460765760] [perception.obstacle_segmentation.elevation_map.elevation_map_loader] onVectorMap(): subscribe vector_map
[component_container_mt-1] [INFO 1689293078.477021059] [perception.obstacle_segmentation.elevation_map.elevation_map_loader] publish(): Load elevation map from: /home/hrkota/pilot-auto.x1.eve/install/elevation_map_loader/share/elevation_map_loader/data/elevation_maps/2da791365627241513c56a88a78baaf17d86b5e90febcb8987ec92c9e99ad2c6
[component_container_mt-1] [ERROR 1689293078.490381622] [rosbag2_storage] get_interface_instance(): Could not open '/home/hrkota/pilot-auto.x1.eve/install/elevation_map_loader/share/elevation_map_loader/data/elevation_maps/2da791365627241513c56a88a78baaf17d86b5e90febcb8987ec92c9e99ad2c6/2da791365627241513c56a88a78baaf17d86b5e90febcb8987ec92c9e99ad2c6_0.db3' with 'sqlite3'. Error: Failed to setup storage. Error: Error when processing SQL statement. SQLite error (26): file is not a database
[component_container_mt-1] [ERROR 1689293078.490400289] [rosbag2_storage] open_read_only(): Could not load/open plugin with storage id 'sqlite3'
[component_container_mt-1] [ERROR 1689293078.490461256] [perception.obstacle_segmentation.elevation_map.elevation_map_loader] publish(): No storage could be initialized. Abort
[component_container_mt-1] [ERROR 1689293078.490484395] [perception.obstacle_segmentation.elevation_map.elevation_map_loader] publish(): Try to loading bag, but bag is broken. Remove /home/hrkota/pilot-auto.x1.eve/install/elevation_map_loader/share/elevation_map_loader/data/elevation_maps/2da791365627241513c56a88a78baaf17d86b5e90febcb8987ec92c9e99ad2c6
[component_container_mt-1] [INFO 1689293078.490577377] [perception.obstacle_segmentation.elevation_map.elevation_map_loader] publish(): Create elevation map from pointcloud map 
[component_container_mt-1] [INFO 1689293079.589844157] [perception.obstacle_segmentation.elevation_map.elevation_map_loader] printTimeElapsedToRosInfoStream(): Finish creating elevation map. Total time: 1.077 sec
[component_container_mt-1] [INFO 1689293083.657039493] [rosbag2_storage] open(): Opened database '/home/hrkota/pilot-auto.x1.eve/install/elevation_map_loader/share/elevation_map_loader/data/elevation_maps/2da791365627241513c56a88a78baaf17d86b5e90febcb8987ec92c9e99ad2c6/2da791365627241513c56a88a78baaf17d86b5e90febcb8987ec92c9e99ad2c6_0.db3' for READ_WRITE.
[component_container_mt-1] [INFO 1689293083.663860301] [perception.obstacle_segmentation.elevation_map.elevation_map_loader] saveElevationMap(): Saving elevation map successful: true
```

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
