### PR TITLE
feat(tier4_perception_launch): make switchable detection by tracker in x2 project

### DIFF
--- a/launch/tier4_perception_launch/launch/object_recognition/detection/camera_lidar_fusion_based_detection.launch.xml
+++ b/launch/tier4_perception_launch/launch/object_recognition/detection/camera_lidar_fusion_based_detection.launch.xml
@@ -190,7 +190,7 @@
   </group>
 
   <!-- DetectionByTracker -->
-  <group>
+  <group if="$(var use_detection_by_tracker)">
     <push-ros-namespace namespace="detection_by_tracker"/>
     <include file="$(find-pkg-share detection_by_tracker)/launch/detection_by_tracker.launch.xml"/>
   </group>
@@ -326,19 +326,24 @@
 
   <!-- Merger -->
   <group>
+    <!-- 1st merger to merge camera_lidar_fusion + ML lidar detection-->
     <let name="merger/input/objects" value="$(var lidar_detection_model)/validation/objects" if="$(var use_validator)"/>
     <let name="merger/input/objects" value="$(var lidar_detection_model)/objects" unless="$(var use_validator)"/>
+    <let name="detection_end_here" value="$(eval &quot;'$(var use_detection_by_tracker)'=='false' and '$(var use_object_filter)'=='false' &quot;)"/>
+    <let name="merger/output/objects" value="$(var output/objects)" if="$(var detection_end_here)"/>
+    <let name="merger/output/objects" value="$(var lidar_detection_model)_roi_cluster_fusion/objects" unless="$(var detection_end_here)"/>
     <include file="$(find-pkg-share object_merger)/launch/object_association_merger.launch.xml">
       <arg name="input/object0" value="$(var merger/input/objects)"/>
       <arg name="input/object1" value="clustering/camera_lidar_fusion/objects"/>
-      <arg name="output/object" value="$(var lidar_detection_model)_roi_cluster_fusion/objects"/>
+      <arg name="output/object" value="$(var merger/output/objects)"/>
       <arg name="priority_mode" value="0"/>
       <arg name="data_association_matrix_path" value="$(var object_recognition_detection_object_merger_data_association_matrix_param_path)"/>
       <arg name="distance_threshold_list_path" value="$(var object_recognition_detection_object_merger_distance_threshold_list_path)"/>
     </include>
   </group>
 
-  <group>
+  <group if="$(var use_detection_by_tracker)">
+    <!-- 2nd merger to merge detection_by_tracker -->
     <let name="merger/output/objects" value="objects_before_filter" if="$(var use_object_filter)"/>
     <let name="merger/output/objects" value="$(var output/objects)" unless="$(var use_object_filter)"/>
     <include file="$(find-pkg-share object_merger)/launch/object_association_merger.launch.xml">
@@ -353,16 +358,20 @@
 
   <!-- Filter -->
   <group if="$(eval &quot;'$(var objects_filter_method)'=='lanelet_filter'&quot;)">
+    <let name="filter/input/objects" value="objects_before_filter" if="$(var use_detection_by_tracker)"/>
+    <let name="filter/input/objects" value="$(var lidar_detection_model)_roi_cluster_fusion/objects" unless="$(var use_detection_by_tracker)"/>
     <include file="$(find-pkg-share detected_object_validation)/launch/object_lanelet_filter.launch.xml" if="$(var use_object_filter)">
-      <arg name="input/object" value="objects_before_filter"/>
+      <arg name="input/object" value="$(var filter/input/objects)"/>
       <arg name="output/object" value="$(var output/objects)"/>
       <arg name="filtering_range_param" value="$(var object_recognition_detection_object_lanelet_filter_param_path)"/>
     </include>
   </group>
 
   <group if="$(eval &quot;'$(var objects_filter_method)'=='position_filter'&quot;)">
+    <let name="filter/input/objects" value="objects_before_filter" if="$(var use_detection_by_tracker)"/>
+    <let name="filter/input/objects" value="$(var lidar_detection_model)_roi_cluster_fusion/objects" unless="$(var use_detection_by_tracker)"/>
     <include file="$(find-pkg-share detected_object_validation)/launch/object_position_filter.launch.xml" if="$(var use_object_filter)">
-      <arg name="input/object" value="objects_before_filter"/>
+      <arg name="input/object" value="$(var filter/input/objects)"/>
       <arg name="output/object" value="$(var output/objects)"/>
       <arg name="filtering_range_param" value="$(var object_recognition_detection_object_position_filter_param_path)"/>
     </include>

--- a/launch/tier4_perception_launch/launch/object_recognition/detection/camera_lidar_fusion_based_detection.launch.xml
+++ b/launch/tier4_perception_launch/launch/object_recognition/detection/camera_lidar_fusion_based_detection.launch.xml
@@ -126,7 +126,7 @@
       </include>
     </group>
 
-    <group>
+    <group if="$(var use_detection_by_tracker)">
       <include file="$(find-pkg-share shape_estimation)/launch/shape_estimation.launch.xml">
         <arg name="input/objects" value="clusters"/>
         <arg name="output/objects" value="objects_with_feature"/>

