### PR TITLE
fix(avoidance): fix trimmed shift line alignment

### DIFF
--- a/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/avoidance_module.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/scene_module/avoidance/avoidance_module.hpp
@@ -333,6 +333,8 @@ private:
   AvoidLineArray applyPreProcessToRawShiftLines(
     AvoidLineArray & current_raw_shift_points, DebugData & debug) const;
 
+  AvoidLineArray getFillGapShiftLines(const AvoidLineArray & shift_lines) const;
+
   /*
    * @brief merge negative & positive shift lines.
    * @param original shift lines.

--- a/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
@@ -720,6 +720,8 @@ void AvoidanceModule::updateRegisteredRawShiftLines()
 AvoidLineArray AvoidanceModule::applyPreProcessToRawShiftLines(
   AvoidLineArray & raw_shift_lines, DebugData & debug) const
 {
+  const auto fill_gap_shift_lines = getFillGapShiftLines(raw_shift_lines);
+
   /**
    * Use all registered points. For the current points, if the similar one of the current
    * points are already registered, will not use it.
@@ -749,6 +751,8 @@ AvoidLineArray AvoidanceModule::applyPreProcessToRawShiftLines(
    * Add gap filled shift lines so that merged shift lines connect smoothly.
    */
   fillShiftLineGap(raw_shift_lines);
+  raw_shift_lines.insert(
+    raw_shift_lines.end(), fill_gap_shift_lines.begin(), fill_gap_shift_lines.end());
   debug.gap_filled = raw_shift_lines;
 
   /**
@@ -985,10 +989,6 @@ AvoidLineArray AvoidanceModule::calcRawShiftLinesFromObjects(
       al_avoid.end_longitudinal = o.longitudinal - offset;
       al_avoid.id = getOriginalShiftLineUniqueId();
       al_avoid.object = o;
-
-      if (is_valid_shift_line(al_avoid)) {
-        avoid_lines.push_back(al_avoid);
-      }
     }
 
     AvoidLine al_return;
@@ -1007,10 +1007,11 @@ AvoidLineArray AvoidanceModule::calcRawShiftLinesFromObjects(
         o.longitudinal + offset + std::min(feasible_return_distance, return_remaining_distance);
       al_return.id = getOriginalShiftLineUniqueId();
       al_return.object = o;
+    }
 
-      if (is_valid_shift_line(al_return)) {
-        avoid_lines.push_back(al_return);
-      }
+    if (is_valid_shift_line(al_avoid) && is_valid_shift_line(al_return)) {
+      avoid_lines.push_back(al_avoid);
+      avoid_lines.push_back(al_return);
     }
 
     o.is_avoidable = true;
@@ -1221,6 +1222,38 @@ AvoidLineArray AvoidanceModule::extractShiftLinesFromLine(ShiftLineData & shift_
   }
 
   return merged_avoid_lines;
+}
+
+AvoidLineArray AvoidanceModule::getFillGapShiftLines(const AvoidLineArray & shift_lines) const
+{
+  AvoidLineArray ret{};
+
+  if (shift_lines.empty()) {
+    return ret;
+  }
+
+  const auto calc_gap_shift_line = [&](const auto & line1, const auto & line2) {
+    AvoidLine gap_filled_line{};
+    gap_filled_line.start_shift_length = line1.end_shift_length;
+    gap_filled_line.start_longitudinal = line1.end_longitudinal;
+    gap_filled_line.end_shift_length = line2.start_shift_length;
+    gap_filled_line.end_longitudinal = line2.start_longitudinal;
+    gap_filled_line.id = getOriginalShiftLineUniqueId();
+
+    return gap_filled_line;
+  };
+
+  // fill gap among shift lines.
+  for (size_t i = 0; i < shift_lines.size() - 1; i += 2) {
+    if (shift_lines.at(i).end_longitudinal > shift_lines.at(i + 1).start_longitudinal) {
+      continue;
+    }
+    ret.push_back(calc_gap_shift_line(shift_lines.at(i), shift_lines.at(i + 1)));
+  }
+
+  utils::avoidance::fillAdditionalInfoFromLongitudinal(avoidance_data_, ret);
+
+  return ret;
 }
 
 void AvoidanceModule::fillShiftLineGap(AvoidLineArray & shift_lines) const


### PR DESCRIPTION
## Description
https://github.com/autowarefoundation/autoware.universe/pull/4632
Hotfix to beta/v0.10.0

> Refactored the `avoidance_module` to handle small gaps in shift lines more robustly. Modified the `trimSmallShiftLine` function in `avoidance_module.cpp` to merge adjacent shift lines instead of discarding them.
![Screenshot from 2023-08-15 17-19-15](https://github.com/autowarefoundation/autoware.universe/assets/44889564/b24cea44-6beb-4462-b49b-d68feded95a1)

<!-- Write a brief description of this PR. -->

## Tests performed
(TIER IV Internal https://evaluation.tier4.jp/evaluation/reports/5e54ef73-e07b-59eb-9a34-8e4dabc8bd70?project_id=prd_jt )
<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
