### PR TITLE
feat(system_error_monitor): add ignore_until_waiting_for_route module

### DIFF
--- a/system/system_error_monitor/config/system_error_monitor.param.yaml
+++ b/system/system_error_monitor/config/system_error_monitor.param.yaml
@@ -4,7 +4,7 @@
 #   lf_at: diag level where it becomes Latent Fault
 #   spf_at: diag level where it becomes Single Point Fault
 #   auto_recovery: Determines whether the system will automatically recover when it recovers from an error.
-#   ignore_until_waiting_for_route: Determines whether the system will ignore the error before planning and control until waiting for route.
+#   ignore_until_waiting_for_route: Determines whether the system will ignore the module until waiting for route.
 # Note:
 # empty-value for sf_at, lf_at and spf_at is "none"
 # default values are:

--- a/system/system_error_monitor/config/system_error_monitor.param.yaml
+++ b/system/system_error_monitor/config/system_error_monitor.param.yaml
@@ -12,6 +12,7 @@
 #   lf_at: "warn"
 #   spf_at: "error"
 #   auto_recovery: "true"
+#   before_planning_control_ignore: "false"
 ---
 /**:
   ros__parameters:

--- a/system/system_error_monitor/config/system_error_monitor.param.yaml
+++ b/system/system_error_monitor/config/system_error_monitor.param.yaml
@@ -4,7 +4,7 @@
 #   lf_at: diag level where it becomes Latent Fault
 #   spf_at: diag level where it becomes Single Point Fault
 #   auto_recovery: Determines whether the system will automatically recover when it recovers from an error.
-#   before_planning_control_ignore: Determines whether the system will ignore the error before planning and control for when initializing and wait for route.
+#   ignore_until_waiting_for_route: Determines whether the system will ignore the error before planning and control until waiting for route.
 # Note:
 # empty-value for sf_at, lf_at and spf_at is "none"
 # default values are:
@@ -12,7 +12,7 @@
 #   lf_at: "warn"
 #   spf_at: "error"
 #   auto_recovery: "true"
-#   before_planning_control_ignore: "false"
+#   ignore_until_waiting_for_route: "false"
 ---
 /**:
   ros__parameters:

--- a/system/system_error_monitor/config/system_error_monitor.param.yaml
+++ b/system/system_error_monitor/config/system_error_monitor.param.yaml
@@ -4,7 +4,7 @@
 #   lf_at: diag level where it becomes Latent Fault
 #   spf_at: diag level where it becomes Single Point Fault
 #   auto_recovery: Determines whether the system will automatically recover when it recovers from an error.
-#
+#   before_planning_control_ignore: Determines whether the system will ignore the error before planning and control for when initializing and wait for route.
 # Note:
 # empty-value for sf_at, lf_at and spf_at is "none"
 # default values are:

--- a/system/system_error_monitor/config/system_error_monitor.planning_simulation.param.yaml
+++ b/system/system_error_monitor/config/system_error_monitor.planning_simulation.param.yaml
@@ -12,15 +12,16 @@
 #   lf_at: "warn"
 #   spf_at: "error"
 #   auto_recovery: "true"
+#   before_planning_control_ignore: "false"
 ---
 /**:
   ros__parameters:
     required_modules:
       autonomous_driving:
-        /autoware/control/autonomous_driving/node_alive_monitoring: default
+        /autoware/control/autonomous_driving/node_alive_monitoring: { sf_at: "none", lf_at: "warn", spf_at: "error", auto_recovery: "false", before_planning_control_ignore: "true"}
         /autoware/control/autonomous_driving/performance_monitoring/lane_departure: default
         /autoware/control/control_command_gate/node_alive_monitoring: default
-        /autoware/control/autonomous_emergency_braking/performance_monitoring/emergency_stop: { sf_at: "none", lf_at: "warn", spf_at: "error", auto_recovery: "false"}
+        /autoware/control/autonomous_emergency_braking/performance_monitoring/emergency_stop: { sf_at: "none", lf_at: "warn", spf_at: "error", auto_recovery: "false", before_planning_control_ignore: "false"}
 
         /autoware/localization/node_alive_monitoring: default
         # /autoware/localization/performance_monitoring/matching_score: { sf_at: "warn", lf_at: "none", spf_at: "none" }
@@ -30,7 +31,7 @@
 
         /autoware/perception/node_alive_monitoring: default
 
-        /autoware/planning/node_alive_monitoring: default
+        /autoware/planning/node_alive_monitoring: { sf_at: "none", lf_at: "warn", spf_at: "error", auto_recovery: "false", before_planning_control_ignore: "true"}
         /autoware/planning/performance_monitoring/trajectory_validation: default
 
         /autoware/sensing/node_alive_monitoring: default
@@ -43,7 +44,7 @@
 
       external_control:
         /autoware/control/control_command_gate/node_alive_monitoring: default
-        /autoware/control/autonomous_emergency_braking/performance_monitoring/emergency_stop: { sf_at: "none", lf_at: "warn", spf_at: "error", auto_recovery: "false"}
+        /autoware/control/autonomous_emergency_braking/performance_monitoring/emergency_stop: { sf_at: "none", lf_at: "warn", spf_at: "error", auto_recovery: "false", before_planning_control_ignore: "false"}
         /autoware/control/external_control/external_command_selector/node_alive_monitoring: default
 
         /autoware/system/node_alive_monitoring: default

--- a/system/system_error_monitor/config/system_error_monitor.planning_simulation.param.yaml
+++ b/system/system_error_monitor/config/system_error_monitor.planning_simulation.param.yaml
@@ -4,7 +4,7 @@
 #   lf_at: diag level where it becomes Latent Fault
 #   spf_at: diag level where it becomes Single Point Fault
 #   auto_recovery: Determines whether the system will automatically recover when it recovers from an error.
-#   before_planning_control_ignore: Determines whether the system will ignore the error before planning and control for when initializing and wait for route.
+#  ignore_until_waiting_for_route: Determines whether the system will ignore the error before planning and control until waiting for route.
 # Note:
 # empty-value for sf_at, lf_at and spf_at is "none"
 # default values are:
@@ -12,16 +12,16 @@
 #   lf_at: "warn"
 #   spf_at: "error"
 #   auto_recovery: "true"
-#   before_planning_control_ignore: "false"
+#  ignore_until_waiting_for_route: "false"
 ---
 /**:
   ros__parameters:
     required_modules:
       autonomous_driving:
-        /autoware/control/autonomous_driving/node_alive_monitoring: { sf_at: "none", lf_at: "warn", spf_at: "error", auto_recovery: "false", before_planning_control_ignore: "true"}
+        /autoware/control/autonomous_driving/node_alive_monitoring: { sf_at: "none", lf_at: "warn", spf_at: "error", auto_recovery: "false",ignore_until_waiting_for_route: "true"}
         /autoware/control/autonomous_driving/performance_monitoring/lane_departure: default
         /autoware/control/control_command_gate/node_alive_monitoring: default
-        /autoware/control/autonomous_emergency_braking/performance_monitoring/emergency_stop: { sf_at: "none", lf_at: "warn", spf_at: "error", auto_recovery: "false", before_planning_control_ignore: "false"}
+        /autoware/control/autonomous_emergency_braking/performance_monitoring/emergency_stop: { sf_at: "none", lf_at: "warn", spf_at: "error", auto_recovery: "false",ignore_until_waiting_for_route: "false"}
 
         /autoware/localization/node_alive_monitoring: default
         # /autoware/localization/performance_monitoring/matching_score: { sf_at: "warn", lf_at: "none", spf_at: "none" }
@@ -31,7 +31,7 @@
 
         /autoware/perception/node_alive_monitoring: default
 
-        /autoware/planning/node_alive_monitoring: { sf_at: "none", lf_at: "warn", spf_at: "error", auto_recovery: "false", before_planning_control_ignore: "true"}
+        /autoware/planning/node_alive_monitoring: { sf_at: "none", lf_at: "warn", spf_at: "error", auto_recovery: "false",ignore_until_waiting_for_route: "true"}
         /autoware/planning/performance_monitoring/trajectory_validation: default
 
         /autoware/sensing/node_alive_monitoring: default
@@ -44,7 +44,7 @@
 
       external_control:
         /autoware/control/control_command_gate/node_alive_monitoring: default
-        /autoware/control/autonomous_emergency_braking/performance_monitoring/emergency_stop: { sf_at: "none", lf_at: "warn", spf_at: "error", auto_recovery: "false", before_planning_control_ignore: "false"}
+        /autoware/control/autonomous_emergency_braking/performance_monitoring/emergency_stop: { sf_at: "none", lf_at: "warn", spf_at: "error", auto_recovery: "false",ignore_until_waiting_for_route: "false"}
         /autoware/control/external_control/external_command_selector/node_alive_monitoring: default
 
         /autoware/system/node_alive_monitoring: default

--- a/system/system_error_monitor/config/system_error_monitor.planning_simulation.param.yaml
+++ b/system/system_error_monitor/config/system_error_monitor.planning_simulation.param.yaml
@@ -4,7 +4,7 @@
 #   lf_at: diag level where it becomes Latent Fault
 #   spf_at: diag level where it becomes Single Point Fault
 #   auto_recovery: Determines whether the system will automatically recover when it recovers from an error.
-#  ignore_until_waiting_for_route: Determines whether the system will ignore the error before planning and control until waiting for route.
+#   ignore_until_waiting_for_route: Determines whether the system will ignore the module until waiting for route.
 # Note:
 # empty-value for sf_at, lf_at and spf_at is "none"
 # default values are:
@@ -12,7 +12,7 @@
 #   lf_at: "warn"
 #   spf_at: "error"
 #   auto_recovery: "true"
-#  ignore_until_waiting_for_route: "false"
+#   ignore_until_waiting_for_route: "false"
 ---
 /**:
   ros__parameters:

--- a/system/system_error_monitor/config/system_error_monitor.planning_simulation.param.yaml
+++ b/system/system_error_monitor/config/system_error_monitor.planning_simulation.param.yaml
@@ -4,7 +4,7 @@
 #   lf_at: diag level where it becomes Latent Fault
 #   spf_at: diag level where it becomes Single Point Fault
 #   auto_recovery: Determines whether the system will automatically recover when it recovers from an error.
-#
+#   before_planning_control_ignore: Determines whether the system will ignore the error before planning and control for when initializing and wait for route.
 # Note:
 # empty-value for sf_at, lf_at and spf_at is "none"
 # default values are:

--- a/system/system_error_monitor/include/system_error_monitor/system_error_monitor_core.hpp
+++ b/system/system_error_monitor/include/system_error_monitor/system_error_monitor_core.hpp
@@ -48,7 +48,7 @@ struct DiagConfig
   std::string lf_at;
   std::string spf_at;
   bool auto_recovery;
-  bool before_planning_control_ignore;
+  bool ignore_until_waiting_for_route;
 };
 
 using RequiredModules = std::vector<DiagConfig>;

--- a/system/system_error_monitor/include/system_error_monitor/system_error_monitor_core.hpp
+++ b/system/system_error_monitor/include/system_error_monitor/system_error_monitor_core.hpp
@@ -48,6 +48,7 @@ struct DiagConfig
   std::string lf_at;
   std::string spf_at;
   bool auto_recovery;
+  bool before_planning_control_ignore;
 };
 
 using RequiredModules = std::vector<DiagConfig>;

--- a/system/system_error_monitor/src/system_error_monitor_core.cpp
+++ b/system/system_error_monitor/src/system_error_monitor_core.cpp
@@ -220,7 +220,7 @@ bool ignoreBeforePlanningControl(
     (autoware_state.state == AutowareState::WAITING_FOR_ROUTE) ||
     (autoware_state.state == AutowareState::PLANNING);
 
-  if (is_in_autonomous_ignore_state && required_module.before_planning_control_ignore) {
+  if (is_in_autonomous_ignore_state && required_module.ignore_until_waiting_for_route) {
     return true;
   }
   return false;
@@ -338,22 +338,22 @@ void AutowareErrorMonitor::loadRequiredModules(const std::string & key)
     std::string auto_recovery_approval_str;
     this->get_parameter_or(auto_recovery_key, auto_recovery_approval_str, std::string("true"));
 
-    const auto before_planning_control_ignore_key =
-      module_name_with_prefix + std::string(".before_planning_control_ignore");
-    std::string before_planning_control_ignore_str;
+    const auto ignore_until_waiting_for_route_key =
+      module_name_with_prefix + std::string(".ignore_until_waiting_for_route");
+    std::string ignore_until_waiting_for_route_str;
     this->get_parameter_or(
-      before_planning_control_ignore_key, before_planning_control_ignore_str, std::string("false"));
+      ignore_until_waiting_for_route_key, ignore_until_waiting_for_route_str, std::string("false"));
 
     // Convert auto_recovery_approval_str to bool
     bool auto_recovery_approval{};
     std::istringstream(auto_recovery_approval_str) >> std::boolalpha >> auto_recovery_approval;
 
-    bool before_planning_control_ignore{};
-    std::istringstream(before_planning_control_ignore_str) >> std::boolalpha >>
-      before_planning_control_ignore;
+    bool ignore_until_waiting_for_route{};
+    std::istringstream(ignore_until_waiting_for_route_str) >> std::boolalpha >>
+      ignore_until_waiting_for_route;
 
     required_modules.push_back(
-      {param_module, sf_at, lf_at, spf_at, auto_recovery_approval, before_planning_control_ignore});
+      {param_module, sf_at, lf_at, spf_at, auto_recovery_approval, ignore_until_waiting_for_route});
   }
 
   required_modules_map_.insert(std::make_pair(key, required_modules));

--- a/system/system_error_monitor/src/system_error_monitor_core.cpp
+++ b/system/system_error_monitor/src/system_error_monitor_core.cpp
@@ -520,7 +520,7 @@ uint8_t AutowareErrorMonitor::getHazardLevel(
   using autoware_auto_system_msgs::msg::HazardStatus;
 
   if (isOverLevel(diag_level, required_module.spf_at)) {
-    if (ignoreBeforePlanningControl(*autoware_state_, required_module)) {
+    if (ignoreUntilWaitingForRoute(*autoware_state_, required_module)) {
       return HazardStatus::NO_FAULT;
     }
     return HazardStatus::SINGLE_POINT_FAULT;

--- a/system/system_error_monitor/src/system_error_monitor_core.cpp
+++ b/system/system_error_monitor/src/system_error_monitor_core.cpp
@@ -208,7 +208,7 @@ int isInNoFaultCondition(
 
   return false;
 }
-bool ignoreBeforePlanningControl(
+bool ignoreUntilWaitingForRoute(
   const autoware_auto_system_msgs::msg::AutowareState & autoware_state,
   const DiagConfig & required_module)
 {
@@ -217,8 +217,7 @@ bool ignoreBeforePlanningControl(
 
   const auto is_in_autonomous_ignore_state =
     (autoware_state.state == AutowareState::INITIALIZING) ||
-    (autoware_state.state == AutowareState::WAITING_FOR_ROUTE) ||
-    (autoware_state.state == AutowareState::PLANNING);
+    (autoware_state.state == AutowareState::WAITING_FOR_ROUTE);
 
   if (is_in_autonomous_ignore_state && required_module.ignore_until_waiting_for_route) {
     return true;

--- a/system/system_error_monitor/src/system_error_monitor_core.cpp
+++ b/system/system_error_monitor/src/system_error_monitor_core.cpp
@@ -338,23 +338,22 @@ void AutowareErrorMonitor::loadRequiredModules(const std::string & key)
     std::string auto_recovery_approval_str;
     this->get_parameter_or(auto_recovery_key, auto_recovery_approval_str, std::string("true"));
 
-    const auto before_planning_control_ignore_key = module_name_with_prefix +
-                                                    std::string(".before_planning_control_ignore");
+    const auto before_planning_control_ignore_key =
+      module_name_with_prefix + std::string(".before_planning_control_ignore");
     std::string before_planning_control_ignore_str;
     this->get_parameter_or(
-      before_planning_control_ignore_key, before_planning_control_ignore_str,
-      std::string("false"));
+      before_planning_control_ignore_key, before_planning_control_ignore_str, std::string("false"));
 
     // Convert auto_recovery_approval_str to bool
     bool auto_recovery_approval{};
     std::istringstream(auto_recovery_approval_str) >> std::boolalpha >> auto_recovery_approval;
 
     bool before_planning_control_ignore{};
-    std::istringstream(before_planning_control_ignore_str) >>
-      std::boolalpha >> before_planning_control_ignore;
+    std::istringstream(before_planning_control_ignore_str) >> std::boolalpha >>
+      before_planning_control_ignore;
 
-    required_modules.push_back({param_module, sf_at, lf_at, spf_at, auto_recovery_approval,
-                                before_planning_control_ignore});
+    required_modules.push_back(
+      {param_module, sf_at, lf_at, spf_at, auto_recovery_approval, before_planning_control_ignore});
   }
 
   required_modules_map_.insert(std::make_pair(key, required_modules));
@@ -516,7 +515,7 @@ uint8_t AutowareErrorMonitor::getHazardLevel(
   using autoware_auto_system_msgs::msg::HazardStatus;
 
   if (isOverLevel(diag_level, required_module.spf_at)) {
-    if(ignoreBeforePlanningControl(*autoware_state_, required_module)){
+    if (ignoreBeforePlanningControl(*autoware_state_, required_module)) {
       return HazardStatus::NO_FAULT;
     }
     return HazardStatus::SINGLE_POINT_FAULT;
@@ -672,8 +671,6 @@ bool AutowareErrorMonitor::canAutoRecovery() const
   }
   return true;
 }
-
-
 
 bool AutowareErrorMonitor::isEmergencyHoldingRequired() const
 {


### PR DESCRIPTION
## Description

初期化中やwait for route中に不要なdiagがtimeoutのerror_diagになっている状態を無効化する関数を追加
configで
before_planning_control_ignore: "true"にすることでspf->nfに変更する。
defaultについてはfalseに設定しています。
configの追加のためlaunchと同時にマージをする必要があります。

## Related links

https://tier4.atlassian.net/browse/AEAP-763
https://github.com/tier4/autoware_launch.x1.eve/pull/431


## Tests performed

Psimでwait for routeのときにplanning,controlのtimeoutが出ていないことを確認した。

![image](https://github.com/tier4/autoware.universe/assets/54956813/8b1902c9-623a-434a-847c-16e24c4d476a)


## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters. -->

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
