### PR TITLE
fix(traffic_light_arbiter): use the shape as a key to find the highest confidence signal

### DIFF
--- a/perception/traffic_light_arbiter/src/traffic_light_arbiter.cpp
+++ b/perception/traffic_light_arbiter/src/traffic_light_arbiter.cpp
@@ -138,14 +138,14 @@ void TrafficLightArbiter::arbitrateAndPublish(const builtin_interfaces::msg::Tim
 
   const auto get_highest_confidence_elements =
     [](const std::vector<ElementAndPriority> & elements_and_priority_vector) {
-      using Key = std::tuple<Element::_color_type, Element::_shape_type>;
+      using Key = Element::_shape_type;
       std::map<Key, ElementAndPriority> highest_score_element_and_priority_map;
       std::vector<Element> highest_score_elements_vector;
 
       for (const auto & elements_and_priority : elements_and_priority_vector) {
         const auto & element = elements_and_priority.first;
         const auto & element_priority = elements_and_priority.second;
-        const auto key = std::make_tuple(element.color, element.shape);
+        const auto key = element.shape;
         auto [iter, success] =
           highest_score_element_and_priority_map.try_emplace(key, elements_and_priority);
         const auto & iter_element = iter->second.first;


### PR DESCRIPTION
## Description

cherry pick bug fix
- https://github.com/autowarefoundation/autoware.universe/pull/4635

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
