### PR TITLE
feat(obstacle_stop): upd obstacle hunting

### DIFF
--- a/planning/obstacle_stop_planner/README.md
+++ b/planning/obstacle_stop_planner/README.md
@@ -41,13 +41,13 @@ When the deceleration section is inserted, the start point of the section is ins
 
 ### Common Parameter
 
-| Parameter                  | Type   | Description                                                                              |
-| -------------------------- | ------ | ---------------------------------------------------------------------------------------- |
-| `enable_slow_down`         | bool   | enable slow down planner [-]                                                             |
-| `max_velocity`             | double | max velocity [m/s]                                                                       |
-| `hunting_threshold`        | double | # even if the obstacle disappears, the stop judgment continues for hunting_threshold [s] |
-| `lowpass_gain`             | double | low pass gain for calculating acceleration [-]                                           |
-| `max_yaw_deviation_deg`    | double | # maximum ego yaw deviation from trajectory [deg] (measures against overlapping lanes)   |
+| Parameter                  | Type   | Description                                                                               |
+| -------------------------- | ------ | ----------------------------------------------------------------------------------------- |
+| `enable_slow_down`         | bool   | enable slow down planner [-]                                                              |
+| `max_velocity`             | double | max velocity [m/s]                                                                        |
+| `chattering_threshold`     | double | even if the obstacle disappears, the stop judgment continues for chattering_threshold [s] |
+| `lowpass_gain`             | double | low pass gain for calculating acceleration [-]                                            |
+| `max_yaw_deviation_deg`    | double | # maximum ego yaw deviation from trajectory [deg] (measures against overlapping lanes)    |
 
 ### Obstacle Stop Planner
 

--- a/planning/obstacle_stop_planner/README.md
+++ b/planning/obstacle_stop_planner/README.md
@@ -39,6 +39,16 @@ When the deceleration section is inserted, the start point of the section is ins
 
 ## Modules
 
+### Common Parameter
+
+| Parameter                  | Type   | Description                                                                              |
+| -------------------------- | ------ | ---------------------------------------------------------------------------------------- |
+| `enable_slow_down`         | bool   | enable slow down planner [-]                                                             |
+| `max_velocity`             | double | max velocity [m/s]                                                                       |
+| `chattering_threshold`     | double | # even if the obstacle disappears, the stop judgment continues for hunting_threshold [s] |
+| `lowpass_gain`             | double | low pass gain for calculating acceleration [-]                                           |
+| `max_yaw_deviation_deg`    | double | # maximum ego yaw deviation from trajectory [deg] (measures against overlapping lanes)   |
+
 ### Obstacle Stop Planner
 
 #### Role

--- a/planning/obstacle_stop_planner/README.md
+++ b/planning/obstacle_stop_planner/README.md
@@ -45,7 +45,7 @@ When the deceleration section is inserted, the start point of the section is ins
 | -------------------------- | ------ | ---------------------------------------------------------------------------------------- |
 | `enable_slow_down`         | bool   | enable slow down planner [-]                                                             |
 | `max_velocity`             | double | max velocity [m/s]                                                                       |
-| `chattering_threshold`     | double | # even if the obstacle disappears, the stop judgment continues for hunting_threshold [s] |
+| `hunting_threshold`        | double | # even if the obstacle disappears, the stop judgment continues for hunting_threshold [s] |
 | `lowpass_gain`             | double | low pass gain for calculating acceleration [-]                                           |
 | `max_yaw_deviation_deg`    | double | # maximum ego yaw deviation from trajectory [deg] (measures against overlapping lanes)   |
 

--- a/planning/obstacle_stop_planner/README.md
+++ b/planning/obstacle_stop_planner/README.md
@@ -43,11 +43,7 @@ When the deceleration section is inserted, the start point of the section is ins
 
 | Parameter               | Type   | Description                                                                               |
 | ----------------------- | ------ | ----------------------------------------------------------------------------------------- |
-| `enable_slow_down`      | bool   | enable slow down planner [-]                                                              |
-| `max_velocity`          | double | max velocity [m/s]                                                                        |
 | `chattering_threshold`  | double | even if the obstacle disappears, the stop judgment continues for chattering_threshold [s] |