--- a/launch/tier4_perception_launch/launch/object_recognition/detection/camera_lidar_radar_fusion_based_detection.launch.xml
+++ b/launch/tier4_perception_launch/launch/object_recognition/detection/camera_lidar_radar_fusion_based_detection.launch.xml
@@ -148,7 +148,7 @@
       </include>
     </group>
 
-    <group>
+    <group if="$(var use_detection_by_tracker)">
       <include file="$(find-pkg-share shape_estimation)/launch/shape_estimation.launch.xml">
         <arg name="input/objects" value="clusters"/>
         <arg name="output/objects" value="objects_with_feature"/>

--- a/launch/tier4_perception_launch/launch/object_recognition/detection/camera_lidar_radar_fusion_based_detection.launch.xml
+++ b/launch/tier4_perception_launch/launch/object_recognition/detection/camera_lidar_radar_fusion_based_detection.launch.xml
@@ -213,7 +213,7 @@
   </group>
 
   <!-- DetectionByTracker -->
-  <group>
+  <group if="$(var use_detection_by_tracker)">
     <push-ros-namespace namespace="detection_by_tracker"/>
     <include file="$(find-pkg-share detection_by_tracker)/launch/detection_by_tracker.launch.xml"/>
   </group>
@@ -362,21 +362,26 @@
 
   <!-- Merger -->
   <group>
+    <!-- 1st merger to merge camera_lidar_fusion + ML lidar detection-->
     <let name="merger/input/objects" value="$(var lidar_detection_model)/validation/objects" if="$(var use_validator)"/>
     <let name="merger/input/objects" value="$(var lidar_detection_model)/objects" unless="$(var use_validator)"/>
+    <let name="without_dbt_and_filter" value="$(eval &quot;'$(var use_detection_by_tracker)'=='false' and '$(var use_object_filter)'=='false' &quot;)"/>
+    <let name="merger/output/objects" value="near_objects" if="$(var without_dbt_and_filter)"/>
+    <let name="merger/output/objects" value="$(var lidar_detection_model)_roi_cluster_fusion/objects" unless="$(var without_dbt_and_filter)"/>
     <include file="$(find-pkg-share object_merger)/launch/object_association_merger.launch.xml">
       <arg name="input/object0" value="$(var merger/input/objects)"/>
       <arg name="input/object1" value="clustering/camera_lidar_fusion/objects"/>
-      <arg name="output/object" value="$(var lidar_detection_model)_roi_cluster_fusion/objects"/>
+      <arg name="output/object" value="$(var merger/output/objects)"/>
       <arg name="priority_mode" value="0"/>
       <arg name="data_association_matrix_path" value="$(var object_recognition_detection_object_merger_data_association_matrix_param_path)"/>
       <arg name="distance_threshold_list_path" value="$(var object_recognition_detection_object_merger_distance_threshold_list_path)"/>
     </include>
   </group>
 
-  <group>
+  <group if="$(var use_detection_by_tracker)">
+    <!-- 2nd merger to merge detection_by_tracker -->
     <let name="merger/output/objects" value="objects_before_filter" if="$(var use_object_filter)"/>
-    <let name="merger/output/objects" value="$(var output/objects)" unless="$(var use_object_filter)"/>
+    <let name="merger/output/objects" value="near_objects" unless="$(var use_object_filter)"/>
     <include file="$(find-pkg-share object_merger)/launch/object_association_merger.launch.xml">
       <arg name="input/object0" value="$(var lidar_detection_model)_roi_cluster_fusion/objects"/>
       <arg name="input/object1" value="detection_by_tracker/objects"/>
@@ -389,16 +394,20 @@
 
   <!-- Filter -->
   <group if="$(eval &quot;'$(var objects_filter_method)'=='lanelet_filter'&quot;)">
+    <let name="filter/input/objects" value="objects_before_filter" if="$(var use_detection_by_tracker)"/>
+    <let name="filter/input/objects" value="$(var lidar_detection_model)_roi_cluster_fusion/objects" unless="$(var use_detection_by_tracker)"/>
     <include file="$(find-pkg-share detected_object_validation)/launch/object_lanelet_filter.launch.xml" if="$(var use_object_filter)">
-      <arg name="input/object" value="objects_before_filter"/>
+      <arg name="input/object" value="$(var filter/input/objects)"/>
       <arg name="output/object" value="near_objects"/>
       <arg name="filtering_range_param" value="$(var object_recognition_detection_object_lanelet_filter_param_path)"/>
     </include>
   </group>
 
   <group if="$(eval &quot;'$(var objects_filter_method)'=='position_filter'&quot;)">
+    <let name="filter/input/objects" value="objects_before_filter" if="$(var use_detection_by_tracker)"/>
+    <let name="filter/input/objects" value="$(var lidar_detection_model)_roi_cluster_fusion/objects" unless="$(var use_detection_by_tracker)"/>
     <include file="$(find-pkg-share detected_object_validation)/launch/object_position_filter.launch.xml" if="$(var use_object_filter)">
-      <arg name="input/object" value="objects_before_filter"/>
+      <arg name="input/object" value="$(var filter/input/objects)"/>
       <arg name="output/object" value="near_objects"/>
       <arg name="filtering_range_param" value="$(var object_recognition_detection_object_position_filter_param_path)"/>
     </include>

