### PR TITLE
feat(map_loader): display curbstone as marker array (#4958)

### DIFF
--- a/map/map_loader/src/lanelet2_map_loader/lanelet2_map_visualization_node.cpp
+++ b/map/map_loader/src/lanelet2_map_loader/lanelet2_map_visualization_node.cpp
@@ -127,13 +127,14 @@ void Lanelet2MapVisualizationNode::onMapBin(
     lanelet::utils::query::getAllPolygonsByType(viz_lanelet_map, "hatched_road_markings");
   std::vector<lanelet::NoParkingAreaConstPtr> no_parking_reg_elems =
     lanelet::utils::query::noParkingAreas(all_lanelets);
+  lanelet::ConstLineStrings3d curbstones = lanelet::utils::query::curbstones(viz_lanelet_map);
 
   std_msgs::msg::ColorRGBA cl_road, cl_shoulder, cl_cross, cl_partitions, cl_pedestrian_markings,
     cl_ll_borders, cl_shoulder_borders, cl_stoplines, cl_trafficlights, cl_detection_areas,
     cl_speed_bumps, cl_crosswalks, cl_parking_lots, cl_parking_spaces, cl_lanelet_id,
     cl_obstacle_polygons, cl_no_stopping_areas, cl_no_obstacle_segmentation_area,
     cl_no_obstacle_segmentation_area_for_run_out, cl_hatched_road_markings_area,
-    cl_hatched_road_markings_line, cl_no_parking_areas;
+    cl_hatched_road_markings_line, cl_no_parking_areas, cl_curbstones;
   setColor(&cl_road, 0.27, 0.27, 0.27, 0.999);
   setColor(&cl_shoulder, 0.15, 0.15, 0.15, 0.999);
   setColor(&cl_cross, 0.27, 0.3, 0.27, 0.5);
@@ -156,6 +157,7 @@ void Lanelet2MapVisualizationNode::onMapBin(
   setColor(&cl_hatched_road_markings_area, 0.3, 0.3, 0.3, 0.5);
   setColor(&cl_hatched_road_markings_line, 0.5, 0.5, 0.5, 0.999);
   setColor(&cl_no_parking_areas, 0.42, 0.42, 0.42, 0.5);
+  setColor(&cl_curbstones, 0.1, 0.1, 0.2, 0.999);
 
   visualization_msgs::msg::MarkerArray map_marker_array;
 
@@ -241,6 +243,10 @@ void Lanelet2MapVisualizationNode::onMapBin(
   insertMarkerArray(
     &map_marker_array,
     lanelet::visualization::noParkingAreasAsMarkerArray(no_parking_reg_elems, cl_no_parking_areas));
+
+  insertMarkerArray(
+    &map_marker_array,
+    lanelet::visualization::lineStringsAsMarkerArray(curbstones, "curbstone", cl_curbstones, 0.2));
 
   pub_marker_->publish(map_marker_array);
 }


### PR DESCRIPTION
(cherry-pick)display curbstone as marker array
original PR: https://github.com/autowarefoundation/autoware.universe/pull/4958
Issue: https://tier4.atlassian.net/browse/RT0-29081
## Description
curbstone(縁石)がrvizに表示されていないため、実車実験やpsimで車両がcurbstoneにどれぐらい近づいているか把握できない。対策としてMarkerArrayを追加し、curbstoneをrvizで表示する。
https://tier4.atlassian.net/browse/RT0-29081


## Tests performed
藍色の線でcurbstoneが表示される。
![image](https://github.com/tier4/autoware.universe/assets/19224532/e131da9a-05a9-4d8c-8e84-dbc43943fd8b)



## Effects on system behavior

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
