### PR TITLE
Changing the logic of external_request_lane_change

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/utils/utils.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/utils/utils.cpp
@@ -277,7 +277,8 @@ lanelet::ConstLanelets getTargetNeighborLanes(
     if (route_handler.getNumLaneToPreferredLane(current_lane) != 0) {
       if (
         type == LaneChangeModuleType::NORMAL ||
-        type == LaneChangeModuleType::AVOIDANCE_BY_LANE_CHANGE) {
+        type == LaneChangeModuleType::AVOIDANCE_BY_LANE_CHANGE ||
+        type == LaneChangeModuleType::EXTERNAL_REQUEST) {
         neighbor_lanes.push_back(current_lane);
       }
     } else {


### PR DESCRIPTION
## Description
Now external_request_lane_change_module suggests changing the lane only if the ego is on the target lane. In order for external_request_lane_change_module to offer to change the lane even if it is not on the target lane, it is necessary to make a small change to the lane_change_module code.
