### PR TITLE
fix: resolve build error of dummy diag publisher

### DIFF
--- a/system/dummy_diag_publisher/src/dummy_diag_publisher_core.cpp
+++ b/system/dummy_diag_publisher/src/dummy_diag_publisher_core.cpp
@@ -140,7 +140,7 @@ rclcpp::NodeOptions override_options(rclcpp::NodeOptions options)
 }
 
 DummyDiagPublisher::DummyDiagPublisher(const rclcpp::NodeOptions & options)
-: Node("dummy_diag_publisher", override_options(options)), updater_(this)
+: Node("dummy_diag_publisher", override_options(options))
 
 {
   // Parameter


### PR DESCRIPTION
## Description
I did wrong commit in [PR1414](https://github.com/tier4/autoware.universe/pull/1414).
This PR fix build issue of this PR. Sorry for inconvenient.
## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
