### PR TITLE
chore(build): include missing lanelet2 header (#4819)

### DIFF
--- a/localization/ar_tag_based_localizer/src/tag_tf_caster_core.cpp
+++ b/localization/ar_tag_based_localizer/src/tag_tf_caster_core.cpp
@@ -19,6 +19,7 @@
 #include <Eigen/Core>
 #include <Eigen/Geometry>
 
+#include <lanelet2_core/LaneletMap.h>
 #ifdef ROS_DISTRO_GALACTIC
 #include <tf2_eigen/tf2_eigen.h>
 #else

--- a/map/util/lanelet2_map_preprocessor/src/fix_lane_change_tags.cpp
+++ b/map/util/lanelet2_map_preprocessor/src/fix_lane_change_tags.cpp
@@ -21,6 +21,7 @@
 #include <lanelet2_core/geometry/Lanelet.h>
 #include <lanelet2_core/primitives/LaneletSequence.h>
 #include <lanelet2_io/Io.h>
+#include <lanelet2_routing/RoutingGraph.h>
 
 #include <iostream>
 #include <unordered_set>

--- a/perception/traffic_light_arbiter/src/traffic_light_arbiter.cpp
+++ b/perception/traffic_light_arbiter/src/traffic_light_arbiter.cpp
@@ -16,6 +16,7 @@
 #include <rclcpp/time.hpp>
 #include <traffic_light_arbiter/traffic_light_arbiter.hpp>
 
+#include <lanelet2_core/LaneletMap.h>
 #include <lanelet2_core/primitives/BasicRegulatoryElements.h>
 
 #include <map>


### PR DESCRIPTION
## Description

Cherry-pick of https://github.com/autowarefoundation/autoware.universe/pull/4819
autoware_common側の変更でビルドが通らなくなるので↑のhotfix

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
