### PR TITLE
fix(image_projection_based_fusion): re-organize the parameters for image projection fusion (autowarefoundation#6075)

### DIFF
--- a/launch/tier4_perception_launch/launch/object_recognition/detection/camera_lidar_fusion_based_detection.launch.xml
+++ b/launch/tier4_perception_launch/launch/object_recognition/detection/camera_lidar_fusion_based_detection.launch.xml
@@ -12,9 +12,6 @@
   <arg name="use_object_filter" default="true" description="use object filter"/>
   <arg name="use_pointcloud_container" default="false" description="use pointcloud container for detection preprocessor"/>
   <arg name="use_validator" default="true" description="use obstacle_pointcloud based validator"/>
-  <arg name="remove_unknown" default="true"/>
-  <arg name="fusion_distance" default="100.0"/>
-  <arg name="trust_object_distance" default="100.0"/>
   <arg name="use_roi_based_cluster" default="false"/>
 
   <!-- Camera parameters -->
@@ -113,6 +110,7 @@
         <arg name="input/image7" value="$(var image_raw7)"/>
         <arg name="input/pointcloud" value="/perception/object_recognition/detection/pointcloud_map_filtered/pointcloud"/>
         <arg name="output_clusters" value="roi_cluster/clusters"/>
+        <arg name="param_path" value="$(var roi_pointcloud_fusion_param_path)"/>
       </include>
     </group>
 
@@ -167,9 +165,7 @@
           <arg name="input/image6" value="$(var image_raw6)"/>
           <arg name="input/image7" value="$(var image_raw7)"/>
           <arg name="output/clusters" value="clusters"/>
-          <arg name="remove_unknown" value="$(var remove_unknown)"/>
-          <arg name="fusion_distance" value="$(var fusion_distance)"/>
-          <arg name="trust_object_distance" value="$(var trust_object_distance)"/>
+          <arg name="param_path" value="$(var roi_cluster_fusion_param_path)"/>
         </include>
       </group>
 
@@ -305,6 +301,7 @@
       <arg name="input/image7" value="$(var image_raw7)"/>
       <arg name="input/objects" value="$(var lidar_detection_model)/objects"/>
       <arg name="output/objects" value="$(var lidar_detection_model)/roi_fusion/objects"/>
+      <arg name="param_path" value="$(var roi_detected_object_fusion_param_path)"/>
     </include>
   </group>
 

--- a/launch/tier4_perception_launch/launch/object_recognition/detection/camera_lidar_radar_fusion_based_detection.launch.xml
+++ b/launch/tier4_perception_launch/launch/object_recognition/detection/camera_lidar_radar_fusion_based_detection.launch.xml
@@ -139,6 +139,7 @@
         <arg name="input/image7" value="$(var image_raw7)"/>
         <arg name="input/pointcloud" value="/perception/object_recognition/detection/pointcloud_map_filtered/pointcloud"/>
         <arg name="output_clusters" value="roi_cluster/clusters"/>
+        <arg name="param_path" value="$(var roi_pointcloud_fusion_param_path)"/>
       </include>
     </group>
 
@@ -193,9 +194,7 @@
           <arg name="input/image6" value="$(var image_raw6)"/>
           <arg name="input/image7" value="$(var image_raw7)"/>
           <arg name="output/clusters" value="clusters"/>
-          <arg name="remove_unknown" value="$(var remove_unknown)"/>
-          <arg name="fusion_distance" value="$(var fusion_distance)"/>
-          <arg name="trust_object_distance" value="$(var trust_object_distance)"/>
+          <arg name="param_path" value="$(var roi_cluster_fusion_param_path)"/>
         </include>
       </group>
 
@@ -344,6 +343,7 @@
       <arg name="input/image7" value="$(var image_raw7)"/>
       <arg name="input/objects" value="$(var target_objects)"/>
       <arg name="output/objects" value="$(var lidar_detection_model)/roi_fusion/objects"/>
+      <arg name="param_path" value="$(var roi_detected_object_fusion_param_path)"/>
     </include>
   </group>
 

--- a/launch/tier4_perception_launch/launch/object_recognition/detection/detection.launch.xml
+++ b/launch/tier4_perception_launch/launch/object_recognition/detection/detection.launch.xml
@@ -34,11 +34,6 @@
   <arg name="radar_lanelet_filtering_range_param" default="$(find-pkg-share detected_object_validation)/config/object_lanelet_filter.param.yaml"/>
   <arg name="radar_object_clustering_param_path" default="$(find-pkg-share radar_object_clustering)/config/radar_object_clustering.param.yaml"/>
 
-  <!-- Camera-LiDAR fusion parameters -->
-  <arg name="remove_unknown" default="true"/>
-  <arg name="fusion_distance" default="100.0"/>
-  <arg name="trust_object_distance" default="100.0"/>
-
   <!-- Camera-LiDAR-Radar fusion based detection -->
   <group if="$(eval '&quot;$(var mode)&quot;==&quot;camera_lidar_radar_fusion&quot;')">
     <include file="$(find-pkg-share tier4_perception_launch)/launch/object_recognition/detection/camera_lidar_radar_fusion_based_detection.launch.xml">
@@ -65,14 +60,14 @@
       <arg name="use_object_filter" value="$(var use_object_filter)"/>
       <arg name="use_pointcloud_container" value="$(var use_pointcloud_container)"/>
       <arg name="container_name" value="$(var container_name)"/>
-      <arg name="remove_unknown" value="$(var remove_unknown)"/>
-      <arg name="fusion_distance" value="$(var fusion_distance)"/>
-      <arg name="trust_object_distance" value="$(var trust_object_distance)"/>
       <arg name="use_low_height_cropbox" value="$(var use_low_height_cropbox)"/>
       <arg name="use_roi_based_cluster" value="$(var use_roi_based_cluster)"/>
       <arg name="detection_by_tracker_param_path" value="$(var detection_by_tracker_param_path)"/>
       <arg name="input/radar" value="$(var input/radar)"/>
       <arg name="radar_lanelet_filtering_range_param" value="$(var radar_lanelet_filtering_range_param)"/>
+      <arg name="roi_cluster_fusion_param_path" value="$(var roi_cluster_fusion_param_path)"/>
+      <arg name="roi_pointcloud_fusion_param_path" value="$(var roi_pointcloud_fusion_param_path)"/>
+      <arg name="roi_detected_object_fusion_param_path" value="$(var roi_detected_object_fusion_param_path)"/>
     </include>
   </group>
 

--- a/launch/tier4_perception_launch/launch/perception.launch.xml
+++ b/launch/tier4_perception_launch/launch/perception.launch.xml
@@ -10,6 +10,9 @@
   <arg name="object_recognition_detection_object_merger_data_association_matrix_param_path"/>
   <arg name="object_recognition_detection_object_merger_distance_threshold_list_path"/>
   <arg name="object_recognition_detection_fusion_sync_param_path"/>
+  <arg name="object_recognition_detection_roi_cluster_fusion_param_path"/>
+  <arg name="object_recognition_detection_roi_pointcloud_fusion_param_path"/>
+  <arg name="object_recognition_detection_roi_detected_object_fusion_param_path"/>
   <arg name="object_recognition_detection_lidar_model_param_path"/>
   <arg name="object_recognition_detection_radar_lanelet_filtering_range_param"/>
   <arg name="object_recognition_detection_radar_object_clustering_param_path"/>
@@ -94,11 +97,6 @@
     description="options: `traffic_light_classifier_mobilenetv2_batch_*` or `traffic_light_classifier_efficientNet_b1_batch_*`. The batch number must be either one of 1, 4, 6"
   />
 
-  <!-- Camera-Lidar fusion parameters -->
-  <arg name="remove_unknown" default="true"/>
-  <arg name="fusion_distance" default="100.0"/>
-  <arg name="trust_object_distance" default="100.0"/>
-
   <!-- Whether to use detection by tracker -->
   <arg name="use_detection_by_tracker" default="true"/>
 
@@ -172,6 +170,9 @@
           <arg name="camera_info7" value="$(var camera_info7)"/>
           <arg name="image_number" value="$(var image_number)"/>
           <arg name="sync_param_path" value="$(var object_recognition_detection_fusion_sync_param_path)"/>
+          <arg name="roi_cluster_fusion_param_path" value="$(var object_recognition_detection_roi_cluster_fusion_param_path)"/>
+          <arg name="roi_pointcloud_fusion_param_path" value="$(var object_recognition_detection_roi_pointcloud_fusion_param_path)"/>
+          <arg name="roi_detected_object_fusion_param_path" value="$(var object_recognition_detection_roi_detected_object_fusion_param_path)"/>
           <arg name="lidar_model_param_path" value="$(var object_recognition_detection_lidar_model_param_path)"/>
           <arg name="euclidean_param_path" value="$(var object_recognition_detection_euclidean_cluster_param_path)"/>
           <arg name="outlier_param_path" value="$(var object_recognition_detection_outlier_param_path)"/>
@@ -185,9 +186,6 @@
           <arg name="use_object_filter" value="$(var use_object_filter)"/>
           <arg name="use_pointcloud_container" value="$(var use_pointcloud_container)"/>
           <arg name="container_name" value="$(var pointcloud_container_name)"/>
-          <arg name="remove_unknown" value="$(var remove_unknown)"/>
-          <arg name="fusion_distance" value="$(var fusion_distance)"/>
-          <arg name="trust_object_distance" value="$(var trust_object_distance)"/>
           <arg name="use_roi_based_cluster" value="$(var use_roi_based_cluster)"/>
         </include>
       </group>


### PR DESCRIPTION
…age projection fusion (#6075)

re-organize the parameters for image projection fusion

## Description

- Cherry-pick https://github.com/autowarefoundation/autoware.universe/pull/6075


- Need to merge together with https://github.com/tier4/autoware_launch.x2/pull/568

<!-- Write a brief description of this PR. -->

## Related Link

https://tier4.atlassian.net/browse/RT1-4990

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
