### PR TITLE
feat(lane_departure_checker): add border types to check (#4861)

### DIFF
--- a/control/lane_departure_checker/README.md
+++ b/control/lane_departure_checker/README.md
@@ -63,15 +63,30 @@ This package includes the following features:
 
 ### Node Parameters
 
-| Name                          | Type   | Description                                                   | Default value |
-| :---------------------------- | :----- | :------------------------------------------------------------ | :------------ |
-| update_rate                   | double | Frequency for publishing [Hz]                                 | 10.0          |
-| visualize_lanelet             | bool   | Flag for visualizing lanelet                                  | False         |
-| include_right_lanes           | bool   | Flag for including right lanelet in borders                   | False         |
-| include_left_lanes            | bool   | Flag for including left lanelet in borders                    | False         |
-| include_opposite_lanes        | bool   | Flag for including opposite lanelet in borders                | False         |
-| include_conflicting_lanes     | bool   | Flag for including conflicting lanelet in borders             | False         |
-| road_border_departure_checker | bool   | Flag for checking if the vehicle will departs the road border | False         |
+#### General Parameters
+
+| Name                       | Type   | Description                                                                                                 | Default value |
+| :------------------------- | :----- | :---------------------------------------------------------------------------------------------------------- | :------------ |
+| will_out_of_lane_checker   | bool   | Enable checker whether ego vehicle footprint will depart from lane                                          | True          |
+| out_of_lane_checker        | bool   | Enable checker whether ego vehicle footprint is out of lane                                                 | True          |
+| boundary_departure_checker | bool   | Enable checker whether ego vehicle footprint wil depart from boundary specified by boundary_types_to_detect | False         |
+| update_rate                | double | Frequency for publishing [Hz]                                                                               | 10.0          |
+| visualize_lanelet          | bool   | Flag for visualizing lanelet                                                                                | False         |
+
+#### Parameters For Lane Departure
+
+| Name                      | Type | Description                                       | Default value |
+| :------------------------ | :--- | :------------------------------------------------ | :------------ |
+| include_right_lanes       | bool | Flag for including right lanelet in borders       | False         |
+| include_left_lanes        | bool | Flag for including left lanelet in borders        | False         |
+| include_opposite_lanes    | bool | Flag for including opposite lanelet in borders    | False         |
+| include_conflicting_lanes | bool | Flag for including conflicting lanelet in borders | False         |
+
+#### Parameters For Road Border Departure
+
+| Name                     | Type                       | Description                                                 | Default value |
+| :----------------------- | :------------------------- | :---------------------------------------------------------- | :------------ |
+| boundary_types_to_detect | std::vector\<std::string\> | line_string types to detect with boundary_departure_checker | [road_border] |
 
 ### Core Parameters
 

--- a/control/lane_departure_checker/config/lane_departure_checker.param.yaml
+++ b/control/lane_departure_checker/config/lane_departure_checker.param.yaml
@@ -1,5 +1,10 @@
 /**:
   ros__parameters:
+    # Enable feature
+    will_out_of_lane_checker: true
+    out_of_lane_checker: true
+    boundary_departure_checker: false
+
     # Node
     update_rate: 10.0
     visualize_lanelet: false
@@ -7,7 +12,8 @@
     include_left_lanes: false
     include_opposite_lanes: false
     include_conflicting_lanes: false
-    road_border_departure_checker: false
+    boundary_types_to_detect: [road_border]
+
 
     # Core
     footprint_margin_scale: 1.0

--- a/control/lane_departure_checker/include/lane_departure_checker/lane_departure_checker.hpp
+++ b/control/lane_departure_checker/include/lane_departure_checker/lane_departure_checker.hpp
@@ -73,6 +73,7 @@ struct Input
   lanelet::ConstLanelets shoulder_lanelets{};
   Trajectory::ConstSharedPtr reference_trajectory{};
   Trajectory::ConstSharedPtr predicted_trajectory{};
+  std::vector<std::string> boundary_types_to_detect{};
 };
 
 struct Output
@@ -80,7 +81,7 @@ struct Output
   std::map<std::string, double> processing_time_map{};
   bool will_leave_lane{};
   bool is_out_of_lane{};
-  bool will_cross_road_border{};
+  bool will_cross_boundary{};
   PoseDeviation trajectory_deviation{};
   lanelet::ConstLanelets candidate_lanelets{};
   TrajectoryPoints resampled_trajectory{};
@@ -137,9 +138,10 @@ private:
     const lanelet::ConstLanelets & candidate_lanelets,
     const std::vector<LinearRing2d> & vehicle_footprints);
 
-  static bool willCrossRoadBorder(
+  static bool willCrossBoundary(
     const lanelet::ConstLanelets & candidate_lanelets,
-    const std::vector<LinearRing2d> & vehicle_footprints);
+    const std::vector<LinearRing2d> & vehicle_footprints,
+    const std::vector<std::string> & boundary_types_to_detects);
 
   static bool isCrossingRoadBorder(
     const lanelet::BasicLineString2d & road_border, const std::vector<LinearRing2d> & footprints);

--- a/control/lane_departure_checker/include/lane_departure_checker/lane_departure_checker_node.hpp
+++ b/control/lane_departure_checker/include/lane_departure_checker/lane_departure_checker_node.hpp
@@ -37,6 +37,7 @@
 
 #include <map>
 #include <memory>
+#include <string>
 #include <vector>
 
 namespace lane_departure_checker
@@ -45,13 +46,17 @@ using autoware_auto_mapping_msgs::msg::HADMapBin;
 
 struct NodeParam
 {
+  bool will_out_of_lane_checker;
+  bool out_of_lane_checker;
+  bool boundary_departure_checker;
+
   double update_rate;
   bool visualize_lanelet;
   bool include_right_lanes;
   bool include_left_lanes;
   bool include_opposite_lanes;
   bool include_conflicting_lanes;
-  bool road_border_departure_checker;
+  std::vector<std::string> boundary_types_to_detect;
 };
 
 class LaneDepartureCheckerNode : public rclcpp::Node


### PR DESCRIPTION
laucherの変更は[こちら](https://github.com/tier4/autoware_launch.x2/pull/460)

逸脱判定機能追加チケット:https://tier4.atlassian.net/browse/RT1-3073
今回PRの対応チケット:https://tier4.atlassian.net/browse/RT0-28965

TODO
- [ ] 塩尻のrosbagを使って走行し、MRMが頻発しないことを確認する。その際逸脱判定対象はcurbestone**のみ**とする。

rosbagは以下を参照
https://star4.slack.com/archives/CRUE57C30/p1695967493388629?thread_ts=1695964275.721019&cid=CRUE57C30



description
---
Add features for lane_departure_checker package

- add flag to control enable/disable feature of ego vehicle's footprint (is out of lane / will leave from lane / will leave from boundary)
- add array to choose type of lanelet's line string(e.g. road_border and curbstone, etc..)
- update README.md
