### PR TITLE
feat(out_of_lane): consider "critical" decisions and make them more stable

### DIFF
--- a/launch/tier4_planning_launch/launch/scenario_planning/lane_driving/behavior_planning/behavior_planning.launch.py
+++ b/launch/tier4_planning_launch/launch/scenario_planning/lane_driving/behavior_planning/behavior_planning.launch.py
@@ -24,6 +24,7 @@ from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch.substitutions import LaunchConfiguration
 from launch.substitutions import PythonExpression
 from launch_ros.actions import ComposableNodeContainer
+from launch_ros.actions import Node
 from launch_ros.descriptions import ComposableNode
 from launch_ros.substitutions import FindPackageShare
 import yaml
@@ -150,9 +151,10 @@ def launch_setup(context, *args, **kwargs):
         with open(path) as f:
             behavior_velocity_planner_params.update(yaml.safe_load(f)["/**"]["ros__parameters"])
 
-    behavior_velocity_planner_component = ComposableNode(
+    behavior_velocity_planner_component = Node(
         package="behavior_velocity_planner",
-        plugin="behavior_velocity_planner::BehaviorVelocityPlannerNode",
+        # plugin="behavior_velocity_planner::BehaviorVelocityPlannerNode",
+        executable="behavior_velocity_planner_node",
         name="behavior_velocity_planner",
         namespace="",
         remappings=[
@@ -202,7 +204,8 @@ def launch_setup(context, *args, **kwargs):
             motion_velocity_smoother_param,
             behavior_velocity_smoother_type_param,
         ],
-        extra_arguments=[{"use_intra_process_comms": LaunchConfiguration("use_intra_process")}],
+        # extra_arguments=[{"use_intra_process_comms": LaunchConfiguration("use_intra_process")}],
+        prefix="konsole -e gdb -ex run --args",
     )
 
     container = ComposableNodeContainer(
@@ -212,7 +215,7 @@ def launch_setup(context, *args, **kwargs):
         executable=LaunchConfiguration("container_executable"),
         composable_node_descriptions=[
             behavior_path_planner_component,
-            behavior_velocity_planner_component,
+            # behavior_velocity_planner_component,
             glog_component,
         ],
         output="screen",
@@ -261,6 +264,7 @@ def launch_setup(context, *args, **kwargs):
     group = GroupAction(
         [
             container,
+            behavior_velocity_planner_component,
             load_compare_map,
             load_vector_map_inside_area_filter,
         ]

--- a/launch/tier4_planning_launch/launch/scenario_planning/lane_driving/behavior_planning/behavior_planning.launch.py
+++ b/launch/tier4_planning_launch/launch/scenario_planning/lane_driving/behavior_planning/behavior_planning.launch.py
@@ -24,7 +24,6 @@ from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch.substitutions import LaunchConfiguration
 from launch.substitutions import PythonExpression
 from launch_ros.actions import ComposableNodeContainer
-from launch_ros.actions import Node
 from launch_ros.descriptions import ComposableNode
 from launch_ros.substitutions import FindPackageShare
 import yaml
@@ -151,10 +150,9 @@ def launch_setup(context, *args, **kwargs):
         with open(path) as f:
             behavior_velocity_planner_params.update(yaml.safe_load(f)["/**"]["ros__parameters"])
 
-    behavior_velocity_planner_component = Node(
+    behavior_velocity_planner_component = ComposableNode(
         package="behavior_velocity_planner",
-        # plugin="behavior_velocity_planner::BehaviorVelocityPlannerNode",
-        executable="behavior_velocity_planner_node",
+        plugin="behavior_velocity_planner::BehaviorVelocityPlannerNode",
         name="behavior_velocity_planner",
         namespace="",
         remappings=[
@@ -204,8 +202,7 @@ def launch_setup(context, *args, **kwargs):
             motion_velocity_smoother_param,
             behavior_velocity_smoother_type_param,
         ],
-        # extra_arguments=[{"use_intra_process_comms": LaunchConfiguration("use_intra_process")}],
-        prefix="konsole -e gdb -ex run --args",
+        extra_arguments=[{"use_intra_process_comms": LaunchConfiguration("use_intra_process")}],
     )
 
     container = ComposableNodeContainer(
@@ -215,7 +212,7 @@ def launch_setup(context, *args, **kwargs):
         executable=LaunchConfiguration("container_executable"),
         composable_node_descriptions=[
             behavior_path_planner_component,
-            # behavior_velocity_planner_component,
+            behavior_velocity_planner_component,
             glog_component,
         ],
         output="screen",
@@ -264,7 +261,6 @@ def launch_setup(context, *args, **kwargs):
     group = GroupAction(
         [
             container,
-            behavior_velocity_planner_component,
             load_compare_map,
             load_vector_map_inside_area_filter,
         ]

--- a/launch/tier4_planning_launch/launch/scenario_planning/lane_driving/behavior_planning/behavior_planning.launch.py
+++ b/launch/tier4_planning_launch/launch/scenario_planning/lane_driving/behavior_planning/behavior_planning.launch.py
@@ -206,6 +206,11 @@ def launch_setup(context, *args, **kwargs):
         ],
         # extra_arguments=[{"use_intra_process_comms": LaunchConfiguration("use_intra_process")}],
         prefix="konsole -e gdb -ex run --args",
+        arguments=[
+            "--ros-args",
+            "--log-level",
+            "planning.scenario_planning.lane_driving.behavior_planning.behavior_velocity_planner.out_of_lane_module:=debug",
+        ],
     )
 
     container = ComposableNodeContainer(

--- a/launch/tier4_planning_launch/launch/scenario_planning/lane_driving/behavior_planning/behavior_planning.launch.py
+++ b/launch/tier4_planning_launch/launch/scenario_planning/lane_driving/behavior_planning/behavior_planning.launch.py
@@ -206,11 +206,6 @@ def launch_setup(context, *args, **kwargs):
         ],
         # extra_arguments=[{"use_intra_process_comms": LaunchConfiguration("use_intra_process")}],
         prefix="konsole -e gdb -ex run --args",
-        arguments=[
-            "--ros-args",
-            "--log-level",
-            "planning.scenario_planning.lane_driving.behavior_planning.behavior_velocity_planner.out_of_lane_module:=debug",
-        ],
     )
 
     container = ComposableNodeContainer(

--- a/planning/behavior_velocity_out_of_lane_module/src/debug.cpp
+++ b/planning/behavior_velocity_out_of_lane_module/src/debug.cpp
@@ -116,8 +116,12 @@ void add_range_markers(
 {
   auto debug_marker = get_base_marker();
   debug_marker.ns = "ranges";
-  debug_marker.color = tier4_autoware_utils::createMarkerColor(0.2, 0.9, 0.1, 0.5);
+  debug_marker.scale.x = 0.5;
   for (const auto & range : ranges) {
+    if (range.is_critical)
+      debug_marker.color = tier4_autoware_utils::createMarkerColor(0.8, 0.9, 0.1, 0.5);
+    else
+      debug_marker.color = tier4_autoware_utils::createMarkerColor(0.2, 0.9, 0.1, 0.5);
     debug_marker.points.clear();
     debug_marker.points.push_back(
       path.points[first_ego_idx + range.entering_path_idx].point.pose.position);
@@ -146,7 +150,7 @@ void add_range_markers(
   debug_marker.points.clear();
   for (const auto & range : ranges) {
     debug_marker.type = debug_marker.LINE_STRIP;
-    if (range.debug.decision) {
+    if (range.decision) {
       debug_marker.points.push_back(tier4_autoware_utils::createMarkerPosition(
         range.entering_point.x(), range.entering_point.y(), z));
       debug_marker.points.push_back(

--- a/planning/behavior_velocity_out_of_lane_module/src/decisions.cpp
+++ b/planning/behavior_velocity_out_of_lane_module/src/decisions.cpp
@@ -292,10 +292,6 @@ bool should_not_enter(
       logger, "\t\t[%s] going at %2.2fm/s",
       tier4_autoware_utils::toHexString(object.object_id).c_str(),
       object.kinematics.initial_twist_with_covariance.twist.linear.x);
-    if (object.kinematics.initial_twist_with_covariance.twist.linear.x < params.objects_min_vel) {
-      RCLCPP_DEBUG(logger, " SKIP (velocity bellow threshold %2.2fm/s)\n", params.objects_min_vel);
-      continue;  // skip objects with velocity bellow a threshold
-    }
     // skip objects that are already on the interval
     const auto enter_exit_time =
       params.objects_use_predicted_paths

--- a/planning/behavior_velocity_out_of_lane_module/src/decisions.hpp
+++ b/planning/behavior_velocity_out_of_lane_module/src/decisions.hpp
@@ -75,16 +75,6 @@ std::optional<std::pair<double, double>> object_time_to_range(
 /// @param [in] logger ros logger
 bool will_collide_on_range(
   const RangeTimes & range_times, const PlannerParam & params, const rclcpp::Logger & logger);
-/// @brief check whether we should avoid entering the given range
-/// @param [in] range the range to check
-/// @param [in] inputs information used to take decisions (ranges, ego and objects data, route
-/// handler, lanelets)
-/// @param [in] params parameters
-/// @param [in] logger ros logger
-/// @return return true if we should avoid entering the range
-bool should_not_enter(
-  const OverlapRange & range, const DecisionInputs & inputs, const PlannerParam & params,
-  const rclcpp::Logger & logger);
 /// @brief set the velocity of a decision (or unset it) based on the distance away from the range
 /// @param [out] decision decision to update (either set its velocity or unset the decision)
 /// @param [in] distance distance between ego and the range corresponding to the decision
@@ -97,18 +87,17 @@ void set_decision_velocity(
 /// handler, lanelets)
 /// @param [in] params parameters
 /// @param [in] logger ros logger
-/// @return return an optional decision to slowdown or stop
-std::optional<Slowdown> calculate_decision(
-  const OverlapRange & range, const DecisionInputs & inputs, const PlannerParam & params,
+void calculate_decision(
+  OverlapRange & range, const DecisionInputs & inputs, const PlannerParam & params,
   const rclcpp::Logger & logger);
-/// @brief calculate decisions to slowdown or stop before some overlapping ranges
+/// @brief calculate decisions to slowdown or stop before for the given overlapping ranges
 /// @param [in] inputs information used to take decisions (ranges, ego and objects data, route
 /// handler, lanelets)
 /// @param [in] params parameters
 /// @param [in] logger ros logger
-/// @return return the calculated decisions to slowdown or stop
-std::vector<Slowdown> calculate_decisions(
-  const DecisionInputs & inputs, const PlannerParam & params, const rclcpp::Logger & logger);
+void calculate_decisions(
+  std::vector<OverlapRange> & ranges, const DecisionInputs & inputs, const PlannerParam & params,
+  const rclcpp::Logger & logger);
 }  // namespace behavior_velocity_planner::out_of_lane
 
 #endif  // DECISIONS_HPP_

--- a/planning/behavior_velocity_out_of_lane_module/src/filter_predicted_objects.hpp
+++ b/planning/behavior_velocity_out_of_lane_module/src/filter_predicted_objects.hpp
@@ -36,11 +36,13 @@ autoware_auto_perception_msgs::msg::PredictedObjects filter_predicted_objects(
   autoware_auto_perception_msgs::msg::PredictedObjects filtered_objects;
   filtered_objects.header = objects.header;
   for (const auto & object : objects.objects) {
+    const auto is_low_velocity =
+      object.kinematics.initial_twist_with_covariance.twist.linear.x < params.objects_min_vel;
     const auto is_pedestrian =
       std::find_if(object.classification.begin(), object.classification.end(), [](const auto & c) {
         return c.label == autoware_auto_perception_msgs::msg::ObjectClassification::PEDESTRIAN;
       }) != object.classification.end();
-    if (is_pedestrian) continue;
+    if (is_low_velocity || is_pedestrian) continue;
 
     auto filtered_object = object;
     const auto is_invalid_predicted_path = [&](const auto & predicted_path) {

--- a/planning/behavior_velocity_out_of_lane_module/src/lanelets_selection.cpp
+++ b/planning/behavior_velocity_out_of_lane_module/src/lanelets_selection.cpp
@@ -72,7 +72,14 @@ lanelet::ConstLanelets calculate_other_lanelets(
       continue;
     const auto is_path_lanelet = contains_lanelet(path_lanelets, ll.second.id());
     const auto is_ignored_lanelet = contains_lanelet(ignored_lanelets, ll.second.id());
-    if (!is_path_lanelet && !is_ignored_lanelet && !is_overlapped_by_path_lanelets(ll.second))
+    const auto is_already_overlapped =
+      boost::geometry::intersects(
+        ego_data.current_footprint, ll.second.leftBound2d().basicLineString()) ||
+      boost::geometry::intersects(
+        ego_data.current_footprint, ll.second.rightBound2d().basicLineString());
+    if (
+      !is_path_lanelet && !is_ignored_lanelet && !is_overlapped_by_path_lanelets(ll.second) &&
+      !is_already_overlapped)
       other_lanelets.push_back(ll.second);
   }
   return other_lanelets;

--- a/planning/behavior_velocity_out_of_lane_module/src/overlapping_range.cpp
+++ b/planning/behavior_velocity_out_of_lane_module/src/overlapping_range.cpp
@@ -119,6 +119,9 @@ OverlapRanges calculate_overlapping_ranges(
       calculate_overlapping_ranges(path_footprints, path_lanelets, lanelet, params);
     ranges.insert(ranges.end(), lanelet_ranges.begin(), lanelet_ranges.end());
   }
+  std::sort(ranges.begin(), ranges.end(), [&](const auto & r1, const auto & r2) {
+    return r1.entering_path_idx < r2.entering_path_idx;
+  });
   return ranges;
 }
 

--- a/planning/behavior_velocity_out_of_lane_module/src/overlapping_range.hpp
+++ b/planning/behavior_velocity_out_of_lane_module/src/overlapping_range.hpp
@@ -49,7 +49,8 @@ OverlapRanges calculate_overlapping_ranges(
 /// @param [in] path_lanelets path lanelets used to calculate arc length along the ego path
 /// @param [in] lanelets lanelets used to calculate the overlaps
 /// @param [in] params parameters
-/// @return the overlapping ranges found between the footprints and the lanelets
+/// @return the overlapping ranges found between the footprints and the lanelets, sorted by
+/// increasing arc length along the path
 OverlapRanges calculate_overlapping_ranges(
   const std::vector<lanelet::BasicPolygon2d> & path_footprints,
   const lanelet::ConstLanelets & path_lanelets, const lanelet::ConstLanelets & lanelets,

--- a/planning/behavior_velocity_out_of_lane_module/src/scene_out_of_lane.cpp
+++ b/planning/behavior_velocity_out_of_lane_module/src/scene_out_of_lane.cpp
@@ -142,7 +142,15 @@ bool OutOfLaneModule::modifyPathVelocity(PathWithLaneId * path, StopReason * sto
     (!prev_inserted_point_ || prev_inserted_point_->slowdown.lane_to_avoid.id() ==
                                 point_to_insert->slowdown.lane_to_avoid.id()))
     prev_inserted_point_time_ = clock_->now();
-  if (!point_to_insert && prev_inserted_point_) point_to_insert = prev_inserted_point_;
+  if (!point_to_insert && prev_inserted_point_) {
+    // if the path changed the prev point is no longer on the path so we project it
+    const auto insert_arc_length = motion_utils::calcSignedArcLength(
+      path->points, 0LU, prev_inserted_point_->point.point.pose.position);
+    prev_inserted_point_->point.point.pose =
+      motion_utils::calcInterpolatedPose(path->points, insert_arc_length);
+    point_to_insert = prev_inserted_point_;
+  }
+
   if (point_to_insert) {
     prev_inserted_point_ = point_to_insert;
     RCLCPP_INFO(logger_, "Avoiding lane %lu", point_to_insert->slowdown.lane_to_avoid.id());

--- a/planning/behavior_velocity_out_of_lane_module/src/scene_out_of_lane.cpp
+++ b/planning/behavior_velocity_out_of_lane_module/src/scene_out_of_lane.cpp
@@ -62,18 +62,6 @@ bool OutOfLaneModule::modifyPathVelocity(PathWithLaneId * path, StopReason * sto
   ego_data.path.points = path->points;
   ego_data.first_path_idx =
     motion_utils::findNearestSegmentIndex(ego_data.path.points, ego_data.pose.position);
-  for (const auto & p : prev_overlapping_path_points_) {
-    const auto nearest_idx =
-      motion_utils::findNearestIndex(ego_data.path.points, p.point.pose, 1.0);
-    const auto insert_idx =
-      motion_utils::findNearestSegmentIndex(ego_data.path.points, p.point.pose, 1.0);
-    if (nearest_idx && insert_idx && *insert_idx > ego_data.first_path_idx) {
-      if (
-        tier4_autoware_utils::calcDistance2d(
-          ego_data.path.points[*nearest_idx].point.pose, p.point.pose) > 0.5)
-        ego_data.path.points.insert(std::next(ego_data.path.points.begin(), *insert_idx), p);
-    }
-  }
   motion_utils::removeOverlapPoints(ego_data.path.points);
   ego_data.velocity = planner_data_->current_velocity->twist.linear.x;
   ego_data.max_decel = -planner_data_->max_stop_acceleration_threshold;
@@ -114,10 +102,6 @@ bool OutOfLaneModule::modifyPathVelocity(PathWithLaneId * path, StopReason * sto
   stopwatch.tic("calculate_overlapping_ranges");
   auto ranges =  // these are already sorted by increasing arc length along the path
     calculate_overlapping_ranges(path_footprints, path_lanelets, other_lanelets, params_);
-  prev_overlapping_path_points_.clear();
-  for (const auto & range : ranges)
-    prev_overlapping_path_points_.push_back(
-      ego_data.path.points[ego_data.first_path_idx + range.entering_path_idx]);
   const auto calculate_overlapping_ranges_us = stopwatch.toc("calculate_overlapping_ranges");
   // Calculate stop and slowdown points
   stopwatch.tic("calculate_decisions");
@@ -142,7 +126,21 @@ bool OutOfLaneModule::modifyPathVelocity(PathWithLaneId * path, StopReason * sto
     (!prev_inserted_point_ || prev_inserted_point_->slowdown.lane_to_avoid.id() ==
                                 point_to_insert->slowdown.lane_to_avoid.id()))
     prev_inserted_point_time_ = clock_->now();
-  if (!point_to_insert && prev_inserted_point_) {
+  // reuse previous stop point if there is no new one or if its velocity is not higher than the new
+  // one and its arc length is lower
+  const auto should_use_prev_inserted_point = [&]() {
+    if (
+      point_to_insert && prev_inserted_point_ &&
+      prev_inserted_point_->slowdown.velocity <= point_to_insert->slowdown.velocity) {
+      const auto arc_length = motion_utils::calcSignedArcLength(
+        path->points, 0LU, point_to_insert->point.point.pose.position);
+      const auto prev_arc_length = motion_utils::calcSignedArcLength(
+        path->points, 0LU, prev_inserted_point_->point.point.pose.position);
+      return prev_arc_length < arc_length;
+    }
+    return !point_to_insert && prev_inserted_point_;
+  }();
+  if (should_use_prev_inserted_point) {
     // if the path changed the prev point is no longer on the path so we project it
     const auto insert_arc_length = motion_utils::calcSignedArcLength(
       path->points, 0LU, prev_inserted_point_->point.point.pose.position);
@@ -150,7 +148,6 @@ bool OutOfLaneModule::modifyPathVelocity(PathWithLaneId * path, StopReason * sto
       motion_utils::calcInterpolatedPose(path->points, insert_arc_length);
     point_to_insert = prev_inserted_point_;
   }
-
   if (point_to_insert) {
     prev_inserted_point_ = point_to_insert;
     RCLCPP_INFO(logger_, "Avoiding lane %lu", point_to_insert->slowdown.lane_to_avoid.id());

--- a/planning/behavior_velocity_out_of_lane_module/src/scene_out_of_lane.cpp
+++ b/planning/behavior_velocity_out_of_lane_module/src/scene_out_of_lane.cpp
@@ -149,7 +149,6 @@ bool OutOfLaneModule::modifyPathVelocity(PathWithLaneId * path, StopReason * sto
 
   ego_data.first_path_idx =
     motion_utils::findNearestSegmentIndex(ego_data.path.points, ego_data.pose.position);
-  std::printf("1st path index = %lu\n", ego_data.first_path_idx);
   ego_data.velocity = planner_data_->current_velocity->twist.linear.x;
   ego_data.max_decel = -planner_data_->max_stop_acceleration_threshold;
   stopwatch.tic("calculate_path_footprints");

--- a/planning/behavior_velocity_out_of_lane_module/src/scene_out_of_lane.cpp
+++ b/planning/behavior_velocity_out_of_lane_module/src/scene_out_of_lane.cpp
@@ -246,8 +246,7 @@ bool OutOfLaneModule::modifyPathVelocity(PathWithLaneId * path, StopReason * sto
                       path->points, point_to_insert->point.point.pose.position) +
                     1;
     planning_utils::insertVelocity(
-      *path, point_to_insert->point, point_to_insert->slowdown.velocity, path_idx,
-      params_.precision);
+      *path, point_to_insert->point, point_to_insert->slowdown.velocity, path_idx);
     if (point_to_insert->slowdown.velocity == 0.0) {
       tier4_planning_msgs::msg::StopFactor stop_factor;
       stop_factor.stop_pose = point_to_insert->point.point.pose;

--- a/planning/behavior_velocity_out_of_lane_module/src/scene_out_of_lane.hpp
+++ b/planning/behavior_velocity_out_of_lane_module/src/scene_out_of_lane.hpp
@@ -50,8 +50,6 @@ public:
 private:
   PlannerParam params_;
 
-  std::vector<autoware_auto_planning_msgs::msg::PathPointWithLaneId>
-    prev_overlapping_path_points_{};
   std::optional<SlowdownToInsert> prev_inserted_point_{};
   rclcpp::Time prev_inserted_point_time_{};
 

--- a/planning/behavior_velocity_out_of_lane_module/src/scene_out_of_lane.hpp
+++ b/planning/behavior_velocity_out_of_lane_module/src/scene_out_of_lane.hpp
@@ -50,6 +50,7 @@ public:
 private:
   PlannerParam params_;
 
+  std::vector<PathPointWithLaneId> prev_path_points_{};
   std::optional<SlowdownToInsert> prev_inserted_point_{};
   rclcpp::Time prev_inserted_point_time_{};
 

--- a/planning/behavior_velocity_out_of_lane_module/src/types.hpp
+++ b/planning/behavior_velocity_out_of_lane_module/src/types.hpp
@@ -120,19 +120,20 @@ struct Overlap
 /// @brief range along the path where ego overlaps another lane
 struct OverlapRange
 {
-  lanelet::ConstLanelet lane;
+  lanelet::ConstLanelet lane{};
   size_t entering_path_idx{};
   size_t exiting_path_idx{};
-  lanelet::BasicPoint2d entering_point;  // pose of the overlapping point closest along the lane
-  lanelet::BasicPoint2d exiting_point;   // pose of the overlapping point furthest along the lane
-  double inside_distance{};              // [m] how much ego footprint enters the lane
+  lanelet::BasicPoint2d entering_point{};  // pose of the overlapping point closest along the lane
+  lanelet::BasicPoint2d exiting_point{};   // pose of the overlapping point furthest along the lane
+  double inside_distance{};                // [m] how much ego footprint enters the lane
+  std::optional<Slowdown> decision{};
+  bool is_critical = false;
   mutable struct
   {
-    std::vector<Overlap> overlaps;
-    std::optional<Slowdown> decision;
-    RangeTimes times;
+    std::vector<Overlap> overlaps{};
+    RangeTimes times{};
     std::optional<autoware_auto_perception_msgs::msg::PredictedObject> object{};
-  } debug;
+  } debug{};
 };
 using OverlapRanges = std::vector<OverlapRange>;
 /// @brief representation of a lane and its current overlap range
@@ -141,8 +142,8 @@ struct OtherLane
   bool range_is_open = false;
   RangeBound first_range_bound{};
   RangeBound last_range_bound{};
-  lanelet::ConstLanelet lanelet;
-  lanelet::BasicPolygon2d polygon;
+  lanelet::ConstLanelet lanelet{};
+  lanelet::BasicPolygon2d polygon{};
 
   explicit OtherLane(lanelet::ConstLanelet ll) : lanelet(std::move(ll))
   {
@@ -172,13 +173,13 @@ struct EgoData
   size_t first_path_idx{};
   double velocity{};   // [m/s]
   double max_decel{};  // [m/s²]
-  geometry_msgs::msg::Pose pose;
+  geometry_msgs::msg::Pose pose{};
+  lanelet::BasicPolygon2d current_footprint{};
 };
 
 /// @brief data needed to make decisions
 struct DecisionInputs
 {
-  OverlapRanges ranges{};
   EgoData ego_data;
   autoware_auto_perception_msgs::msg::PredictedObjects objects{};
   std::shared_ptr<route_handler::RouteHandler> route_handler{};


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
- Reuse previous path for more stability.
- Consider "critical" overlaps where there is no space to fit ego + the dynamic object.
- Prioritize stopping at the critical overlaps, even if another non-critical overlap precedes it.

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Psim.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

More stable `out_of_lane` decisions.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
