### PR TITLE
feat(system_error_monitor): add ignore hartbeat timeout in initializing state

### DIFF
--- a/system/system_error_monitor/src/system_error_monitor_core.cpp
+++ b/system/system_error_monitor/src/system_error_monitor_core.cpp
@@ -483,7 +483,7 @@ void AutowareErrorMonitor::onTimer()
     if ((autoware_state_->state == autoware_auto_system_msgs::msg::AutowareState::INITIALIZING)) {
       RCLCPP_WARN_THROTTLE(
         get_logger(), *get_clock(), std::chrono::milliseconds(1000).count(),
-        "ignore hartbeat timeout in initializing state");
+        "ignore heartbeat timeout in initializing state");
       return;
     }
     updateTimeoutHazardStatus();

--- a/system/system_error_monitor/src/system_error_monitor_core.cpp
+++ b/system/system_error_monitor/src/system_error_monitor_core.cpp
@@ -480,6 +480,12 @@ void AutowareErrorMonitor::onTimer()
   }
 
   if (isDataHeartbeatTimeout()) {
+    if ((autoware_state_->state == autoware_auto_system_msgs::msg::AutowareState::INITIALIZING)) {
+      RCLCPP_WARN_THROTTLE(
+        get_logger(), *get_clock(), std::chrono::milliseconds(1000).count(),
+        "ignore hartbeat timeout in initializing state");
+      return;
+    }
     updateTimeoutHazardStatus();
     publishHazardStatus(hazard_status_);
     return;

--- a/system/system_error_monitor/src/system_error_monitor_core.cpp
+++ b/system/system_error_monitor/src/system_error_monitor_core.cpp
@@ -478,7 +478,7 @@ void AutowareErrorMonitor::onTimer()
     }
     return;
   }
-  // If the processing load is high during AutowareState INITIALZING,add a disable function to avoid
+  // If the processing load is high during AutowareState INITIALIZING,add a disable function to avoid
   // Emergencies in isDataHeartbeatTimeout().
   if (isDataHeartbeatTimeout()) {
     if ((autoware_state_->state == autoware_auto_system_msgs::msg::AutowareState::INITIALIZING)) {

--- a/system/system_error_monitor/src/system_error_monitor_core.cpp
+++ b/system/system_error_monitor/src/system_error_monitor_core.cpp
@@ -478,8 +478,8 @@ void AutowareErrorMonitor::onTimer()
     }
     return;
   }
-  // If the processing load is high during AutowareState INITIALIZING,add a disable function to avoid
-  // Emergencies in isDataHeartbeatTimeout().
+  // If the processing load is high during AutowareState INITIALIZING,add a disable function to
+  // avoid Emergencies in isDataHeartbeatTimeout().
   if (isDataHeartbeatTimeout()) {
     if ((autoware_state_->state == autoware_auto_system_msgs::msg::AutowareState::INITIALIZING)) {
       RCLCPP_WARN_THROTTLE(

--- a/system/system_error_monitor/src/system_error_monitor_core.cpp
+++ b/system/system_error_monitor/src/system_error_monitor_core.cpp
@@ -478,8 +478,8 @@ void AutowareErrorMonitor::onTimer()
     }
     return;
   }
-  // If the processing load is high during AutowareState INITIALIZING,add a disable function to
-  // avoid Emergencies in isDataHeartbeatTimeout().
+  // Heartbeat in AutowareState,diag_array times out during AutowareState INITIALIZING due to high processing load,add a disable function to
+  // avoid Emergencies in isDataHeartbeatTimeout() in AutowareState INITIALIZING.
   if (isDataHeartbeatTimeout()) {
     if ((autoware_state_->state == autoware_auto_system_msgs::msg::AutowareState::INITIALIZING)) {
       RCLCPP_WARN_THROTTLE(

--- a/system/system_error_monitor/src/system_error_monitor_core.cpp
+++ b/system/system_error_monitor/src/system_error_monitor_core.cpp
@@ -478,7 +478,7 @@ void AutowareErrorMonitor::onTimer()
     }
     return;
   }
-
+// If the processing load is high during AutowareState INITIALZING,add a disable function to avoid Emergencies in isDataHeartbeatTimeout().
   if (isDataHeartbeatTimeout()) {
     if ((autoware_state_->state == autoware_auto_system_msgs::msg::AutowareState::INITIALIZING)) {
       RCLCPP_WARN_THROTTLE(

--- a/system/system_error_monitor/src/system_error_monitor_core.cpp
+++ b/system/system_error_monitor/src/system_error_monitor_core.cpp
@@ -478,8 +478,9 @@ void AutowareErrorMonitor::onTimer()
     }
     return;
   }
-  // Heartbeat in AutowareState,diag_array times out during AutowareState INITIALIZING due to high processing load,add a disable function to
-  // avoid Emergencies in isDataHeartbeatTimeout() in AutowareState INITIALIZING.
+  // Heartbeat in AutowareState,diag_array times out during AutowareState INITIALIZING due to high
+  // processing load,add a disable function to avoid Emergencies in isDataHeartbeatTimeout() in
+  // AutowareState INITIALIZING.
   if (isDataHeartbeatTimeout()) {
     if ((autoware_state_->state == autoware_auto_system_msgs::msg::AutowareState::INITIALIZING)) {
       RCLCPP_WARN_THROTTLE(

--- a/system/system_error_monitor/src/system_error_monitor_core.cpp
+++ b/system/system_error_monitor/src/system_error_monitor_core.cpp
@@ -478,7 +478,8 @@ void AutowareErrorMonitor::onTimer()
     }
     return;
   }
-// If the processing load is high during AutowareState INITIALZING,add a disable function to avoid Emergencies in isDataHeartbeatTimeout().
+  // If the processing load is high during AutowareState INITIALZING,add a disable function to avoid
+  // Emergencies in isDataHeartbeatTimeout().
   if (isDataHeartbeatTimeout()) {
     if ((autoware_state_->state == autoware_auto_system_msgs::msg::AutowareState::INITIALIZING)) {
       RCLCPP_WARN_THROTTLE(


### PR DESCRIPTION
## Description
問題としては、初期化中に処理負荷が高い処理が実行中に
isDataHeartbeatTimeout()でemとなる現象が発現する。
そのため、
初期化中のheart_beattimeoutを無効化する。

無効化処理時が発生しているかを解析者にlogとして残るように、logも追加する。

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

[INTERNA  slack LINK](https://star4.slack.com/archives/C04CKSQ7ZFZ/p1697706212101009)
[INTERNAL Ticket LINK](https://tier4.atlassian.net/browse/AEAP-790)

## Tests performed
初期化中のheart_beattimeoutを無効化する。
=>
変更前には
![IMG_7303](https://github.com/tier4/autoware.universe/assets/54956813/a75de223-5891-4031-8c12-2370dd7f9127)

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters. -->



## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
