### PR TITLE
fix: crosswalk pedestrian lights

### DIFF
--- a/perception/crosswalk_traffic_light_estimator/src/node.cpp
+++ b/perception/crosswalk_traffic_light_estimator/src/node.cpp
@@ -230,6 +230,7 @@ void CrosswalkTrafficLightEstimatorNode::setCrosswalkTrafficSignal(
     TrafficSignal output_traffic_signal;
     TrafficSignalElement output_traffic_signal_element;
     output_traffic_signal_element.color = color;
+    output_traffic_signal_element.shape = TrafficSignalElement::CIRCLE;
     output_traffic_signal_element.confidence = 1.0;
     output_traffic_signal.elements.push_back(output_traffic_signal_element);
     output_traffic_signal.traffic_signal_id = tl_reg_elem->id();

--- a/planning/behavior_velocity_crosswalk_module/src/scene_crosswalk.cpp
+++ b/planning/behavior_velocity_crosswalk_module/src/scene_crosswalk.cpp
@@ -955,8 +955,10 @@ bool CrosswalkModule::isRedSignalForPedestrians() const
       continue;
     }
 
-    if (lights.front().color == TrafficSignalElement::RED) {
-      return true;
+    for (const auto & element : lights) {
+      if (
+        element.color == TrafficSignalElement::RED && element.shape == TrafficSignalElement::CIRCLE)
+        return true;
     }
   }
 


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

cherry-pick following PRs
- https://github.com/autowarefoundation/autoware.universe/pull/5168
- https://github.com/autowarefoundation/autoware.universe/pull/5169

This fixes the bug that crosswalk module doesn't ignore the red pedestrian light.

Related ticket:
[TEIR IV INTERNAL](https://tier4.atlassian.net/browse/RT0-29271)


## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

See https://github.com/autowarefoundation/autoware.universe/pull/5169

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
