### PR TITLE
ci: backport dispatch-push-event workflow to v0.3.17

### DIFF
--- a/.github/workflows/dispatch-push-event.yaml
+++ b/.github/workflows/dispatch-push-event.yaml
@@ -1,0 +1,45 @@
+name: dispatch-push-event
+on:
+  push:
+
+jobs:
+  search-dispatch-repo:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        include:
+          - { version: beta/v0.3.**, dispatch-repo: pilot-auto.x1.eve }
+    outputs:
+      dispatch-repo: ${{ steps.search-dispatch-repo.outputs.value }}
+    steps:
+      - name: Search dispatch repo
+        id: search-dispatch-repo
+        run: |
+          if [[ ${{ github.ref_name }} =~ ${{ matrix.version }} ]]; then
+            echo ::set-output name=value::"${{ matrix.dispatch-repo }}"
+            echo "Detected beta branch: ${{ github.ref_name }}"
+            echo "Dispatch repository: ${{ matrix.dispatch-repo }}"
+          fi
+
+  dispatch-push-event:
+    runs-on: ubuntu-latest
+    needs: search-dispatch-repo
+    if: ${{ needs.search-dispatch-repo.outputs.dispatch-repo != '' }}
+    steps:
+      - name: Generate token
+        id: generate-token
+        uses: tibdex/github-app-token@v1
+        with:
+          app_id: ${{ secrets.INTERNAL_APP_ID }}
+          private_key: ${{ secrets.INTERNAL_PRIVATE_KEY }}
+
+      # 注意: workflow_dispatchで指定するブランチはmain固定となっているため、dispatch-repoのmainブランチにupdate-beta-branch.yamlが存在することが前提条件。
+      - name: Dispatch the update-beta-branch workflow
+        run: |
+          curl -L \
+          -X POST \
+          -H "Accept: application/vnd.github+json" \
+          -H "Authorization: Bearer ${{ steps.generate-token.outputs.token }}" \
+          -H "X-GitHub-Api-Version: 2022-11-28" \
+          https://api.github.com/repos/tier4/${{ needs.search-dispatch-repo.outputs.dispatch-repo }}/actions/workflows/update-beta-branch.yaml/dispatches \
+          -d '{"ref":"main"}'


### PR DESCRIPTION
#803 のbackport PRです。mainブランチにワークフローがあっても、beta/v0.3.17での変更でActionがトリガーされないため、こちらにも取り込みます。