### PR TITLE
fix(behavior_path_planner): node died when change ego behavior

### DIFF
--- a/planning/behavior_path_planner/src/turn_signal_decider.cpp
+++ b/planning/behavior_path_planner/src/turn_signal_decider.cpp
@@ -49,9 +49,18 @@ TurnIndicatorsCommand TurnSignalDecider::getTurnSignal(
   const double backward_length = 50.0;
   const lanelet::ConstLanelets current_lanes = util::calcLaneAroundPose(
     planner_data->route_handler, current_pose, forward_length, backward_length);
+
+  if (current_lanes.empty()) {
+    return turn_signal_info.turn_signal;
+  }
+
   const PathWithLaneId extended_path = util::getCenterLinePath(
     route_handler, current_lanes, current_pose, backward_length, forward_length,
     planner_data->parameters);
+
+  if (extended_path.points.empty()) {
+    return turn_signal_info.turn_signal;
+  }
 
   // Closest ego segment
   const size_t ego_seg_idx = motion_utils::findFirstNearestSegmentIndexWithSoftConstraints(


### PR DESCRIPTION
## Description

実証実験中に、経路から外れる時に、behavior path plannerが死ぬため、以下のPRを取り込む。
https://github.com/autowarefoundation/autoware.universe/pull/2382
[チケット](https://tier4.atlassian.net/browse/RT0-31302)

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
