### PR TITLE
feat(imu_corrector): cherry pick diagnostics modification in gyro_bias_estimatior from awf

### DIFF
--- a/sensing/imu_corrector/README.md
+++ b/sensing/imu_corrector/README.md
@@ -70,11 +70,11 @@ In the future, with careful implementation for pose errors, the IMU bias estimat
 
 ### Parameters
 
+Note that this node also uses `angular_velocity_offset_x`, `angular_velocity_offset_y`, `angular_velocity_offset_z` parameters from `imu_corrector.param.yaml`.
+
 | Name                                  | Type   | Description                                                                                 |
 | ------------------------------------- | ------ | ------------------------------------------------------------------------------------------- |
-| `angular_velocity_offset_x`           | double | roll rate offset in imu_link [rad/s]                                                        |
-| `angular_velocity_offset_y`           | double | pitch rate offset imu_link [rad/s]                                                          |
-| `angular_velocity_offset_z`           | double | yaw rate offset imu_link [rad/s]                                                            |
 | `gyro_bias_threshold`                 | double | threshold of the bias of the gyroscope [rad/s]                                              |
 | `timer_callback_interval_sec`         | double | seconds about the timer callback function [sec]                                             |
+| `diagnostics_updater_interval_sec`    | double | period of the diagnostics updater [sec]                                                     |
 | `straight_motion_ang_vel_upper_limit` | double | upper limit of yaw angular velocity, beyond which motion is not considered straight [rad/s] |

--- a/sensing/imu_corrector/config/gyro_bias_estimator.param.yaml
+++ b/sensing/imu_corrector/config/gyro_bias_estimator.param.yaml
@@ -2,4 +2,5 @@
   ros__parameters:
     gyro_bias_threshold: 0.0015 # [rad/s]
     timer_callback_interval_sec: 0.5 # [sec]
+    diagnostics_updater_interval_sec: 0.5 # [sec]
     straight_motion_ang_vel_upper_limit: 0.015 # [rad/s]

--- a/sensing/imu_corrector/src/gyro_bias_estimator.hpp
+++ b/sensing/imu_corrector/src/gyro_bias_estimator.hpp
@@ -49,6 +49,7 @@ private:
   void callback_imu(const Imu::ConstSharedPtr imu_msg_ptr);
   void callback_odom(const Odometry::ConstSharedPtr odom_msg_ptr);
   void timer_callback();
+  void validate_gyro_bias();
 
   static geometry_msgs::msg::Vector3 transform_vector3(
     const geometry_msgs::msg::Vector3 & vec,
@@ -68,6 +69,7 @@ private:
   const double angular_velocity_offset_y_;
   const double angular_velocity_offset_z_;
   const double timer_callback_interval_sec_;
+  const double diagnostics_updater_interval_sec_;
   const double straight_motion_ang_vel_upper_limit_;
 
   diagnostic_updater::Updater updater_;
@@ -80,6 +82,20 @@ private:
 
   std::vector<geometry_msgs::msg::Vector3Stamped> gyro_all_;
   std::vector<geometry_msgs::msg::PoseStamped> pose_buf_;
+
+  struct DiagnosticsInfo
+  {
+    unsigned char level;
+    std::string summary_message;
+    double gyro_bias_x_for_imu_corrector;
+    double gyro_bias_y_for_imu_corrector;
+    double gyro_bias_z_for_imu_corrector;
+    double estimated_gyro_bias_x;
+    double estimated_gyro_bias_y;
+    double estimated_gyro_bias_z;
+  };
+
+  DiagnosticsInfo diagnostics_info_;
 };
 }  // namespace imu_corrector
 


### PR DESCRIPTION
## Description

Make the diagnostics publication from gyro_bias_estiamator constant.
The default period is 0.5 seconds.
You can change this in `gyro_bias_estimator.param.yaml` but note that the period will be `min(timer_callback_interval_sec, diagnostics_updater_interval_sec)`.

Cherry-pick from the autowarefoundation/autoware.universe #6139

## Tests performed

I've test this code via [rosbag replay simulation tutorial](https://autowarefoundation.github.io/autoware-documentation/main/tutorials/ad-hoc-simulation/rosbag-replay-simulation/).

## Effects on system behavior

`/diagnostics` from gyro_bias_estimator should be more periodical than before
The content of the `/diagnostics` will be changed as mentioned in #6139

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
