### PR TITLE
fix: change stop_filter vx 0.1 -> 0.01 

### DIFF
--- a/localization/stop_filter/config/stop_filter.param.yaml
+++ b/localization/stop_filter/config/stop_filter.param.yaml
@@ -1,4 +1,4 @@
 /**:
   ros__parameters:
-    vx_threshold: 0.1  # [m/s]
+    vx_threshold: 0.01  # [m/s]
     wz_threshold: 0.02  # [rad/s]


### PR DESCRIPTION
## Description

RoboShuttleは速度の分解能が0.001m/sまであるが、stop_filterは0.1m/sで0にしてしまうため、しきい値を変更する
現在stop_filterのconfigがlauncherに存在しないため、暫定的にこのファイルを修正する

## Related links

[CompanyName internal link](https://tier4.atlassian.net/browse/VEH-1001)

## How was this PR tested?
![image](https://github.com/user-attachments/assets/8db1f7f3-00dd-41d3-9006-1ca570eee6c3)

0.01m/sを下回らないと0m/sにならないことが確認できた

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
