### PR TITLE
fix(traffic_light_classifier): fix traffic light monitor warning (#8412)

### DIFF
--- a/perception/traffic_light_classifier/src/nodelet.cpp
+++ b/perception/traffic_light_classifier/src/nodelet.cpp
@@ -84,7 +84,10 @@ void TrafficLightClassifierNodelet::imageRoiCallback(
   if (classifier_ptr_.use_count() == 0) {
     return;
   }
+  tier4_perception_msgs::msg::TrafficLightArray output_msg;
   if (input_rois_msg->rois.empty()) {
+    output_msg.header = input_image_msg->header;
+    traffic_signal_array_pub_->publish(output_msg);
     return;
   }
 
@@ -97,7 +100,6 @@ void TrafficLightClassifierNodelet::imageRoiCallback(
       input_image_msg->encoding.c_str());
   }
 
-  tier4_perception_msgs::msg::TrafficLightArray output_msg;
   output_msg.signals.resize(input_rois_msg->rois.size());
 
   std::vector<cv::Mat> images;


### PR DESCRIPTION
## Description
cherry-pick of https://github.com/autowarefoundation/autoware.universe/pull/8412

## Related links

https://github.com/autowarefoundation/autoware.universe/pull/8412

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
