### PR TITLE
feat(mrm_handler): operate mrm only when autonomous operation mode

### DIFF
--- a/system/mrm_handler/include/mrm_handler/mrm_handler_core.hpp
+++ b/system/mrm_handler/include/mrm_handler/mrm_handler_core.hpp
@@ -148,7 +148,8 @@ private:
   bool isStopped();
   bool isDrivingBackwards();
   bool isEmergency() const;
-  bool isAutonomous();
+  bool isControlModeAutonomous();
+  bool isOperationModeAutonomous();
   bool isPullOverStatusAvailable();
   bool isComfortableStopStatusAvailable();
   bool isEmergencyStopStatusAvailable();

--- a/system/mrm_handler/src/mrm_handler/mrm_handler_core.cpp
+++ b/system/mrm_handler/src/mrm_handler/mrm_handler_core.cpp
@@ -396,12 +396,13 @@ void MrmHandler::updateMrmState()
   }
 
   // Get mode
-  const bool is_auto_mode = isAutonomous();
+  const bool is_control_mode_autonomous = isControlModeAutonomous();
+  const bool is_operation_mode_autonomous = isOperationModeAutonomous();
 
   // State Machine
   switch (mrm_state_.state) {
     case MrmState::NORMAL:
-      if (is_auto_mode) {
+      if (is_control_mode_autonomous && is_operation_mode_autonomous) {
         transitionTo(MrmState::MRM_OPERATING);
       }
       return;
@@ -537,12 +538,20 @@ bool MrmHandler::isEmergency() const
          is_operation_mode_availability_timeout;
 }
 
-bool MrmHandler::isAutonomous()
+bool MrmHandler::isControlModeAutonomous()
 {
   using autoware_vehicle_msgs::msg::ControlModeReport;
   auto mode = sub_control_mode_.takeData();
   if (mode == nullptr) return false;
   return mode->mode == ControlModeReport::AUTONOMOUS;
+}
+
+bool MrmHandler::isOperationModeAutonomous()
+{
+  using autoware_adapi_v1_msgs::msg::OperationModeState;
+  auto state = sub_operation_mode_state_.takeData();
+  if (state == nullptr) return false;
+  return state->mode == OperationModeState::AUTONOMOUS;
 }
 
 bool MrmHandler::isPullOverStatusAvailable()


### PR DESCRIPTION
For the simulation test, all of the scenario tests will be failed. Let me cherry-pick this PR, that has been merged in awf/autoware.universe.

We had talked about it in [slack](https://star4.slack.com/archives/C04TZBEABDM/p1719885974285699?thread_ts=1719815589.540119&cid=C04TZBEABDM)

PR: https://github.com/autowarefoundation/autoware.universe/pull/7784