### PR TITLE
fix(object_merger): preserve unknown objects close to known objects (…

### DIFF
--- a/perception/object_merger/README.md
+++ b/perception/object_merger/README.md
@@ -34,7 +34,7 @@ The successive shortest path algorithm is used to solve the data association pro
 | `max_rad_matrix`            | double                | Maximum angle table for data association                                                                                                                                                                                              |
 | `base_link_frame_id`        | double                | association frame                                                                                                                                                                                                                     |
 | `distance_threshold_list`   | `std::vector<double>` | Distance threshold for each class used in judging overlap. The class order depends on [ObjectClassification](https://github.com/tier4/autoware_auto_msgs/blob/tier4/main/autoware_auto_perception_msgs/msg/ObjectClassification.idl). |
-| `generalized_iou_threshold` | double                | Generalized IoU threshold                                                                                                                                                                                                             |
+| `generalized_iou_threshold` | `std::vector<double>` | Generalized IoU threshold for each class                                                                                                                                                                                              |
 
 ## Tips
 

--- a/perception/object_merger/config/overlapped_judge.param.yaml
+++ b/perception/object_merger/config/overlapped_judge.param.yaml
@@ -3,3 +3,6 @@
     distance_threshold_list:
       #UNKNOWN, CAR, TRUCK, BUS,  TRAILER, MOTORBIKE, BICYCLE,PEDESTRIAN
       [9.0,     9.0, 9.0,   9.0,  9.0,     9.0,       9.0,    9.0]         #UNKNOWN
+
+    generalized_iou_threshold:
+      [-0.1, -0.1, -0.1, -0.6,  -0.6, -0.1, -0.1, -0.1]

--- a/perception/object_merger/include/object_association_merger/node.hpp
+++ b/perception/object_merger/include/object_association_merger/node.hpp
@@ -76,7 +76,7 @@ private:
   {
     double precision_threshold;
     double recall_threshold;
-    double generalized_iou_threshold;
+    std::map<int, double> generalized_iou_threshold;
     std::map<int /*class label*/, double /*distance_threshold*/> distance_threshold_map;
   } overlapped_judge_param_;
 };

--- a/perception/object_merger/launch/object_association_merger.launch.xml
+++ b/perception/object_merger/launch/object_association_merger.launch.xml
@@ -14,7 +14,7 @@
     <param from="$(var data_association_matrix_path)"/>
     <param from="$(var distance_threshold_list_path)"/>
     <param name="priority_mode" value="$(var priority_mode)"/>
-    <param name="generalized_iou_threshold" value="-0.6"/>
     <param name="precision_threshold_to_judge_overlapped" value="0.4"/>
+    <param name="remove_overlapped_unknown_objects" value="true"/>
   </node>
 </launch>

--- a/perception/object_merger/src/object_association_merger/node.cpp
+++ b/perception/object_merger/src/object_association_merger/node.cpp
@@ -35,8 +35,11 @@ bool isUnknownObjectOverlapped(
   const autoware_auto_perception_msgs::msg::DetectedObject & unknown_object,
   const autoware_auto_perception_msgs::msg::DetectedObject & known_object,
   const double precision_threshold, const double recall_threshold,
-  std::map<int, double> distance_threshold_map, const double generalized_iou_threshold)
+  std::map<int, double> distance_threshold_map,
+  const std::map<int, double> generalized_iou_threshold_map)
 {
+  const double generalized_iou_threshold = generalized_iou_threshold_map.at(
+    object_recognition_utils::getHighestProbLabel(known_object.classification));
   const double distance_threshold = distance_threshold_map.at(
     object_recognition_utils::getHighestProbLabel(known_object.classification));
   const double sq_distance_threshold = std::pow(distance_threshold, 2.0);
@@ -95,7 +98,7 @@ ObjectAssociationMergerNode::ObjectAssociationMergerNode(const rclcpp::NodeOptio
   overlapped_judge_param_.recall_threshold =
     declare_parameter<double>("recall_threshold_to_judge_overlapped", 0.5);
   overlapped_judge_param_.generalized_iou_threshold =
-    declare_parameter<double>("generalized_iou_threshold");
+    convertListToClassMap(declare_parameter<std::vector<double>>("generalized_iou_threshold"));
 
   // get distance_threshold_map from distance_threshold_list
   /** TODO(Shin-kyoto):


### PR DESCRIPTION
…#4499)

* fix(object_merger): separate GIoU



* fix: update GIoU threshold



---------

## Description

<!-- Write a brief description of this PR. -->

Hotfix for v0.43.0 related to object_merger to keep small unknown objects like cones near by known objects such as truck, car. 

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
