### PR TITLE
fix(drivable_area_expansion): fix bug when reusing previous path poin…

### DIFF
--- a/planning/behavior_path_planner/src/utils/drivable_area_expansion/drivable_area_expansion.cpp
+++ b/planning/behavior_path_planner/src/utils/drivable_area_expansion/drivable_area_expansion.cpp
@@ -51,7 +51,17 @@ void reuse_previous_poses(
                                                         prev_poses, 0, ego_point) < 0.0;
   const auto ego_is_far = !prev_poses.empty() &&
                           tier4_autoware_utils::calcDistance2d(ego_point, prev_poses.front()) < 0.0;
-  if (!ego_is_behind && !ego_is_far && prev_poses.size() > 1) {
+  // make sure the reused points are not behind the current original drivable area
+  LineString2d left_bound;
+  LineString2d right_bound;
+  for (const auto & p : path.left_bound) left_bound.push_back(convert_point(p));
+  for (const auto & p : path.right_bound) right_bound.push_back(convert_point(p));
+  LineString2d prev_poses_ls;
+  for (const auto & p : prev_poses) prev_poses_ls.push_back(convert_point(p.position));
+  auto prev_poses_across_bounds = boost::geometry::intersects(left_bound, prev_poses_ls) ||
+                                  boost::geometry::intersects(right_bound, prev_poses_ls);
+
+  if (!ego_is_behind && !ego_is_far && prev_poses.size() > 1 && !prev_poses_across_bounds) {
     const auto first_idx =
       motion_utils::findNearestSegmentIndex(prev_poses, path.points.front().point.pose);
     const auto deviation =


### PR DESCRIPTION
## Description

Cherry pick hot fix.
- https://github.com/autowarefoundation/autoware.universe/pull/5586

Related link: [TIER IV INTERNAL JIRA](https://tier4.atlassian.net/browse/RT0-30774)

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

PSim

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
