### PR TITLE
fix(mrm_stop_operator): use adapi mrm state

### DIFF
--- a/system/mrm_stop_operator/package.xml
+++ b/system/mrm_stop_operator/package.xml
@@ -17,6 +17,7 @@
   <depend>rclcpp_components</depend>
   <depend>tier4_planning_msgs</depend>
   <depend>tier4_system_msgs</depend>
+  <depend>autoware_adapi_v1_msgs</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>autoware_lint_common</test_depend>

--- a/system/mrm_stop_operator/package.xml
+++ b/system/mrm_stop_operator/package.xml
@@ -12,12 +12,12 @@
   <build_depend>autoware_cmake</build_depend>
 
   <!-- depend -->
+  <depend>autoware_adapi_v1_msgs</depend>
   <depend>autoware_auto_vehicle_msgs</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
   <depend>tier4_planning_msgs</depend>
   <depend>tier4_system_msgs</depend>
-  <depend>autoware_adapi_v1_msgs</depend>
 
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>autoware_lint_common</test_depend>

--- a/system/mrm_stop_operator/src/mrm_stop_operator.cpp
+++ b/system/mrm_stop_operator/src/mrm_stop_operator.cpp
@@ -45,7 +45,7 @@ MrmStopOperator::MrmStopOperator(const rclcpp::NodeOptions & node_options)
     create_publisher<tier4_planning_msgs::msg::VelocityLimitClearCommand>(
       "~/output/velocity_limit_clear_command", rclcpp::QoS{10}.transient_local());
   pub_mrm_state_ =
-    create_publisher<tier4_system_msgs::msg::MrmState>("~/output/mrm_state", rclcpp::QoS{1});
+    create_publisher<autoware_adapi_v1_msgs::msg::MrmState>("~/output/mrm_state", rclcpp::QoS{1});
 
   // Timer
   const auto update_period_ns = rclcpp::Rate(10).period();
@@ -80,24 +80,24 @@ void MrmStopOperator::onMrmRequest(const tier4_system_msgs::msg::MrmBehavior::Co
     pub_velocity_limit_->publish(velocity_limit);
 
     last_mrm_request_ = *msg;
-    current_mrm_state_.behavior = *msg;
-    current_mrm_state_.state = tier4_system_msgs::msg::MrmState::MRM_OPERATING;
+    current_mrm_state_.behavior = msg->type;
+    current_mrm_state_.state = autoware_adapi_v1_msgs::msg::MrmState::MRM_OPERATING;
   }
 }
 
 void MrmStopOperator::initState()
 {
   last_mrm_request_.type = tier4_system_msgs::msg::MrmBehavior::NONE;
-  current_mrm_state_.state = tier4_system_msgs::msg::MrmState::NORMAL;
-  current_mrm_state_.behavior.type = tier4_system_msgs::msg::MrmBehavior::NONE;
+  current_mrm_state_.state = autoware_adapi_v1_msgs::msg::MrmState::NORMAL;
+  current_mrm_state_.behavior = autoware_adapi_v1_msgs::msg::MrmState::NONE;
 }
 
 void MrmStopOperator::onTimer()
 {
-  if (current_mrm_state_.state == tier4_system_msgs::msg::MrmState::MRM_OPERATING) {
-    if (current_mrm_state_.behavior.type == tier4_system_msgs::msg::MrmBehavior::COMFORTABLE_STOP) {
+  if (current_mrm_state_.state == autoware_adapi_v1_msgs::msg::MrmState::MRM_OPERATING) {
+    if (current_mrm_state_.behavior == autoware_adapi_v1_msgs::msg::MrmState::COMFORTABLE_STOP) {
       if (isStopped()) {
-        current_mrm_state_.state = tier4_system_msgs::msg::MrmState::MRM_SUCCEEDED;
+        current_mrm_state_.state = autoware_adapi_v1_msgs::msg::MrmState::MRM_SUCCEEDED;
       } else {
         // nothing to do
       }

--- a/system/mrm_stop_operator/src/mrm_stop_operator.hpp
+++ b/system/mrm_stop_operator/src/mrm_stop_operator.hpp
@@ -22,7 +22,7 @@
 #include <tier4_planning_msgs/msg/velocity_limit.hpp>
 #include <tier4_planning_msgs/msg/velocity_limit_clear_command.hpp>
 #include <tier4_system_msgs/msg/mrm_behavior.hpp>
-#include <tier4_system_msgs/msg/mrm_state.hpp>
+#include <autoware_adapi_v1_msgs/msg/mrm_state.hpp>
 
 namespace mrm_stop_operator
 {
@@ -56,7 +56,7 @@ private:
   rclcpp::Publisher<tier4_planning_msgs::msg::VelocityLimit>::SharedPtr pub_velocity_limit_;
   rclcpp::Publisher<tier4_planning_msgs::msg::VelocityLimitClearCommand>::SharedPtr
     pub_velocity_limit_clear_command_;
-  rclcpp::Publisher<tier4_system_msgs::msg::MrmState>::SharedPtr pub_mrm_state_;
+  rclcpp::Publisher<autoware_adapi_v1_msgs::msg::MrmState>::SharedPtr pub_mrm_state_;
   // Service
 
   // Client
@@ -68,7 +68,7 @@ private:
 
   // State
   tier4_system_msgs::msg::MrmBehavior last_mrm_request_;
-  tier4_system_msgs::msg::MrmState current_mrm_state_;
+  autoware_adapi_v1_msgs::msg::MrmState current_mrm_state_;
 
   void initState();
   void onTimer();

--- a/system/mrm_stop_operator/src/mrm_stop_operator.hpp
+++ b/system/mrm_stop_operator/src/mrm_stop_operator.hpp
@@ -18,11 +18,11 @@
 // include
 #include <rclcpp/rclcpp.hpp>
 
+#include <autoware_adapi_v1_msgs/msg/mrm_state.hpp>
 #include <autoware_auto_vehicle_msgs/msg/velocity_report.hpp>
 #include <tier4_planning_msgs/msg/velocity_limit.hpp>
 #include <tier4_planning_msgs/msg/velocity_limit_clear_command.hpp>
 #include <tier4_system_msgs/msg/mrm_behavior.hpp>
-#include <autoware_adapi_v1_msgs/msg/mrm_state.hpp>
 
 namespace mrm_stop_operator
 {


### PR DESCRIPTION
## Description
This PR exchanges mrm_state to adapi's one in mrm_stop_operator.

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
