### PR TITLE
feat: keep stop policy v0.11.2 (reopen)

### DIFF
--- a/planning/behavior_path_planner/config/avoidance/avoidance.param.yaml
+++ b/planning/behavior_path_planner/config/avoidance/avoidance.param.yaml
@@ -192,6 +192,10 @@
         stop_buffer: 1.0                                # [m]
 
       policy:
+        # policy for rtc request. select "shift_line" or "maneuver".
+        # "shift_line": request approval for each shift line.
+        # "maneuver": request approval for avoidance maneuver (avoid + return).
+        approval: "shift_line"
         # policy for vehicle slow down behavior. select "best_effort" or "reliable".
         # "best_effort": slow down deceleration & jerk are limited by constraints.
         #                but there is a possibility that the vehicle can't stop in front of the vehicle.

--- a/planning/behavior_path_planner/include/behavior_path_planner/utils/avoidance/avoidance_module_data.hpp
+++ b/planning/behavior_path_planner/include/behavior_path_planner/utils/avoidance/avoidance_module_data.hpp
@@ -281,6 +281,9 @@ struct AvoidanceParameters
   bool use_shorten_margin_immediately{false};
 
   // policy
+  std::string policy_approval{"shift_line"};
+
+  // policy
   std::string policy_deceleration{"best_effort"};
 
   // policy

--- a/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
@@ -85,6 +85,11 @@ bool isBestEffort(const std::string & policy)
 {
   return policy == "best_effort";
 }
+
+bool perManeuver(const std::string & policy)
+{
+  return policy == "maneuver";
+}
 }  // namespace
 
 AvoidanceModule::AvoidanceModule(
@@ -2316,9 +2321,18 @@ AvoidLineArray AvoidanceModule::findNewShiftLine(const AvoidLineArray & candidat
       break;
     }
 
-    if (!is_ignore_shift(candidate)) {
-      return get_subsequent_shift(i);
+    if (is_ignore_shift(candidate)) {
+      continue;
     }
+
+    if (perManeuver(parameters_->policy_approval)) {
+      debug.step4_new_shift_line = shift_lines;
+      return shift_lines;
+    }
+
+    const auto new_shift_lines = get_subsequent_shift(i);
+    debug.step4_new_shift_line = new_shift_lines;
+    return new_shift_lines;
   }
 
   DEBUG_PRINT("No new shift point exists.");

--- a/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance/avoidance_module.cpp
@@ -2326,12 +2326,10 @@ AvoidLineArray AvoidanceModule::findNewShiftLine(const AvoidLineArray & candidat
     }
 
     if (perManeuver(parameters_->policy_approval)) {
-      debug.step4_new_shift_line = shift_lines;
-      return shift_lines;
+      return candidates;
     }
 
     const auto new_shift_lines = get_subsequent_shift(i);
-    debug.step4_new_shift_line = new_shift_lines;
     return new_shift_lines;
   }
 

--- a/planning/behavior_path_planner/src/scene_module/avoidance/manager.cpp
+++ b/planning/behavior_path_planner/src/scene_module/avoidance/manager.cpp
@@ -218,6 +218,7 @@ AvoidanceModuleManager::AvoidanceModuleManager(
   // policy
   {
     std::string ns = "avoidance.policy.";
+    p.policy_approval = getOrDeclareParameter<std::string>(*node, ns + "approval");
     p.policy_deceleration = getOrDeclareParameter<std::string>(*node, ns + "deceleration");
     p.policy_lateral_margin = getOrDeclareParameter<std::string>(*node, ns + "lateral_margin");
     p.use_shorten_margin_immediately =


### PR DESCRIPTION
## Description
launcher https://github.com/tier4/autoware_launch.x2/pull/573

cherry-pick this PR
[feat(avoidance): keep stopping until all shift lines are registered by satoshi-ota · Pull Request #5658 · autowarefoundation/autoware.universe](https://github.com/autowarefoundation/autoware.universe/pull/5658)
https://tier4.atlassian.net/browse/RT1-4491
<!-- Write a brief description of this PR. -->

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

PSim

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
