### PR TITLE
fix(tier4_system_launch): change mrm state name

### DIFF
--- a/launch/tier4_system_launch/launch/system.main.mrm-v0.6.tmp.launch.xml
+++ b/launch/tier4_system_launch/launch/system.main.mrm-v0.6.tmp.launch.xml
@@ -116,7 +116,7 @@
     <group if="$(var use_diagnostic_graph)">
       <include file="$(find-pkg-share mrm_handler)/launch/mrm_handler.launch.xml">
         <arg name="config_file" value="$(var mrm_handler_param_path)"/>
-        <arg name="output_mrm_state" value="/system/fail_safe/mrm_state/tmp"/>
+        <arg name="output_mrm_state" value="/system/fail_safe/mrm_state"/>
       </include>
     </group>
 
@@ -165,7 +165,7 @@
   <group>
     <include file="$(find-pkg-share leader_election_converter)/launch/leader_election_converter.launch.xml">
       <arg name="param_file" value="$(find-pkg-share autoware_launch)/config/system/leader_election_converter/leader_election_converter.param.yaml"/>
-      <arg name="input_mrm_state" value="/system/fail_safe/mrm_state/tmp"/>
+      <arg name="input_mrm_state" value="/system/fail_safe/mrm_state"/>
     </include>
   </group>
 


### PR DESCRIPTION
## Description
This PR changes `/system/fail_safe/mrm_state/tmp` to `/system/fail_safe/mrm_state`

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
