### PR TITLE
fix(tier4_planning_rviz_plugin): update vehicle info parameters in panel received from global parameter

### DIFF
--- a/common/tier4_planning_rviz_plugin/include/path/display_base.hpp
+++ b/common/tier4_planning_rviz_plugin/include/path/display_base.hpp
@@ -506,6 +506,10 @@ protected:
       vehicle_footprint_info_ = std::make_shared<VehicleFootprintInfo>(
         vehicle_info_->vehicle_length_m, vehicle_info_->vehicle_width_m,
         vehicle_info_->rear_overhang_m);
+
+      property_vehicle_length_.setValue(vehicle_info_->vehicle_length_m);
+      property_vehicle_width_.setValue(vehicle_info_->vehicle_width_m);
+      property_rear_overhang_.setValue(vehicle_info_->rear_overhang_m);
     } else {
       const float length{property_vehicle_length_.getFloat()};
       const float width{property_vehicle_width_.getFloat()};


### PR DESCRIPTION
## Description

rviz pluginでglobal parameterから取ってきたvehicle infoの値がパネルの値に反映されていなかった
https://star4.slack.com/archives/G015H42UVBK/p1694007269443579?thread_ts=1694005783.661109&cid=G015H42UVBK
https://tier4.atlassian.net/browse/RT0-29005

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
