### PR TITLE
fix(image_transport_decompressor): missing config setting (#7615)

### DIFF
--- a/sensing/image_transport_decompressor/CMakeLists.txt
+++ b/sensing/image_transport_decompressor/CMakeLists.txt
@@ -24,4 +24,5 @@ rclcpp_components_register_node(image_transport_decompressor
 
 ament_auto_package(INSTALL_TO_SHARE
   launch
+  config
 )


### PR DESCRIPTION
## Description
yoloxで使用するimage_tranport_decomposerが参照するconfigがビルド対象に含まれておらず、roscube側で起動時即死します。
https://github.com/autowarefoundation/autoware.universe/pull/7615

## Tests performed

<!-- Describe how you have tested this PR. -->
<!-- Although the default value is set to "Not Applicable.", please update this section if the type is either [feat, fix, perf], or if requested by the reviewers. -->

Not applicable.

## Effects on system behavior

<!-- Describe how this PR affects the system behavior. -->

Not applicable.

## Interface changes

<!-- Describe any changed interfaces, such as topics, services, or parameters, including debugging interfaces -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [ ] I've confirmed the [contribution guidelines].
- [ ] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [ ] There are no open discussions or they are tracked via tickets.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/
