### PR TITLE
fix(lane_change): transit rtc status to failure for some condition

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/interface.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_lane_change_module/src/interface.cpp
@@ -257,11 +257,17 @@ bool LaneChangeInterface::canTransitFailureState()
 
   if (!module_type_->isValidPath()) {
     log_debug_throttled("Transit to failure state due not to find valid path");
+    updateRTCStatus(
+      std::numeric_limits<double>::lowest(), std::numeric_limits<double>::lowest(), true,
+      State::FAILED);
     return true;
   }
 
   if (module_type_->isAbortState() && module_type_->hasFinishedAbort()) {
     log_debug_throttled("Abort process has completed.");
+    updateRTCStatus(
+      std::numeric_limits<double>::lowest(), std::numeric_limits<double>::lowest(), true,
+      State::FAILED);
     return true;
   }
 

--- a/planning/behavior_path_planner/autoware_behavior_path_planner_common/include/autoware/behavior_path_planner_common/interface/scene_module_interface.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner_common/include/autoware/behavior_path_planner_common/interface/scene_module_interface.hpp
@@ -340,7 +340,7 @@ private:
         }
 
         if (rtc.second->isTerminated(uuid_map_.at(rtc.first))) {
-          return true;
+          return false;
         }
 
         return rtc.second->isActivated(uuid_map_.at(rtc.first));


### PR DESCRIPTION
## Description
LC module kept rtc cooperateStatus as `RUNNING`, where it needed to be `FAILED`. This caused many LC module appearing on the FOA screen.
![image](https://github.com/user-attachments/assets/132adc63-c8f0-463f-9077-24497e6c6f44)

It can be easily reproduced in PSim as below:
[Screencast from 2024年09月09日 16時54分38秒.webm](https://github.com/user-attachments/assets/7be75bde-320e-4550-b768-9ab8d8f06e08)
This PR solves the problem by appropriately transiting the RTC cooperateStatus. 

## Related links
None

## How was this PR tested?
PSim
[Screencast from 2024年09月09日 17時00分58秒.webm](https://github.com/user-attachments/assets/b1583af1-737e-4a00-b8d5-de5fc7732954)


## Notes for reviewers
None.

## Interface changes
None.

## Effects on system behavior
None.
