### PR TITLE
fix(lane_change): prevent node from dying for trimmed shifted path (#5271)

### DIFF
--- a/planning/behavior_path_planner/src/utils/lane_change/utils.cpp
+++ b/planning/behavior_path_planner/src/utils/lane_change/utils.cpp
@@ -304,6 +304,15 @@ std::optional<LaneChangePath> constructCandidatePath(
       "failed to generate shifted path.");
   }
 
+  // TODO(Zulfaqar Azmi): have to think of a more feasible solution for points being remove by path
+  // shifter.
+  if (shifted_path.path.points.size() < shift_line.end_idx + 1) {
+    RCLCPP_DEBUG(
+      rclcpp::get_logger("behavior_path_planner").get_child("utils").get_child(__func__),
+      "path points are removed by PathShifter.");
+    return std::nullopt;
+  }
+
   const auto & prepare_length = lane_change_length.prepare;
   const auto & lane_changing_length = lane_change_length.lane_changing;
 

--- a/planning/behavior_path_planner/src/utils/path_utils.cpp
+++ b/planning/behavior_path_planner/src/utils/path_utils.cpp
@@ -223,7 +223,7 @@ std::pair<TurnIndicatorsCommand, double> getPathTurnSignal(
   turn_signal.command = TurnIndicatorsCommand::NO_COMMAND;
   const double max_time = std::numeric_limits<double>::max();
   const double max_distance = std::numeric_limits<double>::max();
-  if (path.shift_length.empty()) {
+  if (path.shift_length.size() < shift_line.end_idx + 1) {
     return std::make_pair(turn_signal, max_distance);
   }
   const auto base_link2front = common_parameter.base_link2front;


### PR DESCRIPTION
## Description

prevent node from dying for trimmed shifted path
https://github.com/autowarefoundation/autoware.universe/pull/5271
<!-- Write a brief description of this PR. -->

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed
See https://github.com/autowarefoundation/autoware.universe/pull/5271
<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes

Not applicable.
<!-- Describe any changed interfaces, such as topics, services, or parameters. -->

## Effects on system behavior

Not applicable.
<!-- Describe how this PR affects the system behavior. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
