### PR TITLE
fix(interpolation): add check size of query_keys

### DIFF
--- a/common/interpolation/include/interpolation/interpolation_utils.hpp
+++ b/common/interpolation/include/interpolation/interpolation_utils.hpp
@@ -65,6 +65,12 @@ inline void validateKeys(
       "The size of points is less than 2. base_keys.size() = " + std::to_string(base_keys.size()));
   }
 
+  // when size of vectors are less than 2
+  if (query_keys.size() < 2) {
+    throw std::invalid_argument(
+      "The size of points is less than 2. base_keys.size() = " + std::to_string(query_keys.size()));
+  }
+  
   // when indices are not sorted
   if (!isIncreasing(base_keys) || !isNotDecreasing(query_keys)) {
     throw std::invalid_argument("Either base_keys or query_keys is not sorted.");

--- a/common/interpolation/include/interpolation/interpolation_utils.hpp
+++ b/common/interpolation/include/interpolation/interpolation_utils.hpp
@@ -68,7 +68,8 @@ inline void validateKeys(
   // when size of vectors are less than 2
   if (query_keys.size() < 2) {
     throw std::invalid_argument(
-      "The size of points is less than 2. query_keys.size() = " + std::to_string(query_keys.size()));
+      "The size of points is less than 2. query_keys.size() = " +
+      std::to_string(query_keys.size()));
   }
 
   // when indices are not sorted

--- a/common/interpolation/include/interpolation/interpolation_utils.hpp
+++ b/common/interpolation/include/interpolation/interpolation_utils.hpp
@@ -70,7 +70,7 @@ inline void validateKeys(
     throw std::invalid_argument(
       "The size of points is less than 2. base_keys.size() = " + std::to_string(query_keys.size()));
   }
-  
+
   // when indices are not sorted
   if (!isIncreasing(base_keys) || !isNotDecreasing(query_keys)) {
     throw std::invalid_argument("Either base_keys or query_keys is not sorted.");

--- a/common/interpolation/include/interpolation/interpolation_utils.hpp
+++ b/common/interpolation/include/interpolation/interpolation_utils.hpp
@@ -68,7 +68,7 @@ inline void validateKeys(
   // when size of vectors are less than 2
   if (query_keys.size() < 2) {
     throw std::invalid_argument(
-      "The size of points is less than 2. base_keys.size() = " + std::to_string(query_keys.size()));
+      "The size of points is less than 2. query_keys.size() = " + std::to_string(query_keys.size()));
   }
 
   // when indices are not sorted


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
走行中に、motion_planning_containerが落ちることによって、EMが発生する問題の対策PRとなる。

### 原因
coredumpの結果より、スプライン補間時に利用する点の情報が不足しているため、
存在しないオブジェクト情報に対するアクセスが原因と分かった。

```
#9  0x00007fdfee95d366 in interpolation_utils::validateKeys ()
    at /home/autoware/autoware.proj/src/autoware/universe/common/interpolation/include/interpolation/interpolation_utils.hpp:75
#10 0x00007fdfee95dc36 in SplineInterpolation::getSplineInterpolatedValues ()
    at /home/autoware/autoware.proj/src/autoware/universe/common/interpolation/src/spline_interpolation.cpp:152
#11 0x00007fdfee95f1bb in interpolation::slerp ()
    at /home/autoware/autoware.proj/src/autoware/universe/common/interpolation/src/spline_interpolation.cpp:94
#12 0x00007fdfeea9a3a6 in interpolation_utils::interpolate2DTrajectoryPoints () at /home/autoware/autoware.proj/src/autoware/universe/planning/obstacle_avoidance_planner/src/utils.cpp:346
```

### 対策
query_keysはサイズチェックを実施し、オブジェクト情報が不足している時はアクセスしないようにする。

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

https://tier4.atlassian.net/browse/AEAP-1142

## Tests performed

<!-- Describe how you have tested this PR. -->

### 機能評価
- 問題のあったrosbagを再生した時に、追加したエラーメッセージがコンソールに出力される事：
- 問題のあったrosbagを再生した時に、EMが発生しない事：
 
### リグレッション評価
- 問題のあった経路を走行した時に、EMが発生しない事：

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters. -->

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/