--- a/launch/tier4_perception_launch/launch/object_recognition/detection/lidar_based_detection.launch.xml
+++ b/launch/tier4_perception_launch/launch/object_recognition/detection/lidar_based_detection.launch.xml
@@ -58,7 +58,7 @@
   </group>
 
   <!-- DetectionByTracker -->
-  <group>
+  <group if="$(var use_detection_by_tracker)">
     <push-ros-namespace namespace="detection_by_tracker"/>
     <include file="$(find-pkg-share detection_by_tracker)/launch/detection_by_tracker.launch.xml"/>
   </group>
@@ -127,18 +127,23 @@
 
   <!-- Merger -->
   <group>
+    <!-- 1st merger to merge clustering + ML lidar detection-->
     <let name="merger/input/objects" value="$(var lidar_detection_model)/validation/objects" if="$(var use_validator)"/>
     <let name="merger/input/objects" value="$(var lidar_detection_model)/objects" unless="$(var use_validator)"/>
+    <let name="detection_end_here" value="$(eval &quot;'$(var use_detection_by_tracker)'=='false' and '$(var use_object_filter)'=='false' &quot;)"/>
+    <let name="merger/output/objects" value="temporary_merged_objects" unless="$(var detection_end_here)"/>
+    <let name="merger/output/objects" value="$(var output/objects)" if="$(var detection_end_here)"/>
     <include file="$(find-pkg-share object_merger)/launch/object_association_merger.launch.xml">
       <arg name="input/object0" value="$(var merger/input/objects)"/>
       <arg name="input/object1" value="clustering/objects"/>
-      <arg name="output/object" value="temporary_merged_objects"/>
+      <arg name="output/object" value="$(var merger/output/objects)"/>
       <arg name="data_association_matrix_path" value="$(var object_recognition_detection_object_merger_data_association_matrix_param_path)"/>
       <arg name="distance_threshold_list_path" value="$(var object_recognition_detection_object_merger_distance_threshold_list_path)"/>
     </include>
   </group>
 
-  <group>
+  <group if="$(var use_detection_by_tracker)">
+    <!-- 2nd merger to merge detection_by_tracker -->
     <let name="merger/output/objects" value="objects_before_filter" if="$(var use_object_filter)"/>
     <let name="merger/output/objects" value="$(var output/objects)" unless="$(var use_object_filter)"/>
     <include file="$(find-pkg-share object_merger)/launch/object_association_merger.launch.xml">
@@ -153,16 +158,20 @@
 
   <!-- Filter -->
   <group if="$(eval &quot;'$(var objects_filter_method)'=='lanelet_filter'&quot;)">
+    <let name="filter/input/objects" value="objects_before_filter" if="$(var use_detection_by_tracker)"/>
+    <let name="filter/input/objects" value="temporary_merged_objects" unless="$(var use_detection_by_tracker)"/>
     <include file="$(find-pkg-share detected_object_validation)/launch/object_lanelet_filter.launch.xml" if="$(var use_object_filter)">
-      <arg name="input/object" value="objects_before_filter"/>
+      <arg name="input/object" value="$(var filter/input/objects)"/>
       <arg name="output/object" value="$(var output/objects)"/>
       <arg name="filtering_range_param" value="$(var object_recognition_detection_object_lanelet_filter_param_path)"/>
     </include>
   </group>
 
   <group if="$(eval &quot;'$(var objects_filter_method)'=='position_filter'&quot;)">
+    <let name="filter/input/objects" value="objects_before_filter" if="$(var use_detection_by_tracker)"/>
+    <let name="filter/input/objects" value="temporary_merged_objects" unless="$(var use_detection_by_tracker)"/>
     <include file="$(find-pkg-share detected_object_validation)/launch/object_position_filter.launch.xml" if="$(var use_object_filter)">
-      <arg name="input/object" value="objects_before_filter"/>
+      <arg name="input/object" value="$(var filter/input/objects)"/>
       <arg name="output/object" value="$(var output/objects)"/>
       <arg name="filtering_range_param" value="$(var object_recognition_detection_object_position_filter_param_path)"/>
     </include>

--- a/launch/tier4_perception_launch/launch/perception.launch.xml
+++ b/launch/tier4_perception_launch/launch/perception.launch.xml
@@ -93,6 +93,9 @@
   <arg name="remove_unknown" default="true"/>
   <arg name="trust_distance" default="30.0"/>
 
+  <!-- skip detection by tracker -->
+  <arg name="use_detection_by_tracker" default="true"/>
+
   <!-- Perception module -->
   <group>
     <push-ros-namespace namespace="perception"/>


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->

As described in awf PR https://github.com/autowarefoundation/autoware.universe/pull/5313, this PR aiming to turn off detection_by_tracker to lower computation burden in X2 sihojiri.

Set `use_detection_by_tracker` to false if you want skip the process/

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Check node diagram in Lsim.

Discussed in [Ticket](https://tier4.atlassian.net/browse/RT0-29473?focusedCommentId=141703&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-141703).



## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
