### PR TITLE
feat(behavior_path_planner): (TEMPORARY) steering factor for lane change abort

### DIFF
--- a/planning/behavior_path_lane_change_module/src/interface.cpp
+++ b/planning/behavior_path_lane_change_module/src/interface.cpp
@@ -369,10 +369,12 @@ void LaneChangeInterface::updateSteeringFactorPtr(const BehaviorModuleOutput & o
   const auto finish_distance = motion_utils::calcSignedArcLength(
     output.path.points, current_position, status.lane_change_path.info.shift_line.end.position);
 
+  const auto factor_status = module_type_->isAbortState() ? uint16_t(100) : SteeringFactor::TURNING;
+
   steering_factor_interface_ptr_->updateSteeringFactor(
     {status.lane_change_path.info.shift_line.start, status.lane_change_path.info.shift_line.end},
     {start_distance, finish_distance}, PlanningBehavior::LANE_CHANGE, steering_factor_direction,
-    SteeringFactor::TURNING, "");
+    factor_status, "");
 }
 
 void LaneChangeInterface::updateSteeringFactorPtr(

--- a/planning/behavior_path_planner/include/behavior_path_planner/planner_manager.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/planner_manager.hpp
@@ -286,6 +286,8 @@ private:
 
     module_ptr->publishRTCStatus();
 
+    module_ptr->publishSteeringFactor();
+
     module_ptr->publishObjectsOfInterestMarker();
 
     processing_time_.at(module_ptr->name()) += stop_watch_.toc(module_ptr->name(), true);


### PR DESCRIPTION
## Description

Publish steering factor status for lane change abort
If lane change is aborted, its status becomes `100`.

Required cherry-pick is including in this PR.

- https://github.com/autowarefoundation/autoware.universe/pull/5914
<!-- Write a brief description of this PR. -->

If `beta/v0.19.1` is created, it will change the base branch to `beta/v0.19.1`.

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

[Screencast from 2023年12月26日 13時20分19秒.webm](https://github.com/tier4/autoware.universe/assets/10190493/adf2178b-5675-4962-bfa0-0612cf68b307)


## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
