### PR TITLE
fix(pseudo occulusion): fix out of range access

### DIFF
--- a/planning/obstacle_cruise_planner/src/node.cpp
+++ b/planning/obstacle_cruise_planner/src/node.cpp
@@ -1181,6 +1181,14 @@ std::optional<SlowDownObstacle> ObstacleCruisePlannerNode::createSlowDownObstacl
       if (id == 0) {
         continue;
       }
+
+      if (!route_handler_->getLaneletMapPtr()->polygonLayer.exists(id)) {
+        RCLCPP_DEBUG(
+          rclcpp::get_logger("ObstacleCruisePlanner"),
+          "Specified Lanelet polygon id [%ld] is not exsit in the map", id);
+        continue;
+      }
+
       const auto intersection_poly =
         lanelet::utils::to2D(route_handler_->getLaneletMapPtr()->polygonLayer.get(id))
           .basicPolygon();


### PR DESCRIPTION
## Description
地図にないpolygonIDを指定すると例外をキャッチできずノードが死ぬ問題の修正です。

## Tests performed
適当な番号999999とかをいれたり、お台場の地図で動かして、弾けることを確認しました。
また、作動してほしい場所での動作に影響がないことを確認しました。

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
