### PR TITLE
fix(out_of_lane): prevent crash when current footprint is empty

### DIFF
--- a/planning/behavior_path_planner/src/utils/drivable_area_expansion/drivable_area_expansion.cpp
+++ b/planning/behavior_path_planner/src/utils/drivable_area_expansion/drivable_area_expansion.cpp
@@ -20,7 +20,18 @@
 #include "behavior_path_planner/utils/drivable_area_expansion/parameters.hpp"
 #include "behavior_path_planner/utils/drivable_area_expansion/types.hpp"
 
+#include <Eigen/Geometry>
+
 #include <boost/geometry.hpp>
+
+// for writing the svg file
+#include <fstream>
+#include <iostream>
+// for the geometry types
+#include <tier4_autoware_utils/geometry/geometry.hpp>
+// for the svg mapper
+#include <boost/geometry/io/svg/svg_mapper.hpp>
+#include <boost/geometry/io/svg/write.hpp>
 
 namespace drivable_area_expansion
 {
@@ -82,84 +93,222 @@ polygon_t createExpandedDrivableAreaPolygon(
   return expanded_da_poly;
 }
 
-std::array<ring_t::const_iterator, 4> findLeftRightRanges(
-  const PathWithLaneId & path, const ring_t & expanded_drivable_area)
+void copy_z_over_arc_length(
+  const std::vector<geometry_msgs::msg::Point> & from, std::vector<geometry_msgs::msg::Point> & to)
 {
+  if (from.empty() || to.empty()) return;
+  to.front().z = from.front().z;
+  if (from.size() < 2 || to.size() < 2) return;
+  to.back().z = from.back().z;
+  auto i_from = 1lu;
+  auto s_from = tier4_autoware_utils::calcDistance2d(from[0], from[1]);
+  auto s_to = 0.0;
+  auto s_from_prev = 0.0;
+  for (auto i_to = 1lu; i_to + 1 < to.size(); ++i_to) {
+    s_to += tier4_autoware_utils::calcDistance2d(to[i_to - 1], to[i_to]);
+    for (; s_from < s_to && i_from + 1 < from.size(); ++i_from) {
+      s_from_prev = s_from;
+      s_from += tier4_autoware_utils::calcDistance2d(from[i_from], from[i_from + 1]);
+    }
+    if (s_from - s_from_prev != 0.0) {
+      const auto ratio = (s_to - s_from_prev) / (s_from - s_from_prev);
+      to[i_to].z = interpolation::lerp(from[i_from - 1].z, from[i_from].z, ratio);
+    } else {
+      to[i_to].z = to[i_to - 1].z;
+    }
+  }
+}
+
+void updateDrivableAreaBounds(PathWithLaneId & path, const polygon_t & expanded_drivable_area)
+{
+  const auto original_left_bound = path.left_bound;
+  const auto original_right_bound = path.right_bound;
   const auto is_left_of_segment = [](const point_t & a, const point_t & b, const point_t & p) {
     return (b.x() - a.x()) * (p.y() - a.y()) - (b.y() - a.y()) * (p.x() - a.x()) > 0;
   };
+
+  const auto start_segment =
+    segment_t{convert_point(path.left_bound.front()), convert_point(path.right_bound.front())};
+  const auto end_segment =
+    segment_t{convert_point(path.left_bound.back()), convert_point(path.right_bound.back())};
+  point_t start_segment_center;
+  boost::geometry::centroid(start_segment, start_segment_center);
+  const auto path_start_segment =
+    segment_t{start_segment_center, convert_point(path.points[1].point.pose.position)};
+  point_t end_segment_center;
+  boost::geometry::centroid(end_segment, end_segment_center);
+  const auto path_end_segment =
+    segment_t{convert_point(path.points.back().point.pose.position), end_segment_center};
   const auto is_left_of_path_start = [&](const point_t & p) {
     return is_left_of_segment(
       convert_point(path.points[0].point.pose.position),
       convert_point(path.points[1].point.pose.position), p);
   };
-  const auto is_left_of_path_end = [&, size = path.points.size()](const point_t & p) {
+  const auto is_left_of_path_end = [&](const point_t & p) {
     return is_left_of_segment(
-      convert_point(path.points[size - 2].point.pose.position),
-      convert_point(path.points[size - 1].point.pose.position), p);
+      convert_point(path.points.back().point.pose.position), end_segment_center, p);
   };
-  const auto dist_to_path_start = [start = convert_point(path.points.front().point.pose.position)](
-                                    const auto & p) { return boost::geometry::distance(start, p); };
-  const auto dist_to_path_end = [end = convert_point(path.points.back().point.pose.position)](
-                                  const auto & p) { return boost::geometry::distance(end, p); };
+  const auto segment_to_line_intersection =
+    [](const auto p1, const auto p2, const auto q1, const auto q2) -> std::optional<point_t> {
+    const auto line = Eigen::Hyperplane<double, 2>::Through(q1, q2);
+    const auto segment = Eigen::Hyperplane<double, 2>::Through(p1, p2);
+    const auto intersection = line.intersection(segment);
+    std::optional<point_t> result;
+    const auto is_on_segment =
+      (p1.x() <= p2.x() ? intersection.x() >= p1.x() && intersection.x() <= p2.x()
+                        : intersection.x() <= p1.x() && intersection.x() >= p2.x()) &&
+      (p1.y() <= p2.y() ? intersection.y() >= p1.y() && intersection.y() <= p2.y()
+                        : intersection.y() <= p1.y() && intersection.y() >= p2.y());
+    if (is_on_segment) result = point_t{intersection.x(), intersection.y()};
+    return result;
+  };
+  struct Intersection
+  {
+    ring_t::const_iterator segment_it;
+    point_t intersection_point;
+    double distance = std::numeric_limits<double>::max();
+  };
+  const auto & da = expanded_drivable_area.outer();
+  Intersection start_left;
+  start_left.segment_it = da.end();
+  Intersection end_left;
+  end_left.segment_it = da.end();
+  Intersection start_right;
+  start_right.segment_it = da.end();
+  Intersection end_right;
+  end_right.segment_it = da.end();
 
-  double min_start_dist = std::numeric_limits<double>::max();
-  auto start_transition = expanded_drivable_area.end();
-  double min_end_dist = std::numeric_limits<double>::max();
-  auto end_transition = expanded_drivable_area.end();
-  for (auto it = expanded_drivable_area.begin(); std::next(it) != expanded_drivable_area.end();
-       ++it) {
-    if (is_left_of_path_start(*it) != is_left_of_path_start(*std::next(it))) {
-      const auto dist = dist_to_path_start(*it);
-      if (dist < min_start_dist) {
-        start_transition = it;
-        min_start_dist = dist;
+  // Declare a stream and an SVG mapper
+  std::ofstream svg("/home/mclement/Pictures/debug.svg");
+  boost::geometry::svg_mapper<tier4_autoware_utils::Point2d> mapper(svg, 400, 400);
+  for (auto it = da.begin(); it != da.end(); ++it) {
+    if (boost::geometry::distance(*it, start_segment.first) < 1e-3) {
+      start_left.intersection_point = *it;
+      start_left.segment_it = it;
+      start_left.distance = 0.0;
+    } else if (boost::geometry::distance(*it, start_segment.second) < 1e-3) {
+      start_right.intersection_point = *it;
+      start_right.segment_it = it;
+      start_right.distance = 0.0;
+    } else if (boost::geometry::distance(*it, end_segment.first) < 1e-3) {
+      end_left.intersection_point = *it;
+      end_left.segment_it = it;
+      end_left.distance = 0.0;
+    } else if (boost::geometry::distance(*it, end_segment.second) < 1e-3) {
+      end_right.intersection_point = *it;
+      end_right.segment_it = it;
+      end_right.distance = 0.0;
+    }
+    const auto inter_start =
+      std::next(it) == da.end()
+        ? segment_to_line_intersection(*it, da.front(), start_segment.first, start_segment.second)
+        : segment_to_line_intersection(
+            *it, *std::next(it), start_segment.first, start_segment.second);
+    if (inter_start) {
+      const auto dist = boost::geometry::distance(*inter_start, path_start_segment);
+      if (is_left_of_path_start(*inter_start)) {
+        if (dist < start_left.distance) {
+          start_left.intersection_point = *inter_start;
+          start_left.segment_it = it;
+          start_left.distance = dist;
+        }
+      } else {
+        if (dist < start_right.distance) {
+          start_right.intersection_point = *inter_start;
+          start_right.segment_it = it;
+          start_right.distance = dist;
+        }
       }
     }
-    if (is_left_of_path_end(*it) != is_left_of_path_end(*std::next(it))) {
-      const auto dist = dist_to_path_end(*it);
-      if (dist < min_end_dist) {
-        end_transition = it;
-        min_end_dist = dist;
+    const auto inter_end =
+      std::next(it) == da.end()
+        ? segment_to_line_intersection(*it, da.front(), end_segment.first, end_segment.second)
+        : segment_to_line_intersection(*it, *std::next(it), end_segment.first, end_segment.second);
+    if (inter_end) {
+      const auto dist = boost::geometry::distance(*inter_end, path_end_segment);
+      if (is_left_of_path_end(*inter_end)) {
+        if (dist < end_left.distance) {
+          end_left.intersection_point = *inter_end;
+          end_left.segment_it = it;
+          end_left.distance = dist;
+        }
+      } else {
+        if (dist < end_right.distance) {
+          end_right.intersection_point = *inter_end;
+          end_right.segment_it = it;
+          end_right.distance = dist;
+        }
       }
     }
   }
-  const auto left_start =
-    is_left_of_path_start(*start_transition) ? start_transition : std::next(start_transition);
-  const auto right_start =
-    is_left_of_path_start(*start_transition) ? std::next(start_transition) : start_transition;
-  const auto left_end =
-    is_left_of_path_end(*end_transition) ? end_transition : std::next(end_transition);
-  const auto right_end =
-    is_left_of_path_end(*end_transition) ? std::next(end_transition) : end_transition;
-  return {left_start, left_end, right_start, right_end};
-}
+  mapper.add(expanded_drivable_area);
+  mapper.add(path_start_segment);
+  mapper.add(path_end_segment);
+  mapper.add(start_segment);
+  mapper.add(end_segment);
+  mapper.map(expanded_drivable_area, "fill-opacity:0.0;fill:black;stroke:black;stroke-width:1", 1);
+  mapper.map(start_segment, "fill-opacity:0.5;fill:blue;stroke:blue;stroke-width:2", 2);
+  mapper.map(end_segment, "fill-opacity:0.5;fill:blue;stroke:blue;stroke-width:2", 2);
+  mapper.map(path_start_segment, "fill-opacity:0.5;fill:green;stroke:green;stroke-width:2", 2);
+  mapper.map(path_end_segment, "fill-opacity:0.5;fill:green;stroke:green;stroke-width:2", 2);
+  mapper.map(
+    start_left.intersection_point, "fill-opacity:0.5;fill:red;stroke:red;stroke-width:2", 2);
+  mapper.map(
+    start_right.intersection_point, "fill-opacity:0.5;fill:red;stroke:red;stroke-width:2", 2);
+  mapper.map(end_left.intersection_point, "fill-opacity:0.5;fill:red;stroke:red;stroke-width:2", 2);
+  mapper.map(
+    end_right.intersection_point, "fill-opacity:0.5;fill:red;stroke:red;stroke-width:2", 2);
 
-void updateDrivableAreaBounds(PathWithLaneId & path, const polygon_t & expanded_drivable_area)
-{
+  if (
+    start_left.segment_it == da.end() || start_right.segment_it == da.end() ||
+    end_left.segment_it == da.end() || end_right.segment_it == da.end()) {
+    std::cerr << (start_left.segment_it == da.end()) << " " << (start_right.segment_it == da.end())
+              << " " << (end_left.segment_it == da.end()) << " "
+              << (end_right.segment_it == da.end()) << std::endl;
+    return;
+  }
+
   path.left_bound.clear();
   path.right_bound.clear();
-  const auto begin = expanded_drivable_area.outer().begin();
-  const auto end = std::prev(expanded_drivable_area.outer().end());
-  const auto & [left_start, left_end, right_start, right_end] =
-    findLeftRightRanges(path, expanded_drivable_area.outer());
-  // NOTE: clockwise ordering -> positive increment for left bound, negative for right bound
-  if (left_start < left_end) {
-    path.left_bound.reserve(std::distance(left_start, left_end));
-    for (auto it = left_start; it <= left_end; ++it) path.left_bound.push_back(convert_point(*it));
-  } else {  // loop back
-    path.left_bound.reserve(std::distance(left_start, end) + std::distance(begin, left_end));
-    for (auto it = left_start; it != end; ++it) path.left_bound.push_back(convert_point(*it));
-    for (auto it = begin; it <= left_end; ++it) path.left_bound.push_back(convert_point(*it));
+  path.left_bound.push_back(convert_point(start_left.intersection_point));
+  path.right_bound.push_back(convert_point(start_right.intersection_point));
+  if (!boost::geometry::equals(start_right.intersection_point, *start_right.segment_it))
+    path.right_bound.push_back(convert_point(*start_right.segment_it));
+  if (start_left.segment_it < end_left.segment_it) {
+    for (auto it = std::next(start_left.segment_it); it <= end_left.segment_it; ++it)
+      path.left_bound.push_back(convert_point(*it));
+  } else {
+    for (auto it = std::next(start_left.segment_it); it < da.end(); ++it)
+      path.left_bound.push_back(convert_point(*it));
+    for (auto it = da.begin(); it <= end_left.segment_it; ++it)
+      path.left_bound.push_back(convert_point(*it));
   }
-  if (right_start > right_end) {
-    path.right_bound.reserve(std::distance(right_end, right_start));
-    for (auto it = right_start; it >= right_end; --it)
+  if (!boost::geometry::equals(end_left.intersection_point, *end_left.segment_it))
+    path.left_bound.push_back(convert_point(end_left.intersection_point));
+  if (start_right.segment_it < end_right.segment_it) {
+    for (auto it = std::prev(start_right.segment_it); it >= da.begin(); --it)
       path.right_bound.push_back(convert_point(*it));
-  } else {  // loop back
-    path.right_bound.reserve(std::distance(begin, right_start) + std::distance(right_end, end));
-    for (auto it = right_start; it >= begin; --it) path.right_bound.push_back(convert_point(*it));
-    for (auto it = end - 1; it >= right_end; --it) path.right_bound.push_back(convert_point(*it));
+    for (auto it = std::prev(da.end()); it > end_right.segment_it; --it)
+      path.right_bound.push_back(convert_point(*it));
+  } else {
+    for (auto it = std::prev(start_right.segment_it); it > end_right.segment_it; --it)
+      path.right_bound.push_back(convert_point(*it));
+  }
+  if (!boost::geometry::equals(end_right.intersection_point, *std::next(end_right.segment_it)))
+    path.right_bound.push_back(convert_point(end_right.intersection_point));
+
+  // remove possible duplicated points
+  const auto point_cmp = [](const auto & p1, const auto & p2) {
+    return p1.x == p2.x && p1.y == p2.y;
+  };
+  std::unique(path.left_bound.begin(), path.left_bound.end(), point_cmp);
+  std::unique(path.right_bound.begin(), path.right_bound.end(), point_cmp);
+  copy_z_over_arc_length(original_left_bound, path.left_bound);
+  copy_z_over_arc_length(original_right_bound, path.right_bound);
+
+  for (const auto & p : path.right_bound) {
+    mapper.add(convert_point(p));
+    mapper.map(convert_point(p), "fill-opacity:0.5;fill:grey;stroke:grey;stroke-width:2", 1);
   }
 }
 

--- a/planning/behavior_path_planner/src/utils/drivable_area_expansion/drivable_area_expansion.cpp
+++ b/planning/behavior_path_planner/src/utils/drivable_area_expansion/drivable_area_expansion.cpp
@@ -24,15 +24,6 @@
 
 #include <boost/geometry.hpp>
 
-// for writing the svg file
-#include <fstream>
-#include <iostream>
-// for the geometry types
-#include <tier4_autoware_utils/geometry/geometry.hpp>
-// for the svg mapper
-#include <boost/geometry/io/svg/svg_mapper.hpp>
-#include <boost/geometry/io/svg/write.hpp>
-
 namespace drivable_area_expansion
 {
 
@@ -178,9 +169,6 @@ void updateDrivableAreaBounds(PathWithLaneId & path, const polygon_t & expanded_
   Intersection end_right;
   end_right.segment_it = da.end();
 
-  // Declare a stream and an SVG mapper
-  std::ofstream svg("/home/mclement/Pictures/debug.svg");
-  boost::geometry::svg_mapper<tier4_autoware_utils::Point2d> mapper(svg, 400, 400);
   for (auto it = da.begin(); it != da.end(); ++it) {
     if (boost::geometry::distance(*it, start_segment.first) < 1e-3) {
       start_left.intersection_point = *it;
@@ -241,24 +229,6 @@ void updateDrivableAreaBounds(PathWithLaneId & path, const polygon_t & expanded_
       }
     }
   }
-  mapper.add(expanded_drivable_area);
-  mapper.add(path_start_segment);
-  mapper.add(path_end_segment);
-  mapper.add(start_segment);
-  mapper.add(end_segment);
-  mapper.map(expanded_drivable_area, "fill-opacity:0.0;fill:black;stroke:black;stroke-width:1", 1);
-  mapper.map(start_segment, "fill-opacity:0.5;fill:blue;stroke:blue;stroke-width:2", 2);
-  mapper.map(end_segment, "fill-opacity:0.5;fill:blue;stroke:blue;stroke-width:2", 2);
-  mapper.map(path_start_segment, "fill-opacity:0.5;fill:green;stroke:green;stroke-width:2", 2);
-  mapper.map(path_end_segment, "fill-opacity:0.5;fill:green;stroke:green;stroke-width:2", 2);
-  mapper.map(
-    start_left.intersection_point, "fill-opacity:0.5;fill:red;stroke:red;stroke-width:2", 2);
-  mapper.map(
-    start_right.intersection_point, "fill-opacity:0.5;fill:red;stroke:red;stroke-width:2", 2);
-  mapper.map(end_left.intersection_point, "fill-opacity:0.5;fill:red;stroke:red;stroke-width:2", 2);
-  mapper.map(
-    end_right.intersection_point, "fill-opacity:0.5;fill:red;stroke:red;stroke-width:2", 2);
-
   if (
     start_left.segment_it == da.end() || start_right.segment_it == da.end() ||
     end_left.segment_it == da.end() || end_right.segment_it == da.end()) {
@@ -305,11 +275,6 @@ void updateDrivableAreaBounds(PathWithLaneId & path, const polygon_t & expanded_
   std::unique(path.right_bound.begin(), path.right_bound.end(), point_cmp);
   copy_z_over_arc_length(original_left_bound, path.left_bound);
   copy_z_over_arc_length(original_right_bound, path.right_bound);
-
-  for (const auto & p : path.right_bound) {
-    mapper.add(convert_point(p));
-    mapper.map(convert_point(p), "fill-opacity:0.5;fill:grey;stroke:grey;stroke-width:2", 1);
-  }
 }
 
 }  // namespace drivable_area_expansion

--- a/planning/behavior_path_planner/src/utils/drivable_area_expansion/drivable_area_expansion.cpp
+++ b/planning/behavior_path_planner/src/utils/drivable_area_expansion/drivable_area_expansion.cpp
@@ -117,7 +117,7 @@ void updateDrivableAreaBounds(PathWithLaneId & path, const polygon_t & expanded_
   const auto is_left_of_segment = [](const point_t & a, const point_t & b, const point_t & p) {
     return (b.x() - a.x()) * (p.y() - a.y()) - (b.y() - a.y()) * (p.x() - a.x()) > 0;
   };
-
+  // prepare delimiting lines: start and end of the original expanded drivable area
   const auto start_segment =
     segment_t{convert_point(path.left_bound.front()), convert_point(path.right_bound.front())};
   const auto end_segment =
@@ -130,15 +130,6 @@ void updateDrivableAreaBounds(PathWithLaneId & path, const polygon_t & expanded_
   boost::geometry::centroid(end_segment, end_segment_center);
   const auto path_end_segment =
     segment_t{convert_point(path.points.back().point.pose.position), end_segment_center};
-  const auto is_left_of_path_start = [&](const point_t & p) {
-    return is_left_of_segment(
-      convert_point(path.points[0].point.pose.position),
-      convert_point(path.points[1].point.pose.position), p);
-  };
-  const auto is_left_of_path_end = [&](const point_t & p) {
-    return is_left_of_segment(
-      convert_point(path.points.back().point.pose.position), end_segment_center, p);
-  };
   const auto segment_to_line_intersection =
     [](const auto p1, const auto p2, const auto q1, const auto q2) -> std::optional<point_t> {
     const auto line = Eigen::Hyperplane<double, 2>::Through(q1, q2);
@@ -153,40 +144,34 @@ void updateDrivableAreaBounds(PathWithLaneId & path, const polygon_t & expanded_
     if (is_on_segment) result = point_t{intersection.x(), intersection.y()};
     return result;
   };
+  // find intersection between the expanded drivable area and the delimiting lines
+  const auto & da = expanded_drivable_area.outer();
   struct Intersection
   {
-    ring_t::const_iterator segment_it;
     point_t intersection_point;
+    ring_t::const_iterator segment_it;
     double distance = std::numeric_limits<double>::max();
-  };
-  const auto & da = expanded_drivable_area.outer();
-  Intersection start_left;
-  start_left.segment_it = da.end();
-  Intersection end_left;
-  end_left.segment_it = da.end();
-  Intersection start_right;
-  start_right.segment_it = da.end();
-  Intersection end_right;
-  end_right.segment_it = da.end();
-
-  for (auto it = da.begin(); it != da.end(); ++it) {
-    if (boost::geometry::distance(*it, start_segment.first) < 1e-3) {
-      start_left.intersection_point = *it;
-      start_left.segment_it = it;
-      start_left.distance = 0.0;
-    } else if (boost::geometry::distance(*it, start_segment.second) < 1e-3) {
-      start_right.intersection_point = *it;
-      start_right.segment_it = it;
-      start_right.distance = 0.0;
-    } else if (boost::geometry::distance(*it, end_segment.first) < 1e-3) {
-      end_left.intersection_point = *it;
-      end_left.segment_it = it;
-      end_left.distance = 0.0;
-    } else if (boost::geometry::distance(*it, end_segment.second) < 1e-3) {
-      end_right.intersection_point = *it;
-      end_right.segment_it = it;
-      end_right.distance = 0.0;
+    explicit Intersection(ring_t::const_iterator it) : segment_it(it) {}
+    void update(const point_t & p, const ring_t::const_iterator & it, const double dist)
+    {
+      intersection_point = p;
+      segment_it = it;
+      distance = dist;
     }
+  };
+  Intersection start_left(da.end());
+  Intersection end_left(da.end());
+  Intersection start_right(da.end());
+  Intersection end_right(da.end());
+  for (auto it = da.begin(); it != da.end(); ++it) {
+    if (boost::geometry::distance(*it, start_segment.first) < 1e-3)
+      start_left.update(*it, it, 0.0);
+    else if (boost::geometry::distance(*it, start_segment.second) < 1e-3)
+      start_right.update(*it, it, 0.0);
+    else if (boost::geometry::distance(*it, end_segment.first) < 1e-3)
+      end_left.update(*it, it, 0.0);
+    else if (boost::geometry::distance(*it, end_segment.second) < 1e-3)
+      end_right.update(*it, it, 0.0);
     const auto inter_start =
       std::next(it) == da.end()
         ? segment_to_line_intersection(*it, da.front(), start_segment.first, start_segment.second)
@@ -194,19 +179,13 @@ void updateDrivableAreaBounds(PathWithLaneId & path, const polygon_t & expanded_
             *it, *std::next(it), start_segment.first, start_segment.second);
     if (inter_start) {
       const auto dist = boost::geometry::distance(*inter_start, path_start_segment);
-      if (is_left_of_path_start(*inter_start)) {
-        if (dist < start_left.distance) {
-          start_left.intersection_point = *inter_start;
-          start_left.segment_it = it;
-          start_left.distance = dist;
-        }
-      } else {
-        if (dist < start_right.distance) {
-          start_right.intersection_point = *inter_start;
-          start_right.segment_it = it;
-          start_right.distance = dist;
-        }
-      }
+      const auto is_left_of_path_start = is_left_of_segment(
+        convert_point(path.points[0].point.pose.position),
+        convert_point(path.points[1].point.pose.position), *inter_start);
+      if (is_left_of_path_start && dist < start_left.distance)
+        start_left.update(*inter_start, it, dist);
+      else if (!is_left_of_path_start && dist < start_right.distance)
+        start_right.update(*inter_start, it, dist);
     }
     const auto inter_end =
       std::next(it) == da.end()
@@ -214,30 +193,20 @@ void updateDrivableAreaBounds(PathWithLaneId & path, const polygon_t & expanded_
         : segment_to_line_intersection(*it, *std::next(it), end_segment.first, end_segment.second);
     if (inter_end) {
       const auto dist = boost::geometry::distance(*inter_end, path_end_segment);
-      if (is_left_of_path_end(*inter_end)) {
-        if (dist < end_left.distance) {
-          end_left.intersection_point = *inter_end;
-          end_left.segment_it = it;
-          end_left.distance = dist;
-        }
-      } else {
-        if (dist < end_right.distance) {
-          end_right.intersection_point = *inter_end;
-          end_right.segment_it = it;
-          end_right.distance = dist;
-        }
-      }
+      const auto is_left_of_path_end = is_left_of_segment(
+        convert_point(path.points.back().point.pose.position), end_segment_center, *inter_end);
+      if (is_left_of_path_end && dist < end_left.distance)
+        end_left.update(*inter_end, it, dist);
+      else if (!is_left_of_path_end && dist < end_right.distance)
+        end_right.update(*inter_end, it, dist);
     }
   }
-  if (
+  if (  // illformed expanded drivable area -> keep the original bounds
     start_left.segment_it == da.end() || start_right.segment_it == da.end() ||
     end_left.segment_it == da.end() || end_right.segment_it == da.end()) {
-    std::cerr << (start_left.segment_it == da.end()) << " " << (start_right.segment_it == da.end())
-              << " " << (end_left.segment_it == da.end()) << " "
-              << (end_right.segment_it == da.end()) << std::endl;
     return;
   }
-
+  // extract the expanded left and right bound from the expanded drivable area
   path.left_bound.clear();
   path.right_bound.clear();
   path.left_bound.push_back(convert_point(start_left.intersection_point));
@@ -266,7 +235,6 @@ void updateDrivableAreaBounds(PathWithLaneId & path, const polygon_t & expanded_
   }
   if (!boost::geometry::equals(end_right.intersection_point, *std::next(end_right.segment_it)))
     path.right_bound.push_back(convert_point(end_right.intersection_point));
-
   // remove possible duplicated points
   const auto point_cmp = [](const auto & p1, const auto & p2) {
     return p1.x == p2.x && p1.y == p2.y;
@@ -276,5 +244,4 @@ void updateDrivableAreaBounds(PathWithLaneId & path, const polygon_t & expanded_
   copy_z_over_arc_length(original_left_bound, path.left_bound);
   copy_z_over_arc_length(original_right_bound, path.right_bound);
 }
-
 }  // namespace drivable_area_expansion

--- a/planning/behavior_velocity_out_of_lane_module/src/debug.cpp
+++ b/planning/behavior_velocity_out_of_lane_module/src/debug.cpp
@@ -64,7 +64,7 @@ void add_current_overlap_marker(
   debug_marker.points.clear();
   for (const auto & p : current_footprint)
     debug_marker.points.push_back(tier4_autoware_utils::createMarkerPosition(p.x(), p.y(), z));
-  debug_marker.points.push_back(debug_marker.points.front());
+  if (!debug_marker.points.empty()) debug_marker.points.push_back(debug_marker.points.front());
   if (current_overlapped_lanelets.empty())
     debug_marker.color = tier4_autoware_utils::createMarkerColor(0.1, 1.0, 0.1, 0.5);
   else


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
The `out_of_lane` module causes a crash if some structure is empty, which happens when we set the `skip_if_already_overlapping` parameter to `false`.
This PR is required for https://github.com/tier4/autoware_launch.x2/pull/337

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Psim and evaluator: https://evaluation.tier4.jp/evaluation/reports/db55bce2-aa24-5a27-bb2c-e9d7528474fd?project_id=x2_dev

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->
None

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
