### PR TITLE
fix(pointcloud_preprocessor): typo consecutive_concatenate_failures

### DIFF
--- a/sensing/pointcloud_preprocessor/src/concatenate_data/concatenate_and_time_sync_nodelet.cpp
+++ b/sensing/pointcloud_preprocessor/src/concatenate_data/concatenate_and_time_sync_nodelet.cpp
@@ -705,7 +705,7 @@ void PointCloudConcatenateDataSynchronizerComponent::checkConcatStatus()
   {
     diagnostic_msgs::msg::KeyValue key_value_msg;
     key_value_msg.key = "consecutiveConcatenateFailures";
-    key_value_msg.value = std::to_string(consecutive_concatenate_failures_);
+    key_value_msg.value = std::to_string(consecutive_concatenate_failures);
     diag_status_msg.values.push_back(key_value_msg);
   }
 


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
In https://github.com/tier4/autoware.universe/pull/1309, `consecutive_concatenate_failures_` should be `consecutive_concatenate_failures`

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
