### PR TITLE
fix(out_of_lane): ignore overlaps over all lanelets crossed by the ego path

### DIFF
--- a/planning/behavior_velocity_out_of_lane_module/src/lanelets_selection.hpp
+++ b/planning/behavior_velocity_out_of_lane_module/src/lanelets_selection.hpp
@@ -33,6 +33,14 @@ inline bool contains_lanelet(const lanelet::ConstLanelets & lanelets, const lane
            return l.id() == id;
          }) != lanelets.end();
 };
+
+/// @brief calculate lanelets crossed by the ego path
+/// @details calculated from the ids of the path msg, the lanelets containing path points
+/// @param [in] ego_data data about the ego vehicle
+/// @param [in] route_handler route handler
+/// @return lanelets crossed by the ego vehicle
+lanelet::ConstLanelets calculate_path_lanelets(
+  const EgoData & ego_data, const route_handler::RouteHandler & route_handler);
 /// @brief calculate lanelets that should be ignored
 /// @param [in] ego_data data about the ego vehicle
 /// @param [in] path_lanelets lanelets driven by the ego vehicle

--- a/planning/behavior_velocity_out_of_lane_module/src/overlapping_range.cpp
+++ b/planning/behavior_velocity_out_of_lane_module/src/overlapping_range.cpp
@@ -34,6 +34,7 @@ Overlap calculate_overlap(
   Overlap overlap;
   const auto & left_bound = lanelet.leftBound2d().basicLineString();
   const auto & right_bound = lanelet.rightBound2d().basicLineString();
+  // TODO(Maxime): these intersects (for each path footprint, for each lanelet) are too expensive
   const auto overlap_left = boost::geometry::intersects(path_footprint, left_bound);
   const auto overlap_right = boost::geometry::intersects(path_footprint, right_bound);
 

--- a/planning/behavior_velocity_out_of_lane_module/src/scene_out_of_lane.cpp
+++ b/planning/behavior_velocity_out_of_lane_module/src/scene_out_of_lane.cpp
@@ -66,7 +66,7 @@ bool OutOfLaneModule::modifyPathVelocity(PathWithLaneId * path, StopReason * sto
   ego_data.pose = planner_data_->current_odometry->pose;
   ego_data.path.points = path->points;
   ego_data.first_path_idx =
-    motion_utils::findNearestSegmentIndex(ego_data.path.points, ego_data.pose.position);
+    motion_utils::findNearestSegmentIndex(path->points, ego_data.pose.position);
   motion_utils::removeOverlapPoints(ego_data.path.points);
   ego_data.velocity = planner_data_->current_velocity->twist.linear.x;
   ego_data.max_decel = -planner_data_->max_stop_acceleration_threshold;
@@ -75,13 +75,13 @@ bool OutOfLaneModule::modifyPathVelocity(PathWithLaneId * path, StopReason * sto
   const auto path_footprints = calculate_path_footprints(ego_data, params_);
   const auto calculate_path_footprints_us = stopwatch.toc("calculate_path_footprints");
   // Calculate lanelets to ignore and consider
-  const auto path_lanelets = planning_utils::getLaneletsOnPath(
-    ego_data.path, planner_data_->route_handler_->getLaneletMapPtr(),
-    planner_data_->current_odometry->pose);
+  stopwatch.tic("calculate_lanelets");
+  const auto path_lanelets = calculate_path_lanelets(ego_data, *planner_data_->route_handler_);
   const auto ignored_lanelets =
     calculate_ignored_lanelets(ego_data, path_lanelets, *planner_data_->route_handler_, params_);
   const auto other_lanelets = calculate_other_lanelets(
     ego_data, path_lanelets, ignored_lanelets, *planner_data_->route_handler_, params_);
+  const auto calculate_lanelets_us = stopwatch.toc("calculate_lanelets");
 
   debug_data_.footprints = path_footprints;
   debug_data_.path_lanelets = path_lanelets;
@@ -98,6 +98,7 @@ bool OutOfLaneModule::modifyPathVelocity(PathWithLaneId * path, StopReason * sto
       });
     if (overlapped_lanelet_it != other_lanelets.end()) {
       debug_data_.current_overlapped_lanelets.push_back(*overlapped_lanelet_it);
+      // TODO(Maxime): we may want to just add the overlapped lane to the ignored lanelets
       RCLCPP_DEBUG(logger_, "Ego is already overlapping a lane, skipping the module ()\n");
       return true;
     }
@@ -183,13 +184,15 @@ bool OutOfLaneModule::modifyPathVelocity(PathWithLaneId * path, StopReason * sto
   RCLCPP_DEBUG(
     logger_,
     "Total time = %2.2fus\n"
+    "\tcalculate_lanelets = %2.0fus\n"
     "\tcalculate_path_footprints = %2.0fus\n"
     "\tcalculate_overlapping_ranges = %2.0fus\n"
     "\tcalculate_decisions = %2.0fus\n"
     "\tcalc_slowdown_points = %2.0fus\n"
     "\tinsert_slowdown_points = %2.0fus\n",
-    total_time_us, calculate_path_footprints_us, calculate_overlapping_ranges_us,
-    calculate_decisions_us, calc_slowdown_points_us, insert_slowdown_points_us);
+    total_time_us, calculate_lanelets_us, calculate_path_footprints_us,
+    calculate_overlapping_ranges_us, calculate_decisions_us, calc_slowdown_points_us,
+    insert_slowdown_points_us);
   return true;
 }
 


### PR DESCRIPTION
## Description

Cherry-pick https://github.com/autowarefoundation/autoware.universe/pull/6334

## Related links

- https://tier4.atlassian.net/browse/RT1-4533
- https://tier4.atlassian.net/browse/RT1-4534

## Tests performed

Evaluator: https://evaluation.tier4.jp/evaluation/reports/9762ef84-5c89-5f73-8571-4f4e141a359e?project_id=prd_jt

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters. -->
None

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->
`out_of_lane` module causes less stops.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [X] I've confirmed the [contribution guidelines].
- [X] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
