### PR TITLE
feat(pointcloud preprocessor): add hysteresis to diag

### DIFF
--- a/launch/tier4_perception_launch/launch/obstacle_segmentation/ground_segmentation/ground_segmentation.launch.py
+++ b/launch/tier4_perception_launch/launch/obstacle_segmentation/ground_segmentation/ground_segmentation.launch.py
@@ -435,7 +435,7 @@ class GroundSegmentationPipeline:
         return ComposableNode(
             package="pointcloud_preprocessor",
             plugin="pointcloud_preprocessor::PointCloudConcatenationComponent",
-            name="concatenate_data",
+            name="concatenate_ground",
             remappings=[
                 ("output", output_topic),
             ],

--- a/sensing/pointcloud_preprocessor/include/pointcloud_preprocessor/concatenate_data/concatenate_and_time_sync_nodelet.hpp
+++ b/sensing/pointcloud_preprocessor/include/pointcloud_preprocessor/concatenate_data/concatenate_and_time_sync_nodelet.hpp
@@ -181,7 +181,7 @@ private:
   void timer_callback();
 
   void checkConcatStatus();
-  int concat_miss_count_{0};
+  int consecutive_concatenate_failures{0};
 
   std::string replaceSyncTopicNamePostfix(
     const std::string & original_topic_name, const std::string & postfix);

--- a/sensing/pointcloud_preprocessor/include/pointcloud_preprocessor/concatenate_data/concatenate_and_time_sync_nodelet.hpp
+++ b/sensing/pointcloud_preprocessor/include/pointcloud_preprocessor/concatenate_data/concatenate_and_time_sync_nodelet.hpp
@@ -63,11 +63,11 @@
 // ROS includes
 #include "autoware_point_types/types.hpp"
 
-#include <diagnostic_updater/diagnostic_updater.hpp>
 #include <point_cloud_msg_wrapper/point_cloud_msg_wrapper.hpp>
 #include <tier4_autoware_utils/ros/debug_publisher.hpp>
 #include <tier4_autoware_utils/system/stop_watch.hpp>
 
+#include <diagnostic_msgs/msg/diagnostic_array.hpp>
 #include <diagnostic_msgs/msg/diagnostic_status.hpp>
 #include <geometry_msgs/msg/twist_stamped.hpp>
 #include <geometry_msgs/msg/twist_with_covariance_stamped.hpp>
@@ -138,7 +138,7 @@ private:
   rclcpp::Subscription<nav_msgs::msg::Odometry>::SharedPtr sub_odom_;
 
   rclcpp::TimerBase::SharedPtr timer_;
-  diagnostic_updater::Updater updater_{this};
+  rclcpp::Publisher<diagnostic_msgs::msg::DiagnosticArray>::SharedPtr diagnostics_pub_;
 
   const std::string input_twist_topic_type_;
 
@@ -180,7 +180,7 @@ private:
   void odom_callback(const nav_msgs::msg::Odometry::ConstSharedPtr input);
   void timer_callback();
 
-  void checkConcatStatus(diagnostic_updater::DiagnosticStatusWrapper & stat);
+  void checkConcatStatus();
   std::string replaceSyncTopicNamePostfix(
     const std::string & original_topic_name, const std::string & postfix);
 

--- a/sensing/pointcloud_preprocessor/include/pointcloud_preprocessor/concatenate_data/concatenate_and_time_sync_nodelet.hpp
+++ b/sensing/pointcloud_preprocessor/include/pointcloud_preprocessor/concatenate_data/concatenate_and_time_sync_nodelet.hpp
@@ -181,6 +181,8 @@ private:
   void timer_callback();
 
   void checkConcatStatus();
+  int concat_miss_count_{0};
+
   std::string replaceSyncTopicNamePostfix(
     const std::string & original_topic_name, const std::string & postfix);
 

--- a/sensing/pointcloud_preprocessor/src/concatenate_data/concatenate_and_time_sync_nodelet.cpp
+++ b/sensing/pointcloud_preprocessor/src/concatenate_data/concatenate_and_time_sync_nodelet.cpp
@@ -697,19 +697,19 @@ void PointCloudConcatenateDataSynchronizerComponent::checkConcatStatus()
   }
 
   if(not_subscribed_topic_names_.size() > 0) {
-    concat_miss_count_ += 1;
+    consecutive_concatenate_failures += 1;
   }else{
-    concat_miss_count_ = 0;    
+    consecutive_concatenate_failures = 0;    
   }
 
   {
     diagnostic_msgs::msg::KeyValue key_value_msg;
-    key_value_msg.key = "miss_count";
-    key_value_msg.value = std::to_string(concat_miss_count_);
+    key_value_msg.key = "consecutiveConcatenateFailures";
+    key_value_msg.value = std::to_string(consecutive_concatenate_failures_);
     diag_status_msg.values.push_back(key_value_msg);
   }
 
