### PR TITLE
fix(autoware_auto_tf2): remove tf2 geometry function duplicated in tf2 geometry msgs (backport #5089)

### DIFF
--- a/common/autoware_auto_tf2/include/autoware_auto_tf2/tf2_autoware_auto_msgs.hpp
+++ b/common/autoware_auto_tf2/include/autoware_auto_tf2/tf2_autoware_auto_msgs.hpp
@@ -38,60 +38,6 @@ using BoundingBox = autoware_auto_perception_msgs::msg::BoundingBox;
 
 namespace tf2
 {
-
-
-/*************/
-/** Point32 **/
-/*************/
-
-/** \brief Apply a geometry_msgs TransformStamped to a geometry_msgs Point32 type.
- * This function is a specialization of the doTransform template defined in tf2/convert.h.
- * \param t_in The point to transform, as a Point32 message.
- * \param t_out The transformed point, as a Point32 message.
- * \param transform The timestamped transform to apply, as a TransformStamped message.
- */
-template<>
-inline
-void doTransform(
-  const geometry_msgs::msg::Point32 & t_in, geometry_msgs::msg::Point32 & t_out,
-  const geometry_msgs::msg::TransformStamped & transform)
-{
-  const KDL::Vector v_out = gmTransformToKDL(transform) * KDL::Vector(t_in.x, t_in.y, t_in.z);
-  t_out.x = static_cast<float>(v_out[0]);
-  t_out.y = static_cast<float>(v_out[1]);
-  t_out.z = static_cast<float>(v_out[2]);
-}
-
-
-/*************/
-/** Polygon **/
-/*************/
-
-/** \brief Apply a geometry_msgs TransformStamped to a geometry_msgs Polygon type.
- * This function is a specialization of the doTransform template defined in tf2/convert.h.
- * \param t_in The polygon to transform.
- * \param t_out The transformed polygon.
- * \param transform The timestamped transform to apply, as a TransformStamped message.
- */
-template<>
-inline
-void doTransform(
-  const geometry_msgs::msg::Polygon & t_in, geometry_msgs::msg::Polygon & t_out,
-  const geometry_msgs::msg::TransformStamped & transform)
-{
-  // Don't call the Point32 doTransform to avoid doing this conversion every time
-  const auto kdl_frame = gmTransformToKDL(transform);
-  // We don't use std::back_inserter to allow aliasing between t_in and t_out
-  t_out.points.resize(t_in.points.size());
-  for (size_t i = 0; i < t_in.points.size(); ++i) {
-    const KDL::Vector v_out = kdl_frame * KDL::Vector(
-      t_in.points[i].x, t_in.points[i].y, t_in.points[i].z);
-    t_out.points[i].x = static_cast<float>(v_out[0]);
-    t_out.points[i].y = static_cast<float>(v_out[1]);
-    t_out.points[i].z = static_cast<float>(v_out[2]);
-  }
-}
-
 /******************/
 /** Quaternion32 **/
 /******************/


### PR DESCRIPTION
## Description

2023-09-27時点のHumble Syncにおいて、ビルドが通らなくなっている
https://github.com/autowarefoundation/autoware.universe/pull/5089 を参考に修正が必要な場所をpickした

## Related links

https://star4.slack.com/archives/C04CKSQ7ZFZ/p1695796136636259

## Tests performed

以下のビルドエラーが解消されていることを確認した

```
Starting >>> autoware_auto_tf2
Finished <<< autoware_auto_vehicle_msgs [13.4s]                                                                        
--- stderr: autoware_auto_tf2                                
In file included from /home/hrkota/pilot-auto.x1.eve/src/autoware/universe/common/autoware_auto_tf2/test/test_tf2_autoware_auto_msgs.cpp:22:
/home/hrkota/pilot-auto.x1.eve/src/autoware/universe/common/autoware_auto_tf2/include/autoware_auto_tf2/tf2_autoware_auto_msgs.hpp:55:6: error: redefinition of ‘void tf2::doTransform(const T&, T&, const TransformStamped&) [with T = geometry_msgs::msg::Point32_<std::allocator<void> >; geometry_msgs::msg::TransformStamped = geometry_msgs::msg::TransformStamped_<std::allocator<void> >]’
   55 | void doTransform(
      |      ^~~~~~~~~~~
In file included from /home/hrkota/pilot-auto.x1.eve/src/autoware/universe/common/autoware_auto_tf2/test/test_tf2_autoware_auto_msgs.cpp:21:
/opt/ros/humble/include/tf2_geometry_msgs/tf2_geometry_msgs/tf2_geometry_msgs.hpp:260:6: note: ‘void tf2::doTransform(const T&, T&, const TransformStamped&) [with T = geometry_msgs::msg::Point32_<std::allocator<void> >; geometry_msgs::msg::TransformStamped = geometry_msgs::msg::TransformStamped_<std::allocator<void> >]’ previously declared here
  260 | void doTransform(
      |      ^~~~~~~~~~~
In file included from /home/hrkota/pilot-auto.x1.eve/src/autoware/universe/common/autoware_auto_tf2/test/test_tf2_autoware_auto_msgs.cpp:22:
/home/hrkota/pilot-auto.x1.eve/src/autoware/universe/common/autoware_auto_tf2/include/autoware_auto_tf2/tf2_autoware_auto_msgs.hpp:78:6: error: redefinition of ‘void tf2::doTransform(const T&, T&, const TransformStamped&) [with T = geometry_msgs::msg::Polygon_<std::allocator<void> >; geometry_msgs::msg::TransformStamped = geometry_msgs::msg::TransformStamped_<std::allocator<void> >]’
   78 | void doTransform(
      |      ^~~~~~~~~~~
In file included from /home/hrkota/pilot-auto.x1.eve/src/autoware/universe/common/autoware_auto_tf2/test/test_tf2_autoware_auto_msgs.cpp:21:
/opt/ros/humble/include/tf2_geometry_msgs/tf2_geometry_msgs/tf2_geometry_msgs.hpp:460:6: note: ‘void tf2::doTransform(const T&, T&, const TransformStamped&) [with T = geometry_msgs::msg::Polygon_<std::allocator<void> >; geometry_msgs::msg::TransformStamped = geometry_msgs::msg::TransformStamped_<std::allocator<void> >]’ previously declared here
  460 | void doTransform(
      |      ^~~~~~~~~~~
gmake[2]: *** [CMakeFiles/test_tf2_autoware_auto_msgs.dir/build.make:76: CMakeFiles/test_tf2_autoware_auto_msgs.dir/test/test_tf2_autoware_auto_msgs.cpp.o] Error 1
gmake[1]: *** [CMakeFiles/Makefile2:156: CMakeFiles/test_tf2_autoware_auto_msgs.dir/all] Error 2
gmake: *** [Makefile:146: all] Error 2
---
Failed   <<< autoware_auto_tf2 [10.7s, exited with code 2]

```

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters. -->

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
