### PR TITLE
fix(simple_planning_simulator): change default value of manual gear, DRIVE -> PARK (backport #5563)

### DIFF
--- a/simulator/simple_planning_simulator/src/simple_planning_simulator/simple_planning_simulator_core.cpp
+++ b/simulator/simple_planning_simulator/src/simple_planning_simulator/simple_planning_simulator_core.cpp
@@ -206,7 +206,7 @@ SimplePlanningSimulator::SimplePlanningSimulator(const rclcpp::NodeOptions & opt
 
   // control mode
   current_control_mode_.mode = ControlModeReport::AUTONOMOUS;
-  current_manual_gear_cmd_.command = GearCommand::DRIVE;
+  current_manual_gear_cmd_.command = GearCommand::PARK;
 }
 
 void SimplePlanningSimulator::initialize_vehicle_model()


### PR DESCRIPTION
## Description

https://github.com/autowarefoundation/autoware.universe/pull/5563 backport
simulatorの手動モード時のギア初期値をDRIVEからPARKに変更する

## Related links

https://tier4.atlassian.net/browse/RT0-29756

## Tests performed

https://tier4.atlassian.net/browse/RT0-29756 のチケットの確認結果に記載した

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters. -->

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
