### PR TITLE
fix(behavior_path): only apply spline interpolation for its output, not for turn_signal processing

### DIFF
--- a/planning/behavior_path_planner/include/behavior_path_planner/behavior_path_planner_node.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/behavior_path_planner_node.hpp
@@ -50,8 +50,8 @@
 
 #include <memory>
 #include <string>
-#include <vector>
 #include <utility>
+#include <vector>
 
 namespace behavior_path_planner
 {

--- a/planning/behavior_path_planner/include/behavior_path_planner/behavior_path_planner_node.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/behavior_path_planner_node.hpp
@@ -136,7 +136,8 @@ private:
   /**
    * @brief extract path from behavior tree output
    */
-  std::pair<PathWithLaneId::SharedPtr, PathWithLaneId::SharedPtr> getPath(const BehaviorModuleOutput & bt_out);
+  std::pair<PathWithLaneId::SharedPtr, PathWithLaneId::SharedPtr> getPath(
+    const BehaviorModuleOutput & bt_out);
 
   /**
    * @brief extract path candidate from behavior tree output

--- a/planning/behavior_path_planner/include/behavior_path_planner/behavior_path_planner_node.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/behavior_path_planner_node.hpp
@@ -136,7 +136,7 @@ private:
   /**
    * @brief extract path from behavior tree output
    */
-  PathWithLaneId::SharedPtr getPath(const BehaviorModuleOutput & bt_out);
+  std::pair<PathWithLaneId::SharedPtr, PathWithLaneId::SharedPtr> getPath(const BehaviorModuleOutput & bt_out);
 
   /**
    * @brief extract path candidate from behavior tree output

--- a/planning/behavior_path_planner/include/behavior_path_planner/behavior_path_planner_node.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/behavior_path_planner_node.hpp
@@ -51,6 +51,7 @@
 #include <memory>
 #include <string>
 #include <vector>
+#include <utility>
 
 namespace behavior_path_planner
 {


### PR DESCRIPTION
## Description

https://github.com/tier4/autoware.universe/pull/782 において、behavior_pathの出力経路をspline補間するように修正したが、turn_signalの処理はspline補間を実施しないのが前提のロジックとなってしまっっているため、チャタリングする問題が発生していた
そこで、spline補間する対象をbehavior_pathの出力経路に限定し、turn_signalの処理にはspline補間をしない経路を与えるかたちに修正する

## Related links

https://tier4.atlassian.net/browse/AEAP-768

## Tests performed

AEAP-768で問題が出ている箇所を走行し、turn_signalがチャタリングしないことを確認した

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters. -->

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
