### PR TITLE
fix(behavior_path_planner): use the avoid_linestring.distance param

### DIFF
--- a/planning/behavior_path_planner/src/utils/drivable_area_expansion/expansion.cpp
+++ b/planning/behavior_path_planner/src/utils/drivable_area_expansion/expansion.cpp
@@ -160,8 +160,9 @@ multi_polygon_t createExpansionPolygons(
                                       : footprint_dist;
         auto expansion_polygon = createExpansionPolygon(base_ls, expansion_dist, is_left);
         auto limited_dist = expansion_dist;
-        const auto uncrossable_dist_limit =
-          calculateDistanceLimit(base_ls, expansion_polygon, uncrossable_lines);
+        const auto uncrossable_dist_limit = std::max(
+          0.0, calculateDistanceLimit(base_ls, expansion_polygon, uncrossable_lines) -
+                 params.avoid_linestring_dist);
         if (uncrossable_dist_limit < limited_dist) {
           limited_dist = uncrossable_dist_limit;
           if (params.compensate_uncrossable_lines) {


### PR DESCRIPTION
## Description

Add change from https://github.com/autowarefoundation/autoware.universe/pull/4198
Allows to set a buffer distance between the expanded drivable area and the linestrings to avoid.

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