-  if(concat_miss_count_ > 2){
+  if(consecutive_concatenate_failures > 1){
     diag_status_msg.level = diagnostic_msgs::msg::DiagnosticStatus::WARN;
     diag_status_msg.message = "Some topics are not concatenated";
   }else{

--- a/sensing/pointcloud_preprocessor/src/concatenate_data/concatenate_and_time_sync_nodelet.cpp
+++ b/sensing/pointcloud_preprocessor/src/concatenate_data/concatenate_and_time_sync_nodelet.cpp
@@ -211,9 +211,8 @@ PointCloudConcatenateDataSynchronizerComponent::PointCloudConcatenateDataSynchro
 
   // Diagnostic Updater
   {
-    updater_.setHardwareID("concatenate_data_checker");
-    updater_.add(
-      "concat_status", this, &PointCloudConcatenateDataSynchronizerComponent::checkConcatStatus);
+    diagnostics_pub_ =
+      this->create_publisher<diagnostic_msgs::msg::DiagnosticArray>("/diagnostics", 10);
   }
 }
 
@@ -463,7 +462,7 @@ void PointCloudConcatenateDataSynchronizerComponent::publish()
     }
   }
 
-  updater_.force_update();
+  checkConcatStatus();
 
   cloud_stdmap_ = cloud_stdmap_tmp_;
   std::for_each(std::begin(cloud_stdmap_tmp_), std::end(cloud_stdmap_tmp_), [](auto & e) {
@@ -684,12 +683,17 @@ void PointCloudConcatenateDataSynchronizerComponent::odom_callback(
   twist_ptr_queue_.push_back(twist_ptr);
 }
 
-void PointCloudConcatenateDataSynchronizerComponent::checkConcatStatus(
-  diagnostic_updater::DiagnosticStatusWrapper & stat)
+void PointCloudConcatenateDataSynchronizerComponent::checkConcatStatus()
 {
+  diagnostic_msgs::msg::DiagnosticStatus diag_status_msg;
+  diag_status_msg.name = std::string(this->get_name()) + ": concat_status";
+  diag_status_msg.hardware_id = "concatenate_data_checker";
+
   for (const std::string & e : input_topics_) {
-    const std::string subscribe_status = not_subscribed_topic_names_.count(e) ? "NG" : "OK";
-    stat.add(e, subscribe_status);
+    diagnostic_msgs::msg::KeyValue key_value_msg;
+    key_value_msg.key = e;
+    key_value_msg.value = not_subscribed_topic_names_.count(e) ? "NG" : "OK";
+    diag_status_msg.values.push_back(key_value_msg);
   }
 
   const int8_t level = not_subscribed_topic_names_.empty()
@@ -698,7 +702,15 @@ void PointCloudConcatenateDataSynchronizerComponent::checkConcatStatus(
   const std::string message = not_subscribed_topic_names_.empty()
                                 ? "Concatenate all topics"
                                 : "Some topics are not concatenated";
-  stat.summary(level, message);
+  diag_status_msg.level = level;
+  diag_status_msg.message = message;
+
+  diagnostic_msgs::msg::DiagnosticArray diag_msg;
+  diag_msg.header.stamp = this->now();
+  diag_msg.status.push_back(diag_status_msg);
+
+  diagnostics_pub_->publish(diag_msg);
+
 }
 }  // namespace pointcloud_preprocessor
 

--- a/sensing/pointcloud_preprocessor/src/concatenate_data/concatenate_and_time_sync_nodelet.cpp
+++ b/sensing/pointcloud_preprocessor/src/concatenate_data/concatenate_and_time_sync_nodelet.cpp
@@ -696,10 +696,10 @@ void PointCloudConcatenateDataSynchronizerComponent::checkConcatStatus()
     diag_status_msg.values.push_back(key_value_msg);
   }
 
-  if(not_subscribed_topic_names_.size() > 0) {
+  if (not_subscribed_topic_names_.size() > 0) {
     consecutive_concatenate_failures += 1;
-  }else{
-    consecutive_concatenate_failures = 0;    
+  } else {
+    consecutive_concatenate_failures = 0;
   }
 
   {
@@ -709,10 +709,10 @@ void PointCloudConcatenateDataSynchronizerComponent::checkConcatStatus()
     diag_status_msg.values.push_back(key_value_msg);
   }
 
-  if(consecutive_concatenate_failures > 1){
+  if (consecutive_concatenate_failures > 1) {
     diag_status_msg.level = diagnostic_msgs::msg::DiagnosticStatus::WARN;
     diag_status_msg.message = "Some topics are not concatenated";
-  }else{
+  } else {
     diag_status_msg.level = diagnostic_msgs::msg::DiagnosticStatus::OK;
     diag_status_msg.message = "Concatenate all topics";
   }
@@ -722,7 +722,6 @@ void PointCloudConcatenateDataSynchronizerComponent::checkConcatStatus()
   diag_msg.status.push_back(diag_status_msg);
 
   diagnostics_pub_->publish(diag_msg);
-
 }
 }  // namespace pointcloud_preprocessor
 

--- a/sensing/pointcloud_preprocessor/src/concatenate_data/concatenate_and_time_sync_nodelet.cpp
+++ b/sensing/pointcloud_preprocessor/src/concatenate_data/concatenate_and_time_sync_nodelet.cpp
@@ -696,14 +696,26 @@ void PointCloudConcatenateDataSynchronizerComponent::checkConcatStatus()
     diag_status_msg.values.push_back(key_value_msg);
   }
 
