### PR TITLE
fix(star/goal_planner): improve start/goal planner

### DIFF
--- a/common/autoware_motion_utils/src/trajectory/trajectory.cpp
+++ b/common/autoware_motion_utils/src/trajectory/trajectory.cpp
@@ -238,14 +238,14 @@ calcCurvature<std::vector<autoware_planning_msgs::msg::TrajectoryPoint>>(
   const std::vector<autoware_planning_msgs::msg::TrajectoryPoint> & points);
 
 //
-template std::vector<std::pair<double, double>>
-calcCurvatureAndArcLength<std::vector<autoware_planning_msgs::msg::PathPoint>>(
+template std::vector<std::pair<double, std::pair<double, double>>>
+calcCurvatureAndSegmentLength<std::vector<autoware_planning_msgs::msg::PathPoint>>(
   const std::vector<autoware_planning_msgs::msg::PathPoint> & points);
-template std::vector<std::pair<double, double>>
-calcCurvatureAndArcLength<std::vector<tier4_planning_msgs::msg::PathPointWithLaneId>>(
+template std::vector<std::pair<double, std::pair<double, double>>>
+calcCurvatureAndSegmentLength<std::vector<tier4_planning_msgs::msg::PathPointWithLaneId>>(
   const std::vector<tier4_planning_msgs::msg::PathPointWithLaneId> & points);
-template std::vector<std::pair<double, double>>
-calcCurvatureAndArcLength<std::vector<autoware_planning_msgs::msg::TrajectoryPoint>>(
+template std::vector<std::pair<double, std::pair<double, double>>>
+calcCurvatureAndSegmentLength<std::vector<autoware_planning_msgs::msg::TrajectoryPoint>>(
   const std::vector<autoware_planning_msgs::msg::TrajectoryPoint> & points);
 
 //

--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/config/goal_planner.param.yaml
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/config/goal_planner.param.yaml
@@ -22,6 +22,7 @@
         lateral_offset_interval: 0.25
         ignore_distance_from_lane_start: 0.0
         margin_from_boundary: 0.5
+        high_curvature_threshold: 0.1
 
       # occupancy grid map
       occupancy_grid:

--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/include/autoware/behavior_path_goal_planner_module/goal_planner_parameters.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/include/autoware/behavior_path_goal_planner_module/goal_planner_parameters.hpp
@@ -60,6 +60,7 @@ struct GoalPlannerParameters
   double lateral_offset_interval{0.0};
   double ignore_distance_from_lane_start{0.0};
   double margin_from_boundary{0.0};
+  double high_curvature_threshold{0.0};
 
   // occupancy grid map
   bool use_occupancy_grid_for_goal_search{false};

--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/include/autoware/behavior_path_goal_planner_module/pull_over_planner_base.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/include/autoware/behavior_path_goal_planner_module/pull_over_planner_base.hpp
@@ -52,6 +52,7 @@ struct PullOverPath
   size_t goal_id{};
   size_t id{};
   bool decided_velocity{false};
+  double max_curvature{0.0};  // max curvature of the parking path
 
   PathWithLaneId getFullPath() const
   {
@@ -72,6 +73,7 @@ struct PullOverPath
     return path;
   }
 
+  // path from the pull over start pose to the end pose
   PathWithLaneId getParkingPath() const
   {
     const PathWithLaneId full_path = getFullPath();

--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/manager.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/manager.cpp
@@ -61,6 +61,7 @@ void GoalPlannerModuleManager::init(rclcpp::Node * node)
     p.ignore_distance_from_lane_start =
       node->declare_parameter<double>(ns + "ignore_distance_from_lane_start");
     p.margin_from_boundary = node->declare_parameter<double>(ns + "margin_from_boundary");
+    p.high_curvature_threshold = node->declare_parameter<double>(ns + "high_curvature_threshold");
 
     const std::string parking_policy_name =
       node->declare_parameter<std::string>(ns + "parking_policy");

--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/shift_pull_over.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/shift_pull_over.cpp
@@ -308,8 +308,19 @@ double ShiftPullOver::calcBeforeShiftedArcLength(
 
   double before_arc_length{0.0};
   double after_arc_length{0.0};
-  for (const auto & [k, segment_length] :
-       autoware::motion_utils::calcCurvatureAndArcLength(reversed_path.points)) {
+
+  const auto curvature_and_segment_length =
+    autoware::motion_utils::calcCurvatureAndSegmentLength(reversed_path.points);
+
+  for (size_t i = 0; i < curvature_and_segment_length.size(); ++i) {
+    const auto & [k, segment_length_pair] = curvature_and_segment_length[i];
+
+    // If it is the last point, add the lengths of the previous and next segments.
+    // For other points, only add the length of the previous segment.
+    const double segment_length = i == curvature_and_segment_length.size() - 1
+                                    ? segment_length_pair.first
+                                    : segment_length_pair.first + segment_length_pair.second;
+
     // after shifted segment length
     const double after_segment_length =
       k > 0 ? segment_length * (1 + k * dr) : segment_length / (1 - k * dr);

--- a/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/include/autoware/behavior_path_start_planner_module/data_structs.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/include/autoware/behavior_path_start_planner_module/data_structs.hpp
@@ -90,6 +90,9 @@ struct StartPlannerDebugData
   std::vector<Pose> start_pose_candidates;
   size_t selected_start_pose_candidate_index;
   double margin_for_start_pose_candidate;
+
+  // for isPreventingRearVehicleFromPassingThrough
+  std::optional<Pose> estimated_stop_pose;
 };
 
 struct StartPlannerParameters

--- a/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/include/autoware/behavior_path_start_planner_module/start_planner_module.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/include/autoware/behavior_path_start_planner_module/start_planner_module.hpp
@@ -229,7 +229,30 @@ private:
 
   bool isModuleRunning() const;
   bool isCurrentPoseOnMiddleOfTheRoad() const;
+
+  /**
+   * @brief Check if the ego vehicle is preventing the rear vehicle from passing through.
+   *
+   * This function just call isPreventingRearVehicleFromPassingThrough(const Pose & ego_pose) with
+   * two poses. If rear vehicle is obstructed by ego vehicle at either of the two poses, it returns
+   * true.
+   *
+   * @return true if the ego vehicle is preventing the rear vehicle from passing through with the
+   * current pose or the pose if it stops.
+   */
   bool isPreventingRearVehicleFromPassingThrough() const;
+
+  /**
+    * @brief Check if the ego vehicle is preventing the rear vehicle from passing through.
+    *
+    * This function measures the distance to the lane boundary from the current pose and the pose if
+it stops, and determines whether there is enough space for the rear vehicle to pass through. If
+    * it is obstructing at either of the two poses, it returns true.
+    *
+    * @return true if the ego vehicle is preventing the rear vehicle from passing through with given
+ego pose.
+    */
+  bool isPreventingRearVehicleFromPassingThrough(const Pose & ego_pose) const;
 
   bool isCloseToOriginalStartPose() const;
   bool hasArrivedAtGoal() const;

--- a/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/src/shift_pull_out.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/src/shift_pull_out.cpp
@@ -423,8 +423,17 @@ double ShiftPullOut::calcBeforeShiftedArcLength(
   double before_arc_length{0.0};
   double after_arc_length{0.0};
 
-  for (const auto & [k, segment_length] :
-       autoware::motion_utils::calcCurvatureAndArcLength(path.points)) {
+  const auto curvatures_and_segment_lengths =
+    autoware::motion_utils::calcCurvatureAndSegmentLength(path.points);
+  for (size_t i = 0; i < curvatures_and_segment_lengths.size(); ++i) {
+    const auto & [k, segment_length_pair] = curvatures_and_segment_lengths.at(i);
+
+    // If it is the last point, add the lengths of the previous and next segments.
+    // For other points, only add the length of the previous segment.
+    const double segment_length = i == curvatures_and_segment_lengths.size() - 1
+                                    ? segment_length_pair.first + segment_length_pair.second
+                                    : segment_length_pair.first;
+
     // after shifted segment length
     const double after_segment_length =
       k < 0 ? segment_length * (1 - k * dr) : segment_length / (1 + k * dr);

--- a/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/src/start_planner_module.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_start_planner_module/src/start_planner_module.cpp
@@ -368,7 +368,35 @@ bool StartPlannerModule::isCurrentPoseOnMiddleOfTheRoad() const
 
 bool StartPlannerModule::isPreventingRearVehicleFromPassingThrough() const
 {
+  // prepare poses for preventing check
+  // - current_pose
+  // - estimated_stop_pose (The position assumed when stopped with the minimum stop distance,
+  // although it is NOT actually stopped)
   const auto & current_pose = planner_data_->self_odometry->pose.pose;
+  std::vector<Pose> preventing_check_pose{current_pose};
+  const auto min_stop_distance =
+    autoware::behavior_path_planner::utils::parking_departure::calcFeasibleDecelDistance(
+      planner_data_, parameters_->maximum_deceleration_for_stop, parameters_->maximum_jerk_for_stop,
+      0.0);
+  debug_data_.estimated_stop_pose.reset();  // debug
+  if (min_stop_distance.has_value()) {
+    const auto current_path = getCurrentPath();
+    const auto estimated_stop_pose = calcLongitudinalOffsetPose(
+      current_path.points, current_pose.position, min_stop_distance.value());
+    if (estimated_stop_pose.has_value()) {
+      preventing_check_pose.push_back(estimated_stop_pose.value());
+      debug_data_.estimated_stop_pose = estimated_stop_pose.value();  // debug
+    }
+  }
+
+  // check if any of the preventing check poses are preventing rear vehicle from passing through
+  return std::any_of(
+    preventing_check_pose.begin(), preventing_check_pose.end(),
+    [&](const auto & pose) { return isPreventingRearVehicleFromPassingThrough(pose); });
+}
+
+bool StartPlannerModule::isPreventingRearVehicleFromPassingThrough(const Pose & ego_pose) const
+{
   const auto & dynamic_object = planner_data_->dynamic_object;
   const auto & route_handler = planner_data_->route_handler;
   const Pose start_pose = planner_data_->route_handler->getOriginalStartPose();
@@ -414,8 +442,8 @@ bool StartPlannerModule::isPreventingRearVehicleFromPassingThrough() const
       geometry_msgs::msg::Pose & ego_overhang_point_as_pose,
       const bool ego_is_merging_from_the_left) -> std::optional<std::pair<double, double>> {
     const auto local_vehicle_footprint = vehicle_info_.createFootprint();
-    const auto vehicle_footprint = transformVector(
-      local_vehicle_footprint, autoware::universe_utils::pose2transform(current_pose));
+    const auto vehicle_footprint =
+      transformVector(local_vehicle_footprint, autoware::universe_utils::pose2transform(ego_pose));
     double smallest_lateral_gap_between_ego_and_border = std::numeric_limits<double>::max();
     double corresponding_lateral_gap_with_other_lane_bound = std::numeric_limits<double>::max();
 
@@ -481,7 +509,7 @@ bool StartPlannerModule::isPreventingRearVehicleFromPassingThrough() const
     // Check backwards just in case the Vehicle behind ego is in a different lanelet
     constexpr double backwards_length = 200.0;
     const auto prev_lanes = autoware::behavior_path_planner::utils::getBackwardLanelets(
-      *route_handler, target_lanes, current_pose, backwards_length);
+      *route_handler, target_lanes, ego_pose, backwards_length);
     // return all the relevant lanelets
     lanelet::ConstLanelets relevant_lanelets{closest_lanelet_const};
     relevant_lanelets.insert(relevant_lanelets.end(), prev_lanes.begin(), prev_lanes.end());
@@ -491,7 +519,7 @@ bool StartPlannerModule::isPreventingRearVehicleFromPassingThrough() const
 
   // filtering objects with velocity, position and class
   const auto filtered_objects = utils::path_safety_checker::filterObjects(
-    dynamic_object, route_handler, relevant_lanelets.value(), current_pose.position,
+    dynamic_object, route_handler, relevant_lanelets.value(), ego_pose.position,
     objects_filtering_params_);
   if (filtered_objects.objects.empty()) return false;
 
@@ -508,7 +536,7 @@ bool StartPlannerModule::isPreventingRearVehicleFromPassingThrough() const
       target_objects_on_lane.on_current_lane.begin(), target_objects_on_lane.on_current_lane.end(),
       [&](const auto & o) {
         const auto arc_length = autoware::motion_utils::calcSignedArcLength(
-          centerline_path.points, current_pose.position, o.initial_pose.pose.position);
+          centerline_path.points, ego_pose.position, o.initial_pose.pose.position);
         if (arc_length > 0.0) return;
         if (std::abs(arc_length) >= std::abs(arc_length_to_closet_object)) return;
         arc_length_to_closet_object = arc_length;
@@ -1722,6 +1750,16 @@ void StartPlannerModule::setDebugData()
       showPredictedPath(debug_data_.collision_check, "predicted_path_for_safety_check"),
       info_marker_);
     add(showPolygon(debug_data_.collision_check, "ego_and_target_polygon_relation"), info_marker_);
+
+    // visualize estimated_stop_pose for isPreventingRearVehicleFromPassingThrough()
+    if (debug_data_.estimated_stop_pose.has_value()) {
+      auto footprint_marker = createDefaultMarker(
+        "map", rclcpp::Clock{RCL_ROS_TIME}.now(), "estimated_stop_pose", 0, Marker::LINE_STRIP,
+        createMarkerScale(0.2, 0.2, 0.2), purple_color);
+      footprint_marker.lifetime = rclcpp::Duration::from_seconds(1.5);
+      addFootprintMarker(footprint_marker, debug_data_.estimated_stop_pose.value(), vehicle_info_);
+      debug_marker_.markers.push_back(footprint_marker);
+    }
 
     // set objects of interest
     for (const auto & [uuid, data] : debug_data_.collision_check) {


### PR DESCRIPTION
## Description


- goal plannerで曲率の高い経路の優先度を下げる
- start plannerで後方車両への過剰な安全判定を修正
- start/goal plannerでのutilsでの曲率計算を修正

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

https://evaluation.tier4.jp/evaluation/reports/466a4830-cd49-5899-bf57-0e9d0e47250c?project_id=prd_jt

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
