### PR TITLE
fix(start/goal_planner): bug of autoware prefix and current_pose

### DIFF
--- a/planning/behavior_path_goal_planner_module/src/goal_planner_module.cpp
+++ b/planning/behavior_path_goal_planner_module/src/goal_planner_module.cpp
@@ -276,7 +276,7 @@ void GoalPlannerModule::onTimer()
       // calculate absolute maximum curvature of parking path(start pose to end pose) for path
       // priority
       const std::vector<double> curvatures =
-        autoware::motion_utils::calcCurvature(pull_over_path->getParkingPath().points);
+        motion_utils::calcCurvature(pull_over_path->getParkingPath().points);
       pull_over_path->max_curvature = std::abs(*std::max_element(
         curvatures.begin(), curvatures.end(),
         [](const double & a, const double & b) { return std::abs(a) < std::abs(b); }));

--- a/planning/behavior_path_start_planner_module/src/start_planner_module.cpp
+++ b/planning/behavior_path_start_planner_module/src/start_planner_module.cpp
@@ -366,7 +366,7 @@ bool StartPlannerModule::isPreventingRearVehicleFromPassingThrough() const
   const auto & current_pose = planner_data_->self_odometry->pose.pose;
   std::vector<Pose> preventing_check_pose{current_pose};
   const auto min_stop_distance =
-    autoware::behavior_path_planner::utils::parking_departure::calcFeasibleDecelDistance(
+    behavior_path_planner::utils::parking_departure::calcFeasibleDecelDistance(
       planner_data_, parameters_->maximum_deceleration_for_stop, parameters_->maximum_jerk_for_stop,
       0.0);
   debug_data_.estimated_stop_pose.reset();  // debug
@@ -500,7 +500,7 @@ bool StartPlannerModule::isPreventingRearVehicleFromPassingThrough(const Pose & 
     // Check backwards just in case the Vehicle behind ego is in a different lanelet
     constexpr double backwards_length = 200.0;
     const auto prev_lanes = behavior_path_planner::utils::getBackwardLanelets(
-      *route_handler, target_lanes, current_pose, backwards_length);
+      *route_handler, target_lanes, ego_pose, backwards_length);
     // return all the relevant lanelets
     lanelet::ConstLanelets relevant_lanelets{closest_lanelet_const};
     relevant_lanelets.insert(relevant_lanelets.end(), prev_lanes.begin(), prev_lanes.end());
@@ -527,7 +527,7 @@ bool StartPlannerModule::isPreventingRearVehicleFromPassingThrough(const Pose & 
       target_objects_on_lane.on_current_lane.begin(), target_objects_on_lane.on_current_lane.end(),
       [&](const auto & o) {
         const auto arc_length = motion_utils::calcSignedArcLength(
-          centerline_path.points, current_pose.position, o.initial_pose.pose.position);
+          centerline_path.points, ego_pose.position, o.initial_pose.pose.position);
         if (arc_length > 0.0) return;
         if (std::abs(arc_length) >= std::abs(arc_length_to_closet_object)) return;
         arc_length_to_closet_object = arc_length;


### PR DESCRIPTION
## Description

Resolve those build errors accompanied by https://github.com/tier4/autoware.universe/pull/1419


```
/home/shmpwk/xx1/pilot-auto.xx1.v0.45.0.0/src/autoware/universe/planning/behavior_path_start_planner_module/src/start_planner_module.cpp: In member function ‘bool behavior_path_planner::StartPlannerModule::isPreventingRearVehicleFromPassingThrough() const’:
/home/shmpwk/xx1/pilot-auto.xx1.v0.45.0.0/src/autoware/universe/planning/behavior_path_start_planner_module/src/start_planner_module.cpp:369:5: error: ‘autoware’ has not been declared
  369 |     autoware::behavior_path_planner::utils::parking_departure::calcFeasibleDecelDistance(
      |     ^~~~~~~~
/home/shmpwk/xx1/pilot-auto.xx1.v0.45.0.0/src/autoware/universe/planning/behavior_path_start_planner_module/src/start_planner_module.cpp: In lambda function:
/home/shmpwk/xx1/pilot-auto.xx1.v0.45.0.0/src/autoware/universe/planning/behavior_path_start_planner_module/src/start_planner_module.cpp:503:37: error: ‘current_pose’ was not declared in this scope
  503 |       *route_handler, target_lanes, current_pose, backwards_length);
      |                                     ^~~~~~~~~~~~
/home/shmpwk/xx1/pilot-auto.xx1.v0.45.0.0/src/autoware/universe/planning/behavior_path_start_planner_module/src/start_planner_module.cpp: In lambda function:
/home/shmpwk/xx1/pilot-auto.xx1.v0.45.0.0/src/autoware/universe/planning/behavior_path_start_planner_module/src/start_planner_module.cpp:530:35: error: ‘current_pose’ was not declared in this scope
  530 |           centerline_path.points, current_pose.position, o.initial_pose.pose.position);
      |                                   ^~~~~~~~~~~~
gmake[2]: *** [CMakeFiles/behavior_path_start_planner_module.dir/build.make:76: CMakeFiles/behavior_path_start_planner_module.dir/src/start_planner_module.cpp.o] Error 1
gmake[2]: *** Waiting for unfinished jobs....
gmake[1]: *** [CMakeFiles/Makefile2:137: CMakeFiles/behavior_path_start_planner_module.dir/all] Error 2
gmake: *** [Makefile:146: all] Error 2
---
Failed   <<< behavior_path_start_planner_module [27.8s, exited with code 2]

```

```
/home/shmpwk/xx1/pilot-auto.xx1.v0.45.0.0/src/autoware/universe/planning/behavior_path_goal_planner_module/src/goal_planner_module.cpp: In lambda function:
/home/shmpwk/xx1/pilot-auto.xx1.v0.45.0.0/src/autoware/universe/planning/behavior_path_goal_planner_module/src/goal_planner_module.cpp:279:9: error: ‘autoware’ has not been declared
  279 |         autoware::motion_utils::calcCurvature(pull_over_path->getParkingPath().points);
      |         ^~~~~~~~
gmake[2]: *** [CMakeFiles/behavior_path_goal_planner_module.dir/build.make:160: CMakeFiles/behavior_path_goal_planner_module.dir/src/goal_planner_module.cpp.o] Error 1
gmake[2]: *** Waiting for unfinished jobs....
gmake[1]: *** [CMakeFiles/Makefile2:137: CMakeFiles/behavior_path_goal_planner_module.dir/all] Error 2
gmake: *** [Makefile:146: all] Error 2
---
Failed   <<< behavior_path_goal_planner_module [34.5s, exited with code 2]
```


## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
