### PR TITLE
feat(start_planner): add offset to not finish before engage (autowarefoundation#4121)

### DIFF
--- a/planning/behavior_path_planner/src/scene_module/start_planner/start_planner_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/start_planner/start_planner_module.cpp
@@ -726,7 +726,9 @@ bool StartPlannerModule::hasFinishedPullOut() const
   const auto arclength_pull_out_end =
     lanelet::utils::getArcCoordinates(status_.current_lanes, status_.pull_out_path.end_pose);
 
-  const bool has_finished = arclength_current.length - arclength_pull_out_end.length > 0.0;
+  // offset to not finish the module before engage
+  constexpr double offset = 0.1;
+  const bool has_finished = arclength_current.length - arclength_pull_out_end.length > offset;
 
 #ifdef USE_OLD_ARCHITECTURE
   is_executed_ = !has_finished;


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->


cherry-pick https://github.com/autowarefoundation/autoware.universe/pull/4121


## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed

<!-- Describe how you have tested this PR. -->

psim and scenario test in main

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters. -->

none

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

none

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
