### PR TITLE
feat(mrm_handler): input gear command (#8080)

### DIFF
--- a/system/mrm_handler/include/mrm_handler/mrm_handler_core.hpp
+++ b/system/mrm_handler/include/mrm_handler/mrm_handler_core.hpp
@@ -86,6 +86,8 @@ private:
   autoware::universe_utils::InterProcessPollingSubscriber<
     autoware_adapi_v1_msgs::msg::OperationModeState>
     sub_operation_mode_state_{this, "~/input/api/operation_mode/state"};
+  autoware::universe_utils::InterProcessPollingSubscriber<autoware_vehicle_msgs::msg::GearCommand>
+    sub_gear_cmd_{this, "~/input/gear"};
 
   tier4_system_msgs::msg::OperationModeAvailability::ConstSharedPtr operation_mode_availability_;
 
@@ -146,7 +148,6 @@ private:
   void handleFailedRequest();
   autoware_adapi_v1_msgs::msg::MrmState::_behavior_type getCurrentMrmBehavior();
   bool isStopped();
-  bool isDrivingBackwards();
   bool isEmergency() const;
   bool isControlModeAutonomous();
   bool isOperationModeAutonomous();

--- a/system/mrm_handler/launch/mrm_handler.launch.xml
+++ b/system/mrm_handler/launch/mrm_handler.launch.xml
@@ -7,6 +7,7 @@
   <arg name="input_mrm_comfortable_stop_state" default="/system/mrm/comfortable_stop/status"/>
   <arg name="input_mrm_emergency_stop_state" default="/system/mrm/emergency_stop/status"/>
   <arg name="input_api_operation_mode_state" default="/api/operation_mode/state"/>
+  <arg name="input_gear" default="/control/command/gear_cmd"/>
 
   <arg name="output_gear" default="/system/emergency/gear_cmd"/>
   <arg name="output_hazard" default="/system/emergency/hazard_lights_cmd"/>
@@ -26,6 +27,7 @@
     <remap from="~/input/mrm/comfortable_stop/status" to="$(var input_mrm_comfortable_stop_state)"/>
     <remap from="~/input/mrm/emergency_stop/status" to="$(var input_mrm_emergency_stop_state)"/>
     <remap from="~/input/api/operation_mode/state" to="$(var input_api_operation_mode_state)"/>
+    <remap from="~/input/gear" to="$(var input_gear)"/>
 
     <remap from="~/output/gear" to="$(var output_gear)"/>
     <remap from="~/output/hazard" to="$(var output_hazard)"/>

--- a/system/mrm_handler/src/mrm_handler/mrm_handler_core.cpp
+++ b/system/mrm_handler/src/mrm_handler/mrm_handler_core.cpp
@@ -130,19 +130,20 @@ void MrmHandler::publishGearCmd()
 {
   using autoware_vehicle_msgs::msg::GearCommand;
   GearCommand msg;
-
   msg.stamp = this->now();
-  const auto command = [&]() {
-    // If stopped and use_parking is not true, send the last gear command
-    if (isStopped())
-      return (param_.use_parking_after_stopped) ? GearCommand::PARK : last_gear_command_;
-    return (isDrivingBackwards()) ? GearCommand::REVERSE : GearCommand::DRIVE;
-  }();
 
-  msg.command = command;
-  last_gear_command_ = msg.command;
+  if (isEmergency()) {
+    // gear command is created within mrm_handler
+    msg.command =
+      (param_.use_parking_after_stopped && isStopped()) ? GearCommand::PARK : last_gear_command_;
+  } else {
+    // use the same gear as the input gear
+    auto gear = sub_gear_cmd_.takeData();
+    msg.command = (gear == nullptr) ? last_gear_command_ : gear->command;
+    last_gear_command_ = msg.command;
+  }
+
   pub_gear_cmd_->publish(msg);
-  return;
 }
 
 void MrmHandler::publishMrmState()
@@ -522,14 +523,6 @@ bool MrmHandler::isStopped()
   if (odom == nullptr) return false;
   constexpr auto th_stopped_velocity = 0.001;
   return (std::abs(odom->twist.twist.linear.x) < th_stopped_velocity);
-}
-
-bool MrmHandler::isDrivingBackwards()
-{
-  auto odom = sub_odom_.takeData();
-  if (odom == nullptr) return false;
-  constexpr auto th_moving_backwards = -0.001;
-  return odom->twist.twist.linear.x < th_moving_backwards;
 }
 
 bool MrmHandler::isEmergency() const


### PR DESCRIPTION
cherry-pick https://github.com/autowarefoundation/autoware.universe/pull/8080

---------

## Description

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
