### PR TITLE
feat(behavior_velocity): support new traffic signal interface

### DIFF
--- a/common/tier4_traffic_light_rviz_plugin/README.md
+++ b/common/tier4_traffic_light_rviz_plugin/README.md
@@ -8,9 +8,9 @@ This plugin panel publishes dummy traffic light signals.
 
 ### Output
 
-| Name                                                    | Type                                                     | Description                   |
-| ------------------------------------------------------- | -------------------------------------------------------- | ----------------------------- |
-| `/perception/traffic_light_recognition/traffic_signals` | `autoware_auto_perception_msgs::msg::TrafficSignalArray` | Publish traffic light signals |
+| Name                                                    | Type                                                | Description                   |
+| ------------------------------------------------------- | --------------------------------------------------- | ----------------------------- |
+| `/perception/traffic_light_recognition/traffic_signals` | `autoware_perception_msgs::msg::TrafficSignalArray` | Publish traffic light signals |
 
 ## HowToUse
 

--- a/common/tier4_traffic_light_rviz_plugin/package.xml
+++ b/common/tier4_traffic_light_rviz_plugin/package.xml
@@ -11,7 +11,7 @@
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>autoware_auto_mapping_msgs</depend>
-  <depend>autoware_auto_perception_msgs</depend>
+  <depend>autoware_perception_msgs</depend>
   <depend>lanelet2_extension</depend>
   <depend>libqt5-core</depend>
   <depend>libqt5-gui</depend>

--- a/common/tier4_traffic_light_rviz_plugin/src/traffic_light_publish_panel.cpp
+++ b/common/tier4_traffic_light_rviz_plugin/src/traffic_light_publish_panel.cpp
@@ -34,6 +34,7 @@
 #include <utility>
 #include <vector>
 
