### PR TITLE
feat(intersection): ensure temporal stop before peeking into oncoming lane

### DIFF
--- a/planning/behavior_velocity_intersection_module/config/intersection.param.yaml
+++ b/planning/behavior_velocity_intersection_module/config/intersection.param.yaml
@@ -45,9 +45,14 @@
         min_vehicle_brake_for_rss: -2.5 # [m/s^2]
         max_vehicle_velocity_for_rss: 16.66 # [m/s] == 60kmph
         denoise_kernel: 1.0 # [m]
-        possible_object_bbox: [1.0, 2.0] # [m x m]
-        ignore_parked_vehicle_speed_threshold: 0.333 # == 1.2km/h
-        stop_release_margin_time: 1.0 # [s]
+        possible_object_bbox: [1.5, 2.5] # [m x m]
+        ignore_parked_vehicle_speed_threshold: 0.8333 # == 3.0km/h
+        stop_release_margin_time: 1.5 # [s]
+        temporal_stop_before_attention_area: false
+
+      enable_rtc:
+        intersection: true # If set to true, the scene modules require approval from the rtc (request to cooperate) function. If set to false, the modules can be executed without requiring rtc approval
+        intersection_to_occlusion: true
 
       enable_rtc: # If set to true, the scene modules require approval from the rtc (request to cooperate) function. If set to false, the modules can be executed without requiring rtc approval
         intersection: true

--- a/planning/behavior_velocity_intersection_module/src/debug.cpp
+++ b/planning/behavior_velocity_intersection_module/src/debug.cpp
@@ -104,7 +104,33 @@ visualization_msgs::msg::MarkerArray createPoseMarkerArray(
   return msg;
 }
 
