### PR TITLE
fix(behavior_path_planner): fix side shift node die

### DIFF
--- a/planning/behavior_path_planner/src/scene_module/side_shift/side_shift_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/side_shift/side_shift_module.cpp
@@ -185,7 +185,7 @@ void SideShiftModule::updateData()
     }
   }
 
-  if (current_state_ != ModuleStatus::RUNNING) {
+  if (current_state_ != ModuleStatus::RUNNING && current_state_ != ModuleStatus::IDLE) {
     return;
   }
 


### PR DESCRIPTION
## Description
The original motivation of skipping updateData() when module is not running is the other process were not necessary. 
But when `IDLE` status is introduced, condition of not runnnig module is changed from `running` to `running` || `idle`.
So in this PR, skip condition is changed.
<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
