### PR TITLE
fix(map_loader): show traffic light regulatory element id per lanelet…

### DIFF
--- a/map/map_loader/src/lanelet2_map_loader/lanelet2_map_visualization_node.cpp
+++ b/map/map_loader/src/lanelet2_map_loader/lanelet2_map_visualization_node.cpp
@@ -222,6 +222,12 @@ void Lanelet2MapVisualizationNode::onMapBin(
     &map_marker_array,
     lanelet::visualization::autowareTrafficLightsAsMarkerArray(aw_tl_reg_elems, cl_trafficlights));
   insertMarkerArray(
+    &map_marker_array, lanelet::visualization::generateTrafficLightRegulatoryElementIdMaker(
+                         road_lanelets, cl_trafficlights));
+  insertMarkerArray(
+    &map_marker_array, lanelet::visualization::generateTrafficLightRegulatoryElementIdMaker(
+                         crosswalk_lanelets, cl_trafficlights));
+  insertMarkerArray(
     &map_marker_array,
     lanelet::visualization::generateTrafficLightIdMaker(aw_tl_reg_elems, cl_trafficlights));
   insertMarkerArray(


### PR DESCRIPTION
## Description

Cherry pick this PR to improve visualization of traffic light regulatory element ID.
This change only affects the visualization on RViz.
- https://github.com/autowarefoundation/autoware.universe/pull/6028

Related link (TIER IV INTERNAL)
- https://tier4.atlassian.net/browse/RT0-30617

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

I confirmed this PR works on planning simulator.

![image](https://github.com/tier4/autoware.universe/assets/11865769/1dbbb37d-6f91-43eb-a24a-4d9746c1310e)


## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
