### PR TITLE
perf(side_shift): fix unupdated prev path

### DIFF
--- a/planning/behavior_path_side_shift_module/include/behavior_path_side_shift_module/scene.hpp
+++ b/planning/behavior_path_side_shift_module/include/behavior_path_side_shift_module/scene.hpp
@@ -92,7 +92,6 @@ private:
   // member
   PathWithLaneId refined_path_{};
   PathWithLaneId reference_path_{};
-  PathWithLaneId prev_reference_{};
   lanelet::ConstLanelets current_lanelets_;
   std::shared_ptr<SideShiftParameters> parameters_;
 


### PR DESCRIPTION
## Description
Related to [issue](https://tier4.atlassian.net/browse/RT1-6473) in odaiba reference drive.
This PR would make an appropriate side shift path; the path would be inside the driving area (specially behind the ego vehicle).

## Tests performed
PSim
Before
[Screencast from 2024年06月20日 14時32分48秒.webm](https://github.com/tier4/autoware.universe/assets/12757369/2f2dc5b5-1e82-41e1-bd19-d8ca6e783d20)
After
[Screencast from 2024年06月20日 14時43分57秒.webm](https://github.com/tier4/autoware.universe/assets/12757369/b2e8ab46-4bc8-4dbd-b88e-2228bba61541)


## Effects on system behavior
Not applicable.

## Interface changes

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
