### PR TITLE
fix(autoware_universe_utils): fix memory leak of time_keeper

### DIFF
--- a/common/autoware_universe_utils/include/autoware/universe_utils/system/time_keeper.hpp
+++ b/common/autoware_universe_utils/include/autoware/universe_utils/system/time_keeper.hpp
@@ -67,9 +67,9 @@ public:
   /**
    * @brief Get the parent node
    *
-   * @return std::shared_ptr<ProcessingTimeNode> Shared pointer to the parent node
+   * @return std::weak_ptr<ProcessingTimeNode> Weak pointer to the parent node
    */
-  std::shared_ptr<ProcessingTimeNode> get_parent_node() const;
+  std::weak_ptr<ProcessingTimeNode> get_parent_node() const;
 
   /**
    * @brief Get the child nodes
@@ -94,9 +94,10 @@ public:
   std::string get_name() const;
 
 private:
-  const std::string name_;                                    //!< Name of the node
-  double processing_time_{0.0};                               //!< Processing time of the node
-  std::shared_ptr<ProcessingTimeNode> parent_node_{nullptr};  //!< Shared pointer to the parent node
+  const std::string name_;                         //!< Name of the node
+  double processing_time_{0.0};                    //!< Processing time of the node
+  std::string comment_;                            //!< Comment for the node
+  std::weak_ptr<ProcessingTimeNode> parent_node_;  //!< Weak pointer to the parent node
   std::vector<std::shared_ptr<ProcessingTimeNode>>
     child_nodes_;  //!< Vector of shared pointers to the child nodes
 };

--- a/common/autoware_universe_utils/src/system/time_keeper.cpp
+++ b/common/autoware_universe_utils/src/system/time_keeper.cpp
@@ -28,7 +28,7 @@ ProcessingTimeNode::ProcessingTimeNode(const std::string & name) : name_(name)
 std::shared_ptr<ProcessingTimeNode> ProcessingTimeNode::add_child(const std::string & name)
 {
   auto new_child_node = std::make_shared<ProcessingTimeNode>(name);
-  new_child_node->parent_node_ = shared_from_this();
+  new_child_node->parent_node_ = weak_from_this();
   child_nodes_.push_back(new_child_node);
   return new_child_node;
 }
@@ -81,7 +81,7 @@ tier4_debug_msgs::msg::ProcessingTimeTree ProcessingTimeNode::to_msg() const
   return time_tree_msg;
 }
 
-std::shared_ptr<ProcessingTimeNode> ProcessingTimeNode::get_parent_node() const
+std::weak_ptr<ProcessingTimeNode> ProcessingTimeNode::get_parent_node() const
 {
   return parent_node_;
 }
@@ -133,7 +133,7 @@ void TimeKeeper::end_track(const std::string & func_name)
   }
   const double processing_time = stop_watch_.toc(func_name);
   current_time_node_->set_time(processing_time);
-  current_time_node_ = current_time_node_->get_parent_node();
+  current_time_node_ = current_time_node_->get_parent_node().lock();
 
   if (current_time_node_ == nullptr) {
     report();


### PR DESCRIPTION
## Description

same as https://github.com/autowarefoundation/autoware.universe/pull/8425

This PR would fix the memory problem with map_based_prediction.

https://star4.slack.com/archives/C03S84LDJGG/p1723189282452959?thread_ts=1723082650.906059&cid=C03S84LDJGG

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