-| `lowpass_gain`          | double | low pass gain for calculating acceleration [-]                                            |
-| `max_yaw_deviation_deg` | double | # maximum ego yaw deviation from trajectory [deg] (measures against overlapping lanes)    |
 
 ### Obstacle Stop Planner
 

--- a/planning/obstacle_stop_planner/README.md
+++ b/planning/obstacle_stop_planner/README.md
@@ -41,13 +41,13 @@ When the deceleration section is inserted, the start point of the section is ins
 
 ### Common Parameter
 
-| Parameter                  | Type   | Description                                                                               |
-| -------------------------- | ------ | ----------------------------------------------------------------------------------------- |
-| `enable_slow_down`         | bool   | enable slow down planner [-]                                                              |
-| `max_velocity`             | double | max velocity [m/s]                                                                        |
-| `chattering_threshold`     | double | even if the obstacle disappears, the stop judgment continues for chattering_threshold [s] |
-| `lowpass_gain`             | double | low pass gain for calculating acceleration [-]                                            |
-| `max_yaw_deviation_deg`    | double | # maximum ego yaw deviation from trajectory [deg] (measures against overlapping lanes)    |
+| Parameter               | Type   | Description                                                                               |
+| ----------------------- | ------ | ----------------------------------------------------------------------------------------- |
+| `enable_slow_down`      | bool   | enable slow down planner [-]                                                              |
+| `max_velocity`          | double | max velocity [m/s]                                                                        |
+| `chattering_threshold`  | double | even if the obstacle disappears, the stop judgment continues for chattering_threshold [s] |
+| `lowpass_gain`          | double | low pass gain for calculating acceleration [-]                                            |
+| `max_yaw_deviation_deg` | double | # maximum ego yaw deviation from trajectory [deg] (measures against overlapping lanes)    |
 
 ### Obstacle Stop Planner
 

--- a/planning/obstacle_stop_planner/README.md
+++ b/planning/obstacle_stop_planner/README.md
@@ -41,9 +41,9 @@ When the deceleration section is inserted, the start point of the section is ins
 
 ### Common Parameter
 
-| Parameter               | Type   | Description                                                                               |
-| ----------------------- | ------ | ----------------------------------------------------------------------------------------- |
-| `chattering_threshold`  | double | even if the obstacle disappears, the stop judgment continues for chattering_threshold [s] |
+| Parameter              | Type   | Description                                                                               |
+| ---------------------- | ------ | ----------------------------------------------------------------------------------------- |
+| `chattering_threshold` | double | even if the obstacle disappears, the stop judgment continues for chattering_threshold [s] |
 
 ### Obstacle Stop Planner
 

