### PR TITLE
fix(tracking_object_merger): enable to association unknown class in tracker merger #6182

### DIFF
--- a/perception/tracking_object_merger/config/data_association_matrix.param.yaml
+++ b/perception/tracking_object_merger/config/data_association_matrix.param.yaml
@@ -3,7 +3,7 @@
     lidar-lidar:
       can_assign_matrix:
         #UNKNOWN, CAR, TRUCK, BUS,  TRAILER, MOTORBIKE, BICYCLE,PEDESTRIAN
-        [0,       0,   0,     0,    0,       0,         0,      0,         #UNKNOWN
+        [1,       0,   0,     0,    0,       0,         0,      0,         #UNKNOWN
         0,       1,   1,     1,    1,       0,         0,      0,         #CAR
         0,       1,   1,     1,    1,       0,         0,      0,         #TRUCK
         0,       1,   1,     1,    1,       0,         0,      0,         #BUS
@@ -59,7 +59,7 @@
     lidar-radar:
       can_assign_matrix:
         #UNKNOWN, CAR, TRUCK, BUS,  TRAILER, MOTORBIKE, BICYCLE,PEDESTRIAN
-        [0,       0,   0,     0,    0,       0,         0,      0,         #UNKNOWN
+        [1,       0,   0,     0,    0,       0,         0,      0,         #UNKNOWN
         0,       1,   1,     1,    1,       0,         0,      0,         #CAR
         0,       1,   1,     1,    1,       0,         0,      0,         #TRUCK
         0,       1,   1,     1,    1,       0,         0,      0,         #BUS
@@ -115,7 +115,7 @@
     radar-radar:
       can_assign_matrix:
         #UNKNOWN, CAR, TRUCK, BUS,  TRAILER, MOTORBIKE, BICYCLE,PEDESTRIAN
-        [0,       0,   0,     0,    0,       0,         0,      0,         #UNKNOWN
+        [1,       0,   0,     0,    0,       0,         0,      0,         #UNKNOWN
         0,       1,   1,     1,    1,       0,         0,      0,         #CAR
         0,       1,   1,     1,    1,       0,         0,      0,         #TRUCK
         0,       1,   1,     1,    1,       0,         0,      0,         #BUS

--- a/perception/tracking_object_merger/src/utils/utils.cpp
+++ b/perception/tracking_object_merger/src/utils/utils.cpp
@@ -484,9 +484,9 @@ void updateWholeTrackedObject(TrackedObject & main_obj, const TrackedObject & su
 {
   if (!objectsHaveSameMotionDirections(main_obj, sub_obj)) {
     // warning
-    std::cerr << "[object_tracking_merger]: motion direction is different in "
-                 "updateWholeTrackedObject function."
-              << std::endl;
+    // std::cerr << "[object_tracking_merger]: motion direction is different in "
+    //              "updateWholeTrackedObject function."
+    //           << std::endl;
   }
   main_obj = sub_obj;
 }


### PR DESCRIPTION
## Description
cherry-pick 
- https://github.com/autowarefoundation/autoware.universe/pull/6182

https://star4.slack.com/archives/C03QU7K50D8/p1706685403389279
## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