-visualization_msgs::msg::Marker createPointMarkerArray(
+visualization_msgs::msg::MarkerArray createLineMarkerArray(
+  const geometry_msgs::msg::Point & point_start, const geometry_msgs::msg::Point & point_end,
+  const std::string & ns, const int64_t id, const double r, const double g, const double b)
+{
+  visualization_msgs::msg::MarkerArray msg;
+
+  visualization_msgs::msg::Marker marker;
+  marker.header.frame_id = "map";
+  marker.ns = ns + "_line";
+  marker.id = id;
+  marker.lifetime = rclcpp::Duration::from_seconds(0.3);
+  marker.type = visualization_msgs::msg::Marker::ARROW;
+  marker.action = visualization_msgs::msg::Marker::ADD;
+  geometry_msgs::msg::Vector3 arrow;
+  arrow.x = 1.0;
+  arrow.y = 1.0;
+  arrow.z = 1.0;
+  marker.scale = arrow;
+  marker.color = createMarkerColor(r, g, b, 0.999);
+  marker.points.push_back(point_start);
+  marker.points.push_back(point_end);
+
+  msg.markers.push_back(marker);
+  return msg;
+}
+
+[[maybe_unused]] visualization_msgs::msg::Marker createPointMarkerArray(
   const geometry_msgs::msg::Point & point, const std::string & ns, const int64_t id, const double r,
   const double g, const double b)
 {
@@ -176,17 +202,6 @@ visualization_msgs::msg::MarkerArray IntersectionModule::createDebugMarkerArray(
       &debug_marker_array, now);
   }
 
-  if (debug_data_.nearest_occlusion_point) {
-    debug_marker_array.markers.push_back(createPointMarkerArray(
-      debug_data_.nearest_occlusion_point.value(), "nearest_occlusion", module_id_, 0.5, 0.5, 0.0));
-  }
-
-  if (debug_data_.nearest_occlusion_projection_point) {
-    debug_marker_array.markers.push_back(createPointMarkerArray(
-      debug_data_.nearest_occlusion_projection_point.value(), "nearest_occlusion_projection",
-      module_id_, 0.5, 0.5, 0.0));
-  }
-
   size_t i{0};
   for (const auto & p : debug_data_.candidate_collision_object_polygons) {
     appendMarkerArray(
@@ -229,6 +244,13 @@ visualization_msgs::msg::MarkerArray IntersectionModule::createDebugMarkerArray(
       &debug_marker_array, now);
   }
 
+  if (debug_data_.nearest_occlusion_projection) {
+    const auto [point_start, point_end] = debug_data_.nearest_occlusion_projection.value();
+    appendMarkerArray(
+      createLineMarkerArray(
+        point_start, point_end, "nearest_occlusion_projection", lane_id_, 0.5, 0.5, 0.0),
+      &debug_marker_array, now);
+  }
   return debug_marker_array;
 }
 

--- a/planning/behavior_velocity_intersection_module/src/manager.cpp
+++ b/planning/behavior_velocity_intersection_module/src/manager.cpp
@@ -115,6 +115,8 @@ IntersectionModuleManager::IntersectionModuleManager(rclcpp::Node & node)
     node.declare_parameter<double>(ns + ".occlusion.ignore_parked_vehicle_speed_threshold");
   ip.occlusion.stop_release_margin_time =
     node.declare_parameter<double>(ns + ".occlusion.stop_release_margin_time");
+  ip.occlusion.temporal_stop_before_attention_area =
+    node.declare_parameter<bool>(ns + ".occlusion.temporal_stop_before_attention_area");
 }
 
 void IntersectionModuleManager::launchNewModules(

--- a/planning/behavior_velocity_intersection_module/src/scene_intersection.cpp
+++ b/planning/behavior_velocity_intersection_module/src/scene_intersection.cpp
@@ -94,6 +94,11 @@ IntersectionModule::IntersectionModule(
     occlusion_stop_state_machine_.setMarginTime(planner_param_.occlusion.stop_release_margin_time);
     occlusion_stop_state_machine_.setState(StateMachine::State::GO);
   }
+  {
+    temporal_stop_before_attention_state_machine_.setMarginTime(
+      planner_param_.occlusion.before_creep_stop_time);
+    temporal_stop_before_attention_state_machine_.setState(StateMachine::State::STOP);
+  }
 
   decision_state_pub_ =
     node_.create_publisher<std_msgs::msg::String>("~/debug/intersection/decision_state", 1);
@@ -476,7 +481,10 @@ void reactRTCApprovalByDecisionResult(
   // NOTE: creep_velocity should be inserted first at closest_idx if !rtc_default_approved
 
   if (!rtc_occlusion_approved && planner_param.occlusion.enable) {
-    const size_t occlusion_peeking_stop_line = decision_result.occlusion_stop_line_idx;
+    const size_t occlusion_peeking_stop_line =
+      decision_result.temporal_stop_before_attention_required
+        ? decision_result.first_attention_stop_line_idx
+        : decision_result.occlusion_stop_line_idx;
     if (planner_param.occlusion.enable_creeping) {
       const size_t closest_idx = decision_result.closest_idx;
       for (size_t i = closest_idx; i < occlusion_peeking_stop_line; i++) {
@@ -540,7 +548,9 @@ void reactRTCApprovalByDecisionResult(
     }
   }
   if (!rtc_occlusion_approved && planner_param.occlusion.enable) {
-    const auto stop_line_idx = decision_result.occlusion_stop_line_idx;
+    const auto stop_line_idx = decision_result.temporal_stop_before_attention_required
+                                 ? decision_result.first_attention_stop_line_idx
+                                 : decision_result.occlusion_stop_line_idx;
     planning_utils::setVelocityFromIndex(stop_line_idx, 0.0, path);
     debug_data->occlusion_stop_wall_pose =
       planning_utils::getAheadPose(stop_line_idx, baselink2front, *path);
@@ -778,7 +788,8 @@ IntersectionModule::DecisionResult IntersectionModule::modifyPathVelocityDetail(
   const auto & intersection_stop_lines = intersection_stop_lines_opt.value();
   const auto
     [closest_idx, stuck_stop_line_idx_opt, default_stop_line_idx_opt,
-     occlusion_peeking_stop_line_idx_opt, pass_judge_line_idx] = intersection_stop_lines;
+     first_attention_stop_line_idx_opt, occlusion_peeking_stop_line_idx_opt, pass_judge_line_idx] =
+      intersection_stop_lines;
 
   const auto & conflicting_area = intersection_lanelets_.value().conflicting_area();
   const auto path_lanelets_opt = util::generatePathLanelets(
@@ -857,12 +868,13 @@ IntersectionModule::DecisionResult IntersectionModule::modifyPathVelocityDetail(
     return IntersectionModule::Indecisive{};
   }
 
-  if (!occlusion_peeking_stop_line_idx_opt) {
+  if (!first_attention_stop_line_idx_opt || !occlusion_peeking_stop_line_idx_opt) {
     RCLCPP_DEBUG(logger_, "occlusion stop line is null");
     return IntersectionModule::Indecisive{};
   }
   const auto collision_stop_line_idx =
     is_over_default_stop_line ? closest_idx : default_stop_line_idx;
+  const auto first_attention_stop_line_idx = first_attention_stop_line_idx_opt.value();
   const auto occlusion_stop_line_idx = occlusion_peeking_stop_line_idx_opt.value();
 
   const auto & attention_lanelets = intersection_lanelets_.value().attention();
@@ -938,35 +950,63 @@ IntersectionModule::DecisionResult IntersectionModule::modifyPathVelocityDetail(
   if (
     occlusion_stop_state_machine_.getState() == StateMachine::State::STOP ||
     ext_occlusion_requested) {
-    const double dist_stopline = motion_utils::calcSignedArcLength(
+    const double dist_default_stopline = motion_utils::calcSignedArcLength(
       path->points, path->points.at(closest_idx).point.pose.position,
       path->points.at(default_stop_line_idx).point.pose.position);
-    const bool approached_stop_line =
-      (std::fabs(dist_stopline) < planner_param_.common.stop_overshoot_margin);
-    const bool over_stop_line = (dist_stopline < 0.0);
-    const bool is_stopped = planner_data_->isVehicleStopped();
-    if (over_stop_line) {
+    const bool approached_default_stop_line =
+      (std::fabs(dist_default_stopline) < planner_param_.common.stop_overshoot_margin);
+    const bool over_default_stop_line = (dist_default_stopline < 0.0);
+    const bool is_stopped_at_default =
+      planner_data_->isVehicleStopped(planner_param_.occlusion.before_creep_stop_time);
+    if (over_default_stop_line) {
       before_creep_state_machine_.setState(StateMachine::State::GO);
     }
     if (before_creep_state_machine_.getState() == StateMachine::State::GO) {
+      const double dist_first_attention_stopline = motion_utils::calcSignedArcLength(
+        path->points, path->points.at(closest_idx).point.pose.position,
+        path->points.at(first_attention_stop_line_idx).point.pose.position);
+      const bool approached_first_attention_stop_line =
+        (std::fabs(dist_first_attention_stopline) < planner_param_.common.stop_overshoot_margin);
+      const bool over_first_attention_stop_line = (dist_first_attention_stopline < 0.0);
+      const bool is_stopped_at_first_attention =
+        planner_data_->isVehicleStopped(planner_param_.occlusion.before_creep_stop_time);
+      if (planner_param_.occlusion.temporal_stop_before_attention_area) {
+        if (over_first_attention_stop_line) {
+          temporal_stop_before_attention_state_machine_.setState(StateMachine::State::GO);
+        }
+        if (is_stopped_at_first_attention && approached_first_attention_stop_line) {
+          temporal_stop_before_attention_state_machine_.setState(StateMachine::State::GO);
+        }
+      }
+      const bool temporal_stop_before_attention_required =
+        planner_param_.occlusion.temporal_stop_before_attention_area &&
+        temporal_stop_before_attention_state_machine_.getState() == StateMachine::State::STOP;
       if (has_collision_with_margin) {
-        return IntersectionModule::OccludedCollisionStop{
-          is_occlusion_cleared_with_margin, closest_idx, collision_stop_line_idx,
-          occlusion_stop_line_idx};
+        return IntersectionModule::OccludedCollisionStop{is_occlusion_cleared_with_margin,
+                                                         temporal_stop_before_attention_required,
+                                                         closest_idx,
+                                                         collision_stop_line_idx,
+                                                         first_attention_stop_line_idx,
+                                                         occlusion_stop_line_idx};
       } else {
-        return IntersectionModule::PeekingTowardOcclusion{
-          is_occlusion_cleared_with_margin, closest_idx, collision_stop_line_idx,
-          occlusion_stop_line_idx};
+        return IntersectionModule::PeekingTowardOcclusion{is_occlusion_cleared_with_margin,
+                                                          temporal_stop_before_attention_required,
+                                                          closest_idx,
+                                                          collision_stop_line_idx,
+                                                          first_attention_stop_line_idx,
+                                                          occlusion_stop_line_idx};
       }
     } else {
-      if (is_stopped && approached_stop_line) {
+      if (is_stopped_at_default && approached_default_stop_line) {
         // start waiting at the first stop line
         before_creep_state_machine_.setStateWithMarginTime(
           StateMachine::State::GO, logger_.get_child("occlusion state_machine"), *clock_);
       }
+      const auto occlusion_stop_line = planner_param_.occlusion.temporal_stop_before_attention_area
+                                         ? first_attention_stop_line_idx
+                                         : occlusion_stop_line_idx;
       return IntersectionModule::FirstWaitBeforeOcclusion{
-        is_occlusion_cleared_with_margin, closest_idx, default_stop_line_idx,
-        occlusion_stop_line_idx};
+        is_occlusion_cleared_with_margin, closest_idx, default_stop_line_idx, occlusion_stop_line};
     }
   } else if (has_collision_with_margin) {
     return IntersectionModule::NonOccludedCollisionStop{

--- a/planning/behavior_velocity_intersection_module/src/scene_intersection.cpp
+++ b/planning/behavior_velocity_intersection_module/src/scene_intersection.cpp
@@ -19,15 +19,19 @@
 #include <behavior_velocity_planner_common/utilization/boost_geometry_helper.hpp>
 #include <behavior_velocity_planner_common/utilization/path_utilization.hpp>
 #include <behavior_velocity_planner_common/utilization/util.hpp>
-#include <lanelet2_extension/regulatory_elements/road_marking.hpp>
-#include <lanelet2_extension/utility/message_conversion.hpp>
-#include <lanelet2_extension/utility/query.hpp>
 #include <lanelet2_extension/utility/utilities.hpp>
-#include <magic_enum.hpp>
+#include <motion_utils/trajectory/trajectory.hpp>
 #include <opencv2/imgproc.hpp>
+#include <tier4_autoware_utils/geometry/boost_polygon_utils.hpp>
+#include <tier4_autoware_utils/geometry/geometry.hpp>
+#include <tier4_autoware_utils/ros/uuid_helper.hpp>
 
+#include <boost/geometry/algorithms/correct.hpp>
+#include <boost/geometry/algorithms/intersection.hpp>
+
+#include <lanelet2_core/geometry/LineString.h>
 #include <lanelet2_core/geometry/Polygon.h>
-#include <lanelet2_core/primitives/BasicRegulatoryElements.h>
+#include <lanelet2_core/primitives/LineString.h>
 
 #include <algorithm>
 #include <limits>
@@ -1172,7 +1176,8 @@ bool IntersectionModule::isOcclusionCleared(
   const lanelet::CompoundPolygon3d & first_attention_area,
   const util::InterpolatedPathInfo & interpolated_path_info,
   const std::vector<util::DescritizedLane> & lane_divisions,
-  const std::vector<autoware_auto_perception_msgs::msg::PredictedObject> & parked_attention_objects,
+  [[maybe_unused]] const std::vector<autoware_auto_perception_msgs::msg::PredictedObject> &
+    blocking_attention_objects,
   const double occlusion_dist_thr)
 {
   const auto & path_ip = interpolated_path_info.path;
@@ -1190,19 +1195,13 @@ bool IntersectionModule::isOcclusionCleared(
     first_inside_attention_idx_ip_opt
       ? std::make_pair(first_inside_attention_idx_ip_opt.value(), std::get<1>(lane_interval_ip))
       : lane_interval_ip;
+  const auto [lane_start_idx, lane_end_idx] = lane_attention_interval_ip;
 
   const int width = occ_grid.info.width;
   const int height = occ_grid.info.height;
   const double resolution = occ_grid.info.resolution;
   const auto & origin = occ_grid.info.origin.position;
 
-  // NOTE: interesting area is set to 0 for later masking
-  cv::Mat attention_mask(width, height, CV_8UC1, cv::Scalar(0));
-  cv::Mat unknown_mask(width, height, CV_8UC1, cv::Scalar(0));
-
-  // (1) prepare detection area mask
-  // attention: 255
-  // non-attention: 0
   Polygon2d grid_poly;
   grid_poly.outer().emplace_back(origin.x, origin.y);
   grid_poly.outer().emplace_back(origin.x + (width - 1) * resolution, origin.y);
@@ -1212,10 +1211,9 @@ bool IntersectionModule::isOcclusionCleared(
   grid_poly.outer().emplace_back(origin.x, origin.y);
   bg::correct(grid_poly);
 
-  std::vector<std::vector<cv::Point>> attention_area_cv_polygons;
-  for (const auto & attention_area : attention_areas) {
-    const auto area2d = lanelet::utils::to2D(attention_area);
-    Polygon2d area2d_poly;
+  auto findCommonCvPolygons =
+    [&](const auto & area2d, std::vector<std::vector<cv::Point>> & cv_polygons) -> void {
+    tier4_autoware_utils::Polygon2d area2d_poly;
     for (const auto & p : area2d) {
       area2d_poly.outer().emplace_back(p.x(), p.y());
     }
@@ -1224,21 +1222,32 @@ bool IntersectionModule::isOcclusionCleared(
     std::vector<Polygon2d> common_areas;
     bg::intersection(area2d_poly, grid_poly, common_areas);
     if (common_areas.empty()) {
-      continue;
+      return;
     }
     for (size_t i = 0; i < common_areas.size(); ++i) {
       common_areas[i].outer().push_back(common_areas[i].outer().front());
       bg::correct(common_areas[i]);
     }
     for (const auto & common_area : common_areas) {
-      std::vector<cv::Point> attention_area_cv_polygon;
+      std::vector<cv::Point> cv_polygon;
       for (const auto & p : common_area.outer()) {
         const int idx_x = static_cast<int>((p.x() - origin.x) / resolution);
         const int idx_y = static_cast<int>((p.y() - origin.y) / resolution);
-        attention_area_cv_polygon.emplace_back(idx_x, height - 1 - idx_y);
+        cv_polygon.emplace_back(idx_x, height - 1 - idx_y);
       }
-      attention_area_cv_polygons.push_back(attention_area_cv_polygon);
+      cv_polygons.push_back(cv_polygon);
     }
+  };
+
+  // (1) prepare detection area mask
+  // attention: 255
+  // non-attention: 0
+  // NOTE: interesting area is set to 255 for later masking
+  cv::Mat attention_mask(width, height, CV_8UC1, cv::Scalar(0));
+  std::vector<std::vector<cv::Point>> attention_area_cv_polygons;
+  for (const auto & attention_area : attention_areas) {
+    const auto area2d = lanelet::utils::to2D(attention_area);
+    findCommonCvPolygons(area2d, attention_area_cv_polygons);
   }
   for (const auto & poly : attention_area_cv_polygons) {
     cv::fillPoly(attention_mask, poly, cv::Scalar(255), cv::LINE_4);
@@ -1248,30 +1257,7 @@ bool IntersectionModule::isOcclusionCleared(
   std::vector<std::vector<cv::Point>> adjacent_lane_cv_polygons;
   for (const auto & adjacent_lanelet : adjacent_lanelets) {
     const auto area2d = adjacent_lanelet.polygon2d().basicPolygon();
-    Polygon2d area2d_poly;
-    for (const auto & p : area2d) {
-      area2d_poly.outer().emplace_back(p.x(), p.y());
-    }
-    area2d_poly.outer().push_back(area2d_poly.outer().front());
-    bg::correct(area2d_poly);
-    std::vector<Polygon2d> common_areas;
-    bg::intersection(area2d_poly, grid_poly, common_areas);
-    if (common_areas.empty()) {
-      continue;
-    }
-    for (size_t i = 0; i < common_areas.size(); ++i) {
-      common_areas[i].outer().push_back(common_areas[i].outer().front());
-      bg::correct(common_areas[i]);
-    }
-    for (const auto & common_area : common_areas) {
-      std::vector<cv::Point> adjacent_lane_cv_polygon;
-      for (const auto & p : common_area.outer()) {
-        const int idx_x = static_cast<int>((p.x() - origin.x) / resolution);
-        const int idx_y = static_cast<int>((p.y() - origin.y) / resolution);
-        adjacent_lane_cv_polygon.emplace_back(idx_x, height - 1 - idx_y);
-      }
-      adjacent_lane_cv_polygons.push_back(adjacent_lane_cv_polygon);
-    }
+    findCommonCvPolygons(area2d, adjacent_lane_cv_polygons);
   }
   for (const auto & poly : adjacent_lane_cv_polygons) {
     cv::fillPoly(attention_mask, poly, cv::Scalar(0), cv::LINE_AA);
@@ -1279,6 +1265,10 @@ bool IntersectionModule::isOcclusionCleared(
 
   // (2) prepare unknown mask
   // In OpenCV the pixel at (X=x, Y=y) (with left-upper origin) is accessed by img[y, x]
+  // unknown: 255
+  // not-unknown: 0
+  cv::Mat unknown_mask_raw(width, height, CV_8UC1, cv::Scalar(0));
+  cv::Mat unknown_mask(width, height, CV_8UC1, cv::Scalar(0));
   for (int x = 0; x < width; x++) {
     for (int y = 0; y < height; y++) {
       const int idx = y * width + x;
@@ -1286,159 +1276,21 @@ bool IntersectionModule::isOcclusionCleared(
       if (
         planner_param_.occlusion.free_space_max <= intensity &&
         intensity < planner_param_.occlusion.occupied_min) {
-        unknown_mask.at<unsigned char>(height - 1 - y, x) = 255;
+        unknown_mask_raw.at<unsigned char>(height - 1 - y, x) = 255;
       }
     }
   }
-
-  // (3) occlusion mask
-  cv::Mat occlusion_mask_raw(width, height, CV_8UC1, cv::Scalar(0));
-  cv::bitwise_and(attention_mask, unknown_mask, occlusion_mask_raw);
-  // (3.1) apply morphologyEx
-  cv::Mat occlusion_mask;
-  const int morph_size = std::ceil(planner_param_.occlusion.denoise_kernel / resolution);
+  // (2.1) apply morphologyEx
+  const int morph_size = static_cast<int>(planner_param_.occlusion.denoise_kernel / resolution);
   cv::morphologyEx(
-    occlusion_mask_raw, occlusion_mask, cv::MORPH_OPEN,
+    unknown_mask_raw, unknown_mask, cv::MORPH_OPEN,
     cv::getStructuringElement(cv::MORPH_RECT, cv::Size(morph_size, morph_size)));
 
-  // (4) create distance grid
-  // value: 0 - 254: signed distance representing [distance_min, distance_max]
-  // 255: undefined value
-  const double distance_max = std::hypot(width * resolution / 2, height * resolution / 2);
-  const double distance_min = -distance_max;
-  const int undef_pixel = 255;
-  const int max_cost_pixel = 254;
-  auto dist2pixel = [=](const double dist) {
-    return std::min(
-      max_cost_pixel,
-      static_cast<int>((dist - distance_min) / (distance_max - distance_min) * max_cost_pixel));
-  };
-  auto pixel2dist = [=](const int pixel) {
-    return pixel * 1.0 / max_cost_pixel * (distance_max - distance_min) + distance_min;
-  };
-  const int zero_dist_pixel = dist2pixel(0.0);
-  const int parked_vehicle_pixel = zero_dist_pixel - 1;  // magic
+  // (3) occlusion mask
+  cv::Mat occlusion_mask(width, height, CV_8UC1, cv::Scalar(0));
+  cv::bitwise_and(attention_mask, unknown_mask, occlusion_mask);
 
-  auto coord2index = [&](const double x, const double y) {
-    const int idx_x = (x - origin.x) / resolution;
-    const int idx_y = (y - origin.y) / resolution;
-    if (idx_x < 0 || idx_x >= width) return std::make_tuple(false, -1, -1);
-    if (idx_y < 0 || idx_y >= height) return std::make_tuple(false, -1, -1);
-    return std::make_tuple(true, idx_x, idx_y);
-  };
-
-  cv::Mat distance_grid(width, height, CV_8UC1, cv::Scalar(undef_pixel));
-  cv::Mat projection_ind_grid(width, height, CV_32S, cv::Scalar(-1));
-
-  // (4.1) fill zero_dist_pixel on the path
-  const auto [lane_start, lane_end] = lane_attention_interval_ip;
-  for (int i = static_cast<int>(lane_end); i >= static_cast<int>(lane_start); i--) {
-    const auto & path_pos = path_ip.points.at(i).point.pose.position;
-    const int idx_x = (path_pos.x - origin.x) / resolution;
-    const int idx_y = (path_pos.y - origin.y) / resolution;
-    if (idx_x < 0 || idx_x >= width) continue;
-    if (idx_y < 0 || idx_y >= height) continue;
-    distance_grid.at<unsigned char>(height - 1 - idx_y, idx_x) = zero_dist_pixel;
-    projection_ind_grid.at<int>(height - 1 - idx_y, idx_x) = i;
-  }
-
-  // (4.2) fill parked_vehicle_pixel to parked_vehicles (both positive and negative)
-  for (const auto & parked_attention_object : parked_attention_objects) {
-    const auto obj_poly = tier4_autoware_utils::toPolygon2d(parked_attention_object);
-    std::vector<Polygon2d> common_areas;
-    bg::intersection(obj_poly, grid_poly, common_areas);
-    if (common_areas.empty()) continue;
-    for (size_t i = 0; i < common_areas.size(); ++i) {
-      common_areas[i].outer().push_back(common_areas[i].outer().front());
-      bg::correct(common_areas[i]);
-    }
-    std::vector<std::vector<cv::Point>> parked_attention_object_area_cv_polygons;
-    for (const auto & common_area : common_areas) {
-      std::vector<cv::Point> parked_attention_object_area_cv_polygon;
-      for (const auto & p : common_area.outer()) {
-        const int idx_x = static_cast<int>((p.x() - origin.x) / resolution);
-        const int idx_y = static_cast<int>((p.y() - origin.y) / resolution);
-        parked_attention_object_area_cv_polygon.emplace_back(idx_x, height - 1 - idx_y);
-      }
-      parked_attention_object_area_cv_polygons.push_back(parked_attention_object_area_cv_polygon);
-    }
-    for (const auto & poly : parked_attention_object_area_cv_polygons) {
-      cv::fillPoly(distance_grid, poly, cv::Scalar(parked_vehicle_pixel), cv::LINE_AA);
-    }
-  }
-
-  for (const auto & lane_division : lane_divisions) {
-    const auto & divisions = lane_division.divisions;
-    for (const auto & division : divisions) {
-      bool is_in_grid = false;
-      bool zero_dist_cell_found = false;
-      int projection_ind = -1;
-      std::optional<std::tuple<double, double, double, int>> cost_prev_checkpoint =
-        std::nullopt;  // cost, x, y, projection_ind
-      for (auto point = division.begin(); point != division.end(); point++) {
-        const double x = point->x(), y = point->y();
-        const auto [valid, idx_x, idx_y] = coord2index(x, y);
-        // exited grid just now
-        if (is_in_grid && !valid) break;
-
-        // still not entering grid
-        if (!is_in_grid && !valid) continue;
-
-        // From here, "valid"
-        const int pixel = distance_grid.at<unsigned char>(height - 1 - idx_y, idx_x);
-
-        // entered grid for 1st time
-        if (!is_in_grid) {
-          assert(pixel == undef_pixel || pixel == zero_dist_pixel);
-          is_in_grid = true;
-          if (pixel == undef_pixel) {
-            continue;
-          }
-        }
-
-        if (pixel == zero_dist_pixel) {
-          zero_dist_cell_found = true;
-          projection_ind = projection_ind_grid.at<int>(height - 1 - idx_y, idx_x);
-          assert(projection_ind >= 0);
-          cost_prev_checkpoint =
-            std::make_optional<std::tuple<double, double, double, int>>(0.0, x, y, projection_ind);
-          continue;
-        }
-
-        // hit positive parked vehicle
-        if (zero_dist_cell_found && pixel == parked_vehicle_pixel) {
-          while (point != division.end()) {
-            const double x = point->x(), y = point->y();
-            const auto [valid, idx_x, idx_y] = coord2index(x, y);
-            if (valid) occlusion_mask.at<unsigned char>(height - 1 - idx_y, idx_x) = 0;
-            point++;
-          }
-          break;
-        }
-
-        if (zero_dist_cell_found) {
-          // finally traversed to defined cell (first half)
-          const auto [prev_cost, prev_checkpoint_x, prev_checkpoint_y, prev_projection_ind] =
-            cost_prev_checkpoint.value();
-          const double dy = y - prev_checkpoint_y, dx = x - prev_checkpoint_x;
-          double new_dist = prev_cost + std::hypot(dy, dx);
-          const int new_projection_ind = projection_ind_grid.at<int>(height - 1 - idx_y, idx_x);
-          const double cur_dist = pixel2dist(pixel);
-          if (planner_param_.occlusion.do_dp && cur_dist < new_dist) {
-            new_dist = cur_dist;
-            if (new_projection_ind > 0) {
-              projection_ind = std::min<int>(prev_projection_ind, new_projection_ind);
-            }
-          }
-          projection_ind_grid.at<int>(height - 1 - idx_y, idx_x) = projection_ind;
-          distance_grid.at<unsigned char>(height - 1 - idx_y, idx_x) = dist2pixel(new_dist);
-          cost_prev_checkpoint = std::make_optional<std::tuple<double, double, double, int>>(
-            new_dist, x, y, projection_ind);
-        }
-      }
-    }
-  }
-
+  // (4) extract occlusion polygons
   const auto & possible_object_bbox = planner_param_.occlusion.possible_object_bbox;
   const double possible_object_bbox_x = possible_object_bbox.at(0) / resolution;
   const double possible_object_bbox_y = possible_object_bbox.at(1) / resolution;
@@ -1447,19 +1299,12 @@ bool IntersectionModule::isOcclusionCleared(
   cv::findContours(occlusion_mask, contours, cv::RETR_EXTERNAL, cv::CHAIN_APPROX_NONE);
   std::vector<std::vector<cv::Point>> valid_contours;
   for (const auto & contour : contours) {
-    std::vector<cv::Point> valid_contour;
-    for (const auto & p : contour) {
-      if (distance_grid.at<unsigned char>(p.y, p.x) == undef_pixel) {
-        continue;
-      }
-      valid_contour.push_back(p);
-    }
-    if (valid_contour.size() <= 2) {
+    if (contour.size() <= 2) {
       continue;
     }
     std::vector<cv::Point> approx_contour;
     cv::approxPolyDP(
-      valid_contour, approx_contour,
+      contour, approx_contour,
       std::round(std::min(possible_object_bbox_x, possible_object_bbox_y) / std::sqrt(2.0)), true);
     if (approx_contour.size() <= 2) continue;
     // check area
@@ -1486,32 +1331,126 @@ bool IntersectionModule::isOcclusionCleared(
     }
     debug_data_.occlusion_polygons.push_back(polygon_msg);
   }
+  // (4.1) re-draw occluded cells using valid_contours
+  occlusion_mask = cv::Mat(width, height, CV_8UC1, cv::Scalar(0));
+  for (unsigned i = 0; i < valid_contours.size(); ++i) {
+    // NOTE: drawContour does not work well
+    cv::fillPoly(occlusion_mask, valid_contours[i], cv::Scalar(255), cv::LINE_AA);
+  }
 
-  const int min_cost_thr = dist2pixel(occlusion_dist_thr);
-  int min_cost = undef_pixel - 1;
-  geometry_msgs::msg::Point nearest_occlusion_point;
-  for (const auto & occlusion_contour : valid_contours) {
-    for (const auto & p : occlusion_contour) {
-      const int pixel = static_cast<int>(distance_grid.at<unsigned char>(p.y, p.x));
-      const bool occluded = (occlusion_mask.at<unsigned char>(p.y, p.x) == 255);
-      if (pixel == undef_pixel || !occluded) {
+  auto coord2index = [&](const double x, const double y) {
+    const int idx_x = (x - origin.x) / resolution;
+    const int idx_y = (y - origin.y) / resolution;
+    if (idx_x < 0 || idx_x >= width) return std::make_tuple(false, -1, -1);
+    if (idx_y < 0 || idx_y >= height) return std::make_tuple(false, -1, -1);
+    return std::make_tuple(true, idx_x, idx_y);
+  };
+
+  // (5) find distance
+  // (5.1) discretize path_ip with resolution for computational cost
+  LineString2d path_linestring;
+  path_linestring.emplace_back(
+    path_ip.points.at(lane_start_idx).point.pose.position.x,
+    path_ip.points.at(lane_start_idx).point.pose.position.y);
+  {
+    auto prev_path_linestring_point = path_ip.points.at(lane_start_idx).point.pose.position;
+    for (auto i = lane_start_idx + 1; i <= lane_end_idx; i++) {
+      const auto path_linestring_point = path_ip.points.at(i).point.pose.position;
+      if (
+        tier4_autoware_utils::calcDistance2d(prev_path_linestring_point, path_linestring_point) <
+        1.0 /* rough tick for computational cost */) {
         continue;
       }
-      if (pixel < min_cost) {
-        min_cost = pixel;
-        nearest_occlusion_point.x = origin.x + p.x * resolution;
-        nearest_occlusion_point.y = origin.y + (height - 1 - p.y) * resolution;
-        nearest_occlusion_point.z = origin.z;
+      path_linestring.emplace_back(path_linestring_point.x, path_linestring_point.y);
+      prev_path_linestring_point = path_linestring_point;
+    }
+  }
+
+  auto findNearestPointToProjection =
+    [](lanelet::ConstLineString2d division, const Point2d & projection, const double dist_thresh) {
+      double min_dist = std::numeric_limits<double>::infinity();
+      auto nearest = division.end();
+      for (auto it = division.begin(); it != division.end(); it++) {
+        const double dist = std::hypot(it->x() - projection.x(), it->y() - projection.y());
+        if (dist < min_dist) {
+          min_dist = dist;
+          nearest = it;
+        }
+        if (dist < dist_thresh) {
+          break;
+        }
+      }
+      return nearest;
+    };
+  struct NearestOcclusionPoint
+  {
+    int lane_id;
+    int64 division_index;
+    double dist;
+    geometry_msgs::msg::Point point;
+    geometry_msgs::msg::Point projection;
+  } nearest_occlusion_point;
+  double min_dist = std::numeric_limits<double>::infinity();
+  for (const auto & lane_division : lane_divisions) {
+    const auto & divisions = lane_division.divisions;
+    const auto lane_id = lane_division.lane_id;
+    for (unsigned division_index = 0; division_index < divisions.size(); ++division_index) {
+      const auto & division = divisions.at(division_index);
+      LineString2d division_linestring;
+      auto division_point_it = division.begin();
+      division_linestring.emplace_back(division_point_it->x(), division_point_it->y());
+      for (auto point_it = division.begin(); point_it != division.end(); point_it++) {
+        if (
+          std::hypot(
+            point_it->x() - division_point_it->x(), point_it->y() - division_point_it->y()) <
+          3.0 /* rough tick for computational cost */) {
+          continue;
+        }
+        division_linestring.emplace_back(point_it->x(), point_it->y());
+        division_point_it = point_it;
+      }
+
+      // find the intersection point of lane_line and path
+      std::vector<Point2d> intersection_points;
+      boost::geometry::intersection(division_linestring, path_linestring, intersection_points);
+      if (intersection_points.empty()) {
+        continue;
+      }
+      const auto & projection_point = intersection_points.at(0);
+      const auto projection_it =
+        findNearestPointToProjection(division, projection_point, resolution);
+      if (projection_it == division.end()) {
+        continue;
+      }
+      double acc_dist = 0.0;
+      auto acc_dist_it = projection_it;
+      for (auto point_it = projection_it; point_it != division.end(); point_it++) {
+        const double dist =
+          std::hypot(point_it->x() - acc_dist_it->x(), point_it->y() - acc_dist_it->y());
+        acc_dist += dist;
+        acc_dist_it = point_it;
+        const auto [valid, idx_x, idx_y] = coord2index(point_it->x(), point_it->y());
+        // TODO(Mamoru Sobue): add handling for blocking vehicles
+        if (!valid) continue;
+        if (occlusion_mask.at<unsigned char>(height - 1 - idx_y, idx_x) == 255) {
+          if (acc_dist < min_dist) {
+            min_dist = acc_dist;
+            nearest_occlusion_point = {
+              lane_id, std::distance(division.begin(), point_it), acc_dist,
+              tier4_autoware_utils::createPoint(point_it->x(), point_it->y(), origin.z),
+              tier4_autoware_utils::createPoint(projection_it->x(), projection_it->y(), origin.z)};
+          }
+        }
       }
     }
   }
 
-  if (min_cost > min_cost_thr) {
+  if (min_dist == std::numeric_limits<double>::infinity() || min_dist > occlusion_dist_thr) {
     return true;
-  } else {
-    debug_data_.nearest_occlusion_point = nearest_occlusion_point;
-    return false;
   }
+  debug_data_.nearest_occlusion_projection =
+    std::make_pair(nearest_occlusion_point.point, nearest_occlusion_point.projection);
+  return false;
 }
 
 /*

--- a/planning/behavior_velocity_intersection_module/src/scene_intersection.hpp
+++ b/planning/behavior_velocity_intersection_module/src/scene_intersection.hpp
@@ -108,6 +108,7 @@ public:
       std::vector<double> possible_object_bbox;
       double ignore_parked_vehicle_speed_threshold;
       double stop_release_margin_time;
+      bool temporal_stop_before_attention_area;
     } occlusion;
   };
 
@@ -136,15 +137,19 @@ public:
     // NOTE: if intersection_occlusion is disapproved externally through RTC,
     // it indicates "is_forcefully_occluded"
     bool is_actually_occlusion_cleared{false};
+    bool temporal_stop_before_attention_required{false};
     size_t closest_idx{0};
     size_t collision_stop_line_idx{0};
+    size_t first_attention_stop_line_idx{0};
     size_t occlusion_stop_line_idx{0};
   };
   struct OccludedCollisionStop
   {
     bool is_actually_occlusion_cleared{false};
+    bool temporal_stop_before_attention_required{false};
     size_t closest_idx{0};
     size_t collision_stop_line_idx{0};
+    size_t first_attention_stop_line_idx{0};
     size_t occlusion_stop_line_idx{0};
   };
   struct Safe
@@ -217,6 +222,7 @@ private:
   StateMachine collision_state_machine_;     //! for stable collision checking
   StateMachine before_creep_state_machine_;  //! for two phase stop
   StateMachine occlusion_stop_state_machine_;
+  StateMachine temporal_stop_before_attention_state_machine_;
   // NOTE: uuid_ is base member
 
   // for stuck vehicle detection

--- a/planning/behavior_velocity_intersection_module/src/util.cpp
+++ b/planning/behavior_velocity_intersection_module/src/util.cpp
@@ -277,6 +277,8 @@ std::optional<IntersectionStopLines> generateIntersectionStopLines(
       }
     }
   }
+  const auto first_attention_stop_line_ip = static_cast<size_t>(occlusion_peeking_line_ip_int);
+  const bool first_attention_stop_line_valid = occlusion_peeking_line_valid;
   occlusion_peeking_line_ip_int += std::ceil(peeking_offset / ds);
   const auto occlusion_peeking_line_ip = static_cast<size_t>(
     std::clamp<int>(occlusion_peeking_line_ip_int, 0, static_cast<int>(path_ip.points.size()) - 1));
@@ -322,6 +324,7 @@ std::optional<IntersectionStopLines> generateIntersectionStopLines(
     size_t closest_idx{0};
     size_t stuck_stop_line{0};
     size_t default_stop_line{0};
+    size_t first_attention_stop_line{0};
     size_t occlusion_peeking_stop_line{0};
     size_t pass_judge_line{0};
   };
@@ -331,6 +334,7 @@ std::optional<IntersectionStopLines> generateIntersectionStopLines(
     {&closest_idx_ip, &intersection_stop_lines_temp.closest_idx},
     {&stuck_stop_line_ip, &intersection_stop_lines_temp.stuck_stop_line},
     {&default_stop_line_ip, &intersection_stop_lines_temp.default_stop_line},
+    {&first_attention_stop_line_ip, &intersection_stop_lines_temp.first_attention_stop_line},
     {&occlusion_peeking_line_ip, &intersection_stop_lines_temp.occlusion_peeking_stop_line},
     {&pass_judge_line_ip, &intersection_stop_lines_temp.pass_judge_line},
   };
@@ -364,6 +368,10 @@ std::optional<IntersectionStopLines> generateIntersectionStopLines(
   }
   if (default_stop_line_valid) {
     intersection_stop_lines.default_stop_line = intersection_stop_lines_temp.default_stop_line;
+  }
+  if (first_attention_stop_line_valid) {
+    intersection_stop_lines.first_attention_stop_line =
+      intersection_stop_lines_temp.first_attention_stop_line;
   }
   if (occlusion_peeking_line_valid) {
     intersection_stop_lines.occlusion_peeking_stop_line =

--- a/planning/behavior_velocity_intersection_module/src/util_type.hpp
+++ b/planning/behavior_velocity_intersection_module/src/util_type.hpp
@@ -34,22 +34,22 @@ namespace behavior_velocity_planner::util
 
 struct DebugData
 {
-  std::optional<geometry_msgs::msg::Pose> collision_stop_wall_pose = std::nullopt;
-  std::optional<geometry_msgs::msg::Pose> occlusion_stop_wall_pose = std::nullopt;
-  std::optional<geometry_msgs::msg::Pose> occlusion_first_stop_wall_pose = std::nullopt;
-  std::optional<geometry_msgs::msg::Pose> pass_judge_wall_pose = std::nullopt;
-  std::optional<std::vector<lanelet::CompoundPolygon3d>> attention_area = std::nullopt;
-  std::optional<geometry_msgs::msg::Polygon> intersection_area = std::nullopt;
-  std::optional<lanelet::CompoundPolygon3d> ego_lane = std::nullopt;
-  std::optional<std::vector<lanelet::CompoundPolygon3d>> adjacent_area = std::nullopt;
-  std::optional<geometry_msgs::msg::Polygon> stuck_vehicle_detect_area = std::nullopt;
-  std::optional<geometry_msgs::msg::Polygon> candidate_collision_ego_lane_polygon = std::nullopt;
+  std::optional<geometry_msgs::msg::Pose> collision_stop_wall_pose{std::nullopt};
+  std::optional<geometry_msgs::msg::Pose> occlusion_stop_wall_pose{std::nullopt};
+  std::optional<geometry_msgs::msg::Pose> occlusion_first_stop_wall_pose{std::nullopt};
+  std::optional<geometry_msgs::msg::Pose> pass_judge_wall_pose{std::nullopt};
+  std::optional<std::vector<lanelet::CompoundPolygon3d>> attention_area{std::nullopt};
+  std::optional<geometry_msgs::msg::Polygon> intersection_area{std::nullopt};
+  std::optional<lanelet::CompoundPolygon3d> ego_lane{std::nullopt};
+  std::optional<std::vector<lanelet::CompoundPolygon3d>> adjacent_area{std::nullopt};
+  std::optional<geometry_msgs::msg::Polygon> stuck_vehicle_detect_area{std::nullopt};
+  std::optional<geometry_msgs::msg::Polygon> candidate_collision_ego_lane_polygon{std::nullopt};
   std::vector<geometry_msgs::msg::Polygon> candidate_collision_object_polygons;
   autoware_auto_perception_msgs::msg::PredictedObjects conflicting_targets;
   autoware_auto_perception_msgs::msg::PredictedObjects stuck_targets;
-  std::optional<geometry_msgs::msg::Point> nearest_occlusion_point = std::nullopt;
-  std::optional<geometry_msgs::msg::Point> nearest_occlusion_projection_point = std::nullopt;
   std::vector<geometry_msgs::msg::Polygon> occlusion_polygons;
+  std::optional<std::pair<geometry_msgs::msg::Point, geometry_msgs::msg::Point>>
+    nearest_occlusion_projection{std::nullopt};
 };
 
 struct InterpolatedPathInfo

--- a/planning/behavior_velocity_intersection_module/src/util_type.hpp
+++ b/planning/behavior_velocity_intersection_module/src/util_type.hpp
@@ -128,8 +128,10 @@ struct IntersectionStopLines
   size_t closest_idx{0};
   // NOTE: null if path does not conflict with first_conflicting_area
   std::optional<size_t> stuck_stop_line{std::nullopt};
-  // NOTE: null if path is over map stop_line OR its value is calculated negative area
+  // NOTE: null if path is over map stop_line OR its value is calculated negative
   std::optional<size_t> default_stop_line{std::nullopt};
+  // NOTE: null if the index is calculated negative
+  std::optional<size_t> first_attention_stop_line{std::nullopt};
   // NOTE: null if footprints do not change from outside to inside of detection area
   std::optional<size_t> occlusion_peeking_stop_line{std::nullopt};
   // if the value is calculated negative, its value is 0


### PR DESCRIPTION
## Description

depends https://github.com/tier4/autoware.universe/pull/910
launcherのPR: https://github.com/tier4/autoware_launch.xx1/pull/652

https://github.com/autowarefoundation/autoware.universe/pull/5047

対向車線に車両先頭が入る前に必ず一時停止する機能（フラグ）

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed

<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters. -->

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
