### PR TITLE
fix(compare_map_segmentation): vertical check adjust for low height object detection

### DIFF
--- a/perception/compare_map_segmentation/src/voxel_grid_map_loader.cpp
+++ b/perception/compare_map_segmentation/src/voxel_grid_map_loader.cpp
@@ -96,16 +96,6 @@ bool VoxelGridMapLoader::is_close_to_neighbor_voxels(
     return true;
   }
   if (is_in_voxel(
-        pcl::PointXYZ(point.x, point.y, point.z - distance_threshold_z), point, distance_threshold,
-        map, voxel)) {
-    return true;
-  }
-  if (is_in_voxel(
-        pcl::PointXYZ(point.x, point.y, point.z + distance_threshold_z), point, distance_threshold,
-        map, voxel)) {
-    return true;
-  }
-  if (is_in_voxel(
         pcl::PointXYZ(point.x, point.y + distance_threshold, point.z - distance_threshold_z), point,
         distance_threshold, map, voxel)) {
     return true;
@@ -235,16 +225,17 @@ bool VoxelGridMapLoader::is_in_voxel(
   const pcl::PointXYZ & src_point, const pcl::PointXYZ & target_point,
   const double distance_threshold, const PointCloudPtr & map, VoxelGridPointXYZ & voxel) const
 {
+  const double z_distance_threshold = distance_threshold * downsize_ratio_z_axis_;
   int voxel_index =
     voxel.getCentroidIndexAt(voxel.getGridCoordinates(src_point.x, src_point.y, src_point.z));
   if (voxel_index != -1) {  // not empty voxel
     const double dist_x = map->points.at(voxel_index).x - target_point.x;
     const double dist_y = map->points.at(voxel_index).y - target_point.y;
-    const double dist_z = map->points.at(voxel_index).z - target_point.z - 0.1;
+    const double dist_z = map->points.at(voxel_index).z - target_point.z - z_distance_threshold;
     // check if the point is inside the distance threshold voxel
     if (
       std::abs(dist_x) < distance_threshold && std::abs(dist_y) < distance_threshold &&
-      std::abs(dist_z) < distance_threshold * downsize_ratio_z_axis_) {
+      std::abs(dist_z) < z_distance_threshold) {
       return true;
     }
   }


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
- This is a temporal change for compare map filter to retain the obstacle pointcloud of low height objects. 

## Releated Link 

TIER IV INTERNAL LINK: [ticket 1](https://tier4.atlassian.net/browse/RT1-5185) and [ticket 2](https://tier4.atlassian.net/browse/RT0-31059)

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
