### PR TITLE
fix(pid_longitudinal_controller): fix the same point error (#8758)

### DIFF
--- a/control/autoware_pid_longitudinal_controller/src/pid_longitudinal_controller.cpp
+++ b/control/autoware_pid_longitudinal_controller/src/pid_longitudinal_controller.cpp
@@ -488,6 +488,8 @@ PidLongitudinalController::ControlData PidLongitudinalController::getControlData
   // calculate the target motion for delay compensation
   constexpr double min_running_dist = 0.01;
   if (control_data.state_after_delay.running_distance > min_running_dist) {
+    control_data.interpolated_traj.points =
+      autoware::motion_utils::removeOverlapPoints(control_data.interpolated_traj.points);
     const auto target_pose = longitudinal_utils::findTrajectoryPoseAfterDistance(
       control_data.nearest_idx, control_data.state_after_delay.running_distance,
       control_data.interpolated_traj);


### PR DESCRIPTION
## Description
https://tier4.atlassian.net/browse/RT0-33317 の修正PRです。

不具合は速度制御の勾配計算部分において発生しており、
same pointによる nanやゼロ割が発生し、その結果lpfがバグって復帰できない状態となっていました。

この修正により、当該rosbagで再現しないことと、無印でのシナリオテストに問題がないことを確認しました。


## Related links
無印側修正 PR https://github.com/autowarefoundation/autoware.universe/pull/8758


- Link

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.



## Effects on system behavior

None.
