### PR TITLE
fix(simple_planning_simulator): fix ego sign pitch problem (#5616)

### DIFF
--- a/simulator/simple_planning_simulator/README.md
+++ b/simulator/simple_planning_simulator/README.md
@@ -95,6 +95,8 @@ Ego vehicle pitch angle is calculated in the following manner.
 
 ![pitch calculation](./media/pitch-calculation.drawio.svg)
 
+NOTE: driving against the line direction (as depicted in image's bottom row) is not supported and only shown for illustration purposes.
+
 ## Error detection and handling
 
 The only validation on inputs being done is testing for a valid vehicle model type.

--- a/simulator/simple_planning_simulator/src/simple_planning_simulator/simple_planning_simulator_core.cpp
+++ b/simulator/simple_planning_simulator/src/simple_planning_simulator/simple_planning_simulator_core.cpp
@@ -322,8 +322,9 @@ void SimplePlanningSimulator::on_timer()
 
   // calculate longitudinal acceleration by slope
   constexpr double gravity_acceleration = -9.81;
-  const double ego_pitch_angle = enable_road_slope_simulation_ ? calculate_ego_pitch() : 0.0;
-  const double acc_by_slope = gravity_acceleration * std::sin(ego_pitch_angle);
+  const double ego_pitch_angle = calculate_ego_pitch();
+  const double slope_angle = enable_road_slope_simulation_ ? -ego_pitch_angle : 0.0;
+  const double acc_by_slope = gravity_acceleration * std::sin(slope_angle);
 
   // update vehicle dynamics
   {


### PR DESCRIPTION
## Description

https://github.com/autowarefoundation/autoware.universe/pull/5616 のbackport

## Related links

https://tier4.atlassian.net/browse/RT0-29756

## Tests performed

- 変更内容に問題ないことを目視で確認した

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters. -->

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
