### PR TITLE
feat(shape_estimation): fix truck filter max size is too small problem

### DIFF
--- a/perception/shape_estimation/include/shape_estimation/corrector/truck_corrector.hpp
+++ b/perception/shape_estimation/include/shape_estimation/corrector/truck_corrector.hpp
@@ -26,11 +26,11 @@ public:
   {
     corrector_utils::CorrectionBBParameters params;
     params.min_width = 1.5;
-    params.max_width = 3.2;
+    params.max_width = 3.5;
     params.default_width = (params.min_width + params.max_width) * 0.5;
     params.min_length = 4.0;
-    params.max_length = 7.9;
-    params.default_length = (params.min_length + params.max_length) * 0.5;
+    params.max_length = 18.0;
+    params.default_length = 7.0;  // 7m is the most common length of a truck in Japan
     setParams(params);
   }
 

--- a/perception/shape_estimation/lib/filter/truck_filter.cpp
+++ b/perception/shape_estimation/lib/filter/truck_filter.cpp
@@ -19,7 +19,7 @@ bool TruckFilter::filter(
   [[maybe_unused]] const geometry_msgs::msg::Pose & pose)
 {
   constexpr float min_width = 1.5;
-  constexpr float max_width = 3.2;
-  constexpr float max_length = 7.9;  // upto 12m in japanese law
+  constexpr float max_width = 3.5;
+  constexpr float max_length = 18.0;  // upto 12m in japanese law
   return utils::filterVehicleBoundingBox(shape, min_width, max_width, max_length);
 }


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
detection_by_trackerやroi_cluster_fusionで使われるshape fittingにおいてトラックのサイズの制限が現実より大分厳しかったので法令を確認して修正しました。

大きなトラックの検出が今まで一部検出対象外になっていたのを直したので上記の関連手法におけるの出力が少し改善されるはずです。

From awf: https://github.com/autowarefoundation/autoware.universe/pull/5650

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

お台場データで修正。

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
