### PR TITLE
fix(system_monitor): high-memory process are not provided in MEM order (backport #4654)

### DIFF
--- a/system/system_monitor/src/process_monitor/process_monitor.cpp
+++ b/system/system_monitor/src/process_monitor/process_monitor.cpp
@@ -401,7 +401,7 @@ void ProcessMonitor::getHighMemoryProcesses(const std::string & output)
     bp::pipe err_pipe{err_fd[0], err_fd[1]};
     bp::ipstream is_err{std::move(err_pipe)};
 
-    bp::child c("sort -r -k 10", bp::std_out > p2, bp::std_err > is_err, bp::std_in < p1);
+    bp::child c("sort -r -k 10 -n", bp::std_out > p2, bp::std_err > is_err, bp::std_in < p1);
     c.wait();
     if (c.exit_code() != 0) {
       is_err >> os.rdbuf();


### PR DESCRIPTION
## Description

https://github.com/autowarefoundation/autoware.universe/pull/4654 のbackport
メモリを使用するプロセスのランキングを正しく出力する

## Related links

https://tier4.atlassian.net/browse/AEAP-711

## Tests performed

以下のコマンドを起動
`ros2 run system_monitor process_monitor`

以下のように、stress コマンドで予めメモリ負荷をかけておく
`stress --vm 2 --vm-bytes 2G` 

別ターミナルで以下を起動
`ros2 run rqt_runtime_monitor rqt_runtime_monitor`

![image](https://github.com/tier4/autoware.universe/assets/9547070/21cd4e0d-ea48-4776-93d3-c2f24a332fdd)
![image](https://github.com/tier4/autoware.universe/assets/9547070/dd88e878-32cd-4cc7-b2fb-d6beeb03a82e)
![image](https://github.com/tier4/autoware.universe/assets/9547070/35c137cd-6995-444f-9e7f-e15c17a916a1)

メモリの使用量に応じてランク付けされていることを確認した


## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters. -->

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
