### PR TITLE
hotfix(out_of_lane): ignore irrelevant object

### DIFF
--- a/planning/behavior_velocity_out_of_lane_module/README.md
+++ b/planning/behavior_velocity_out_of_lane_module/README.md
@@ -101,7 +101,7 @@ at its current velocity or at half the velocity of the path points, whichever is
 ###### Dynamic objects
 
 Two methods are used to estimate the time when a dynamic objects with reach some point.
-If `objects.use_predicted_paths` is set to `true`, the predicted path of the dynamic object is used.
+If `objects.use_predicted_paths` is set to `true`, the predicted paths of the dynamic object are used if their confidence value is higher than the value set by the `objects.predicted_path_min_confidence` parameter.
 Otherwise, the lanelet map is used to estimate the distance between the object and the point and the time is calculated assuming the object keeps its current velocity.
 
 #### 5. Path update
@@ -138,10 +138,11 @@ Moreover, parameter `action.distance_buffer` adds an extra distance between the 
 | -------------- | ------ | ------------------------------------------------------------------------------------------------------ |
 | `threshold`    | double | [s] consider objects with an estimated time to collision bellow this value while ego is on the overlap |
 
-| Parameter /objects    | Type   | Description                                                                                                                                                               |
-| --------------------- | ------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `minimum_velocity`    | double | [m/s] consider objects with an estimated time to collision bellow this value while on the overlap                                                                         |
-| `use_predicted_paths` | bool   | [-] if true, use the predicted paths to estimate future positions; if false, assume the object moves at constant velocity along _all_ lanelets it currently is located in |
+| Parameter /objects              | Type   | Description                                                                                                                                                               |
+| ------------------------------- | ------ | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `minimum_velocity`              | double | [m/s] consider objects with an estimated time to collision bellow this value while on the overlap                                                                         |
+| `use_predicted_paths`           | bool   | [-] if true, use the predicted paths to estimate future positions; if false, assume the object moves at constant velocity along _all_ lanelets it currently is located in |
+| `predicted_path_min_confidence` | double | [-] minimum confidence required for a predicted path to be considered                                                                                                     |
 
 | Parameter /overlap | Type   | Description                                                                                          |
 | ------------------ | ------ | ---------------------------------------------------------------------------------------------------- |

--- a/planning/behavior_velocity_out_of_lane_module/config/out_of_lane.param.yaml
+++ b/planning/behavior_velocity_out_of_lane_module/config/out_of_lane.param.yaml
@@ -16,6 +16,7 @@
         minimum_velocity: 0.5  # [m/s] objects lower than this velocity will be ignored
         use_predicted_paths: true  # if true, use the predicted paths to estimate future positions.
                                    # if false, assume the object moves at constant velocity along *all* lanelets it currently is located in.
+        predicted_path_min_confidence : 0.1  # when using predicted paths, ignore the ones whose confidence is lower than this value.
 
       overlap:
         minimum_distance: 0.0  # [m] minimum distance inside a lanelet for an overlap to be considered

--- a/planning/behavior_velocity_out_of_lane_module/src/debug.cpp
+++ b/planning/behavior_velocity_out_of_lane_module/src/debug.cpp
@@ -64,7 +64,7 @@ void add_current_overlap_marker(
   debug_marker.points.clear();
   for (const auto & p : current_footprint)
     debug_marker.points.push_back(tier4_autoware_utils::createMarkerPosition(p.x(), p.y(), z));
-  debug_marker.points.push_back(debug_marker.points.front());
+  if (!debug_marker.points.empty()) debug_marker.points.push_back(debug_marker.points.front());
   if (current_overlapped_lanelets.empty())
     debug_marker.color = tier4_autoware_utils::createMarkerColor(0.1, 1.0, 0.1, 0.5);
   else

--- a/planning/behavior_velocity_out_of_lane_module/src/decisions.hpp
+++ b/planning/behavior_velocity_out_of_lane_module/src/decisions.hpp
@@ -56,18 +56,21 @@ double time_along_path(const EgoData & ego_data, const size_t target_idx);
 /// but may not exist (e.g,, predicted path ends before reaching the end of the range)
 /// @param [in] object dynamic object
 /// @param [in] range overlapping range
+/// @param [in] route_handler route handler used to estimate the path of the dynamic object
 /// @param [in] min_confidence minimum confidence to consider a predicted path
 /// @param [in] logger ros logger
 /// @return an optional pair (time at enter [s], time at exit [s]). If the dynamic object drives in
 /// the opposite direction, time at enter > time at exit
 std::optional<std::pair<double, double>> object_time_to_range(
   const autoware_auto_perception_msgs::msg::PredictedObject & object, const OverlapRange & range,
-  const double min_confidence, const rclcpp::Logger & logger);
+  const std::shared_ptr<route_handler::RouteHandler> route_handler, const double min_confidence,
+  const rclcpp::Logger & logger);
 /// @brief use the lanelet map to estimate the times when an object will reach the enter and exit
 /// points of an overlapping range
 /// @param [in] object dynamic object
 /// @param [in] range overlapping range