-  const int8_t level = not_subscribed_topic_names_.empty()
-                         ? diagnostic_msgs::msg::DiagnosticStatus::OK
-                         : diagnostic_msgs::msg::DiagnosticStatus::WARN;
-  const std::string message = not_subscribed_topic_names_.empty()
-                                ? "Concatenate all topics"
-                                : "Some topics are not concatenated";
-  diag_status_msg.level = level;
-  diag_status_msg.message = message;
+  if(not_subscribed_topic_names_.size() > 0) {
+    concat_miss_count_ += 1;
+  }else{
+    concat_miss_count_ = 0;    
+  }
+
+  {
+    diagnostic_msgs::msg::KeyValue key_value_msg;
+    key_value_msg.key = "miss_count";
+    key_value_msg.value = std::to_string(concat_miss_count_);
+    diag_status_msg.values.push_back(key_value_msg);
+  }
+
+  if(concat_miss_count_ > 2){
+    diag_status_msg.level = diagnostic_msgs::msg::DiagnosticStatus::WARN;
+    diag_status_msg.message = "Some topics are not concatenated";
+  }else{
+    diag_status_msg.level = diagnostic_msgs::msg::DiagnosticStatus::OK;
+    diag_status_msg.message = "Concatenate all topics";
+  }
 
   diagnostic_msgs::msg::DiagnosticArray diag_msg;
   diag_msg.header.stamp = this->now();


### PR DESCRIPTION
## Description
- stopped using diagnostics_updater to control /diagnostics publish timing

- Changed to publish diagnostics in WARN only when concat fails for more than 2 consecutive frames

- changed the node name of segmentation to distinguish between sensing concat and segmentation concat

## Related links

<!-- Write the links related to this PR. Private links should be clearly marked as private, for example, '[FOO COMPANY INTERNAL LINK](https://example.com)'. -->

## Tests performed
- Confirmed by actual vehicle

<!-- Describe how you have tested this PR. -->

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters. -->

### ROS Topic Changes

<!-- | Topic Name       | Type                | Direction | Update Description                                            | -->
<!-- | ---------------- | ------------------- | --------- | ------------------------------------------------------------- | -->
<!-- | `/example_topic` | `std_msgs/String`   | Subscribe | Description of what the topic is used for in the system       | -->
<!-- | `/another_topic` | `sensor_msgs/Image` | Publish   | Also explain if it is added / modified / deleted with the PR | -->

### ROS Parameter Changes

<!-- | Parameter Name       | Default Value | Update Description                                  | -->
<!-- | -------------------- | ------------- | --------------------------------------------------- | -->
<!-- | `example_parameters` | `1.0`         | Describe the parameter and also explain the updates | -->

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
