### PR TITLE
fix(behavior_velocity_traffic_light): stop for outdated signals and set prev_state_stop when using time to red signal

### DIFF
--- a/planning/behavior_velocity_traffic_light_module/src/scene.cpp
+++ b/planning/behavior_velocity_traffic_light_module/src/scene.cpp
@@ -247,7 +247,11 @@ bool TrafficLightModule::modifyPathVelocity(PathWithLaneId * path, StopReason * 
     if (planner_param_.v2i_use_rest_time && is_time_to_red_signal_available && !is_stop_required) {
       if (!canPassStopLineBeforeRed(*rest_time_to_red_signal, signed_arc_length_to_stop_point)) {
         *path = insertStopPose(input_path, stop_line_point_idx, stop_line_point, stop_reason);
+        is_prev_state_stop_ = true;
+        return true;
       }
+
+      is_prev_state_stop_ = false;
       return true;
     }
 

--- a/planning/behavior_velocity_traffic_light_module/src/scene.cpp
+++ b/planning/behavior_velocity_traffic_light_module/src/scene.cpp
@@ -233,6 +233,8 @@ bool TrafficLightModule::modifyPathVelocity(PathWithLaneId * path, StopReason * 
 
     const bool is_unknown_signal = isUnknownSignal(looking_tl_state_);
     const bool is_signal_timed_out = isTrafficSignalTimedOut();
+    const bool is_stop_signal = isStopSignal();
+    const bool is_stop_required = is_unknown_signal || is_signal_timed_out || is_stop_signal;
 
     // Decide if stop or proceed using the remaining time to red signal
     // If the upcoming traffic signal color is unknown or timed out, do not use the time to red and
@@ -241,7 +243,6 @@ bool TrafficLightModule::modifyPathVelocity(PathWithLaneId * path, StopReason * 
       planner_data_->getRestTimeToRedSignal(traffic_light_reg_elem_.id());
     const bool is_time_to_red_signal_available =
       (rest_time_to_red_signal.has_value() && !isDataTimeout(rest_time_to_red_signal->stamp));
-    const bool is_stop_required = is_unknown_signal || is_signal_timed_out;
 
     if (planner_param_.v2i_use_rest_time && is_time_to_red_signal_available && !is_stop_required) {
       if (!canPassStopLineBeforeRed(*rest_time_to_red_signal, signed_arc_length_to_stop_point)) {
@@ -250,11 +251,8 @@ bool TrafficLightModule::modifyPathVelocity(PathWithLaneId * path, StopReason * 
       return true;
     }
 
-    // Check if stop is coming.
-    const bool is_stop_signal = isStopSignal();
-
     // Update stop signal received time
-    if (is_stop_signal || is_unknown_signal || is_signal_timed_out) {
+    if (is_stop_required) {
       if (!stop_signal_received_time_ptr_) {
         stop_signal_received_time_ptr_ = std::make_unique<Time>(clock_->now());
       }
@@ -268,7 +266,7 @@ bool TrafficLightModule::modifyPathVelocity(PathWithLaneId * path, StopReason * 
         ? std::max((clock_->now() - *stop_signal_received_time_ptr_).seconds(), 0.0)
         : 0.0;
     const bool to_be_stopped =
-      is_stop_signal && (is_prev_state_stop_ || time_diff > planner_param_.stop_time_hysteresis);
+      is_stop_required && (is_prev_state_stop_ || time_diff > planner_param_.stop_time_hysteresis);
 
     setSafe(!to_be_stopped);
     if (isActivated()) {


### PR DESCRIPTION
## Description
Related: https://tier4.atlassian.net/browse/RT0-30814
:information_source: This fix has been applied only to the beta/v0.19.1 branch, as the use of remaining time data is only implemented in this branch.


I fixed the following bugs:
- The planner failed to insert a point when the signal was outdated
  - https://github.com/tier4/autoware.universe/pull/1259/commits/cbc7016c767cf24e9224ccc3823db55aa95f3f09
- The pass judgment did not function correctly because prev_state_stop_ was not updated when using time to red signal
  - https://github.com/tier4/autoware.universe/pull/1259/commits/6b99e3940a7fff75da6a6ed01b852721a37f624d

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

[Scenario simulator](https://evaluation.tier4.jp/evaluation/reports/05d99f4a-947b-5a85-a78d-175c9a50d5c0/tests/6559f711-adb6-5e70-9639-7bdaccdc63b3?project_id=x2_dev)
No degradation compared to the previous version.
(related link about failed scenarios: https://star4.slack.com/archives/CRUE57C30/p1713335416749819?thread_ts=1713334862.972979&cid=CRUE57C30)

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
