### PR TITLE
feat(blind_spot): consider road_shoulder if exist

### DIFF
--- a/planning/behavior_velocity_blind_spot_module/src/scene.cpp
+++ b/planning/behavior_velocity_blind_spot_module/src/scene.cpp
@@ -550,6 +550,13 @@ std::optional<BlindSpotPolygons> BlindSpotModule::generateBlindSpotPolygons(
       if (adj_lane) {
         return *adj_lane;
       }
+      const auto assoc_shoulder =
+        (turn_direction_ == TurnDirection::LEFT)
+          ? planner_data_->route_handler_->getLeftLanelet(lane, true /* get_shoulder_lane */)
+          : planner_data_->route_handler_->getRightLanelet(lane, true);
+      if (assoc_shoulder) {
+        return assoc_shoulder.value();
+      }
 
       return std::nullopt;
     });


### PR DESCRIPTION
## Description
Equivalent change to
https://github.com/autowarefoundation/autoware.universe/pull/7925


## Related links
**Parent Issue:**

- [TIER IV internal link](https://tier4.atlassian.net/browse/RT0-32251)


<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
