### PR TITLE
feat(motion_velocity_smoother): force slow driving

### DIFF
--- a/planning/motion_velocity_smoother/include/motion_velocity_smoother/motion_velocity_smoother_node.hpp
+++ b/planning/motion_velocity_smoother/include/motion_velocity_smoother/motion_velocity_smoother_node.hpp
@@ -132,6 +132,12 @@ private:
     NORMAL = 3,
   };
 
+  enum class ForceSlowDrivingType{
+    DEACTIVATED = 0,
+    READY = 1,
+    ACTIVATED = 2,
+  };
+
   struct ForceAccelerationParam
   {
     double max_acceleration;
@@ -168,6 +174,7 @@ private:
     bool plan_from_ego_speed_on_manual_mode = true;
 
     ForceAccelerationParam force_acceleration_param;
+    double force_slow_driving_velocity;
   } node_param_{};
 
   struct ExternalVelocityLimit
@@ -257,11 +264,16 @@ private:
 
   // parameter handling
   void initCommonParam();
+
+  // Related to force acceleration
   void onForceAcceleration(
     const std::shared_ptr<SetBool::Request> request, std::shared_ptr<SetBool::Response> response);
   bool force_acceleration_mode_;
+
+  // Related to force slow driving
   void onSlowDriving(
     const std::shared_ptr<SetBool::Request> request, std::shared_ptr<SetBool::Response> response);
+  ForceSlowDrivingType force_slow_driving_mode_;
 
   // debug
   tier4_autoware_utils::StopWatch<std::chrono::milliseconds> stop_watch_;

--- a/planning/motion_velocity_smoother/include/motion_velocity_smoother/motion_velocity_smoother_node.hpp
+++ b/planning/motion_velocity_smoother/include/motion_velocity_smoother/motion_velocity_smoother_node.hpp
@@ -132,7 +132,7 @@ private:
     NORMAL = 3,
   };
 
