### PR TITLE
fix(multi_object_tracker): calculation of detection delay diagnostics

### DIFF
--- a/perception/multi_object_tracker/src/debugger.cpp
+++ b/perception/multi_object_tracker/src/debugger.cpp
@@ -80,7 +80,7 @@ void TrackerDebugger::checkDelay(diagnostic_updater::DiagnosticStatusWrapper & s
     stat.summary(diagnostic_msgs::msg::DiagnosticStatus::ERROR, "Measurement time is not set.");
     return;
   }
-  const double & delay = pipeline_latency_ms_;  // [s]
+  const double & delay = pipeline_latency_ms_ / 1e3;  // [s]
 
   if (delay == 0.0) {
     stat.summary(diagnostic_msgs::msg::DiagnosticStatus::OK, "Detection delay is not calculated.");


### PR DESCRIPTION
## Description
I fixed the calculation of detection delay diagnostics.

Related PR:
- https://github.com/tier4/autoware.universe/pull/1314

Related JIRA:
https://tier4.atlassian.net/browse/RT0-31411

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

I tested on simple planning simulator.

### Before
![image](https://github.com/tier4/autoware.universe/assets/11865769/4077d55b-a1ea-4e31-954d-4c76d224bd0e)


### After
![image](https://github.com/tier4/autoware.universe/assets/11865769/6e63b8e4-d6cb-4f06-a779-9039ddceb97f)


## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
