### PR TITLE
fix(autoware_behavior_path_lane_change_module): avoid empty current lanes

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/scene.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/scene.cpp
@@ -85,6 +85,7 @@ std::pair<bool, bool> NormalLaneChange::getSafePath(LaneChangePath & safe_path) 
   const auto target_lanes = getLaneChangeLanes(current_lanes, direction_);
 
   if (target_lanes.empty()) {
+    safe_path.info.current_lanes = current_lanes;
     return {false, false};
   }
 


### PR DESCRIPTION
## Description

### Overview:
I have modified the lane change module so that it can utilize `current_lanes` even if `target_lanes` is empty.

### Details:
When driving manually with Autoware activated, sometimes `target_lanes` would be empty, which would cause `current_lanes` to be empty as well. 
If current_lanes is empty, an error occurs in the `current_lanes.back()` that is called afterwards.
 
 Specifically, I encountered the error at [utils::lane_change::calcMinimumLaneChangeLength(
route_handler, current_lanes.back(), *lane_change_parameters_, direction_);](https://github.com/tier4/autoware.universe/blob/57a0c2890d87da473f6fa750467275fcf4fdb4f9/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/scene.cpp#L1128])


## Related links

**Parent Issue:**

- Nothing

**Private Links:**

- [TIER IV internal ticket link](https://tier4.atlassian.net/browse/RT0-32963)
- [TIER IV internal slack link](https://star4.slack.com/archives/C074CCKN35E/p1722992833276159)

## How was this PR tested?

I tested by logging simulator with the [TIER IV private rosbag](https://tier4.atlassian.net/browse/RT0-32963) and verified that the planner is now stable and no longer aborts. 
## Notes for reviewers

Recently, this phenomenon has become more frequent, but the reason why target_lanes becomes empty during manual driving remains unclear.

## Interface changes

Does not change.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

Does not change.
