### PR TITLE
fix(staatic_obstacle_avoidance): allow return shift approval even if …

### DIFF
--- a/planning/behavior_path_avoidance_module/src/scene.cpp
+++ b/planning/behavior_path_avoidance_module/src/scene.cpp
@@ -1257,32 +1257,45 @@ bool AvoidanceModule::isValidShiftLine(
     }
   }
 
+  const auto is_return_shift =
+    [](const double start_shift_length, const double end_shift_length, const double threshold) {
+      return std::abs(start_shift_length) > threshold && std::abs(end_shift_length) < threshold;
+    };
+
   // check if the vehicle is in road. (yaw angle is not considered)
   {
     const auto minimum_distance = 0.5 * planner_data_->parameters.vehicle_width +
                                   parameters_->hard_road_shoulder_margin -
                                   parameters_->max_deviation_from_lane;
 
-    const size_t start_idx = shift_lines.front().start_idx;
-    const size_t end_idx = shift_lines.back().end_idx;
+    for (const auto & shift_line : shift_lines) {
+      const size_t start_idx = shift_line.start_idx;
+      const size_t end_idx = shift_line.end_idx;
 
-    const auto path = shifter_for_validate.getReferencePath();
-    const auto left_bound = lanelet::utils::to2D(toLineString3d(avoid_data_.left_bound));
-    const auto right_bound = lanelet::utils::to2D(toLineString3d(avoid_data_.right_bound));
-    for (size_t i = start_idx; i <= end_idx; ++i) {
-      const auto p = getPoint(path.points.at(i));
-      lanelet::BasicPoint2d basic_point{p.x, p.y};
+      if (is_return_shift(
+            shift_line.start_shift_length, shift_line.end_shift_length,
+            parameters_->lateral_small_shift_threshold)) {
+        continue;
+      }
 
-      const auto shift_length = proposed_shift_path.shift_length.at(i);
-      const auto THRESHOLD = minimum_distance + std::abs(shift_length);
+      const auto path = shifter_for_validate.getReferencePath();
+      const auto left_bound = lanelet::utils::to2D(toLineString3d(avoid_data_.left_bound));
+      const auto right_bound = lanelet::utils::to2D(toLineString3d(avoid_data_.right_bound));
+      for (size_t i = start_idx; i <= end_idx; ++i) {
+        const auto p = getPoint(path.points.at(i));
+        lanelet::BasicPoint2d basic_point{p.x, p.y};
 
-      if (
-        boost::geometry::distance(basic_point, (shift_length > 0.0 ? left_bound : right_bound)) <
-        THRESHOLD) {
-        RCLCPP_DEBUG_THROTTLE(
-          getLogger(), *clock_, 1000,
-          "following latest new shift line may cause deviation from drivable area.");
-        return false;
+        const auto shift_length = proposed_shift_path.shift_length.at(i);
+        const auto THRESHOLD = minimum_distance + std::abs(shift_length);
+
+        if (
+          boost::geometry::distance(basic_point, (shift_length > 0.0 ? left_bound : right_bound)) <
+          THRESHOLD) {
+          RCLCPP_DEBUG_THROTTLE(
+            getLogger(), *clock_, 1000,
+            "following latest new shift line may cause deviation from drivable area.");
+          return false;
+        }
       }
     }
   }


### PR DESCRIPTION
## Description
After avoidance is performed, it may be impossible to approve the behavior of returning to the original route due to environmental factors.
This may prevent the vehicle from continuing autonomous driving.
To solve this problem, the behavior of returning to the original route will not take drivable area constraints into account.


## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->
Tested by PSim.
with PR

https://github.com/tier4/autoware.universe/assets/19224532/1beb2227-3b97-4dde-b465-89494072e2f5

without PR

https://github.com/tier4/autoware.universe/assets/19224532/d5809586-90ab-4250-8f78-6a7b4b803af5


## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