+#undef signals
 namespace rviz_plugins
 {
 TrafficLightPublishPanel::TrafficLightPublishPanel(QWidget * parent) : rviz_common::Panel(parent)
@@ -138,55 +139,55 @@ void TrafficLightPublishPanel::onSetTrafficLightState()
   const auto shape = light_shape_combo_->currentText();
   const auto status = light_status_combo_->currentText();
 
-  TrafficLight traffic_light;
+  TrafficSignalElement traffic_light;
   traffic_light.confidence = traffic_light_confidence_input_->value();
 
   if (color == "RED") {
-    traffic_light.color = TrafficLight::RED;
+    traffic_light.color = TrafficSignalElement::RED;
   } else if (color == "AMBER") {
-    traffic_light.color = TrafficLight::AMBER;
+    traffic_light.color = TrafficSignalElement::AMBER;
   } else if (color == "GREEN") {
-    traffic_light.color = TrafficLight::GREEN;
+    traffic_light.color = TrafficSignalElement::GREEN;
   } else if (color == "WHITE") {
-    traffic_light.color = TrafficLight::WHITE;
+    traffic_light.color = TrafficSignalElement::WHITE;
   } else if (color == "UNKNOWN") {
-    traffic_light.color = TrafficLight::UNKNOWN;
+    traffic_light.color = TrafficSignalElement::UNKNOWN;
   }
 
   if (shape == "CIRCLE") {
-    traffic_light.shape = TrafficLight::CIRCLE;
+    traffic_light.shape = TrafficSignalElement::CIRCLE;
   } else if (shape == "LEFT_ARROW") {
-    traffic_light.shape = TrafficLight::LEFT_ARROW;
+    traffic_light.shape = TrafficSignalElement::LEFT_ARROW;
   } else if (shape == "RIGHT_ARROW") {
-    traffic_light.shape = TrafficLight::RIGHT_ARROW;
+    traffic_light.shape = TrafficSignalElement::RIGHT_ARROW;
   } else if (shape == "UP_ARROW") {
-    traffic_light.shape = TrafficLight::UP_ARROW;
+    traffic_light.shape = TrafficSignalElement::UP_ARROW;
   } else if (shape == "DOWN_ARROW") {
-    traffic_light.shape = TrafficLight::DOWN_ARROW;
+    traffic_light.shape = TrafficSignalElement::DOWN_ARROW;
   } else if (shape == "DOWN_LEFT_ARROW") {
-    traffic_light.shape = TrafficLight::DOWN_LEFT_ARROW;
+    traffic_light.shape = TrafficSignalElement::DOWN_LEFT_ARROW;
   } else if (shape == "DOWN_RIGHT_ARROW") {
-    traffic_light.shape = TrafficLight::DOWN_RIGHT_ARROW;
+    traffic_light.shape = TrafficSignalElement::DOWN_RIGHT_ARROW;
   } else if (shape == "UNKNOWN") {
-    traffic_light.shape = TrafficLight::UNKNOWN;
+    traffic_light.shape = TrafficSignalElement::UNKNOWN;
   }
 
   if (status == "SOLID_OFF") {
-    traffic_light.status = TrafficLight::SOLID_OFF;
+    traffic_light.status = TrafficSignalElement::SOLID_OFF;
   } else if (status == "SOLID_ON") {
-    traffic_light.status = TrafficLight::SOLID_ON;
+    traffic_light.status = TrafficSignalElement::SOLID_ON;
   } else if (status == "FLASHING") {
-    traffic_light.status = TrafficLight::FLASHING;
+    traffic_light.status = TrafficSignalElement::FLASHING;
   } else if (status == "UNKNOWN") {
-    traffic_light.status = TrafficLight::UNKNOWN;
+    traffic_light.status = TrafficSignalElement::UNKNOWN;
   }
 
   TrafficSignal traffic_signal;
-  traffic_signal.lights.push_back(traffic_light);
-  traffic_signal.map_primitive_id = traffic_light_id;
+  traffic_signal.elements.push_back(traffic_light);
+  traffic_signal.traffic_signal_id = traffic_light_id;
 
   for (auto & signal : extra_traffic_signals_.signals) {
-    if (signal.map_primitive_id == traffic_light_id) {
+    if (signal.traffic_signal_id == traffic_light_id) {
       signal = traffic_signal;
       return;
     }
@@ -218,7 +219,7 @@ void TrafficLightPublishPanel::onInitialize()
   raw_node_ = this->getDisplayContext()->getRosNodeAbstraction().lock()->get_raw_node();
 
   pub_traffic_signals_ = raw_node_->create_publisher<TrafficSignalArray>(
-    "/perception/traffic_light_recognition/traffic_signals", rclcpp::QoS(1));
+    "/perception/traffic_light_arbiter/traffic_signals", rclcpp::QoS(1));
 
   sub_vector_map_ = raw_node_->create_subscription<HADMapBin>(
     "/map/vector_map", rclcpp::QoS{1}.transient_local(),
@@ -247,7 +248,7 @@ void TrafficLightPublishPanel::createWallTimer()
 void TrafficLightPublishPanel::onTimer()
 {
   if (enable_publish_) {
-    extra_traffic_signals_.header.stamp = rclcpp::Clock().now();
+    extra_traffic_signals_.stamp = rclcpp::Clock().now();
     pub_traffic_signals_->publish(extra_traffic_signals_);
   }
 
@@ -260,35 +261,35 @@ void TrafficLightPublishPanel::onTimer()
   for (size_t i = 0; i < extra_traffic_signals_.signals.size(); ++i) {
     const auto & signal = extra_traffic_signals_.signals.at(i);
 
-    if (signal.lights.empty()) {
+    if (signal.elements.empty()) {
       continue;
     }
 
-    auto id_label = new QLabel(QString::number(signal.map_primitive_id));
+    auto id_label = new QLabel(QString::number(signal.traffic_signal_id));
     id_label->setAlignment(Qt::AlignCenter);
 
     auto color_label = new QLabel();
     color_label->setAlignment(Qt::AlignCenter);
 
-    const auto & light = signal.lights.front();
+    const auto & light = signal.elements.front();
     switch (light.color) {
-      case TrafficLight::RED:
+      case TrafficSignalElement::RED:
         color_label->setText("RED");
         color_label->setStyleSheet("background-color: #FF0000;");
         break;
-      case TrafficLight::AMBER:
+      case TrafficSignalElement::AMBER:
         color_label->setText("AMBER");
         color_label->setStyleSheet("background-color: #FFBF00;");
         break;
-      case TrafficLight::GREEN:
+      case TrafficSignalElement::GREEN:
         color_label->setText("GREEN");
         color_label->setStyleSheet("background-color: #7CFC00;");
         break;
-      case TrafficLight::WHITE:
+      case TrafficSignalElement::WHITE:
         color_label->setText("WHITE");
         color_label->setStyleSheet("background-color: #FFFFFF;");
         break;
-      case TrafficLight::UNKNOWN:
+      case TrafficSignalElement::UNKNOWN:
         color_label->setText("UNKNOWN");
         color_label->setStyleSheet("background-color: #808080;");
         break;
@@ -300,31 +301,28 @@ void TrafficLightPublishPanel::onTimer()
     shape_label->setAlignment(Qt::AlignCenter);
 
     switch (light.shape) {
-      case TrafficLight::CIRCLE:
+      case TrafficSignalElement::CIRCLE:
         shape_label->setText("CIRCLE");
         break;
-      case TrafficLight::LEFT_ARROW:
+      case TrafficSignalElement::LEFT_ARROW:
         shape_label->setText("LEFT_ARROW");
         break;
-      case TrafficLight::RIGHT_ARROW:
+      case TrafficSignalElement::RIGHT_ARROW:
         shape_label->setText("RIGHT_ARROW");
         break;
-      case TrafficLight::UP_ARROW:
+      case TrafficSignalElement::UP_ARROW:
         shape_label->setText("UP_ARROW");
         break;
-      case TrafficLight::DOWN_ARROW:
+      case TrafficSignalElement::DOWN_ARROW:
         shape_label->setText("DOWN_ARROW");
         break;
-      case TrafficLight::DOWN_LEFT_ARROW:
+      case TrafficSignalElement::DOWN_LEFT_ARROW:
         shape_label->setText("DOWN_LEFT_ARROW");
         break;
-      case TrafficLight::DOWN_RIGHT_ARROW:
+      case TrafficSignalElement::DOWN_RIGHT_ARROW:
         shape_label->setText("DOWN_RIGHT_ARROW");
         break;
-      case TrafficLight::FLASHING:
-        shape_label->setText("FLASHING");
-        break;
-      case TrafficLight::UNKNOWN:
+      case TrafficSignalElement::UNKNOWN:
         shape_label->setText("UNKNOWN");
         break;
       default:
@@ -335,16 +333,16 @@ void TrafficLightPublishPanel::onTimer()
     status_label->setAlignment(Qt::AlignCenter);
 
     switch (light.status) {
-      case TrafficLight::SOLID_OFF:
+      case TrafficSignalElement::SOLID_OFF:
         status_label->setText("SOLID_OFF");
         break;
-      case TrafficLight::SOLID_ON:
+      case TrafficSignalElement::SOLID_ON:
         status_label->setText("SOLID_ON");
         break;
-      case TrafficLight::FLASHING:
+      case TrafficSignalElement::FLASHING:
         status_label->setText("FLASHING");
         break;
-      case TrafficLight::UNKNOWN:
+      case TrafficSignalElement::UNKNOWN:
         status_label->setText("UNKNOWN");
         break;
       default:
@@ -375,11 +373,9 @@ void TrafficLightPublishPanel::onVectorMap(const HADMapBin::ConstSharedPtr msg)
   std::string info = "Fetching traffic lights :";
   std::string delim = " ";
   for (auto && tl_reg_elem_ptr : tl_reg_elems) {
-    for (auto && traffic_light : tl_reg_elem_ptr->trafficLights()) {
-      auto id = static_cast<int>(traffic_light.id());
-      info += (std::exchange(delim, ", ") + std::to_string(id));
-      traffic_light_ids_.insert(id);
-    }
+    auto id = static_cast<int>(tl_reg_elem_ptr->id());
+    info += (std::exchange(delim, ", ") + std::to_string(id));
+    traffic_light_ids_.insert(id);
   }
   RCLCPP_INFO_STREAM(raw_node_->get_logger(), info);
   received_vector_map_ = true;

--- a/common/tier4_traffic_light_rviz_plugin/src/traffic_light_publish_panel.hpp
+++ b/common/tier4_traffic_light_rviz_plugin/src/traffic_light_publish_panel.hpp
@@ -27,7 +27,7 @@
 #include <rviz_common/panel.hpp>
 
 #include <autoware_auto_mapping_msgs/msg/had_map_bin.hpp>
-#include <autoware_auto_perception_msgs/msg/traffic_signal_array.hpp>
+#include <autoware_perception_msgs/msg/traffic_signal_array.hpp>
 #endif
 
 #include <set>
@@ -36,10 +36,9 @@ namespace rviz_plugins
 {
 
 using autoware_auto_mapping_msgs::msg::HADMapBin;
-using autoware_auto_perception_msgs::msg::TrafficLight;
-using autoware_auto_perception_msgs::msg::TrafficSignal;
-using autoware_auto_perception_msgs::msg::TrafficSignalArray;
-
+using autoware_perception_msgs::msg::TrafficSignal;
+using autoware_perception_msgs::msg::TrafficSignalArray;
+using autoware_perception_msgs::msg::TrafficSignalElement;
 class TrafficLightPublishPanel : public rviz_common::Panel
 {
   Q_OBJECT

--- a/launch/tier4_planning_launch/launch/scenario_planning/lane_driving/behavior_planning/behavior_planning.launch.py
+++ b/launch/tier4_planning_launch/launch/scenario_planning/lane_driving/behavior_planning/behavior_planning.launch.py
@@ -172,11 +172,7 @@ def launch_setup(context, *args, **kwargs):
             ),
             (
                 "~/input/traffic_signals",
-                "/perception/traffic_light_recognition/traffic_signals",
-            ),
-            (
-                "~/input/external_traffic_signals",
-                "/external/traffic_light_recognition/traffic_signals",
+                "/perception/traffic_light_arbiter/traffic_signals",
             ),
             (
                 "~/input/external_velocity_limit_mps",

--- a/planning/behavior_velocity_crosswalk_module/package.xml
+++ b/planning/behavior_velocity_crosswalk_module/package.xml
@@ -21,6 +21,7 @@
   <depend>autoware_auto_perception_msgs</depend>
   <depend>autoware_auto_planning_msgs</depend>
   <depend>autoware_auto_tf2</depend>
+  <depend>autoware_perception_msgs</depend>
   <depend>behavior_velocity_planner_common</depend>
   <depend>eigen</depend>
   <depend>geometry_msgs</depend>

--- a/planning/behavior_velocity_crosswalk_module/src/scene_crosswalk.cpp
+++ b/planning/behavior_velocity_crosswalk_module/src/scene_crosswalk.cpp
@@ -857,28 +857,25 @@ bool CrosswalkModule::isRedSignalForPedestrians() const
     crosswalk_.regulatoryElementsAs<const lanelet::TrafficLight>();
 
   for (const auto & traffic_lights_reg_elem : traffic_lights_reg_elems) {
-    lanelet::ConstLineStringsOrPolygons3d traffic_lights = traffic_lights_reg_elem->trafficLights();
-    for (const auto & traffic_light : traffic_lights) {
-      const auto ll_traffic_light = static_cast<lanelet::ConstLineString3d>(traffic_light);
-      const auto traffic_signal_stamped = planner_data_->getTrafficSignal(ll_traffic_light.id());
-      if (!traffic_signal_stamped) {
-        continue;
-      }
+    const auto traffic_signal_stamped =
+      planner_data_->getTrafficSignal(traffic_lights_reg_elem->id());
+    if (!traffic_signal_stamped) {
+      continue;
+    }
 
-      if (
-        planner_param_.traffic_light_state_timeout <
-        (clock_->now() - traffic_signal_stamped->header.stamp).seconds()) {
-        continue;
-      }
+    if (
+      planner_param_.traffic_light_state_timeout <
+      (clock_->now() - traffic_signal_stamped->stamp).seconds()) {
+      continue;
+    }
 
-      const auto & lights = traffic_signal_stamped->signal.lights;
-      if (lights.empty()) {
-        continue;
-      }
+    const auto & lights = traffic_signal_stamped->signal.elements;
+    if (lights.empty()) {
+      continue;
+    }
 
-      if (lights.front().color == TrafficLight::RED) {
-        return true;
-      }
+    if (lights.front().color == TrafficSignalElement::RED) {
+      return true;
     }
   }
 

--- a/planning/behavior_velocity_crosswalk_module/src/scene_crosswalk.hpp
+++ b/planning/behavior_velocity_crosswalk_module/src/scene_crosswalk.hpp
@@ -49,8 +49,8 @@ namespace behavior_velocity_planner
 using autoware_auto_perception_msgs::msg::ObjectClassification;
 using autoware_auto_perception_msgs::msg::PredictedObject;
 using autoware_auto_perception_msgs::msg::PredictedObjects;
-using autoware_auto_perception_msgs::msg::TrafficLight;
 using autoware_auto_planning_msgs::msg::PathWithLaneId;
+using autoware_perception_msgs::msg::TrafficSignalElement;
 using lanelet::autoware::Crosswalk;
 using tier4_api_msgs::msg::CrosswalkStatus;
 using tier4_autoware_utils::Polygon2d;

--- a/planning/behavior_velocity_intersection_module/package.xml
+++ b/planning/behavior_velocity_intersection_module/package.xml
@@ -19,6 +19,7 @@
 
   <depend>autoware_auto_perception_msgs</depend>
   <depend>autoware_auto_planning_msgs</depend>
+  <depend>autoware_perception_msgs</depend>
   <depend>behavior_velocity_planner_common</depend>
   <depend>cv_bridge</depend>
   <depend>geometry_msgs</depend>

--- a/planning/behavior_velocity_intersection_module/src/util.cpp
+++ b/planning/behavior_velocity_intersection_module/src/util.cpp
@@ -671,9 +671,10 @@ bool hasAssociatedTrafficLight(lanelet::ConstLanelet lane)
 }
 
 bool isTrafficLightArrowActivated(
-  lanelet::ConstLanelet lane,
-  const std::map<int, autoware_auto_perception_msgs::msg::TrafficSignalStamped> & tl_infos)
+  lanelet::ConstLanelet lane, const std::map<int, TrafficSignalStamped> & tl_infos)
 {
+  using TrafficSignalElement = autoware_perception_msgs::msg::TrafficSignalElement;
+
   const auto & turn_direction = lane.attributeOr("turn_direction", "else");
   std::optional<int> tl_id = std::nullopt;
   for (auto && tl_reg_elem : lane.regulatoryElementsAs<lanelet::TrafficLight>()) {
@@ -690,16 +691,13 @@ bool isTrafficLightArrowActivated(
     return false;
   }
   const auto & tl_info = tl_info_it->second;
-  for (auto && tl_light : tl_info.signal.lights) {
-    if (tl_light.color != autoware_auto_perception_msgs::msg::TrafficLight::GREEN) continue;
-    if (tl_light.status != autoware_auto_perception_msgs::msg::TrafficLight::SOLID_ON) continue;
-    if (
-      turn_direction == std::string("left") &&
-      tl_light.shape == autoware_auto_perception_msgs::msg::TrafficLight::LEFT_ARROW)
+  for (auto && tl_light : tl_info.signal.elements) {
+    if (tl_light.color != TrafficSignalElement::GREEN) continue;
+    if (tl_light.status != TrafficSignalElement::SOLID_ON) continue;
+    if (turn_direction == std::string("left") && tl_light.shape == TrafficSignalElement::LEFT_ARROW)
       return true;
     if (
-      turn_direction == std::string("right") &&
-      tl_light.shape == autoware_auto_perception_msgs::msg::TrafficLight::RIGHT_ARROW)
+      turn_direction == std::string("right") && tl_light.shape == TrafficSignalElement::RIGHT_ARROW)
       return true;
   }
   return false;

--- a/planning/behavior_velocity_intersection_module/src/util.hpp
+++ b/planning/behavior_velocity_intersection_module/src/util.hpp
@@ -111,8 +111,7 @@ std::optional<Polygon2d> getIntersectionArea(
 
 bool hasAssociatedTrafficLight(lanelet::ConstLanelet lane);
 bool isTrafficLightArrowActivated(
-  lanelet::ConstLanelet lane,
-  const std::map<int, autoware_auto_perception_msgs::msg::TrafficSignalStamped> & tl_infos);
+  lanelet::ConstLanelet lane, const std::map<int, TrafficSignalStamped> & tl_infos);
 
 std::vector<DescritizedLane> generateDetectionLaneDivisions(
   lanelet::ConstLanelets detection_lanelets,

--- a/planning/behavior_velocity_planner/README.md
+++ b/planning/behavior_velocity_planner/README.md
@@ -29,15 +29,15 @@ So for example, in order to stop at a stop line with the vehicles' front on the 
 
 ## Input topics
 
-| Name                                      | Type                                                   | Description                                                                                                                     |
-| ----------------------------------------- | ------------------------------------------------------ | ------------------------------------------------------------------------------------------------------------------------------- |
-| `~input/path_with_lane_id`                | autoware_auto_planning_msgs::msg::PathWithLaneId       | path with lane_id                                                                                                               |
-| `~input/vector_map`                       | autoware_auto_mapping_msgs::msg::HADMapBin             | vector map                                                                                                                      |
-| `~input/vehicle_odometry`                 | nav_msgs::msg::Odometry                                | vehicle velocity                                                                                                                |
-| `~input/dynamic_objects`                  | autoware_auto_perception_msgs::msg::PredictedObjects   | dynamic objects                                                                                                                 |
-| `~input/no_ground_pointcloud`             | sensor_msgs::msg::PointCloud2                          | obstacle pointcloud                                                                                                             |
-| `~/input/compare_map_filtered_pointcloud` | sensor_msgs::msg::PointCloud2                          | obstacle pointcloud filtered by compare map. Note that this is used only when the detection method of run out module is Points. |
-| `~input/traffic_signals`                  | autoware_auto_perception_msgs::msg::TrafficSignalArray | traffic light states                                                                                                            |
+| Name                                      | Type                                                 | Description                                                                                                                     |
+| ----------------------------------------- | ---------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------------------- |
+| `~input/path_with_lane_id`                | autoware_auto_planning_msgs::msg::PathWithLaneId     | path with lane_id                                                                                                               |
+| `~input/vector_map`                       | autoware_auto_mapping_msgs::msg::HADMapBin           | vector map                                                                                                                      |
+| `~input/vehicle_odometry`                 | nav_msgs::msg::Odometry                              | vehicle velocity                                                                                                                |
+| `~input/dynamic_objects`                  | autoware_auto_perception_msgs::msg::PredictedObjects | dynamic objects                                                                                                                 |
+| `~input/no_ground_pointcloud`             | sensor_msgs::msg::PointCloud2                        | obstacle pointcloud                                                                                                             |
+| `~/input/compare_map_filtered_pointcloud` | sensor_msgs::msg::PointCloud2                        | obstacle pointcloud filtered by compare map. Note that this is used only when the detection method of run out module is Points. |
+| `~input/traffic_signals`                  | autoware_perception_msgs::msg::TrafficSignalArray    | traffic light states                                                                                                            |
 
 ## Output topics
 

--- a/planning/behavior_velocity_planner/src/node.cpp
+++ b/planning/behavior_velocity_planner/src/node.cpp
@@ -99,7 +99,7 @@ BehaviorVelocityPlannerNode::BehaviorVelocityPlannerNode(const rclcpp::NodeOptio
     std::bind(&BehaviorVelocityPlannerNode::onLaneletMap, this, _1),
     createSubscriptionOptions(this));
   sub_traffic_signals_ =
-    this->create_subscription<autoware_auto_perception_msgs::msg::TrafficSignalArray>(
+    this->create_subscription<autoware_perception_msgs::msg::TrafficSignalArray>(
       "~/input/traffic_signals", 1,
       std::bind(&BehaviorVelocityPlannerNode::onTrafficSignals, this, _1),
       createSubscriptionOptions(this));
@@ -287,15 +287,15 @@ void BehaviorVelocityPlannerNode::onLaneletMap(
 }
 
 void BehaviorVelocityPlannerNode::onTrafficSignals(
-  const autoware_auto_perception_msgs::msg::TrafficSignalArray::ConstSharedPtr msg)
+  const autoware_perception_msgs::msg::TrafficSignalArray::ConstSharedPtr msg)
 {
   std::lock_guard<std::mutex> lock(mutex_);
 
   for (const auto & signal : msg->signals) {
-    autoware_auto_perception_msgs::msg::TrafficSignalStamped traffic_signal;
-    traffic_signal.header = msg->header;
+    TrafficSignalStamped traffic_signal;
+    traffic_signal.stamp = msg->stamp;
     traffic_signal.signal = signal;
-    planner_data_.traffic_light_id_map[signal.map_primitive_id] = traffic_signal;
+    planner_data_.traffic_light_id_map[signal.traffic_signal_id] = traffic_signal;
   }
 }
 

--- a/planning/behavior_velocity_planner/src/node.hpp
+++ b/planning/behavior_velocity_planner/src/node.hpp
@@ -61,7 +61,7 @@ private:
   rclcpp::Subscription<nav_msgs::msg::Odometry>::SharedPtr sub_vehicle_odometry_;
   rclcpp::Subscription<geometry_msgs::msg::AccelWithCovarianceStamped>::SharedPtr sub_acceleration_;
   rclcpp::Subscription<autoware_auto_mapping_msgs::msg::HADMapBin>::SharedPtr sub_lanelet_map_;
-  rclcpp::Subscription<autoware_auto_perception_msgs::msg::TrafficSignalArray>::SharedPtr
+  rclcpp::Subscription<autoware_perception_msgs::msg::TrafficSignalArray>::SharedPtr
     sub_traffic_signals_;
   rclcpp::Subscription<tier4_v2x_msgs::msg::VirtualTrafficLightStateArray>::SharedPtr
     sub_virtual_traffic_light_states_;
@@ -77,7 +77,7 @@ private:
   void onAcceleration(const geometry_msgs::msg::AccelWithCovarianceStamped::ConstSharedPtr msg);
   void onLaneletMap(const autoware_auto_mapping_msgs::msg::HADMapBin::ConstSharedPtr msg);
   void onTrafficSignals(
-    const autoware_auto_perception_msgs::msg::TrafficSignalArray::ConstSharedPtr msg);
+    const autoware_perception_msgs::msg::TrafficSignalArray::ConstSharedPtr msg);
   void onVirtualTrafficLightStates(
     const tier4_v2x_msgs::msg::VirtualTrafficLightStateArray::ConstSharedPtr msg);
   void onOccupancyGrid(const nav_msgs::msg::OccupancyGrid::ConstSharedPtr msg);

--- a/planning/behavior_velocity_planner_common/include/behavior_velocity_planner_common/planner_data.hpp
+++ b/planning/behavior_velocity_planner_common/include/behavior_velocity_planner_common/planner_data.hpp
@@ -17,14 +17,14 @@
 
 #include "route_handler/route_handler.hpp"
 
+#include <behavior_velocity_planner_common/utilization/util.hpp>
 #include <motion_velocity_smoother/smoother/analytical_jerk_constrained_smoother/analytical_jerk_constrained_smoother.hpp>
 #include <motion_velocity_smoother/smoother/smoother_base.hpp>
 #include <vehicle_info_util/vehicle_info_util.hpp>
 
 #include <autoware_auto_mapping_msgs/msg/had_map_bin.hpp>
 #include <autoware_auto_perception_msgs/msg/predicted_objects.hpp>
-#include <autoware_auto_perception_msgs/msg/traffic_signal_array.hpp>
-#include <autoware_auto_perception_msgs/msg/traffic_signal_stamped.hpp>
+#include <autoware_perception_msgs/msg/traffic_signal_array.hpp>
 #include <geometry_msgs/msg/accel_with_covariance_stamped.hpp>
 #include <geometry_msgs/msg/pose_stamped.hpp>
 #include <geometry_msgs/msg/twist_stamped.hpp>
@@ -83,7 +83,7 @@ struct PlannerData
   double ego_nearest_yaw_threshold;
 
   // other internal data
-  std::map<int, autoware_auto_perception_msgs::msg::TrafficSignalStamped> traffic_light_id_map;
+  std::map<int, TrafficSignalStamped> traffic_light_id_map;
   boost::optional<tier4_planning_msgs::msg::VelocityLimit> external_velocity_limit;
   tier4_v2x_msgs::msg::VirtualTrafficLightStateArray::ConstSharedPtr virtual_traffic_light_states;
 
@@ -132,14 +132,12 @@ struct PlannerData
     return true;
   }
 
-  std::shared_ptr<autoware_auto_perception_msgs::msg::TrafficSignalStamped> getTrafficSignal(
-    const int id) const
+  std::shared_ptr<TrafficSignalStamped> getTrafficSignal(const int id) const
   {
     if (traffic_light_id_map.count(id) == 0) {
       return {};
     }
-    return std::make_shared<autoware_auto_perception_msgs::msg::TrafficSignalStamped>(
-      traffic_light_id_map.at(id));
+    return std::make_shared<TrafficSignalStamped>(traffic_light_id_map.at(id));
   }
 };
 }  // namespace behavior_velocity_planner

--- a/planning/behavior_velocity_planner_common/include/behavior_velocity_planner_common/utilization/util.hpp
+++ b/planning/behavior_velocity_planner_common/include/behavior_velocity_planner_common/utilization/util.hpp
@@ -27,6 +27,7 @@
 #include <autoware_auto_planning_msgs/msg/path_with_lane_id.hpp>
 #include <autoware_auto_planning_msgs/msg/trajectory.hpp>
 #include <autoware_auto_planning_msgs/msg/trajectory_point.hpp>
+#include <autoware_perception_msgs/msg/traffic_signal.hpp>
 #include <geometry_msgs/msg/point.hpp>
 #include <geometry_msgs/msg/pose_stamped.hpp>
 #include <geometry_msgs/msg/quaternion.hpp>
@@ -76,6 +77,12 @@ struct PointWithSearchRangeIndex
 {
   geometry_msgs::msg::Point point;
   SearchRangeIndex index;
+};
+
+struct TrafficSignalStamped
+{
+  builtin_interfaces::msg::Time stamp;
+  autoware_perception_msgs::msg::TrafficSignal signal;
 };
 
 using geometry_msgs::msg::Pose;

--- a/planning/behavior_velocity_planner_common/package.xml
+++ b/planning/behavior_velocity_planner_common/package.xml
@@ -19,9 +19,9 @@
 
   <depend>autoware_adapi_v1_msgs</depend>
   <depend>autoware_auto_mapping_msgs</depend>
-  <depend>autoware_auto_perception_msgs</depend>
   <depend>autoware_auto_planning_msgs</depend>
   <depend>autoware_auto_tf2</depend>
+  <depend>autoware_perception_msgs</depend>
   <depend>diagnostic_msgs</depend>
   <depend>eigen</depend>
   <depend>geometry_msgs</depend>

--- a/planning/behavior_velocity_traffic_light_module/package.xml
+++ b/planning/behavior_velocity_traffic_light_module/package.xml
@@ -18,8 +18,8 @@
   <buildtool_depend>eigen3_cmake_module</buildtool_depend>
 
   <depend>autoware_adapi_v1_msgs</depend>
-  <depend>autoware_auto_perception_msgs</depend>
   <depend>autoware_auto_planning_msgs</depend>
+  <depend>autoware_perception_msgs</depend>
   <depend>behavior_velocity_planner_common</depend>
   <depend>eigen</depend>
   <depend>geometry_msgs</depend>

--- a/planning/behavior_velocity_traffic_light_module/src/manager.cpp
+++ b/planning/behavior_velocity_traffic_light_module/src/manager.cpp
@@ -37,7 +37,7 @@ TrafficLightModuleManager::TrafficLightModuleManager(rclcpp::Node & node)
   planner_param_.tl_state_timeout = node.declare_parameter<double>(ns + ".tl_state_timeout");
   planner_param_.enable_pass_judge = node.declare_parameter<bool>(ns + ".enable_pass_judge");
   planner_param_.yellow_lamp_period = node.declare_parameter<double>(ns + ".yellow_lamp_period");
-  pub_tl_state_ = node.create_publisher<autoware_auto_perception_msgs::msg::LookingTrafficSignal>(
+  pub_tl_state_ = node.create_publisher<autoware_perception_msgs::msg::TrafficSignal>(
     "~/output/traffic_signal", 1);
 }
 
@@ -47,9 +47,7 @@ void TrafficLightModuleManager::modifyPathVelocity(
   visualization_msgs::msg::MarkerArray debug_marker_array;
   visualization_msgs::msg::MarkerArray virtual_wall_marker_array;
 
-  autoware_auto_perception_msgs::msg::LookingTrafficSignal tl_state;
-  tl_state.header.stamp = path->header.stamp;
-  tl_state.is_module_running = false;
+  autoware_perception_msgs::msg::TrafficSignal tl_state;
 
   autoware_adapi_v1_msgs::msg::VelocityFactorArray velocity_factor_array;
   velocity_factor_array.header.frame_id = "map";

--- a/planning/behavior_velocity_traffic_light_module/src/manager.hpp
+++ b/planning/behavior_velocity_traffic_light_module/src/manager.hpp
@@ -55,8 +55,7 @@ private:
     const lanelet::TrafficLightConstPtr registered_element) const;
 
   // Debug
-  rclcpp::Publisher<autoware_auto_perception_msgs::msg::LookingTrafficSignal>::SharedPtr
-    pub_tl_state_;
+  rclcpp::Publisher<autoware_perception_msgs::msg::TrafficSignal>::SharedPtr pub_tl_state_;
 
   boost::optional<int> first_ref_stop_path_point_index_;
 };

--- a/planning/behavior_velocity_traffic_light_module/src/scene.cpp
+++ b/planning/behavior_velocity_traffic_light_module/src/scene.cpp
@@ -159,32 +159,6 @@ bool calcStopPointAndInsertIndex(
   }
   return false;
 }
-
-geometry_msgs::msg::Point getTrafficLightPosition(
-  const lanelet::ConstLineStringOrPolygon3d & traffic_light)
-{
-  if (!traffic_light.lineString()) {
-    throw std::invalid_argument{"Traffic light is not LineString"};
-  }
-  geometry_msgs::msg::Point tl_center;
-  auto traffic_light_ls = traffic_light.lineString().value();
-  for (const auto & tl_point : traffic_light_ls) {
-    tl_center.x += tl_point.x() / traffic_light_ls.size();
-    tl_center.y += tl_point.y() / traffic_light_ls.size();
-    tl_center.z += tl_point.z() / traffic_light_ls.size();
-  }
-  return tl_center;
-}
-autoware_auto_perception_msgs::msg::LookingTrafficSignal initializeTrafficSignal(
-  const rclcpp::Time stamp)
-{
-  autoware_auto_perception_msgs::msg::LookingTrafficSignal state;
-  state.header.stamp = stamp;
-  state.is_module_running = true;
-  state.perception.has_state = false;
-  state.result.has_state = false;
-  return state;
-}
 }  // namespace
 
 TrafficLightModule::TrafficLightModule(
@@ -197,7 +171,6 @@ TrafficLightModule::TrafficLightModule(
   traffic_light_reg_elem_(traffic_light_reg_elem),
   lane_(lane),
   state_(State::APPROACH),
-  input_(Input::PERCEPTION),
   is_prev_state_stop_(false)
 {
   velocity_factor_.init(VelocityFactor::TRAFFIC_SIGNAL);
@@ -206,7 +179,6 @@ TrafficLightModule::TrafficLightModule(
 
 bool TrafficLightModule::modifyPathVelocity(PathWithLaneId * path, StopReason * stop_reason)
 {
-  looking_tl_state_ = initializeTrafficSignal(path->header.stamp);
   debug_data_ = DebugData();
   debug_data_.base_link2front = planner_data_->vehicle_info_.max_longitudinal_offset_m;
   first_stop_path_point_index_ = static_cast<int>(path->points.size()) - 1;
@@ -217,9 +189,8 @@ bool TrafficLightModule::modifyPathVelocity(PathWithLaneId * path, StopReason * 
 
   const auto & self_pose = planner_data_->current_odometry;
 
-  // Get lanelet2 traffic lights and stop lines.
+  // Get lanelet2 stop lines.
   lanelet::ConstLineString3d lanelet_stop_lines = *(traffic_light_reg_elem_.stopLine());
-  lanelet::ConstLineStringsOrPolygons3d traffic_lights = traffic_light_reg_elem_.trafficLights();
 
   // Calculate stop pose and insert index
   Eigen::Vector2d stop_line_point{};
@@ -255,7 +226,7 @@ bool TrafficLightModule::modifyPathVelocity(PathWithLaneId * path, StopReason * 
     first_ref_stop_path_point_index_ = stop_line_point_idx;
 
     // Check if stop is coming.
-    setSafe(!isStopSignal(traffic_lights));
+    setSafe(!isStopSignal());
     if (isActivated()) {
       is_prev_state_stop_ = false;
       return true;
@@ -283,33 +254,27 @@ bool TrafficLightModule::modifyPathVelocity(PathWithLaneId * path, StopReason * 
   return false;
 }
 
-bool TrafficLightModule::isStopSignal(const lanelet::ConstLineStringsOrPolygons3d & traffic_lights)
+bool TrafficLightModule::isStopSignal()
 {
-  if (!updateTrafficSignal(traffic_lights)) {
+  if (!updateTrafficSignal()) {
     return false;
   }
 
-  return looking_tl_state_.result.judge ==
-         autoware_auto_perception_msgs::msg::TrafficSignalWithJudge::STOP;
+  return isTrafficSignalStop(looking_tl_state_);
 }
 
-bool TrafficLightModule::updateTrafficSignal(
-  const lanelet::ConstLineStringsOrPolygons3d & traffic_lights)
+bool TrafficLightModule::updateTrafficSignal()
 {
-  autoware_auto_perception_msgs::msg::TrafficSignalStamped tl_state_perception;
-  bool found_perception = getHighestConfidenceTrafficSignal(traffic_lights, tl_state_perception);
+  TrafficSignal signal;
+  bool found_signal = findValidTrafficSignal(signal);
 
-  if (!found_perception) {
+  if (!found_signal) {
     // Don't stop when UNKNOWN or TIMEOUT as discussed at #508
-    input_ = Input::NONE;
     return false;
   }
 
-  if (found_perception) {
-    looking_tl_state_.perception = generateTlStateWithJudgeFromTlState(tl_state_perception.signal);
-    looking_tl_state_.result = looking_tl_state_.perception;
-    input_ = Input::PERCEPTION;
-  }
+  // Found signal associated with the lanelet
+  looking_tl_state_ = signal;
 
   return true;
 }
@@ -337,7 +302,7 @@ bool TrafficLightModule::isPassthrough(const double & signed_arc_length) const
 
   const auto & enable_pass_judge = planner_param_.enable_pass_judge;
 
-  if (enable_pass_judge && !stoppable && !is_prev_state_stop_ && input_ == Input::PERCEPTION) {
+  if (enable_pass_judge && !stoppable && !is_prev_state_stop_) {
     // Cannot stop under acceleration and jerk limits.
     // However, ego vehicle can't enter the intersection while the light is yellow.
     // It is called dilemma zone. Make a stop decision to be safe.
@@ -359,10 +324,9 @@ bool TrafficLightModule::isPassthrough(const double & signed_arc_length) const
 }
 
 bool TrafficLightModule::isTrafficSignalStop(
-  const autoware_auto_perception_msgs::msg::TrafficSignal & tl_state) const
+  const autoware_perception_msgs::msg::TrafficSignal & tl_state) const
 {
-  if (hasTrafficLightCircleColor(
-        tl_state, autoware_auto_perception_msgs::msg::TrafficLight::GREEN)) {
+  if (hasTrafficLightCircleColor(tl_state, TrafficSignalElement::GREEN)) {
     return false;
   }
 
@@ -373,86 +337,43 @@ bool TrafficLightModule::isTrafficSignalStop(
   }
   if (
     turn_direction == "right" &&
-    hasTrafficLightShape(tl_state, autoware_auto_perception_msgs::msg::TrafficLight::RIGHT_ARROW)) {
+    hasTrafficLightShape(tl_state, TrafficSignalElement::RIGHT_ARROW)) {
     return false;
   }
   if (
-    turn_direction == "left" &&
-    hasTrafficLightShape(tl_state, autoware_auto_perception_msgs::msg::TrafficLight::LEFT_ARROW)) {
+    turn_direction == "left" && hasTrafficLightShape(tl_state, TrafficSignalElement::LEFT_ARROW)) {
     return false;
   }
   if (
     turn_direction == "straight" &&
-    hasTrafficLightShape(tl_state, autoware_auto_perception_msgs::msg::TrafficLight::UP_ARROW)) {
+    hasTrafficLightShape(tl_state, TrafficSignalElement::UP_ARROW)) {
     return false;
   }
 
   return true;
 }
 
-bool TrafficLightModule::getHighestConfidenceTrafficSignal(
-  const lanelet::ConstLineStringsOrPolygons3d & traffic_lights,
-  autoware_auto_perception_msgs::msg::TrafficSignalStamped & highest_confidence_tl_state)
+bool TrafficLightModule::findValidTrafficSignal(TrafficSignal & valid_traffic_signal)
 {
-  // search traffic light state
-  bool found = false;
-  double highest_confidence = 0.0;
-  std::string reason;
-  for (const auto & traffic_light : traffic_lights) {
-    // traffic light must be linestrings
-    if (!traffic_light.isLineString()) {
-      reason = "NotLineString";
-      continue;
-    }
-
-    const int id = static_cast<lanelet::ConstLineString3d>(traffic_light).id();
-    RCLCPP_DEBUG(logger_, "traffic light id: %d (on route)", id);
-    const auto tl_state_stamped = planner_data_->getTrafficSignal(id);
-    if (!tl_state_stamped) {
-      reason = "TrafficSignalNotFound";
-      continue;
-    }
-
-    const auto header = tl_state_stamped->header;
-    const auto tl_state = tl_state_stamped->signal;
-    if (!((clock_->now() - header.stamp).seconds() < planner_param_.tl_state_timeout)) {
-      reason = "TimeOut";
-      continue;
-    }
-
-    if (
-      tl_state.lights.empty() ||
-      tl_state.lights.front().color == autoware_auto_perception_msgs::msg::TrafficLight::UNKNOWN) {
-      reason = "TrafficLightUnknown";
-      continue;
-    }
-
-    if (highest_confidence < tl_state.lights.front().confidence) {
-      highest_confidence = tl_state.lights.front().confidence;
-      highest_confidence_tl_state = *tl_state_stamped;
-      try {
-        auto tl_position = getTrafficLightPosition(traffic_light);
-        debug_data_.traffic_light_points.push_back(tl_position);
-        debug_data_.highest_confidence_traffic_light_point = std::make_optional(tl_position);
-      } catch (const std::invalid_argument & ex) {
-        RCLCPP_WARN_STREAM(logger_, ex.what());
-        continue;
-      }
-      found = true;
-    }
-  }
-  if (!found) {
-    std::string not_found_traffic_ids{""};
-    for (size_t i = 0; i < traffic_lights.size(); ++i) {
-      const int id = static_cast<lanelet::ConstLineString3d>(traffic_lights.at(i)).id();
-      not_found_traffic_ids += (i != 0 ? "," : "") + std::to_string(id);
-    }
-
+  // get traffic signal associated with the regulatory element id
+  const auto traffic_signal_stamped = planner_data_->getTrafficSignal(traffic_light_reg_elem_.id());
+  if (!traffic_signal_stamped) {
     RCLCPP_WARN_THROTTLE(
-      logger_, *clock_, 5000 /* ms */, "cannot find traffic light lamp state (%s) due to %s.",
-      not_found_traffic_ids.c_str(), reason.c_str());
+      logger_, *clock_, 5000 /* ms */,
+      "the traffic signal data associated with regulatory element id is not received");
     return false;
   }
+
+  // check if the traffic signal data is outdated
+  const auto is_traffic_signal_timeout =
+    (clock_->now() - traffic_signal_stamped->stamp).seconds() > planner_param_.tl_state_timeout;
+  if (is_traffic_signal_timeout) {
+    RCLCPP_WARN_THROTTLE(
+      logger_, *clock_, 5000 /* ms */, "the received traffic signal data is outdated");
+    return false;
+  }
+
+  valid_traffic_signal = traffic_signal_stamped->signal;
   return true;
 }
 
@@ -496,40 +417,24 @@ autoware_auto_planning_msgs::msg::PathWithLaneId TrafficLightModule::insertStopP
 }
 
 bool TrafficLightModule::hasTrafficLightCircleColor(
-  const autoware_auto_perception_msgs::msg::TrafficSignal & tl_state,
-  const uint8_t & lamp_color) const
+  const autoware_perception_msgs::msg::TrafficSignal & tl_state, const uint8_t & lamp_color) const
 {
-  using autoware_auto_perception_msgs::msg::TrafficLight;
-
   const auto it_lamp =
-    std::find_if(tl_state.lights.begin(), tl_state.lights.end(), [&lamp_color](const auto & x) {
-      return x.shape == TrafficLight::CIRCLE && x.color == lamp_color;
+    std::find_if(tl_state.elements.begin(), tl_state.elements.end(), [&lamp_color](const auto & x) {
+      return x.shape == TrafficSignalElement::CIRCLE && x.color == lamp_color;
     });
 
-  return it_lamp != tl_state.lights.end();
+  return it_lamp != tl_state.elements.end();
 }
 
 bool TrafficLightModule::hasTrafficLightShape(
-  const autoware_auto_perception_msgs::msg::TrafficSignal & tl_state,
-  const uint8_t & lamp_shape) const
+  const autoware_perception_msgs::msg::TrafficSignal & tl_state, const uint8_t & lamp_shape) const
 {
   const auto it_lamp = std::find_if(
-    tl_state.lights.begin(), tl_state.lights.end(),
+    tl_state.elements.begin(), tl_state.elements.end(),
     [&lamp_shape](const auto & x) { return x.shape == lamp_shape; });
 
-  return it_lamp != tl_state.lights.end();
+  return it_lamp != tl_state.elements.end();
 }
 
-autoware_auto_perception_msgs::msg::TrafficSignalWithJudge
-TrafficLightModule::generateTlStateWithJudgeFromTlState(
-  const autoware_auto_perception_msgs::msg::TrafficSignal tl_state) const
-{
-  autoware_auto_perception_msgs::msg::TrafficSignalWithJudge tl_state_with_judge;
-  tl_state_with_judge.signal = tl_state;
-  tl_state_with_judge.has_state = true;
-  tl_state_with_judge.judge = isTrafficSignalStop(tl_state)
-                                ? autoware_auto_perception_msgs::msg::TrafficSignalWithJudge::STOP
-                                : autoware_auto_perception_msgs::msg::TrafficSignalWithJudge::GO;
-  return tl_state_with_judge;
-}
 }  // namespace behavior_velocity_planner

--- a/planning/planning_debug_tools/scripts/perception_reproducer.py
+++ b/planning/planning_debug_tools/scripts/perception_reproducer.py
@@ -25,7 +25,7 @@ import time
 from autoware_auto_perception_msgs.msg import DetectedObjects
 from autoware_auto_perception_msgs.msg import PredictedObjects
 from autoware_auto_perception_msgs.msg import TrackedObjects
-from autoware_auto_perception_msgs.msg import TrafficSignalArray
+from autoware_perception_msgs.msg import TrafficSignalArray
 from geometry_msgs.msg import Quaternion
 from nav_msgs.msg import Odometry
 import numpy as np
@@ -238,11 +238,11 @@ class PerceptionReproducer(Node):
 
                 self.objects_pub.publish(objects_msg)
             if traffic_signals_msg:
-                traffic_signals_msg.header.stamp = timestamp
+                traffic_signals_msg.stamp = timestamp
                 self.traffic_signals_pub.publish(traffic_signals_msg)
                 self.prev_traffic_signals_msg = traffic_signals_msg
             elif self.prev_traffic_signals_msg:
-                self.prev_traffic_signals_msg.header.stamp = timestamp
+                self.prev_traffic_signals_msg.stamp = timestamp
                 self.traffic_signals_pub.publish(self.prev_traffic_signals_msg)
         else:
             print("No ego pose found.")

--- a/planning/planning_test_utils/include/planning_interface_test_manager/planning_interface_test_manager.hpp
+++ b/planning/planning_test_utils/include/planning_interface_test_manager/planning_interface_test_manager.hpp
@@ -38,11 +38,11 @@
 #include <autoware_auto_control_msgs/msg/ackermann_control_command.hpp>
 #include <autoware_auto_mapping_msgs/msg/had_map_bin.hpp>
 #include <autoware_auto_perception_msgs/msg/predicted_objects.hpp>
-#include <autoware_auto_perception_msgs/msg/traffic_signal_array.hpp>
 #include <autoware_auto_planning_msgs/msg/path.hpp>
 #include <autoware_auto_planning_msgs/msg/path_with_lane_id.hpp>
 #include <autoware_auto_planning_msgs/msg/trajectory.hpp>
 #include <autoware_auto_vehicle_msgs/msg/steering_report.hpp>
+#include <autoware_perception_msgs/msg/traffic_signal_array.hpp>
 #include <autoware_planning_msgs/msg/lanelet_route.hpp>
 #include <geometry_msgs/msg/accel_with_covariance_stamped.hpp>
 #include <geometry_msgs/msg/point.hpp>
@@ -77,10 +77,10 @@ namespace planning_test_utils
 using autoware_adapi_v1_msgs::msg::OperationModeState;
 using autoware_auto_mapping_msgs::msg::HADMapBin;
 using autoware_auto_perception_msgs::msg::PredictedObjects;
-using autoware_auto_perception_msgs::msg::TrafficSignalArray;
 using autoware_auto_planning_msgs::msg::Path;
 using autoware_auto_planning_msgs::msg::PathWithLaneId;
 using autoware_auto_planning_msgs::msg::Trajectory;
+using autoware_perception_msgs::msg::TrafficSignalArray;
 using autoware_planning_msgs::msg::LaneletRoute;
 using geometry_msgs::msg::AccelWithCovarianceStamped;
 using geometry_msgs::msg::Point;

--- a/planning/planning_test_utils/package.xml
+++ b/planning/planning_test_utils/package.xml
@@ -15,9 +15,9 @@
 
   <depend>autoware_auto_control_msgs</depend>
   <depend>autoware_auto_mapping_msgs</depend>
-  <depend>autoware_auto_perception_msgs</depend>
   <depend>autoware_auto_planning_msgs</depend>
   <depend>autoware_auto_vehicle_msgs</depend>
+  <depend>autoware_perception_msgs</depend>
   <depend>autoware_planning_msgs</depend>
   <depend>component_interface_specs</depend>
   <depend>component_interface_utils</depend>


### PR DESCRIPTION
## Description
https://github.com/autowarefoundation/autoware.universe/pull/4133
Hotfix to beta/v0.10.0

> In this Pull Request, we are introducing support for the new traffic signal messages within the planning modules.
For more detailed information about the new messages, please refer to the associated issue linked below.
https://github.com/autowarefoundation/autoware.universe/issues/2567

<!-- Write a brief description of this PR. -->

## Related links
https://github.com/tier4/autoware.universe/pull/677

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed
Tested on a simple planning simulator.
<!-- Describe how you have tested this PR. -->

## Notes for reviewers
> For the traffic light module, I have removed the old messages and variables previously used to manage inputs from either Perception or External sources, given that the External input is no longer used.
Moreover, since the input Traffic Signal message, processed by traffic_signal_arbiter, already contains the selected data (either the signal with the highest confidence or the input from the V2X source), I have also removed the process to find the signal with the highest confidence.


<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes
> As mentioned above, Planning modules will support only new interface.
The interface change for perception modules was done in this PR.
https://github.com/autowarefoundation/autoware.universe/pull/4084
<!-- Describe any changed interfaces, such as topics, services, or parameters. -->

## Effects on system behavior
no effects
<!-- Describe how this PR affects the system behavior. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].
- [x] The PR has been properly tested.
- [x] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.
- [x] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
