### PR TITLE
feat(behavior_velocity_traffic_light): stop when the signal is unknown or timed out

### DIFF
--- a/planning/behavior_velocity_traffic_light_module/src/scene.cpp
+++ b/planning/behavior_velocity_traffic_light_module/src/scene.cpp
@@ -228,33 +228,31 @@ bool TrafficLightModule::modifyPathVelocity(PathWithLaneId * path, StopReason * 
 
     first_ref_stop_path_point_index_ = stop_line_point_idx;
 
-    // Check if stop is coming.
-    const bool is_stop_signal = isStopSignal();
+    // Update traffic signal information
+    updateTrafficSignal();
+
+    const bool is_unknown_signal = isUnknownSignal(looking_tl_state_);
+    const bool is_signal_timed_out = isTrafficSignalTimedOut();
 
     // Decide if stop or proceed using the remaining time to red signal
+    // If the upcoming traffic signal color is unknown or timed out, do not use the time to red and
+    // stop for the traffic signal
     const auto rest_time_to_red_signal =
       planner_data_->getRestTimeToRedSignal(traffic_light_reg_elem_.id());
-    if (
-      planner_param_.v2i_use_rest_time && rest_time_to_red_signal &&
-      !isDataTimeout(rest_time_to_red_signal->stamp)) {
-      const double rest_time_allowed_to_go_ahead =
-        rest_time_to_red_signal->time_to_red - planner_param_.v2i_last_time_allowed_to_pass;
+    const bool is_stop_required = is_unknown_signal || is_signal_timed_out;
 
-      const double ego_v = planner_data_->current_velocity->twist.linear.x;
-      if (ego_v >= planner_param_.v2i_velocity_threshold) {
-        if (ego_v * rest_time_allowed_to_go_ahead <= signed_arc_length_to_stop_point) {
-          *path = insertStopPose(input_path, stop_line_point_idx, stop_line_point, stop_reason);
-        }
-      } else {
-        if (rest_time_allowed_to_go_ahead < planner_param_.v2i_required_time_to_departure) {
-          *path = insertStopPose(input_path, stop_line_point_idx, stop_line_point, stop_reason);
-        }
+    if (planner_param_.v2i_use_rest_time && rest_time_to_red_signal && !is_stop_required) {
+      if (!canPassStopLineBeforeRed(*rest_time_to_red_signal, signed_arc_length_to_stop_point)) {
+        *path = insertStopPose(input_path, stop_line_point_idx, stop_line_point, stop_reason);
       }
       return true;
     }
 
+    // Check if stop is coming.
+    const bool is_stop_signal = isStopSignal();
+
     // Update stop signal received time
-    if (is_stop_signal) {
+    if (is_stop_signal || is_unknown_signal || is_signal_timed_out) {
       if (!stop_signal_received_time_ptr_) {
         stop_signal_received_time_ptr_ = std::make_unique<Time>(clock_->now());
       }
@@ -301,8 +299,6 @@ bool TrafficLightModule::modifyPathVelocity(PathWithLaneId * path, StopReason * 
 
 bool TrafficLightModule::isStopSignal()
 {
-  updateTrafficSignal();
-
   // If there is no upcoming traffic signal information,
   //   SIMULATION: it will PASS to prevent stopping on the planning simulator
   //   or scenario simulator.
@@ -312,11 +308,6 @@ bool TrafficLightModule::isStopSignal()
     if (planner_data_->is_simulation) {
       return false;
     }
-    return true;
-  }
-
-  // Stop if the traffic signal information has timed out
-  if (isTrafficSignalTimedOut()) {
     return true;
   }
 
@@ -520,6 +511,41 @@ bool TrafficLightModule::isDataTimeout(const rclcpp::Time & data_time) const
   }
 
   return is_data_timeout;
+}
+
+bool TrafficLightModule::canPassStopLineBeforeRed(
+  const TrafficSignalTimeToRedStamped & time_to_red_signal,
+  const double distance_to_stop_line) const
+{
+  if (isDataTimeout(time_to_red_signal.stamp)) {
+    return false;
+  }
+
+  const double rest_time_allowed_to_go_ahead =
+    time_to_red_signal.time_to_red - planner_param_.v2i_last_time_allowed_to_pass;
+
+  const double ego_v = planner_data_->current_velocity->twist.linear.x;
+  if (ego_v >= planner_param_.v2i_velocity_threshold) {
+    if (ego_v * rest_time_allowed_to_go_ahead <= distance_to_stop_line) {
+      return false;
+    }
+  } else {
+    if (rest_time_allowed_to_go_ahead < planner_param_.v2i_required_time_to_departure) {
+      return false;
+    }
+  }
+
+  return true;
+}
+
+bool TrafficLightModule::isUnknownSignal(const TrafficSignal & tl_state) const
+{
+  if (tl_state.elements.empty()) {
+    return false;
+  }
+
+  const bool has_unknown = hasTrafficLightCircleColor(tl_state, TrafficSignalElement::UNKNOWN);
+  return has_unknown;
 }
 
 }  // namespace behavior_velocity_planner

--- a/planning/behavior_velocity_traffic_light_module/src/scene.hpp
+++ b/planning/behavior_velocity_traffic_light_module/src/scene.hpp
@@ -110,9 +110,15 @@ private:
 
   bool isTrafficSignalTimedOut() const;
 
+  bool isUnknownSignal(const TrafficSignal & tl_state) const;
+
   void updateTrafficSignal();
 
   bool isDataTimeout(const rclcpp::Time & data_time) const;
+
+  bool canPassStopLineBeforeRed(
+    const TrafficSignalTimeToRedStamped & time_to_red_signal,
+    const double distance_to_stop_line) const;
 
   // Lane id
   const int64_t lane_id_;


### PR DESCRIPTION
## Description
I fixed the issue that the ego vehicle doesn't stop even if the signal is UNKNOWN when using the V2I remaining time information.


Related links: 
- [TIER IV INTERNAL JIRA](https://tier4.atlassian.net/browse/RT0-29986)
- [TIER IV INTERNAL Confluence](https://tier4.atlassian.net/wiki/spaces/~283541267/pages/2976122841/X2+V2I)

V2Iの残り時間情報を使う場合に、信号機がUNKNOWNでも停止線で停止しない問題を修正
※この問題はV2Iの残り時間情報を使うuniverse versionでのみ発生するため、beta/v0.19.1に変更を加えている


This PR should be merged after this PR
I will rebase after following PR has been merged.
-> **DONE**
- https://github.com/tier4/autoware.universe/pull/1171

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Simple planning simulator.

### Before
A stop line is not inserted even if the signal is UNKNOWN because the module only checks the remaining time to the RED.

https://github.com/tier4/autoware.universe/assets/11865769/87a7773f-1af9-482c-a011-b2be2584e9d6

### After
A stop line is always inserted when the signal is unknown.

https://github.com/tier4/autoware.universe/assets/11865769/f49b8af2-775e-489e-b78d-d5ca97d43a30


## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
