### PR TITLE
fix(motion_velocity_smoother): make stopping_distance and stopping_velocity be able to work (#6037)

### DIFF
--- a/planning/motion_velocity_smoother/src/motion_velocity_smoother_node.cpp
+++ b/planning/motion_velocity_smoother/src/motion_velocity_smoother_node.cpp
@@ -453,6 +453,9 @@ void MotionVelocitySmootherNode::onCurrentTrajectory(const Trajectory::ConstShar
     return;
   }
 
+  // Set 0 at the end of the trajectory
+  input_points.back().longitudinal_velocity_mps = 0.0;
+
   // calculate prev closest point
   if (!prev_output_.empty()) {
     current_closest_point_from_prev_output_ = calcProjectedTrajectoryPointFromEgo(prev_output_);


### PR DESCRIPTION
## Description

https://github.com/autowarefoundation/autoware.universe/pull/6037 のbackport
engage_velocity適用判定で使用するstop_distの計算において、経路終端が0になっているのが前提だが0になっておらずdouble::max()が常に出力されていたのを修正
https://github.com/tier4/autoware.universe/blob/fed4253d5b8c27f149dc2223e62c5f1a73476c3c/planning/motion_velocity_smoother/src/motion_velocity_smoother_node.cpp#L777

## Related links

https://tier4.atlassian.net/browse/VEH-1001

## Tests performed

psimにおいて、engage_velocity適用判定で使用するstop_distをデバッグコードを仕込んで出力できるようにし、正常な値が計算されていることを確認した
また、これまで停止際にengage_velocityが入力されていたが、入力されないことも確認した

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters. -->

### ROS Topic Changes

<!-- | Topic Name       | Type                | Direction | Update Description                                            | -->
<!-- | ---------------- | ------------------- | --------- | ------------------------------------------------------------- | -->
<!-- | `/example_topic` | `std_msgs/String`   | Subscribe | Description of what the topic is used for in the system       | -->
<!-- | `/another_topic` | `sensor_msgs/Image` | Publish   | Also explain if it is added / modified / deleted with the PR | -->

### ROS Parameter Changes

<!-- | Parameter Name       | Default Value | Update Description                                  | -->
<!-- | -------------------- | ------------- | --------------------------------------------------- | -->
<!-- | `example_parameters` | `1.0`         | Describe the parameter and also explain the updates | -->

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.
- [ ] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
