### PR TITLE
tmp: add mpc steer intervention topic

### DIFF
--- a/control/mpc_lateral_controller/include/mpc_lateral_controller/mpc_lateral_controller.hpp
+++ b/control/mpc_lateral_controller/include/mpc_lateral_controller/mpc_lateral_controller.hpp
@@ -62,6 +62,13 @@ private:
   rclcpp::Publisher<Float32MultiArrayStamped>::SharedPtr m_pub_debug_values;
   rclcpp::Publisher<Float32Stamped>::SharedPtr m_pub_steer_offset;
 
+  // debug
+  Float32MultiArrayStamped::SharedPtr debug_control_;
+  rclcpp::Subscription<Float32MultiArrayStamped>::SharedPtr sub_control_;
+  trajectory_follower::LateralOutput getDebugLateralOutput(
+    const trajectory_follower::LateralOutput & input);
+  void onDebugControl(const Float32MultiArrayStamped::SharedPtr msg) { debug_control_ = msg; };
+
   //!< @brief parameters for path smoothing
   TrajectoryFilteringParam m_trajectory_filtering_param;
 


### PR DESCRIPTION
## Description
(記録用にPR出してます)
実験用に,
$ros2 topic pub /debug_control tier4_debug_msgs/Float32MultiArrayStamped "{stamp: now, data: [0.5, -0.2]}" -1 
で強制的にステアのコントロールを奪うデバッグトピックを追加しました。
一項目が秒数 (< 2.0s), 二項目がステア値(<0.4rad)です。
(mainにはマージしません)


<!-- Write a brief description of this PR. -->

## Tests performed
Psimで確認済
https://github.com/tier4/autoware.universe/assets/59680180/afe9dbe8-826b-4af5-b7ec-21bce59ed529



<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
