### PR TITLE
fix(lane_change): check able to return to current lane

### DIFF
--- a/planning/behavior_path_lane_change_module/src/interface.cpp
+++ b/planning/behavior_path_lane_change_module/src/interface.cpp
@@ -276,6 +276,11 @@ bool LaneChangeInterface::canTransitFailureState()
     return false;
   }
 
+  if (!module_type_->isAbleToReturnCurrentLane()) {
+    log_debug_throttled("It's is not possible to return to original lane. Continue lane change.");
+    return false;
+  }
+
   const auto found_abort_path = module_type_->calcAbortPath();
   if (!found_abort_path) {
     log_debug_throttled(


### PR DESCRIPTION
## Description

cherry pick lane change

Before abort process, lane change module should check if ego vehicle can return to original lane or not. And if it can't, abort path should not be computed.

This is a critical fix. Without this fix, ego will perform unwanted abort and it can be quite dangerous.

https://github.com/autowarefoundation/autoware.universe/pull/6034

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