--- a/planning/obstacle_stop_planner/config/obstacle_stop_planner.param.yaml
+++ b/planning/obstacle_stop_planner/config/obstacle_stop_planner.param.yaml
@@ -1,5 +1,7 @@
 /**:
   ros__parameters:
+    hunting_threshold: 0.5 # even if the obstacle disappears, the stop judgment continues for hunting_threshold [s]
+
     stop_planner:
       stop_margin: 5.0 # stop margin distance from obstacle on the path [m]
       min_behavior_stop_margin: 2.0 # stop margin distance when any other stop point is inserted in stop margin [m]

--- a/planning/obstacle_stop_planner/config/obstacle_stop_planner.param.yaml
+++ b/planning/obstacle_stop_planner/config/obstacle_stop_planner.param.yaml
@@ -1,6 +1,6 @@
 /**:
   ros__parameters:
-    hunting_threshold: 0.5 # even if the obstacle disappears, the stop judgment continues for hunting_threshold [s]
+    chattering_threshold: 0.5                # even if the obstacle disappears, the stop judgment continues for chattering_threshold [s]
 
     stop_planner:
       stop_margin: 5.0 # stop margin distance from obstacle on the path [m]

--- a/planning/obstacle_stop_planner/include/obstacle_stop_planner/node.hpp
+++ b/planning/obstacle_stop_planner/include/obstacle_stop_planner/node.hpp
@@ -57,6 +57,7 @@
 #include <map>
 #include <memory>
 #include <mutex>
+#include <utility>
 #include <vector>
 
 namespace motion_planning
@@ -91,6 +92,17 @@ struct SlowDownSection
   double velocity;
 };
 
+struct ObstacleWithDetectionTime
+{
+  explicit ObstacleWithDetectionTime(const rclcpp::Time & t, pcl::PointXYZ & p)
+  : detection_time(t), point(p)
+  {
+  }
+
+  rclcpp::Time detection_time;
+  pcl::PointXYZ point;
+};
+
 class ObstacleStopPlannerNode : public rclcpp::Node
 {
 public:
@@ -101,7 +113,7 @@ public:
     bool enable_slow_down;         // set True, slow down for obstacle beside the path
     double max_velocity;           // max velocity [m/s]
     double lowpass_gain;           // smoothing calculated current acceleration [-]
-    double hunting_threshold;      // keep slow down or stop state if obstacle vanished [s]
+    double chattering_threshold;   // keep slow down or stop state if obstacle vanished [s]
     double max_yaw_deviation_rad;  // maximum ego yaw deviation from trajectory [rad] (measures
                                    // against overlapping lanes)
   };
@@ -184,14 +196,12 @@ private:
   std::unique_ptr<motion_planning::AdaptiveCruiseController> acc_controller_;
   std::shared_ptr<ObstacleStopPlannerDebugNode> debug_ptr_;
   std::shared_ptr<LowpassFilter1d> lpf_acc_{nullptr};
-  boost::optional<StopPoint> latest_stop_point_{boost::none};
   boost::optional<SlowDownSection> latest_slow_down_section_{boost::none};
+  std::vector<ObstacleWithDetectionTime> obstacle_history_{};
   tf2_ros::Buffer tf_buffer_{get_clock()};
   tf2_ros::TransformListener tf_listener_{tf_buffer_};
   sensor_msgs::msg::PointCloud2::SharedPtr obstacle_ros_pointcloud_ptr_{nullptr};
   PredictedObjects::ConstSharedPtr object_ptr_{nullptr};
-    rclcpp::Time last_detect_time_collision_point_;
-  rclcpp::Time last_detect_time_slowdown_point_;
 
   nav_msgs::msg::Odometry::ConstSharedPtr current_velocity_ptr_{nullptr};
   nav_msgs::msg::Odometry::ConstSharedPtr prev_velocity_ptr_{nullptr};
@@ -307,6 +317,31 @@ private:
 
   void publishDebugData(
     const PlannerData & planner_data, const double current_acc, const double current_vel);
+
+  void updateObstacleHistory(const rclcpp::Time & now)
+  {
+    for (auto itr = obstacle_history_.begin(); itr != obstacle_history_.end();) {
+      const auto expired = (now - itr->detection_time).seconds() > node_param_.chattering_threshold;
+
+      if (expired) {
+        itr = obstacle_history_.erase(itr);
+        continue;
+      }
+
+      itr++;
+    }
+  }
+
+  PointCloud::Ptr getOldPointCloudPtr() const
+  {
+    PointCloud::Ptr ret(new PointCloud);
+
+    for (const auto & p : obstacle_history_) {
+      ret->push_back(p.point);
+    }
+
+    return ret;
+  }
 };
 }  // namespace motion_planning
 

--- a/planning/obstacle_stop_planner/include/obstacle_stop_planner/node.hpp
+++ b/planning/obstacle_stop_planner/include/obstacle_stop_planner/node.hpp
@@ -320,10 +320,10 @@ private:
   void publishDebugData(
     const PlannerData & planner_data, const double current_acc, const double current_vel);
 
-  void updateObstacleHistory(const rclcpp::Time & now)
+  void updateObstacleHistory(const rclcpp::Time & now, const double chattering_threshold)
   {
     for (auto itr = obstacle_history_.begin(); itr != obstacle_history_.end();) {
-      const auto expired = (now - itr->detection_time).seconds() > node_param_.chattering_threshold;
+      const auto expired = (now - itr->detection_time).seconds() > chattering_threshold;
 
       if (expired) {
         itr = obstacle_history_.erase(itr);

--- a/planning/obstacle_stop_planner/include/obstacle_stop_planner/node.hpp
+++ b/planning/obstacle_stop_planner/include/obstacle_stop_planner/node.hpp
@@ -77,6 +77,8 @@ using tier4_planning_msgs::msg::VelocityLimit;
 using tier4_planning_msgs::msg::VelocityLimitClearCommand;
 using vehicle_info_util::VehicleInfo;
 
+using PointCloud = pcl::PointCloud<pcl::PointXYZ>;
+
 struct StopPoint
 {
   TrajectoryPoint point{};

--- a/planning/obstacle_stop_planner/include/obstacle_stop_planner/node.hpp
+++ b/planning/obstacle_stop_planner/include/obstacle_stop_planner/node.hpp
@@ -184,12 +184,14 @@ private:
   std::unique_ptr<motion_planning::AdaptiveCruiseController> acc_controller_;
   std::shared_ptr<ObstacleStopPlannerDebugNode> debug_ptr_;
   std::shared_ptr<LowpassFilter1d> lpf_acc_{nullptr};
-  boost::optional<SlowDownSection> latest_slow_down_section_{};
+  boost::optional<StopPoint> latest_stop_point_{boost::none};
+  boost::optional<SlowDownSection> latest_slow_down_section_{boost::none};
   tf2_ros::Buffer tf_buffer_{get_clock()};
   tf2_ros::TransformListener tf_listener_{tf_buffer_};
   sensor_msgs::msg::PointCloud2::SharedPtr obstacle_ros_pointcloud_ptr_{nullptr};
   PredictedObjects::ConstSharedPtr object_ptr_{nullptr};
-  rclcpp::Time last_detection_time_;
+    rclcpp::Time last_detect_time_collision_point_;
+  rclcpp::Time last_detect_time_slowdown_point_;
 
   nav_msgs::msg::Odometry::ConstSharedPtr current_velocity_ptr_{nullptr};
   nav_msgs::msg::Odometry::ConstSharedPtr prev_velocity_ptr_{nullptr};

--- a/planning/obstacle_stop_planner/src/debug_marker.cpp
+++ b/planning/obstacle_stop_planner/src/debug_marker.cpp
@@ -153,7 +153,6 @@ void ObstacleStopPlannerDebugNode::publish()
   slow_down_range_polygons_.clear();
   slow_down_polygons_.clear();
   stop_pose_ptr_ = nullptr;
-  // target_stop_pose_ptr_ = nullptr;
   slow_down_start_pose_ptr_ = nullptr;
   slow_down_end_pose_ptr_ = nullptr;
   stop_obstacle_point_ptr_ = nullptr;

--- a/planning/obstacle_stop_planner/src/debug_marker.cpp
+++ b/planning/obstacle_stop_planner/src/debug_marker.cpp
@@ -153,7 +153,7 @@ void ObstacleStopPlannerDebugNode::publish()
   slow_down_range_polygons_.clear();
   slow_down_polygons_.clear();
   stop_pose_ptr_ = nullptr;
-  target_stop_pose_ptr_ = nullptr;
+  // target_stop_pose_ptr_ = nullptr;
   slow_down_start_pose_ptr_ = nullptr;
   slow_down_end_pose_ptr_ = nullptr;
   stop_obstacle_point_ptr_ = nullptr;

--- a/planning/obstacle_stop_planner/src/debug_marker.cpp
+++ b/planning/obstacle_stop_planner/src/debug_marker.cpp
@@ -153,6 +153,7 @@ void ObstacleStopPlannerDebugNode::publish()
   slow_down_range_polygons_.clear();
   slow_down_polygons_.clear();
   stop_pose_ptr_ = nullptr;
+  target_stop_pose_ptr_ = nullptr;
   slow_down_start_pose_ptr_ = nullptr;
   slow_down_end_pose_ptr_ = nullptr;
   stop_obstacle_point_ptr_ = nullptr;

--- a/planning/obstacle_stop_planner/src/node.cpp
+++ b/planning/obstacle_stop_planner/src/node.cpp
@@ -663,7 +663,7 @@ void ObstacleStopPlannerNode::searchObstacle(
 
   const auto now = this->now();
   const bool is_stopping = (std::fabs(current_velocity_ptr->twist.twist.linear.x) < 0.001);
-  const double history_erase_sec = (is_stopping) ? node_param_.chattering_threshold : 0.0; 
+  const double history_erase_sec = (is_stopping) ? node_param_.chattering_threshold : 0.0;
   updateObstacleHistory(now, history_erase_sec);
 
   for (size_t i = 0; i < decimate_trajectory.size() - 1; ++i) {

--- a/planning/obstacle_stop_planner/src/node.cpp
+++ b/planning/obstacle_stop_planner/src/node.cpp
@@ -663,7 +663,9 @@ void ObstacleStopPlannerNode::searchObstacle(
 
   const auto now = this->now();
 
-  updateObstacleHistory(now);
+  if (current_velocity_ptr ->twist.twist.linear.x  == 0){
+    updateObstacleHistory(now);
+  }
 
   for (size_t i = 0; i < decimate_trajectory.size() - 1; ++i) {
     // create one step circle center for vehicle

--- a/planning/obstacle_stop_planner/src/node.cpp
+++ b/planning/obstacle_stop_planner/src/node.cpp
@@ -840,12 +840,6 @@ void ObstacleStopPlannerNode::insertVelocity(
         index_with_dist_remain.get().second, dist_baselink_to_obstacle, vehicle_info, current_acc,
         current_vel);
 
-      if (
-        !latest_slow_down_section_ &&
-        dist_baselink_to_obstacle + index_with_dist_remain.get().second <
-          vehicle_info.max_longitudinal_offset_m) {
-      }
-
       insertSlowDownSection(slow_down_section, output);
     }
   }

--- a/planning/obstacle_stop_planner/src/node.cpp
+++ b/planning/obstacle_stop_planner/src/node.cpp
@@ -662,10 +662,9 @@ void ObstacleStopPlannerNode::searchObstacle(
   }
 
   const auto now = this->now();
-
-  if (std::fabs(current_velocity_ptr->twist.twist.linear.x) < 1e-9) {
-    updateObstacleHistory(now);
-  }
+  const bool is_stopping = (std::fabs(current_velocity_ptr->twist.twist.linear.x) < 0.001);
+  const double history_erase_sec = (is_stopping) ? node_param_.chattering_threshold : 0.0; 
+  updateObstacleHistory(now, history_erase_sec);
 
   for (size_t i = 0; i < decimate_trajectory.size() - 1; ++i) {
     // create one step circle center for vehicle

--- a/planning/obstacle_stop_planner/src/node.cpp
+++ b/planning/obstacle_stop_planner/src/node.cpp
@@ -663,7 +663,7 @@ void ObstacleStopPlannerNode::searchObstacle(
 
   const auto now = this->now();
 
-  if (current_velocity_ptr ->twist.twist.linear.x  == 0){
+  if (current_velocity_ptr->twist.twist.linear.x == 0) {
     updateObstacleHistory(now);
   }
 

--- a/planning/obstacle_stop_planner/src/node.cpp
+++ b/planning/obstacle_stop_planner/src/node.cpp
@@ -794,8 +794,9 @@ void ObstacleStopPlannerNode::searchObstacle(
 
 void ObstacleStopPlannerNode::insertVelocity(
   TrajectoryPoints & output, PlannerData & planner_data,
-  [[maybe_unused]]const std_msgs::msg::Header & trajectory_header, const VehicleInfo & vehicle_info,
-  const double current_acc, const double current_vel, const StopParam & stop_param)
+  [[maybe_unused]] const std_msgs::msg::Header & trajectory_header,
+  const VehicleInfo & vehicle_info, const double current_acc, const double current_vel,
+  const StopParam & stop_param)
 {
   if (planner_data.stop_require) {
     // insert stop point

--- a/planning/obstacle_stop_planner/src/node.cpp
+++ b/planning/obstacle_stop_planner/src/node.cpp
@@ -703,7 +703,6 @@ void ObstacleStopPlannerNode::searchObstacle(
         debug_ptr_->pushObstaclePoint(planner_data.nearest_slow_down_point, PointType::SlowDown);
         debug_ptr_->pushPolygon(
           one_step_move_slow_down_range_polygon, p_front.position.z, PolygonType::SlowDown);
-
       }
 
     } else {
@@ -740,7 +739,7 @@ void ObstacleStopPlannerNode::searchObstacle(
       }
     }
   }
-    for (size_t i = 0; i < decimate_trajectory.size() - 1; ++i) {
+  for (size_t i = 0; i < decimate_trajectory.size() - 1; ++i) {
     // create one step circle center for vehicle
     const auto & p_front = decimate_trajectory.at(i).pose;
     const auto & p_back = decimate_trajectory.at(i + 1).pose;
@@ -748,7 +747,7 @@ void ObstacleStopPlannerNode::searchObstacle(
     const Point2d prev_center_point(prev_center_pose.position.x, prev_center_pose.position.y);
     const auto next_center_pose = getVehicleCenterFromBase(p_back, vehicle_info);
     const Point2d next_center_point(next_center_pose.position.x, next_center_pose.position.y);
-        std::vector<cv::Point2d> one_step_move_vehicle_polygon;
+    std::vector<cv::Point2d> one_step_move_vehicle_polygon;
     // create one step polygon for vehicle
     createOneStepPolygon(
       p_front, p_back, one_step_move_vehicle_polygon, vehicle_info, stop_param.lateral_margin);
@@ -773,7 +772,7 @@ void ObstacleStopPlannerNode::searchObstacle(
       debug_ptr_->pushObstaclePoint(planner_data.nearest_collision_point, PointType::Stop);
       debug_ptr_->pushPolygon(
         one_step_move_vehicle_polygon, p_front.position.z, PolygonType::Collision);
-        
+
       planner_data.stop_require = planner_data.found_collision_points;
       mutex_.lock();
       const auto object_ptr = object_ptr_;
@@ -791,9 +790,9 @@ void ObstacleStopPlannerNode::searchObstacle(
       }
 
       break;
-      }
     }
   }
+}
 }
 
 void ObstacleStopPlannerNode::insertVelocity(
@@ -855,7 +854,6 @@ void ObstacleStopPlannerNode::insertVelocity(
 
       insertSlowDownSection(slow_down_section, output);
     }
-
   }
 
   if (node_param_.enable_slow_down && latest_slow_down_section_) {

--- a/planning/obstacle_stop_planner/src/node.cpp
+++ b/planning/obstacle_stop_planner/src/node.cpp
@@ -784,6 +784,10 @@ void ObstacleStopPlannerNode::insertVelocity(
     }
   } else if (!no_hunting_collision_point) {
     if (latest_stop_point_) {
+      // update stop point index with the current trajectory
+      latest_stop_point_.get().index = findFirstNearestSegmentIndexWithSoftConstraints(
+        output, getPose(latest_stop_point_.get().point), node_param_.ego_nearest_dist_threshold,
+        node_param_.ego_nearest_yaw_threshold);
       insertStopPoint(latest_stop_point_.get(), output, planner_data.stop_reason_diag);
       debug_ptr_->pushPose(getPose(latest_stop_point_.get().point), PoseType::Stop);
     }

--- a/planning/obstacle_stop_planner/src/node.cpp
+++ b/planning/obstacle_stop_planner/src/node.cpp
@@ -663,7 +663,7 @@ void ObstacleStopPlannerNode::searchObstacle(
 
   const auto now = this->now();
 
-  if (current_velocity_ptr->twist.twist.linear.x == 0) {
+  if (std::fabs(current_velocity_ptr->twist.twist.linear.x) < 1e-9) {
     updateObstacleHistory(now);
   }
 


### PR DESCRIPTION
このPRはv0.3.17リリース向けに開発していたもののドロップしたPR https://github.com/tier4/autoware.universe/pull/733 を、v0.3.18リリース向けに適用し直すためのPRです。

## Description
本PRは下記問題を対策する。
- 問題A
  - 経路上の障害物を検知した状態で自車両に対して前後方向に検知位置が振動する挙動があり、これにあわせて車両が停車と発車を交互に繰り返す（チャタリングする）。
  - 音声発話として、停車と発車も繰り返す
- 問題B
  - 経路上に複数の障害物を検知した場合、停止線が異常な位置に設定される

### 対策内容
- 対策１
  - 問題Aの対策として、障害物検知による停車時に一定時間その停止計画を維持するようにする事で、検知した障害物が移動した場合でも一定時間停止計画を維持する。
これにより、障害物の移動によるチャタリングを回避する。 
  - 停止状態を維持する時間は、`chattering_threshold`で設定する。(defalut : 0.5s)
    - 本機能は下記の流用である。
      - https://github.com/autowarefoundation/autoware.universe/pull/1458
      - https://github.com/autowarefoundation/autoware.universe/pull/1627
- 対策２
  - 問題Bを対策する。
    - 本機能は下記の流用である。
      - https://github.com/autowarefoundation/autoware.universe/pull/2647
- 対策３
  - 問題Aの追加対策として、対策1の適応範囲を停車時のみとする。
    - 対策1では障害物を一定時間保持する機能（チャタリング防止機能）が全ての障害物に対して有効になるため、走行中の障害物検知に対して意図しない停車（ちょこ停）が発生するリスクがあった。このリスクを低減する措置である。
      - 停車・走行中の判断は、`/localization/kinematic_state`の`twist.twist.linear.x`より判定を実施する。
        - `twist.twist.linear.x=0`の場合を停車、それ以外を走行中としています。
        - `twist.twist.linear.x<0`は、考慮不要です。
      - 対策コミット：https://github.com/tier4/autoware.universe/pull/1068/commits/e72b47407eddb23f737cb30b8025a1833c6e639c

![image](https://github.com/tier4/autoware.universe/assets/107168699/61fe162a-109a-48dd-922f-fca079b900f6)

## Related links

https://tier4.atlassian.net/browse/AEAP-465
https://github.com/tier4/autoware_launch.x1.eve/pull/419

## Tests performed


### 機能検証
`chattering_threshold`の設定値を、default値では機能検証が難しいため、5sに変更して確認を実施。
- 障害物を経路上に設定、障害物検知し停車後に、障害物がなくなっても、即時に再発進しない事を確認済み（Psim）
- 一定時間(`chattering_threshol`で設定した時間)停止後に、再発車する事を確認済み（Psim）
- 経路上に障害物を、２つ設置し、２点間でチャタリングをしない事を確認済み（Psim）

### 機能追加検証
- 停車時に、障害物を経路上にセットした後に、障害物除去後に、5s(`chattering_threshold`の設定値)に障害物停止線が消える事を確認。（Psim）
- 走行中に、障害物を経路上にセットした後に、障害物除去後に、即時に障害物停止線が消える事を確認。（Psim）

### リグレッション評価

- 経路上に障害物がない場合に、停車しないで走行が完了する事を確認済み。(Psim）
- 経路上に障害物がある場合に、障害物検知時に、停止線で停止する事。障害物除去後に、再発車できる事を確認済み(Psim）
- 走行中の経路上に障害物を設置と除去を一瞬で実施した場合、障害物検知状態は一瞬だけで実施されて、障害物検知状態を維持しない事を確認済み（Psim）

### https://github.com/tier4/autoware.universe/pull/1068/commits/809b85e1a32f0b79ca2d58ccb5f95c2b9661efcb の確認

前提条件：chattering_thresholdのパラメーター値：5.0s

Psimの確認内容：
- 障害物除去後に、停止中の障害物停止線が、一定時間後（約5.0s）にクリアされる事を確認済み。
- 障害物除去後に、走行中の障害物停止線が、走行中に即時クリアされる事を確認済み。

## Rview Note
- 音声チャタリングの評価は、リリース評価で実施する。
- 

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [x] The PR follows the [pull request guidelines].
- [x] The PR has been properly tested.
- [x] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.
- [x] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/