### PR TITLE
fix(run_out): clear stop pose to prevent virtual wall from remaining

### DIFF
--- a/planning/behavior_velocity_run_out_module/src/debug.cpp
+++ b/planning/behavior_velocity_run_out_module/src/debug.cpp
@@ -184,6 +184,8 @@ motion_utils::VirtualWalls RunOutDebug::createVirtualWalls()
     wall.pose = p;
     virtual_walls.push_back(wall);
   }
+  stop_pose_.clear();
+
   return virtual_walls;
 }
 


### PR DESCRIPTION
## Description
Cherry pick bug fix for run out.
#4240

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Tested on a simple planning simulator.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

None.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
