### PR TITLE
fix(intersection): fix infinite loop in tsort (#5332)

### DIFF
--- a/planning/behavior_velocity_intersection_module/src/util.cpp
+++ b/planning/behavior_velocity_intersection_module/src/util.cpp
@@ -602,6 +602,8 @@ mergeLaneletsByTopologicalSort(
     id2lanelet[id] = lanelet;
     ind++;
   }
+  // NOTE: this function aims to traverse the detection lanelet backward from ego side to farthest
+  // side, so if lane B follows lane A on the routing_graph, adj[B][A] = true
   for (const auto & lanelet : lanelets) {
     const auto & followings = routing_graph_ptr->following(lanelet);
     const int dst = lanelet.id();
@@ -625,18 +627,25 @@ mergeLaneletsByTopologicalSort(
     if (!has_no_previous(src)) {
       continue;
     }
+    // So `src` has no previous lanelets
     branches[(ind2id[src])] = std::vector<lanelet::Id>{};
     auto & branch = branches[(ind2id[src])];
     lanelet::Id node_iter = ind2id[src];
+    std::set<lanelet::Id> visited_ids;
     while (true) {
       const auto & destinations = adjacency[(id2ind[node_iter])];
-      // NOTE: assuming detection lanelets have only one previous lanelet
+      // NOTE: assuming detection lanelets have only one "previous"(on the routing_graph) lanelet
       const auto next = std::find(destinations.begin(), destinations.end(), true);
       if (next == destinations.end()) {
         branch.push_back(node_iter);
         break;
       }
+      if (visited_ids.find(node_iter) != visited_ids.end()) {
+        // loop detected
+        break;
+      }
       branch.push_back(node_iter);
+      visited_ids.insert(node_iter);
       node_iter = ind2id[std::distance(destinations.begin(), next)];
     }
   }


### PR DESCRIPTION
## Description

cherry-pick of https://github.com/autowarefoundation/autoware.universe/pull/5332

intersectionで特定の地図 (塩尻地図では大丈夫そう) で無限ループが発生することがあったので修正

<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
