### PR TITLE
fix(raw_vehicle_cmd_converter): csv paths are resolved in param.yaml

### DIFF
--- a/vehicle/raw_vehicle_cmd_converter/config/raw_vehicle_cmd_converter.param.yaml
+++ b/vehicle/raw_vehicle_cmd_converter/config/raw_vehicle_cmd_converter.param.yaml
@@ -1,5 +1,8 @@
 /**:
   ros__parameters:
+    csv_path_accel_map: $(find-pkg-share raw_vehicle_cmd_converter)/data/default/accel_map.csv
+    csv_path_brake_map: $(find-pkg-share raw_vehicle_cmd_converter)/data/default/brake_map.csv
+    csv_path_steer_map: $(find-pkg-share raw_vehicle_cmd_converter)/data/default/steer_map.csv
     convert_accel_cmd: true
     convert_brake_cmd: true
     convert_steer_cmd: true

--- a/vehicle/raw_vehicle_cmd_converter/launch/raw_vehicle_converter.launch.xml
+++ b/vehicle/raw_vehicle_cmd_converter/launch/raw_vehicle_converter.launch.xml
@@ -1,9 +1,5 @@
 <?xml version="1.0"?>
 <launch>
-  <arg name="csv_path_accel_map" default="$(find-pkg-share raw_vehicle_cmd_converter)/data/default/accel_map.csv"/>
-  <arg name="csv_path_brake_map" default="$(find-pkg-share raw_vehicle_cmd_converter)/data/default/brake_map.csv"/>
-  <arg name="csv_path_steer_map" default="$(find-pkg-share raw_vehicle_cmd_converter)/data/default/steer_map.csv"/>
-
   <arg name="input_control_cmd" default="/control/command/control_cmd"/>
   <arg name="input_odometry" default="/localization/kinematic_state"/>
   <arg name="input_steering" default="/vehicle/status/steering_status"/>
@@ -13,9 +9,6 @@
 
   <node pkg="raw_vehicle_cmd_converter" exec="raw_vehicle_cmd_converter_node" name="raw_vehicle_cmd_converter" output="screen">
     <param from="$(var config_file)" allow_substs="true"/>
-    <param name="csv_path_accel_map" value="$(var csv_path_accel_map)"/>
-    <param name="csv_path_brake_map" value="$(var csv_path_brake_map)"/>
-    <param name="csv_path_steer_map" value="$(var csv_path_steer_map)"/>
     <remap from="~/input/control_cmd" to="$(var input_control_cmd)"/>
     <remap from="~/input/odometry" to="$(var input_odometry)"/>
     <remap from="~/input/steering" to="$(var input_steering)"/>

--- a/vehicle/raw_vehicle_cmd_converter/schema/raw_vehicle_cmd_converter.schema.json
+++ b/vehicle/raw_vehicle_cmd_converter/schema/raw_vehicle_cmd_converter.schema.json
@@ -6,6 +6,21 @@
     "raw_vehicle_cmd_converter": {
       "type": "object",
       "properties": {
+        "csv_path_accel_map": {
+          "type": "string",
+          "description": "path for acceleration map csv file",
+          "default": "$(find-pkg-share raw_vehicle_cmd_converter)/data/default/accel_map.csv"
+        },
+        "csv_path_brake_map": {
+          "type": "string",
+          "description": "path for brake map csv file",
+          "default": "$(find-pkg-share raw_vehicle_cmd_converter)/data/default/brake_map.csv"
+        },
+        "csv_path_steer_map": {
+          "type": "string",
+          "description": "path for steer map csv file",
+          "default": "$(find-pkg-share raw_vehicle_cmd_converter)/data/default/steer_map.csv"
+        },
         "convert_accel_cmd": {
           "type": "boolean",
           "description": "use accel or not",


### PR DESCRIPTION
…(#6476)

## Description

accel_map.csv, brake_map.csv, steer_map.csvのパス設定はyamlファイルに移動した。
autowarefoundation/autoware.universe側のPRをcherry-pickしました。

## Related links

https://github.com/autowarefoundation/autoware.universe/pull/6476


## Tests performed

ros2 launch j6_gen1_launch vehicle_interface.launch.xml で起動すると、map_pathが正しく読み込んでいることは確認できました。

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
