### PR TITLE
fix(motion_velocity_planner): fix duplicated topic name

### DIFF
--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner_node/src/node.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner_node/src/node.cpp
@@ -83,7 +83,7 @@ MotionVelocityPlannerNode::MotionVelocityPlannerNode(const rclcpp::NodeOptions &
     this->create_publisher<autoware_adapi_v1_msgs::msg::VelocityFactorArray>(
       "~/output/velocity_factors", 1);
   processing_time_publisher_ =
-    this->create_publisher<tier4_debug_msgs::msg::Float64Stamped>("~/debug/processing_time_ms", 1);
+    this->create_publisher<tier4_debug_msgs::msg::Float64Stamped>("~/debug/total_processing_time_ms", 1);
   debug_viz_pub_ =
     this->create_publisher<visualization_msgs::msg::MarkerArray>("~/debug/markers", 1);
   diagnostics_pub_ = this->create_publisher<DiagnosticArray>("/diagnostics", 10);

--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner_node/src/node.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner_node/src/node.cpp
@@ -83,7 +83,7 @@ MotionVelocityPlannerNode::MotionVelocityPlannerNode(const rclcpp::NodeOptions &
     this->create_publisher<autoware_adapi_v1_msgs::msg::VelocityFactorArray>(
       "~/output/velocity_factors", 1);
   processing_time_publisher_ =
-    this->create_publisher<tier4_debug_msgs::msg::Float64Stamped>("~/debug/total_processing_time_ms", 1);
+    this->create_publisher<tier4_debug_msgs::msg::Float64Stamped>("~/debug/processing_time_ms", 1);
   debug_viz_pub_ =
     this->create_publisher<visualization_msgs::msg::MarkerArray>("~/debug/markers", 1);
   diagnostics_pub_ = this->create_publisher<DiagnosticArray>("/diagnostics", 10);

--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner_node/src/node.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner_node/src/node.hpp
@@ -99,7 +99,8 @@ private:
   rclcpp::Publisher<visualization_msgs::msg::MarkerArray>::SharedPtr debug_viz_pub_;
   rclcpp::Publisher<autoware_adapi_v1_msgs::msg::VelocityFactorArray>::SharedPtr
     velocity_factor_publisher_;
-  autoware::universe_utils::ProcessingTimePublisher processing_diag_publisher_{this};
+  autoware::universe_utils::ProcessingTimePublisher processing_diag_publisher_{
+    this, "~/debug/processing_time_ms_diag"};
   rclcpp::Publisher<tier4_debug_msgs::msg::Float64Stamped>::SharedPtr processing_time_publisher_;
   autoware::universe_utils::PublishedTimePublisher published_time_publisher_{this};
   rclcpp::Publisher<DiagnosticArray>::SharedPtr diagnostics_pub_;


### PR DESCRIPTION
## Description

The motion_velocity_planner node implements two publishers with the same topic name.

https://github.com/tier4/autoware.universe/blob/c1011857f1f31ccdff9ede41b51f004889c51786/planning/motion_velocity_planner/autoware_motion_velocity_planner_node/src/node.cpp#L85-L86

https://github.com/tier4/autoware.universe/blob/c1011857f1f31ccdff9ede41b51f004889c51786/planning/motion_velocity_planner/autoware_motion_velocity_planner_node/src/node.hpp#L102

This will result in the following error when starting Autoware.

~~~bash
1725517904.5326092 [ERROR] [launch_ros.actions.load_composable_nodes]: Failed to load node 'motion_velocity_planner' of type 'autoware::motion_velocity_planner::MotionVelocityPlannerNode' in container '/planning/scenario_planning/lane_driving/motion_planning/motion_planning_container': Component constructor threw an exception: could not create publisher: failed to create topic [rt/planning/scenario_planning/lane_driving/motion_planning/motion_velocity_planner/debug/processing_time_ms] because it's already in use in this context with a different message type, at ./src/rmw_node.cpp:1804, at ./src/rcl/publisher.c:116
~~~

In the main branch of awf/autoware.universe, this problem has already been fixed by renaming the diag topic.
ref: https://github.com/tier4/autoware.universe/commit/598d9375e915758711c7b63e0e9446a81efc0430

This PR fixes this problem by renaming the debug topic to `~/debug/total_processing_time_ms`.

https://github.com/tier4/autoware.universe/blob/6f026f8a6300020a3e22e5acdcb25790bb2b0a91/planning/motion_velocity_planner/autoware_motion_velocity_planner_node/src/node.cpp#L85-L86

## Related links

https://github.com/tier4/autoware.universe/pull/1508

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

PSim

## Notes for reviewers

None.

## Interface changes

### Topic changes

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub | `~/debug/processing_time_ms` | `tier4_debug_msgs/msg/Float64Stamped` | Topic description |
| New     | Pub | `~/debug/total_processing_time_ms` | `tier4_debug_msgs/msg/Float64Stamped` | Topic description |

## Effects on system behavior

None.
