### PR TITLE
fix(system_monitor): disable gpu_monitor

### DIFF
--- a/system/system_error_monitor/config/diagnostic_aggregator/system.param.yaml
+++ b/system/system_error_monitor/config/diagnostic_aggregator/system.param.yaml
@@ -68,33 +68,34 @@
                   contains: [": CPU Load Average"]
                   timeout: 3.0
 
-            gpu:
-              type: diagnostic_aggregator/AnalyzerGroup
-              path: gpu
-              analyzers:
-                temperature:
-                  type: diagnostic_aggregator/GenericAnalyzer
-                  path: temperature
-                  contains: [": GPU Temperature"]
-                  timeout: 3.0
+            # Disable due to NVML error
+            # gpu:
+            #   type: diagnostic_aggregator/AnalyzerGroup
+            #   path: gpu
+            #   analyzers:
+            #     temperature:
+            #       type: diagnostic_aggregator/GenericAnalyzer
+            #       path: temperature
+            #       contains: [": GPU Temperature"]
+            #       timeout: 3.0
 
-                usage:
-                  type: diagnostic_aggregator/GenericAnalyzer
-                  path: gpu_usage
-                  contains: [": GPU Usage"]
-                  timeout: 3.0
+            #     usage:
+            #       type: diagnostic_aggregator/GenericAnalyzer
+            #       path: gpu_usage
+            #       contains: [": GPU Usage"]
+            #       timeout: 3.0
 
-                memory_usage:
-                  type: diagnostic_aggregator/GenericAnalyzer
-                  path: memory_usage
-                  contains: [": GPU Memory Usage"]
-                  timeout: 3.0
+            #     memory_usage:
+            #       type: diagnostic_aggregator/GenericAnalyzer
+            #       path: memory_usage
+            #       contains: [": GPU Memory Usage"]
+            #       timeout: 3.0
 
-                thermal_throttling:
-                  type: diagnostic_aggregator/GenericAnalyzer
-                  path: thermal_throttling
-                  contains: [": GPU Thermal Throttling"]
-                  timeout: 3.0
+            #     thermal_throttling:
+            #       type: diagnostic_aggregator/GenericAnalyzer
+            #       path: thermal_throttling
+            #       contains: [": GPU Thermal Throttling"]
+            #       timeout: 3.0
 
             memory:
               type: diagnostic_aggregator/AnalyzerGroup

--- a/system/system_monitor/launch/system_monitor.launch.py
+++ b/system/system_monitor/launch/system_monitor.launch.py
@@ -86,16 +86,18 @@ def launch_setup(context, *args, **kwargs):
             process_monitor_config,
         ],
     )
-    with open(LaunchConfiguration("gpu_monitor_config_file").perform(context), "r") as f:
-        gpu_monitor_config = yaml.safe_load(f)["/**"]["ros__parameters"]
-    gpu_monitor = ComposableNode(
-        package="system_monitor",
-        plugin="GPUMonitor",
-        name="gpu_monitor",
-        parameters=[
-            gpu_monitor_config,
-        ],
-    )
+
+    # Disable due to NVML error
+    # with open(LaunchConfiguration("gpu_monitor_config_file").perform(context), "r") as f:
+    #     gpu_monitor_config = yaml.safe_load(f)["/**"]["ros__parameters"]
+    # gpu_monitor = ComposableNode(
+    #     package="system_monitor",
+    #     plugin="GPUMonitor",
+    #     name="gpu_monitor",
+    #     parameters=[
+    #         gpu_monitor_config,
+    #     ],
+    # )
 
     # set container to run all required components in the same process
     container = ComposableNodeContainer(
@@ -110,7 +112,7 @@ def launch_setup(context, *args, **kwargs):
             net_monitor,
             ntp_monitor,
             process_monitor,
-            gpu_monitor,
+            # gpu_monitor,
         ],
         output="screen",
     )


### PR DESCRIPTION
## Description

- NVMLのエラーにより、gpu_monitorが強制終了してしまうため、無効化する
- 無効化する対象は以下の通り
  - gpu_monitorの起動
  - disgnostics_aggregatorのgpuの記載。これをコメントアウトしないと、 `/autoware/system/resource_monitoring` にてgpuがstaleしてしまうため

## Related links

https://tier4.atlassian.net/browse/AEAP-723

## Tests performed
psimを起動し
- gpu_monitorが起動していないことを確認した
- `/autoware/system/resource_monitoring` がgpu_monitor起因でエラーとならないことを確認した

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters. -->

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
