### PR TITLE
feat(behavior_path_planner): add enable_all_modules_auto_mode argumen…

### DIFF
--- a/launch/tier4_planning_launch/launch/planning.launch.xml
+++ b/launch/tier4_planning_launch/launch/planning.launch.xml
@@ -7,6 +7,8 @@
   <arg name="freespace_planner_param_path"/>
   <!-- planning validator -->
   <arg name="planning_validator_param_path"/>
+  <!-- Auto mode setting-->
+  <arg name="enable_all_modules_auto_mode"/>
 
   <group>
     <push-ros-namespace namespace="planning"/>
@@ -21,7 +23,9 @@
     <!-- scenario planning module -->
     <group>
       <push-ros-namespace namespace="scenario_planning"/>
-      <include file="$(find-pkg-share tier4_planning_launch)/launch/scenario_planning/scenario_planning.launch.xml"/>
+      <include file="$(find-pkg-share tier4_planning_launch)/launch/scenario_planning/scenario_planning.launch.xml">
+        <arg name="enable_all_modules_auto_mode" value="$(var enable_all_modules_auto_mode)"/>
+      </include>
     </group>
 
     <!-- planning validator -->

--- a/launch/tier4_planning_launch/launch/scenario_planning/lane_driving.launch.xml
+++ b/launch/tier4_planning_launch/launch/scenario_planning/lane_driving.launch.xml
@@ -1,4 +1,6 @@
 <launch>
+  <arg name="enable_all_modules_auto_mode"/>
+
   <!-- lane_driving scenario -->
   <group>
     <push-ros-namespace namespace="lane_driving"/>
@@ -8,6 +10,7 @@
       <group>
         <include file="$(find-pkg-share tier4_planning_launch)/launch/scenario_planning/lane_driving/behavior_planning/behavior_planning.launch.xml">
           <arg name="container_type" value="component_container_mt"/>
+          <arg name="enable_all_modules_auto_mode" value="$(var enable_all_modules_auto_mode)"/>
           <!-- This condition should be true if run_out module is enabled and its detection method is Points -->
           <arg name="launch_compare_map_pipeline" value="false"/>
         </include>

--- a/launch/tier4_planning_launch/launch/scenario_planning/lane_driving/behavior_planning/behavior_planning.launch.xml
+++ b/launch/tier4_planning_launch/launch/scenario_planning/lane_driving/behavior_planning/behavior_planning.launch.xml
@@ -4,6 +4,7 @@
   <arg name="input_virtual_traffic_light_topic_name" default="/awapi/tmp/virtual_traffic_light_states"/>
   <arg name="input_vector_map_topic_name" default="/map/vector_map"/>
   <arg name="input_pointcloud_map_topic_name" default="/map/pointcloud_map"/>
+  <arg name="enable_all_modules_auto_mode"/>
 
   <arg name="launch_avoidance_module" default="true"/>
   <arg name="launch_avoidance_by_lane_change_module" default="true"/>
@@ -200,6 +201,7 @@
       <param from="$(var vehicle_param_file)"/>
       <param from="$(var nearest_search_param_path)"/>
       <param name="launch_modules" value="$(var behavior_path_planner_launch_modules)"/>
+      <param name="enable_all_modules_auto_mode" value="$(var enable_all_modules_auto_mode)"/>
       <param from="$(var behavior_path_planner_side_shift_module_param_path)"/>
       <param from="$(var behavior_path_planner_avoidance_module_param_path)"/>
       <param from="$(var behavior_path_planner_avoidance_by_lc_module_param_path)"/>

--- a/launch/tier4_planning_launch/launch/scenario_planning/scenario_planning.launch.xml
+++ b/launch/tier4_planning_launch/launch/scenario_planning/scenario_planning.launch.xml
@@ -1,4 +1,5 @@
 <launch>
+  <arg name="enable_all_modules_auto_mode"/>
   <!-- scenario selector -->
   <group>
     <include file="$(find-pkg-share scenario_selector)/launch/scenario_selector.launch.xml">
@@ -50,7 +51,9 @@
   <group>
     <!-- lane driving -->
     <group>
-      <include file="$(find-pkg-share tier4_planning_launch)/launch/scenario_planning/lane_driving.launch.xml"/>
+      <include file="$(find-pkg-share tier4_planning_launch)/launch/scenario_planning/lane_driving.launch.xml">
+        <arg name="enable_all_modules_auto_mode" value="$(var enable_all_modules_auto_mode)"/>
+      </include>
     </group>
     <!-- parking -->
     <group>

--- a/planning/behavior_path_planner_common/include/behavior_path_planner_common/interface/scene_module_manager_interface.hpp
+++ b/planning/behavior_path_planner_common/include/behavior_path_planner_common/interface/scene_module_manager_interface.hpp
@@ -261,7 +261,14 @@ protected:
     // init manager configuration
     {
       std::string ns = name_ + ".";
-      config_.enable_rtc = getOrDeclareParameter<bool>(*node, ns + "enable_rtc");
+      try {
+        config_.enable_rtc = getOrDeclareParameter<bool>(*node, "enable_all_modules_auto_mode")
+                               ? false
+                               : getOrDeclareParameter<bool>(*node, ns + "enable_rtc");
+      } catch (const std::exception & e) {
+        config_.enable_rtc = getOrDeclareParameter<bool>(*node, ns + "enable_rtc");
+      }
+
       config_.enable_simultaneous_execution_as_approved_module =
         getOrDeclareParameter<bool>(*node, ns + "enable_simultaneous_execution_as_approved_module");
       config_.enable_simultaneous_execution_as_candidate_module = getOrDeclareParameter<bool>(


### PR DESCRIPTION
## Description
v3,0.0からavoidanceのシナリオがfailすることへの対応([スレ](https://star4.slack.com/archives/CRUE57C30/p1706870476120089))
launcherのPR
https://github.com/tier4/autoware_launch.x2/pull/577

cherry-pick元
https://github.com/autowarefoundation/autoware.universe/pull/6093
launcherのcherry-pick元
https://github.com/autowarefoundation/autoware_launch/pull/798
## Tests performed
下記の結果が`enable_all_modules_auto_mode`で変わることを確認した。
`webauto ci scenario run --project-id x2_dev --scenario-id d3fee99e-3756-4eae-be9a-fb6b3c3682d5 --scenario-version-id 6 --scenario-parameters '__tier4_modifier_ego_speed=2.7778,__tier4_modifier_obstacle_margin=1'`


## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