-/// @param [in] lanelets objects to consider
+/// @param [in] inputs information used to take decisions (ranges, ego and objects data, route
+/// handler, lanelets)
 /// @param [in] logger ros logger
 /// @return an optional pair (time at enter [s], time at exit [s]). If the dynamic object drives in
 /// the opposite direction, time at enter > time at exit.
@@ -79,7 +82,7 @@ std::optional<std::pair<double, double>> object_time_to_range(
 /// @param [in] range_times times when ego and the object enter/exit the range
 /// @param [in] params parameters
 /// @param [in] logger ros logger
-bool object_is_incoming(
+bool will_collide_on_range(
   const RangeTimes & range_times, const PlannerParam & params, const rclcpp::Logger & logger);
 /// @brief check whether we should avoid entering the given range
 /// @param [in] range the range to check

--- a/planning/behavior_velocity_out_of_lane_module/src/decisions.hpp
+++ b/planning/behavior_velocity_out_of_lane_module/src/decisions.hpp
@@ -56,22 +56,24 @@ double time_along_path(const EgoData & ego_data, const size_t target_idx);
 /// but may not exist (e.g,, predicted path ends before reaching the end of the range)
 /// @param [in] object dynamic object
 /// @param [in] range overlapping range
+/// @param [in] min_confidence minimum confidence to consider a predicted path
+/// @param [in] logger ros logger
 /// @return an optional pair (time at enter [s], time at exit [s]). If the dynamic object drives in
 /// the opposite direction, time at enter > time at exit
 std::optional<std::pair<double, double>> object_time_to_range(
-  const autoware_auto_perception_msgs::msg::PredictedObject & object, const OverlapRange & range);
+  const autoware_auto_perception_msgs::msg::PredictedObject & object, const OverlapRange & range,
+  const double min_confidence, const rclcpp::Logger & logger);
 /// @brief use the lanelet map to estimate the times when an object will reach the enter and exit
 /// points of an overlapping range
 /// @param [in] object dynamic object
 /// @param [in] range overlapping range
 /// @param [in] lanelets objects to consider
-/// @param [in] route_handler route handler used to estimate the path of the dynamic object
+/// @param [in] logger ros logger
 /// @return an optional pair (time at enter [s], time at exit [s]). If the dynamic object drives in
 /// the opposite direction, time at enter > time at exit.
 std::optional<std::pair<double, double>> object_time_to_range(
   const autoware_auto_perception_msgs::msg::PredictedObject & object, const OverlapRange & range,
-  const lanelet::ConstLanelets & lanelets,
-  const std::shared_ptr<route_handler::RouteHandler> & route_handler);
+  const DecisionInputs & inputs, const rclcpp::Logger & logger);
 /// @brief decide whether an object is coming in the range at the same time as ego
 /// @details the condition depends on the mode (threshold, intervals, ttc)
 /// @param [in] range_times times when ego and the object enter/exit the range

--- a/planning/behavior_velocity_out_of_lane_module/src/manager.cpp
+++ b/planning/behavior_velocity_out_of_lane_module/src/manager.cpp
@@ -44,6 +44,8 @@ OutOfLaneModuleManager::OutOfLaneModuleManager(rclcpp::Node & node)
   pp.objects_min_vel = node.declare_parameter<double>(ns + ".objects.minimum_velocity");
   pp.objects_use_predicted_paths =
     node.declare_parameter<bool>(ns + ".objects.use_predicted_paths");
+  pp.objects_min_confidence =
+    node.declare_parameter<double>(ns + ".objects.predicted_path_min_confidence");
 
   pp.overlap_min_dist = node.declare_parameter<double>(ns + ".overlap.minimum_distance");
   pp.overlap_extra_length = node.declare_parameter<double>(ns + ".overlap.extra_length");

--- a/planning/behavior_velocity_out_of_lane_module/src/types.hpp
+++ b/planning/behavior_velocity_out_of_lane_module/src/types.hpp
@@ -45,6 +45,7 @@ struct PlannerParam
 
   bool objects_use_predicted_paths;  //  # whether to use the objects' predicted paths
   double objects_min_vel;            //  # [m/s] objects lower than this velocity will be ignored
+  double objects_min_confidence;     //  # minimum confidence to consider a predicted path
 
   double overlap_extra_length;  // [m] extra length to add around an overlap range
   double overlap_min_dist;      // [m] min distance inside another lane to consider an overlap


### PR DESCRIPTION
## Description

X2でout of laneの不要な停止・減速が多発

以下をcherry-pick
(本当にcherry-pickしたかったのは最新の「feat(out_of_lane): ignore dynamic objects located in irrelevent lanelets (#4473)」のみだがconflict起きたので全部)
![image](https://github.com/tier4/autoware.universe/assets/20228327/406423d5-bd53-4f9f-b703-15b9f30c8e41)

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
