### PR TITLE
fix(planning_validator): calculate max lateral acceleration after resampling trajectory (autowarefoundation#6679)

### DIFF
--- a/planning/planning_validator/src/planning_validator.cpp
+++ b/planning/planning_validator/src/planning_validator.cpp
@@ -260,7 +260,6 @@ void PlanningValidator::validate(const Trajectory & trajectory)
 
   s.is_valid_finite_value = checkValidFiniteValue(trajectory);
   s.is_valid_interval = checkValidInterval(trajectory);
-  s.is_valid_lateral_acc = checkValidLateralAcceleration(trajectory);
   s.is_valid_longitudinal_max_acc = checkValidMaxLongitudinalAcceleration(trajectory);
   s.is_valid_longitudinal_min_acc = checkValidMinLongitudinalAcceleration(trajectory);
   s.is_valid_velocity_deviation = checkValidVelocityDeviation(trajectory);
@@ -273,6 +272,7 @@ void PlanningValidator::validate(const Trajectory & trajectory)
 
   s.is_valid_relative_angle = checkValidRelativeAngle(resampled);
   s.is_valid_curvature = checkValidCurvature(resampled);
+  s.is_valid_lateral_acc = checkValidLateralAcceleration(resampled);
   s.is_valid_steering = checkValidSteering(resampled);
   s.is_valid_steering_rate = checkValidSteeringRate(resampled);
 


### PR DESCRIPTION
## Description

Cherry-pick the fix of lateral acceleration calculation in planning_validator.
- https://github.com/autowarefoundation/autoware.universe/pull/6679


## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
