### PR TITLE
fix(crosswalk): fix build

### DIFF
--- a/planning/behavior_velocity_crosswalk_module/src/scene_crosswalk.cpp
+++ b/planning/behavior_velocity_crosswalk_module/src/scene_crosswalk.cpp
@@ -747,6 +747,8 @@ Polygon2d CrosswalkModule::getAttentionArea(
       break;
     }
 
+    const auto & p_ego_front = sparse_resample_path.points.at(j).point.pose;
+    const auto & p_ego_back = sparse_resample_path.points.at(j + 1).point.pose;
     const auto ego_one_step_polygon = createOneStepPolygon(p_ego_front, p_ego_back, ego_polygon);
 
     debug_data_.ego_polygons.push_back(toGeometryPointVector(ego_one_step_polygon, ego_pos.z));


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

fix cherry-pick mistakes of https://github.com/tier4/autoware.universe/commit/eb134333639523cc1c74b23667998fbe5e93e212


build failed in
https://evaluation.tier4.jp/evaluation/reports/39b89374-45b2-5c16-b180-58e9ddfed30f?project_id=prd_jt
```
/home/autoware/autoware.proj/src/autoware/universe/planning/behavior_velocity_crosswalk_module/src/scene_crosswalk.cpp: In member function ‘tier4_autoware_utils::Polygon2d behavior_velocity_planner::CrosswalkModule::getAttentionArea(const PathWithLaneId&, const std::pair<double, double>&) const’:
/home/autoware/autoware.proj/src/autoware/universe/planning/behavior_velocity_crosswalk_module/src/scene_crosswalk.cpp:750:60: error: ‘p_ego_front’ was not declared in this scope
  750 |     const auto ego_one_step_polygon = createOneStepPolygon(p_ego_front, p_ego_back, ego_polygon);
      |                                                            ^~~~~~~~~~~
/home/autoware/autoware.proj/src/autoware/universe/planning/behavior_velocity_crosswalk_module/src/scene_crosswalk.cpp:750:73: error: ‘p_ego_back’ was not declared in this scope
  750 |     const auto ego_one_step_polygon = createOneStepPolygon(p_ego_front, p_ego_back, ego_polygon);
      |                                                                         ^~~~~~~~~~
gmake[2]: *** [CMakeFiles/behavior_velocity_crosswalk_module.dir/build.make:104: CMakeFiles/behavior_velocity_crosswalk_module.dir/src/scene_crosswalk.cpp.o] Error 1
gmake[1]: *** [CMakeFiles/Makefile2:137: CMakeFiles/behavior_velocity_crosswalk_module.dir/all] Error 2
gmake: *** [Makefile:146: all] Error 2
---
Failed   <<< behavior_velocity_crosswalk_module [8min 8s, exited with code 2]
```

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

build in my local

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
