### PR TITLE
fix(behavior_velocity_planner_common): sync activation when safety status is set

### DIFF
--- a/planning/behavior_velocity_planner_common/include/behavior_velocity_planner_common/scene_module_interface.hpp
+++ b/planning/behavior_velocity_planner_common/include/behavior_velocity_planner_common/scene_module_interface.hpp
@@ -101,6 +101,7 @@ public:
   boost::optional<int> getFirstStopPathPointIndex() { return first_stop_path_point_index_; }
 
   void setActivation(const bool activated) { activated_ = activated; }
+  void setRTCEnabled(const bool enable_rtc) { rtc_enabled_ = enable_rtc; }
   bool isActivated() const { return activated_; }
   bool isSafe() const { return safe_; }
   double getDistance() const { return distance_; }
@@ -112,6 +113,7 @@ protected:
   const int64_t module_id_;
   bool activated_;
   bool safe_;
+  bool rtc_enabled_;
   double distance_;
   rclcpp::Logger logger_;
   rclcpp::Clock::SharedPtr clock_;
@@ -120,8 +122,15 @@ protected:
   boost::optional<int> first_stop_path_point_index_;
   VelocityFactorInterface velocity_factor_;
 
-  void setSafe(const bool safe) { safe_ = safe; }
+  void setSafe(const bool safe)
+  {
+    safe_ = safe;
+    if (!rtc_enabled_) {
+      syncActivation();
+    }
+  }
   void setDistance(const double distance) { distance_ = distance; }
+  void syncActivation() { setActivation(isSafe()); }
 
   template <class T>
   size_t findEgoSegmentIndex(const std::vector<T> & points) const
@@ -357,6 +366,7 @@ protected:
     for (const auto & scene_module : scene_modules_) {
       const UUID uuid = getUUID(scene_module->getModuleId());
       scene_module->setActivation(rtc_interface_.isActivated(uuid));
+      scene_module->setRTCEnabled(rtc_interface_.isRTCEnabled(uuid));
     }
   }
 

--- a/planning/rtc_interface/include/rtc_interface/rtc_interface.hpp
+++ b/planning/rtc_interface/include/rtc_interface/rtc_interface.hpp
@@ -55,6 +55,7 @@ public:
   void clearCooperateStatus();
   bool isActivated(const UUID & uuid) const;
   bool isRegistered(const UUID & uuid) const;
+  bool isRTCEnabled(const UUID & uuid) const;
   void lockCommandUpdate();
   void unlockCommandUpdate();
 

--- a/planning/rtc_interface/include/rtc_interface/rtc_interface.hpp
+++ b/planning/rtc_interface/include/rtc_interface/rtc_interface.hpp
@@ -53,8 +53,8 @@ public:
     const rclcpp::Time & stamp);
   void removeCooperateStatus(const UUID & uuid);
   void clearCooperateStatus();
-  bool isActivated(const UUID & uuid);
-  bool isRegistered(const UUID & uuid);
+  bool isActivated(const UUID & uuid) const;
+  bool isRegistered(const UUID & uuid) const;
   void lockCommandUpdate();
   void unlockCommandUpdate();
 
@@ -74,10 +74,9 @@ private:
   rclcpp::Publisher<CooperateStatusArray>::SharedPtr pub_statuses_;
   rclcpp::Service<CooperateCommands>::SharedPtr srv_commands_;
   rclcpp::Service<AutoMode>::SharedPtr srv_auto_mode_;
-
-  std::mutex mutex_;
   rclcpp::CallbackGroup::SharedPtr callback_group_;
   rclcpp::Logger logger_;
+
   Module module_;
   CooperateStatusArray registered_status_;
   std::vector<CooperateCommand> stored_commands_;
@@ -87,6 +86,8 @@ private:
   std::string cooperate_status_namespace_ = "/planning/cooperate_status";
   std::string cooperate_commands_namespace_ = "/planning/cooperate_commands";
   std::string enable_auto_mode_namespace_ = "/planning/enable_auto_mode/internal";
+
+  mutable std::mutex mutex_;
 };
 
 }  // namespace rtc_interface

--- a/planning/rtc_interface/src/rtc_interface.cpp
+++ b/planning/rtc_interface/src/rtc_interface.cpp
@@ -280,6 +280,22 @@ bool RTCInterface::isRegistered(const UUID & uuid) const
   return itr != registered_status_.statuses.end();
 }
 
+bool RTCInterface::isRTCEnabled(const UUID & uuid) const
+{
+  std::lock_guard<std::mutex> lock(mutex_);
+  const auto itr = std::find_if(
+    registered_status_.statuses.begin(), registered_status_.statuses.end(),
+    [uuid](auto & s) { return s.uuid == uuid; });
+
+  if (itr != registered_status_.statuses.end()) {
+    return !itr->auto_mode;
+  }
+
+  RCLCPP_WARN_STREAM(
+    getLogger(), "[isRTCEnabled] uuid : " << to_string(uuid) << " is not found." << std::endl);
+  return is_auto_mode_init_;
+}
+
 void RTCInterface::lockCommandUpdate()
 {
   is_locked_ = true;

--- a/planning/rtc_interface/src/rtc_interface.cpp
+++ b/planning/rtc_interface/src/rtc_interface.cpp
@@ -251,7 +251,7 @@ void RTCInterface::clearCooperateStatus()
   stored_commands_.clear();
 }
 
-bool RTCInterface::isActivated(const UUID & uuid)
+bool RTCInterface::isActivated(const UUID & uuid) const
 {
   std::lock_guard<std::mutex> lock(mutex_);
   const auto itr = std::find_if(
@@ -271,7 +271,7 @@ bool RTCInterface::isActivated(const UUID & uuid)
   return false;
 }
 
-bool RTCInterface::isRegistered(const UUID & uuid)
+bool RTCInterface::isRegistered(const UUID & uuid) const
 {
   std::lock_guard<std::mutex> lock(mutex_);
   const auto itr = std::find_if(


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
Cherry-pick for
https://github.com/autowarefoundation/autoware.universe/pull/4420
https://github.com/autowarefoundation/autoware.universe/pull/5697

## Related links

関連チケット
https://tier4.atlassian.net/browse/RT1-4037

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed

<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters. -->

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
