### PR TITLE
fix(autoware_auto_tf2): remove duplicated function in tf2_geometry_msg

### DIFF
--- a/common/autoware_auto_geometry/CMakeLists.txt
+++ b/common/autoware_auto_geometry/CMakeLists.txt
@@ -12,6 +12,12 @@ ament_auto_add_library(${PROJECT_NAME} SHARED
   src/bounding_box.cpp
 )
 
+if(tf2_geometry_msgs_VERSION VERSION_LESS 0.25.4)
+  target_compile_definitions(${PROJECT_NAME} PRIVATE
+    DEFINE_LEGACY_FUNCTION
+  )
+endif()
+
 if(BUILD_TESTING)
   set(GEOMETRY_GTEST geometry_gtest)
   set(GEOMETRY_SRC test/src/test_geometry.cpp

--- a/common/autoware_auto_tf2/CMakeLists.txt
+++ b/common/autoware_auto_tf2/CMakeLists.txt
@@ -17,6 +17,11 @@ if(BUILD_TESTING)
     "tf2_geometry_msgs"
     "tf2_ros"
   )
+  if(tf2_geometry_msgs_VERSION VERSION_LESS 0.25.4)
+    target_compile_definitions(test_tf2_autoware_auto_msgs PRIVATE
+      DEFINE_LEGACY_FUNCTION
+    )
+  endif()
 endif()
 
 ament_auto_package()

--- a/common/autoware_auto_tf2/include/autoware_auto_tf2/tf2_autoware_auto_msgs.hpp
+++ b/common/autoware_auto_tf2/include/autoware_auto_tf2/tf2_autoware_auto_msgs.hpp
@@ -45,7 +45,7 @@ using BoundingBox = autoware_auto_perception_msgs::msg::BoundingBox;
 
 namespace tf2
 {
-
+#ifdef DEFINE_LEGACY_FUNCTION
 /*************/
 /** Point32 **/
 /*************/
@@ -94,6 +94,7 @@ inline void doTransform(
     t_out.points[i].z = static_cast<float>(v_out[2]);
   }
 }
+#endif
 
 /******************/
 /** Quaternion32 **/

--- a/planning/behavior_path_planner/CMakeLists.txt
+++ b/planning/behavior_path_planner/CMakeLists.txt
@@ -57,6 +57,12 @@ ament_auto_add_library(behavior_path_planner_node SHARED
   src/marker_utils/lane_change/debug.cpp
 )
 
+if(tf2_geometry_msgs_VERSION VERSION_LESS 0.25.4)
+  target_compile_definitions(behavior_path_planner_node PRIVATE
+    DEFINE_LEGACY_FUNCTION
+  )
+endif()
+
 target_include_directories(behavior_path_planner_node SYSTEM PUBLIC
   ${EIGEN3_INCLUDE_DIR}
 )

--- a/planning/surround_obstacle_checker/CMakeLists.txt
+++ b/planning/surround_obstacle_checker/CMakeLists.txt
@@ -18,6 +18,12 @@ ament_auto_add_library(${PROJECT_NAME} SHARED
   src/node.cpp
 )
 
+if(tf2_geometry_msgs_VERSION VERSION_LESS 0.25.4)
+  target_compile_definitions(${PROJECT_NAME} PRIVATE
+    DEFINE_LEGACY_FUNCTION
+  )
+endif()
+
 target_link_libraries(${PROJECT_NAME}
   ${PCL_LIBRARIES}
 )


### PR DESCRIPTION
最近tf2_gemotryの更新の影響で、ビルドが通らない問題が発生している。
(https://github.com/autowarefoundation/autoware.universe/issues/5128)
自機環境でsudo apt upgradeをしてから、該当問題が発生することを確認できた。

既に、autowarefoundationの方が以下2つのPRを取り込んでいます。こちらでbeta/v0.11.0へcherry-pickする。
https://github.com/autowarefoundation/autoware.universe/pull/5127
https://github.com/autowarefoundation/autoware.universe/pull/5089
