### PR TITLE
feat(imu_corrector): add gyro bias log

### DIFF
--- a/sensing/imu_corrector/src/gyro_bias_estimator.cpp
+++ b/sensing/imu_corrector/src/gyro_bias_estimator.cpp
@@ -105,6 +105,11 @@ void GyroBiasEstimator::update_diagnostics(diagnostic_updater::DiagnosticStatusW
         "Gyro bias may be incorrect. Please calibrate IMU and reflect the result in "
         "imu_corrector. You may also use the output of gyro_bias_estimator.");
       stat.summary(diagnostic_msgs::msg::DiagnosticStatus::WARN, "WARN");
+      RCLCPP_WARN(
+        get_logger(), "gyro_bias_x: %lf, gyro_bias_y: %lf, gyro_bias_z: %lf",
+        (gyro_bias_.value().x - angular_velocity_offset_x_),
+        (gyro_bias_.value().y - angular_velocity_offset_y_),
+        (gyro_bias_.value().z - angular_velocity_offset_z_));
     }
   }
 }


### PR DESCRIPTION
## Description
sfなどでsyslogに数値などが残らないため、gyro_bias_estimator側にwarnのlogを追加する。


## Related links
https://tier4.atlassian.net/browse/AEAP-746

## Tests performed

<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters. -->

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
