### PR TITLE
fix(compare_map_segmentation): fix process died for invalid access #4676

### DIFF
--- a/perception/compare_map_segmentation/include/compare_map_segmentation/voxel_grid_map_loader.hpp
+++ b/perception/compare_map_segmentation/include/compare_map_segmentation/voxel_grid_map_loader.hpp
@@ -260,7 +260,8 @@ public:
       int index = static_cast<int>(
         std::floor((kv.second.min_b_x - origin_x_) / map_grid_size_x_) +
         map_grids_x_ * std::floor((kv.second.min_b_y - origin_y_) / map_grid_size_y_));
-      if (index >= map_grids_x_ * map_grids_y_) {
+      // TODO(1222-takeshi): check if index is valid
+      if (index >= map_grids_x_ * map_grids_y_ || index < 0) {
         continue;
       }
       current_voxel_grid_array_.at(index) = std::make_shared<MapGridVoxelInfo>(kv.second);


### PR DESCRIPTION
## Description
>Fix a potential bug in compare_map_segmentation that could cause out-of-bounds access to a vector. Add a validity check for the index variable in voxel_grid_map_loader.hpp.
```
[component_container_mt-10] terminate called after throwing an instance of 'std::out_of_range'
[component_container_mt-10]   what():  vector::_M_range_check: __n (which is 18446744073709551615) >= this->size() (which is 320)
```
<!-- Write a brief description of this PR. -->

## Related links
https://github.com/autowarefoundation/autoware.universe/pull/4676

## Tests performed

<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters. -->

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].
- [x] The PR has been properly tested.
- [x] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
