### PR TITLE
fix(pid_longitudinal_controller): fix cherry-pick

### DIFF
--- a/control/pid_longitudinal_controller/src/pid_longitudinal_controller.cpp
+++ b/control/pid_longitudinal_controller/src/pid_longitudinal_controller.cpp
@@ -734,7 +734,7 @@ void PidLongitudinalController::updateControlState(const ControlData & control_d
         auto marker = createDefaultMarker(
           "map", clock_->now(), "stop_reason", 0, Marker::TEXT_VIEW_FACING,
           createMarkerScale(0.0, 0.0, 1.0), createMarkerColor(1.0, 1.0, 1.0, 0.999));
-        marker.pose = autoware::universe_utils::calcOffsetPose(
+        marker.pose = tier4_autoware_utils::calcOffsetPose(
           m_current_kinematic_state.pose.pose, m_wheel_base + m_front_overhang,
           m_vehicle_width / 2 + 2.0, 1.5);
         marker.text = "steering not\nconverged";

--- a/control/trajectory_follower_node/test/test_controller_node.cpp
+++ b/control/trajectory_follower_node/test/test_controller_node.cpp
@@ -598,7 +598,7 @@ TEST_F(FakeNodeFixture, longitudinal_check_steer_converged)
 
     ASSERT_TRUE(tester.received_control_command);
     // Keep stopped state when the lateral control is not converged.
-    EXPECT_DOUBLE_EQ(tester.cmd_msg->longitudinal.velocity, 0.0f);
+    EXPECT_DOUBLE_EQ(tester.cmd_msg->longitudinal.speed, 0.0f);
   }
 
   {  // Check if the ego can keep stopped after the following sequence
@@ -613,6 +613,6 @@ TEST_F(FakeNodeFixture, longitudinal_check_steer_converged)
 
     ASSERT_TRUE(tester.received_control_command);
     // Keep stopped state when the lateral control is not converged.
-    EXPECT_DOUBLE_EQ(tester.cmd_msg->longitudinal.velocity, 0.0f);
+    EXPECT_DOUBLE_EQ(tester.cmd_msg->longitudinal.speed, 0.0f);
   }
 }


### PR DESCRIPTION
## Description

fix of https://github.com/tier4/autoware.universe/pull/1404

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