-  enum class ForceSlowDrivingType{
+  enum class ForceSlowDrivingType {
     DEACTIVATED = 0,
     READY = 1,
     ACTIVATED = 2,

--- a/planning/motion_velocity_smoother/src/motion_velocity_smoother_node.cpp
+++ b/planning/motion_velocity_smoother/src/motion_velocity_smoother_node.cpp
@@ -79,6 +79,7 @@ MotionVelocitySmootherNode::MotionVelocitySmootherNode(const rclcpp::NodeOptions
   srv_slow_driving_ = create_service<SetBool>(
     "~/slow_driving", std::bind(&MotionVelocitySmootherNode::onSlowDriving, this, _1, _2));
   force_acceleration_mode_ = false;
+  force_slow_driving_mode_ = ForceSlowDrivingType::DEACTIVATED;
 
   // parameter update
   set_param_res_ = this->add_on_set_parameters_callback(
@@ -205,6 +206,7 @@ rcl_interfaces::msg::SetParametersResult MotionVelocitySmootherNode::onParameter
     update_param("force_acceleration.engage_velocity", p.force_acceleration_param.engage_velocity);
     update_param(
       "force_acceleration.engage_acceleration", p.force_acceleration_param.engage_acceleration);
+    update_param("force_slow_driving.velocity", p.force_slow_driving_velocity);
   }
 
   {
@@ -334,6 +336,8 @@ void MotionVelocitySmootherNode::initCommonParam()
     declare_parameter<double>("force_acceleration.engage_velocity");
   p.force_acceleration_param.engage_acceleration =
     declare_parameter<double>("force_acceleration.engage_acceleration");
+
+  p.force_slow_driving_velocity = declare_parameter<double>("force_slow_driving.velocity");
 }
 
 void MotionVelocitySmootherNode::publishTrajectory(const TrajectoryPoints & trajectory) const
@@ -504,6 +508,11 @@ void MotionVelocitySmootherNode::onCurrentTrajectory(const Trajectory::ConstShar
     flipVelocity(input_points);
   }
 
+  double vel_threshold = get_parameter("force_slow_driving.velocity").as_double();
+  if (force_slow_driving_mode_ == ForceSlowDrivingType::READY && current_odometry_ptr_->twist.twist.linear.x < vel_threshold) {
+    force_slow_driving_mode_ = ForceSlowDrivingType::ACTIVATED;
+  }
+
   const auto output = calcTrajectoryVelocity(input_points);
   if (output.empty()) {
     RCLCPP_WARN(get_logger(), "Output Point is empty");
@@ -588,6 +597,14 @@ TrajectoryPoints MotionVelocitySmootherNode::calcTrajectoryVelocity(
 
   // Apply velocity to approach stop point
   applyStopApproachingVelocity(traj_extracted);
+
+  // Apply force slow driving if activated
+  double vel_threshold = get_parameter("force_slow_driving.velocity").as_double();
+  if(force_slow_driving_mode_ == ForceSlowDrivingType::ACTIVATED){
+    for (auto & tp : traj_extracted) {
+      tp.longitudinal_velocity_mps = vel_threshold;
+    }
+  }
 
   // Debug
   if (publish_debug_trajs_) {
@@ -1156,12 +1173,25 @@ void MotionVelocitySmootherNode::onForceAcceleration(
   }
 
   response->success = true;
+  response->message = message;
 }
 
 void MotionVelocitySmootherNode::onSlowDriving(
   const std::shared_ptr<SetBool::Request> request, std::shared_ptr<SetBool::Response> response)
 {
-  const std::string message = request->data ? "Slow driving" : "Default";
+  std::string message = "default";
+  if (request->data) {
+    RCLCPP_INFO(get_logger(), "Force slow driving is activated");
+    
+    if(force_slow_driving_mode_ == ForceSlowDrivingType::DEACTIVATED)
+      force_slow_driving_mode_ = ForceSlowDrivingType::READY;
+
+    message = "Activated force slow drving";
+  } else {
+    RCLCPP_INFO(get_logger(), "Force slow driving is deactivated");
+    force_slow_driving_mode_ = ForceSlowDrivingType::DEACTIVATED;
+    message = "Deactivated force slow driving";
+  }
 
   response->success = true;
   response->message = message;

--- a/planning/motion_velocity_smoother/src/motion_velocity_smoother_node.cpp
+++ b/planning/motion_velocity_smoother/src/motion_velocity_smoother_node.cpp
@@ -1180,14 +1180,13 @@ void MotionVelocitySmootherNode::onSlowDriving(
   const std::shared_ptr<SetBool::Request> request, std::shared_ptr<SetBool::Response> response)
 {
   std::string message = "default";
-  if (request->data) {
+  if (request->data && force_slow_driving_mode_ == ForceSlowDrivingType::DEACTIVATED) {
     RCLCPP_INFO(get_logger(), "Force slow driving is activated");
     
-    if(force_slow_driving_mode_ == ForceSlowDrivingType::DEACTIVATED)
-      force_slow_driving_mode_ = ForceSlowDrivingType::READY;
+    force_slow_driving_mode_ = ForceSlowDrivingType::READY;
 
     message = "Activated force slow drving";
-  } else {
+  } else if(!request->data) {
     RCLCPP_INFO(get_logger(), "Force slow driving is deactivated");
     force_slow_driving_mode_ = ForceSlowDrivingType::DEACTIVATED;
     message = "Deactivated force slow driving";


### PR DESCRIPTION
## Description
This PR adds a force slow driving function to the motion_velocity_smoother node. The function is activated when there is a trigger from the FOA. It can only be activated when the ego velocity is lower than the threshold.
ex. Use when start/goal planner is stuck

## Related links
[launch](https://github.com/tier4/autoware_launch.xx1/pull/899)

## How was this PR tested?
Vehicle experiment + PSim

## Notes for reviewers
This is a temporary function.

## Interface changes
None.

## Effects on system behavior
None.
