### PR TITLE
chore: display hazard status that has no hardware_id

### DIFF
--- a/common/tier4_system_rviz_plugin/src/mrm_summary_overlay_display.cpp
+++ b/common/tier4_system_rviz_plugin/src/mrm_summary_overlay_display.cpp
@@ -74,7 +74,7 @@ void insertNewlines(std::string & str, const size_t max_line_length)
 
 std::optional<std::string> generateMrmMessage(diagnostic_msgs::msg::DiagnosticStatus diag_status)
 {
-  if (diag_status.hardware_id == "" || diag_status.hardware_id == "system_error_monitor") {
+  if (diag_status.hardware_id == "system_error_monitor") {
     return std::nullopt;
   } else if (diag_status.level == diagnostic_msgs::msg::DiagnosticStatus::ERROR) {
     std::string msg = "- ERROR: " + diag_status.name + " (" + diag_status.message + ")";


### PR DESCRIPTION
## Description
:warning: This modification is only applied to this branch.

MRM Summary was not displayed when using the diagnostic graph aggregator because the hazard status message has no hardware_id.
So I fixed to display the hazard_status that has no hardware_id.

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

PSim
![image](https://github.com/tier4/autoware.universe/assets/11865769/e19035e6-e10b-499c-b291-23baf83808ef)


## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
