### PR TITLE
feat(behavior_velocity_traffic_light): check if remaining time is available

### DIFF
--- a/planning/behavior_velocity_planner/src/node.cpp
+++ b/planning/behavior_velocity_planner/src/node.cpp
@@ -344,6 +344,11 @@ void BehaviorVelocityPlannerNode::onTrafficSignalsRawV2I(
   std::lock_guard<std::mutex> lock(mutex_);
 
   for (const auto & car_light : msg->car_lights) {
+    // If the time to red is not available, skip it
+    if (!car_light.has_max_rest_time || !car_light.has_min_rest_time) {
+      continue;
+    }
+
     for (const auto & state : car_light.states) {
       TrafficSignalTimeToRedStamped time_to_red;
       time_to_red.stamp = msg->header.stamp;


### PR DESCRIPTION
## Description
※この変更はV2Iの残り時間情報を使うuniverse versionでのみ有効なため、beta/v0.19.1に変更を加えている

Related link: [TIER IV INTERNAL](https://tier4.atlassian.net/browse/RT0-30742)

Handled the case when the remaining time is unavailable.
`has_max_rest_time` is false or `has_min_rest_time` is false


NOTE:
This PR should be merged after this PR
I will rebase after following PR has been merged.
-> **DONE**

- https://github.com/tier4/autoware.universe/pull/1171

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
