### PR TITLE
fix(static_obstacle_avoidance): remove invalid small shift lines

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/src/shift_line_generator.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/src/shift_line_generator.cpp
@@ -827,6 +827,8 @@ AvoidLineArray ShiftLineGenerator::applyFillGapProcess(
   utils::static_obstacle_avoidance::fillAdditionalInfoFromLongitudinal(
     data, debug.step1_front_shift_line);
 
+  applySmallShiftFilter(ret, 1e-3);
+
   return ret;
 }
 


### PR DESCRIPTION
## Description

- https://github.com/autowarefoundation/autoware.universe/pull/8344

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
