### PR TITLE
fix(autoware_external_cmd_converter, system_diagnostic_monitor): fix check_topic_state and local mode config

### DIFF
--- a/system/system_diagnostic_monitor/config/control.yaml
+++ b/system/system_diagnostic_monitor/config/control.yaml
@@ -13,14 +13,14 @@ units:
   - path: /autoware/control/local
     type: and
     list:
-      - { type: link, link: /autoware/control/topic_rate_check/selector }
-      - { type: link, link: /autoware/control/topic_rate_check/local }
+      - { type: link, link: /autoware/control/topic_rate_check/external_cmd_selector }
+      - { type: link, link: /autoware/control/topic_rate_check/external_cmd_converter }
 
   - path: /autoware/control/remote
     type: and
     list:
-      - { type: link, link: /autoware/control/topic_rate_check/selector }
-      - { type: link, link: /autoware/control/topic_rate_check/remote }
+      - { type: link, link: /autoware/control/topic_rate_check/external_cmd_selector }
+      - { type: link, link: /autoware/control/topic_rate_check/external_cmd_converter }
 
   - path: /autoware/control/topic_rate_check/trajectory_follower
     type: diag
@@ -57,17 +57,12 @@ units:
     node: controller_node_exe
     name: control_state
 
-  - path: /autoware/control/topic_rate_check/selector
+  - path: /autoware/control/topic_rate_check/external_cmd_selector
     type: diag
     node: external_cmd_selector
     name: heartbeat
 
-  - path: /autoware/control/topic_rate_check/local
-    type: diag
-    node: joy_controller
-    name: joy_controller_connection
-
-  - path: /autoware/control/topic_rate_check/remote
+  - path: /autoware/control/topic_rate_check/external_cmd_converter
     type: diag
     node: external_cmd_converter
     name: remote_control_topic_status

--- a/vehicle/autoware_external_cmd_converter/src/node.cpp
+++ b/vehicle/autoware_external_cmd_converter/src/node.cpp
@@ -179,6 +179,9 @@ void ExternalCmdConverterNode::check_topic_status(
 {
   using diagnostic_msgs::msg::DiagnosticStatus;
   DiagnosticStatus status;
+
+  current_gate_mode_ = gate_mode_sub_.takeData();
+
   if (!check_emergency_stop_topic_timeout()) {
     status.level = DiagnosticStatus::ERROR;
     status.message = "emergency stop topic is timeout";
@@ -195,6 +198,14 @@ void ExternalCmdConverterNode::check_topic_status(
 
 bool ExternalCmdConverterNode::check_emergency_stop_topic_timeout()
 {
+  if (!current_gate_mode_) {
+    return true;
+  }
+
+  if (current_gate_mode_->data == tier4_control_msgs::msg::GateMode::AUTO) {
+    latest_emergency_stop_heartbeat_received_time_ = nullptr;
+  }
+
   if (!latest_emergency_stop_heartbeat_received_time_) {
     return wait_for_first_topic_;
   }
@@ -205,8 +216,6 @@ bool ExternalCmdConverterNode::check_emergency_stop_topic_timeout()
 
 bool ExternalCmdConverterNode::check_remote_topic_rate()
 {
-  current_gate_mode_ = gate_mode_sub_.takeData();
-
   if (!current_gate_mode_) {
     return true;
   }


### PR DESCRIPTION
## Description
Cherry-pick to use local mode:
https://github.com/autowarefoundation/autoware.universe/pull/7921
https://github.com/autowarefoundation/autoware.universe/pull/7532

## Related links

**Parent Issue:**

- Link
https://github.com/autowarefoundation/autoware.universe/pull/7921
https://github.com/autowarefoundation/autoware.universe/pull/7532

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
