### PR TITLE
beta/v0.3.18.2+control evaluator

### DIFF
--- a/control/autonomous_emergency_braking/package.xml
+++ b/control/autonomous_emergency_braking/package.xml
@@ -8,6 +8,10 @@
   <license>Apache License 2.0</license>
 
   <buildtool_depend>ament_cmake</buildtool_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
+  <test_depend>ament_cmake_ros</test_depend>
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>autoware_lint_common</test_depend>
 
   <build_depend>autoware_cmake</build_depend>
 

--- a/control/autoware_control_evaluator/CMakeLists.txt
+++ b/control/autoware_control_evaluator/CMakeLists.txt
@@ -1,0 +1,24 @@
+cmake_minimum_required(VERSION 3.14)
+project(autoware_control_evaluator)
+
+find_package(autoware_cmake REQUIRED)
+autoware_package()
+
+find_package(pluginlib REQUIRED)
+
+ament_auto_add_library(control_evaluator_node SHARED
+  src/control_evaluator_node.cpp
+  src/metrics/deviation_metrics.cpp
+)
+
+rclcpp_components_register_node(control_evaluator_node
+  PLUGIN "control_diagnostics::ControlEvaluatorNode"
+  EXECUTABLE control_evaluator
+)
+
+
+ament_auto_package(
+  INSTALL_TO_SHARE
+    param
+    launch
+)

--- a/control/autoware_control_evaluator/README.md
+++ b/control/autoware_control_evaluator/README.md
@@ -1,0 +1,5 @@
+# Planning Evaluator
+
+## Purpose
+
+This package provides nodes that generate metrics to evaluate the quality of control.

--- a/control/autoware_control_evaluator/include/autoware/control_evaluator/control_evaluator_node.hpp
+++ b/control/autoware_control_evaluator/include/autoware/control_evaluator/control_evaluator_node.hpp
@@ -25,6 +25,7 @@
 #include <autoware_auto_planning_msgs/msg/route.hpp>
 #include <diagnostic_msgs/msg/diagnostic_array.hpp>
 #include <nav_msgs/msg/odometry.hpp>
+#include <sensor_msgs/msg/imu.hpp>
 
 #include <deque>
 #include <optional>
@@ -44,6 +45,8 @@ using nav_msgs::msg::Odometry;
 using LaneletMapBin = autoware_auto_mapping_msgs::msg::HADMapBin;
 using LaneletRoute = autoware_auto_planning_msgs::msg::HADMapRoute;
 using geometry_msgs::msg::AccelWithCovarianceStamped;
+using sensor_msgs::msg::Imu;
+
 
 /**
  * @brief Node for control evaluation
@@ -62,7 +65,7 @@ public:
   DiagnosticStatus generateAEBDiagnosticStatus(const DiagnosticStatus & diag);
   DiagnosticStatus generateLaneletDiagnosticStatus(const Pose & ego_pose) const;
   DiagnosticStatus generateKinematicStateDiagnosticStatus(
-    const Odometry & odom, const AccelWithCovarianceStamped & accel_stamped);
+    const Odometry & odom, const Imu & imu);
 
   void onDiagnostics(const DiagnosticArray::ConstSharedPtr diag_msg);
   void onTimer();
@@ -75,8 +78,10 @@ private:
 
   autoware::universe_utils::InterProcessPollingSubscriber<Odometry> odometry_sub_{
     this, "~/input/odometry"};
-  autoware::universe_utils::InterProcessPollingSubscriber<AccelWithCovarianceStamped> accel_sub_{
-    this, "~/input/acceleration"};
+  // autoware::universe_utils::InterProcessPollingSubscriber<AccelWithCovarianceStamped> accel_sub_{
+  //   this, "~/input/acceleration"};
+  autoware::universe_utils::InterProcessPollingSubscriber<Imu> imu_sub_{
+    this, "~/input/imu"};
   autoware::universe_utils::InterProcessPollingSubscriber<Trajectory> traj_sub_{
     this, "~/input/trajectory"};
   autoware::universe_utils::InterProcessPollingSubscriber<
@@ -101,7 +106,7 @@ private:
 
   route_handler::RouteHandler route_handler_;
   rclcpp::TimerBase::SharedPtr timer_;
-  std::optional<AccelWithCovarianceStamped> prev_acc_stamped_{std::nullopt};
+  std::optional<Imu> prev_imu_{std::nullopt};
 };
 }  // namespace control_diagnostics
 

--- a/control/autoware_control_evaluator/include/autoware/control_evaluator/control_evaluator_node.hpp
+++ b/control/autoware_control_evaluator/include/autoware/control_evaluator/control_evaluator_node.hpp
@@ -22,7 +22,7 @@
 #include <tier4_autoware_utils/tier4_autoware_utils.hpp>
 
 #include "geometry_msgs/msg/accel_with_covariance_stamped.hpp"
-#include <autoware_planning_msgs/msg/lanelet_route.hpp>
+#include <autoware_auto_planning_msgs/msg/route.hpp>
 #include <diagnostic_msgs/msg/diagnostic_array.hpp>
 #include <nav_msgs/msg/odometry.hpp>
 

--- a/control/autoware_control_evaluator/include/autoware/control_evaluator/control_evaluator_node.hpp
+++ b/control/autoware_control_evaluator/include/autoware/control_evaluator/control_evaluator_node.hpp
@@ -1,0 +1,108 @@
+// Copyright 2024 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef AUTOWARE__CONTROL_EVALUATOR__CONTROL_EVALUATOR_NODE_HPP_
+#define AUTOWARE__CONTROL_EVALUATOR__CONTROL_EVALUATOR_NODE_HPP_
+
+#include "autoware/control_evaluator/metrics/deviation_metrics.hpp"
+
+#include <rclcpp/rclcpp.hpp>
+#include <route_handler/route_handler.hpp>
+#include <tier4_autoware_utils/tier4_autoware_utils.hpp>
+
+#include "geometry_msgs/msg/accel_with_covariance_stamped.hpp"
+#include <autoware_planning_msgs/msg/lanelet_route.hpp>
+#include <diagnostic_msgs/msg/diagnostic_array.hpp>
+#include <nav_msgs/msg/odometry.hpp>
+
+#include <deque>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace control_diagnostics
+{
+
+using autoware_auto_planning_msgs::msg::Trajectory;
+using diagnostic_msgs::msg::DiagnosticArray;
+using diagnostic_msgs::msg::DiagnosticStatus;
+using geometry_msgs::msg::Point;
+using geometry_msgs::msg::Pose;
+using nav_msgs::msg::Odometry;
+using LaneletMapBin = autoware_auto_mapping_msgs::msg::HADMapBin;
+using LaneletRoute = autoware_auto_planning_msgs::msg::HADMapRoute;
+using geometry_msgs::msg::AccelWithCovarianceStamped;
+
+/**
+ * @brief Node for control evaluation
+ */
+class ControlEvaluatorNode : public rclcpp::Node
+{
+public:
+  explicit ControlEvaluatorNode(const rclcpp::NodeOptions & node_options);
+  DiagnosticStatus generateLateralDeviationDiagnosticStatus(
+    const Trajectory & traj, const Point & ego_point);
+  DiagnosticStatus generateYawDeviationDiagnosticStatus(
+    const Trajectory & traj, const Pose & ego_pose);
+  std::optional<DiagnosticStatus> generateStopDiagnosticStatus(
+    const DiagnosticArray & diag, const std::string & function_name);
+
+  DiagnosticStatus generateAEBDiagnosticStatus(const DiagnosticStatus & diag);
+  DiagnosticStatus generateLaneletDiagnosticStatus(const Pose & ego_pose) const;
+  DiagnosticStatus generateKinematicStateDiagnosticStatus(
+    const Odometry & odom, const AccelWithCovarianceStamped & accel_stamped);
+
+  void onDiagnostics(const DiagnosticArray::ConstSharedPtr diag_msg);
+  void onTimer();
+
+private:
+  // The diagnostics cycle is faster than timer, and each node publishes diagnostic separately.
+  // takeData() in onTimer() with a polling subscriber will miss a topic, so save all topics with
+  // onDiagnostics().
+  rclcpp::Subscription<DiagnosticArray>::SharedPtr control_diag_sub_;
+
+  autoware::universe_utils::InterProcessPollingSubscriber<Odometry> odometry_sub_{
+    this, "~/input/odometry"};
+  autoware::universe_utils::InterProcessPollingSubscriber<AccelWithCovarianceStamped> accel_sub_{
+    this, "~/input/acceleration"};
+  autoware::universe_utils::InterProcessPollingSubscriber<Trajectory> traj_sub_{
+    this, "~/input/trajectory"};
+  autoware::universe_utils::InterProcessPollingSubscriber<
+    LaneletRoute, autoware::universe_utils::polling_policy::Newest>
+    route_subscriber_{this, "~/input/route", rclcpp::QoS{1}.transient_local()};
+  autoware::universe_utils::InterProcessPollingSubscriber<
+    LaneletMapBin, autoware::universe_utils::polling_policy::Newest>
+    vector_map_subscriber_{this, "~/input/vector_map", rclcpp::QoS{1}.transient_local()};
+
+  rclcpp::Publisher<DiagnosticArray>::SharedPtr metrics_pub_;
+
+  // update Route Handler
+  void getRouteData();
+
+  // Calculator
+  // Metrics
+  std::deque<rclcpp::Time> stamps_;
+
+  // queue for diagnostics and time stamp
+  std::deque<std::pair<DiagnosticStatus, rclcpp::Time>> diag_queue_;
+  const std::vector<std::string> target_functions_ = {"autonomous_emergency_braking"};
+
+  route_handler::RouteHandler route_handler_;
+  rclcpp::TimerBase::SharedPtr timer_;
+  std::optional<AccelWithCovarianceStamped> prev_acc_stamped_{std::nullopt};
+};
+}  // namespace control_diagnostics
+
+#endif  // AUTOWARE__CONTROL_EVALUATOR__CONTROL_EVALUATOR_NODE_HPP_

--- a/control/autoware_control_evaluator/include/autoware/control_evaluator/metrics/deviation_metrics.hpp
+++ b/control/autoware_control_evaluator/include/autoware/control_evaluator/metrics/deviation_metrics.hpp
@@ -15,9 +15,8 @@
 #ifndef AUTOWARE__CONTROL_EVALUATOR__METRICS__DEVIATION_METRICS_HPP_
 #define AUTOWARE__CONTROL_EVALUATOR__METRICS__DEVIATION_METRICS_HPP_
 
-#include <autoware_planning_msgs/msg/trajectory_point.hpp>
-
-#include <#include "autoware_auto_planning_msgs/msg/trajectory.hpp">
+#include "autoware_auto_planning_msgs/msg/trajectory_point.hpp"
+#include "autoware_auto_planning_msgs/msg/trajectory.hpp"
 
 namespace control_diagnostics
 {

--- a/control/autoware_control_evaluator/include/autoware/control_evaluator/metrics/deviation_metrics.hpp
+++ b/control/autoware_control_evaluator/include/autoware/control_evaluator/metrics/deviation_metrics.hpp
@@ -1,0 +1,49 @@
+// Copyright 2024 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef AUTOWARE__CONTROL_EVALUATOR__METRICS__DEVIATION_METRICS_HPP_
+#define AUTOWARE__CONTROL_EVALUATOR__METRICS__DEVIATION_METRICS_HPP_
+
+#include <autoware_planning_msgs/msg/trajectory_point.hpp>
+
+#include <#include "autoware_auto_planning_msgs/msg/trajectory.hpp">
+
+namespace control_diagnostics
+{
+namespace metrics
+{
+using autoware_auto_planning_msgs::msg::Trajectory;
+using geometry_msgs::msg::Point;
+using geometry_msgs::msg::Pose;
+
+/**
+ * @brief calculate lateral deviation of the given trajectory from the reference trajectory
+ * @param [in] ref reference trajectory
+ * @param [in] point input point
+ * @return lateral deviation
+ */
+double calcLateralDeviation(const Trajectory & traj, const Point & point);
+
+/**
+ * @brief calculate yaw deviation of the given trajectory from the reference trajectory
+ * @param [in] traj input trajectory
+ * @param [in] pose input pose
+ * @return yaw deviation
+ */
+double calcYawDeviation(const Trajectory & traj, const Pose & pose);
+
+}  // namespace metrics
+}  // namespace control_diagnostics
+
+#endif  // AUTOWARE__CONTROL_EVALUATOR__METRICS__DEVIATION_METRICS_HPP_

--- a/control/autoware_control_evaluator/launch/control_evaluator.launch.xml
+++ b/control/autoware_control_evaluator/launch/control_evaluator.launch.xml
@@ -1,0 +1,21 @@
+<launch>
+  <arg name="input/diagnostics" default="/diagnostics"/>
+  <arg name="input/odometry" default="/localization/kinematic_state"/>
+  <arg name="input/acceleration" default="/localization/acceleration"/>
+  <arg name="input/trajectory" default="/planning/scenario_planning/trajectory"/>
+  <arg name="map_topic_name" default="/map/vector_map"/>
+  <arg name="route_topic_name" default="/planning/mission_planning/route"/>
+  <!-- control evaluator -->
+  <group>
+    <node name="control_evaluator" exec="control_evaluator" pkg="autoware_control_evaluator">
+      <param from="$(find-pkg-share autoware_control_evaluator)/param/control_evaluator.defaults.yaml"/>
+      <remap from="~/input/diagnostics" to="$(var input/diagnostics)"/>
+      <remap from="~/input/odometry" to="$(var input/odometry)"/>
+      <remap from="~/input/acceleration" to="$(var input/acceleration)"/>
+      <remap from="~/input/trajectory" to="$(var input/trajectory)"/>
+      <remap from="~/metrics" to="/control/control_evaluator/metrics"/>
+      <remap from="~/input/vector_map" to="$(var map_topic_name)"/>
+      <remap from="~/input/route" to="$(var route_topic_name)"/>
+    </node>
+  </group>
+</launch>

--- a/control/autoware_control_evaluator/package.xml
+++ b/control/autoware_control_evaluator/package.xml
@@ -1,0 +1,35 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>autoware_control_evaluator</name>
+  <version>0.1.0</version>
+  <description>ROS 2 node for evaluating control</description>
+  <maintainer email="daniel.sanchez@tier4.jp">Daniel SANCHEZ</maintainer>
+  <maintainer email="takayuki.murooka@tier4.jp">takayuki MUROOKA</maintainer>
+  <license>Apache License 2.0</license>
+
+  <author email="daniel.sanchez@tier4.jp">Daniel SANCHEZ</author>
+  <author email="takayuki.murooka@tier4.jp">takayuki MUROOKA</author>
+
+  <buildtool_depend>ament_cmake_auto</buildtool_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
+
+  <depend>autoware_evaluator_utils</depend>
+  <depend>autoware_motion_utils</depend>
+  <depend>autoware_planning_msgs</depend>
+  <depend>autoware_route_handler</depend>
+  <depend>autoware_universe_utils</depend>
+  <depend>diagnostic_msgs</depend>
+  <depend>pluginlib</depend>
+  <depend>rclcpp</depend>
+  <depend>rclcpp_components</depend>
+  <!-- <depend>nav_msgs</depend> -->
+
+  <test_depend>ament_cmake_ros</test_depend>
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>autoware_lint_common</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/control/autoware_control_evaluator/package.xml
+++ b/control/autoware_control_evaluator/package.xml
@@ -15,11 +15,8 @@
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <depend>autoware_evaluator_utils</depend>
-  <depend>autoware_motion_utils</depend>
   <depend>tier4_autoware_utils</depend>
   <depend>autoware_auto_planning_msgs</depend>
-  <depend>autoware_route_handler</depend>
-  <depend>autoware_universe_utils</depend>
   <depend>route_handler</depend>
   <depend>diagnostic_msgs</depend>
   <depend>pluginlib</depend>

--- a/control/autoware_control_evaluator/package.xml
+++ b/control/autoware_control_evaluator/package.xml
@@ -16,9 +16,11 @@
 
   <depend>autoware_evaluator_utils</depend>
   <depend>autoware_motion_utils</depend>
-  <depend>autoware_planning_msgs</depend>
+  <depend>tier4_autoware_utils</depend>
+  <depend>autoware_auto_planning_msgs</depend>
   <depend>autoware_route_handler</depend>
   <depend>autoware_universe_utils</depend>
+  <depend>route_handler</depend>
   <depend>diagnostic_msgs</depend>
   <depend>pluginlib</depend>
   <depend>rclcpp</depend>

--- a/control/autoware_control_evaluator/param/control_evaluator.defaults.yaml
+++ b/control/autoware_control_evaluator/param/control_evaluator.defaults.yaml
@@ -1,0 +1,2 @@
+/**:
+  ros__parameters:

--- a/control/autoware_control_evaluator/src/control_evaluator_node.cpp
+++ b/control/autoware_control_evaluator/src/control_evaluator_node.cpp
@@ -92,7 +92,7 @@ DiagnosticStatus ControlEvaluatorNode::generateLaneletDiagnosticStatus(const Pos
   const auto current_lanelets = [&]() {
     lanelet::ConstLanelet closest_route_lanelet;
     route_handler_.getClosestLaneletWithinRoute(ego_pose, &closest_route_lanelet);
-    const auto shoulder_lanelets = route_handler_.getShoulderLaneletsAtPose(ego_pose);
+    const auto shoulder_lanelets = route_handler_.getShoulderLanelets();
     lanelet::ConstLanelets closest_lanelets{closest_route_lanelet};
     closest_lanelets.insert(
       closest_lanelets.end(), shoulder_lanelets.begin(), shoulder_lanelets.end());

--- a/control/autoware_control_evaluator/src/control_evaluator_node.cpp
+++ b/control/autoware_control_evaluator/src/control_evaluator_node.cpp
@@ -1,0 +1,237 @@
+// Copyright 2024 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/control_evaluator/control_evaluator_node.hpp"
+
+#include "autoware/evaluator_utils/evaluator_utils.hpp"
+
+#include <lanelet2_extension/utility/query.hpp>
+#include <lanelet2_extension/utility/utilities.hpp>
+
+#include <algorithm>
+#include <limits>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace control_diagnostics
+{
+ControlEvaluatorNode::ControlEvaluatorNode(const rclcpp::NodeOptions & node_options)
+: Node("control_evaluator", node_options)
+{
+  using std::placeholders::_1;
+  control_diag_sub_ = create_subscription<DiagnosticArray>(
+    "~/input/diagnostics", 1, std::bind(&ControlEvaluatorNode::onDiagnostics, this, _1));
+
+  // Publisher
+  metrics_pub_ = create_publisher<DiagnosticArray>("~/metrics", 1);
+
+  // Timer callback to publish evaluator diagnostics
+  using namespace std::literals::chrono_literals;
+  timer_ =
+    rclcpp::create_timer(this, get_clock(), 100ms, std::bind(&ControlEvaluatorNode::onTimer, this));
+}
+
+void ControlEvaluatorNode::getRouteData()
+{
+  // route
+  {
+    const auto msg = route_subscriber_.takeData();
+    if (msg) {
+      if (msg->segments.empty()) {
+        RCLCPP_ERROR(get_logger(), "input route is empty. ignored");
+      } else {
+        route_handler_.setRoute(*msg);
+      }
+    }
+  }
+
+  // map
+  {
+    const auto msg = vector_map_subscriber_.takeData();
+    if (msg) {
+      route_handler_.setMap(*msg);
+    }
+  }
+}
+
+void ControlEvaluatorNode::onDiagnostics(const DiagnosticArray::ConstSharedPtr diag_msg)
+{
+  // add target diagnostics to the queue and remove old ones
+  for (const auto & function : target_functions_) {
+    autoware::evaluator_utils::updateDiagnosticQueue(*diag_msg, function, now(), diag_queue_);
+  }
+}
+
+DiagnosticStatus ControlEvaluatorNode::generateAEBDiagnosticStatus(const DiagnosticStatus & diag)
+{
+  DiagnosticStatus status;
+  status.level = status.OK;
+  status.name = diag.name;
+  diagnostic_msgs::msg::KeyValue key_value;
+  key_value.key = "decision";
+  const bool is_emergency_brake = (diag.level == DiagnosticStatus::ERROR);
+  key_value.value = (is_emergency_brake) ? "deceleration" : "none";
+  status.values.push_back(key_value);
+  return status;
+}
+
+DiagnosticStatus ControlEvaluatorNode::generateLaneletDiagnosticStatus(const Pose & ego_pose) const
+{
+  const auto current_lanelets = [&]() {
+    lanelet::ConstLanelet closest_route_lanelet;
+    route_handler_.getClosestLaneletWithinRoute(ego_pose, &closest_route_lanelet);
+    const auto shoulder_lanelets = route_handler_.getShoulderLaneletsAtPose(ego_pose);
+    lanelet::ConstLanelets closest_lanelets{closest_route_lanelet};
+    closest_lanelets.insert(
+      closest_lanelets.end(), shoulder_lanelets.begin(), shoulder_lanelets.end());
+    return closest_lanelets;
+  }();
+  const auto arc_coordinates = lanelet::utils::getArcCoordinates(current_lanelets, ego_pose);
+  lanelet::ConstLanelet current_lane;
+  lanelet::utils::query::getClosestLanelet(current_lanelets, ego_pose, &current_lane);
+
+  DiagnosticStatus status;
+  status.name = "ego_lane_info";
+  status.level = status.OK;
+  diagnostic_msgs::msg::KeyValue key_value;
+  key_value.key = "lane_id";
+  key_value.value = std::to_string(current_lane.id());
+  status.values.push_back(key_value);
+  key_value.key = "s";
+  key_value.value = std::to_string(arc_coordinates.length);
+  status.values.push_back(key_value);
+  key_value.key = "t";
+  key_value.value = std::to_string(arc_coordinates.distance);
+  status.values.push_back(key_value);
+  return status;
+}
+
+DiagnosticStatus ControlEvaluatorNode::generateKinematicStateDiagnosticStatus(
+  const Odometry & odom, const AccelWithCovarianceStamped & accel_stamped)
+{
+  DiagnosticStatus status;
+  status.name = "kinematic_state";
+  status.level = status.OK;
+  diagnostic_msgs::msg::KeyValue key_value;
+  key_value.key = "vel";
+  key_value.value = std::to_string(odom.twist.twist.linear.x);
+  status.values.push_back(key_value);
+  key_value.key = "acc";
+  const auto & acc = accel_stamped.accel.accel.linear.x;
+  key_value.value = std::to_string(acc);
+  status.values.push_back(key_value);
+  key_value.key = "jerk";
+  const auto jerk = [&]() {
+    if (!prev_acc_stamped_.has_value()) {
+      prev_acc_stamped_ = accel_stamped;
+      return 0.0;
+    }
+    const auto t = static_cast<double>(accel_stamped.header.stamp.sec) +
+                   static_cast<double>(accel_stamped.header.stamp.nanosec) * 1e-9;
+    const auto prev_t = static_cast<double>(prev_acc_stamped_.value().header.stamp.sec) +
+                        static_cast<double>(prev_acc_stamped_.value().header.stamp.nanosec) * 1e-9;
+    const auto dt = t - prev_t;
+    if (dt < std::numeric_limits<double>::epsilon()) return 0.0;
+
+    const auto prev_acc = prev_acc_stamped_.value().accel.accel.linear.x;
+    prev_acc_stamped_ = accel_stamped;
+    return (acc - prev_acc) / dt;
+  }();
+  key_value.value = std::to_string(jerk);
+  status.values.push_back(key_value);
+  return status;
+}
+
+DiagnosticStatus ControlEvaluatorNode::generateLateralDeviationDiagnosticStatus(
+  const Trajectory & traj, const Point & ego_point)
+{
+  const double lateral_deviation = metrics::calcLateralDeviation(traj, ego_point);
+
+  DiagnosticStatus status;
+  status.level = status.OK;
+  status.name = "lateral_deviation";
+  diagnostic_msgs::msg::KeyValue key_value;
+  key_value.key = "metric_value";
+  key_value.value = std::to_string(lateral_deviation);
+  status.values.push_back(key_value);
+
+  return status;
+}
+
+DiagnosticStatus ControlEvaluatorNode::generateYawDeviationDiagnosticStatus(
+  const Trajectory & traj, const Pose & ego_pose)
+{
+  const double yaw_deviation = metrics::calcYawDeviation(traj, ego_pose);
+
+  DiagnosticStatus status;
+  status.level = status.OK;
+  status.name = "yaw_deviation";
+  diagnostic_msgs::msg::KeyValue key_value;
+  key_value.key = "metric_value";
+  key_value.value = std::to_string(yaw_deviation);
+  status.values.push_back(key_value);
+
+  return status;
+}
+
+void ControlEvaluatorNode::onTimer()
+{
+  DiagnosticArray metrics_msg;
+  const auto traj = traj_sub_.takeData();
+  const auto odom = odometry_sub_.takeData();
+  const auto acc = accel_sub_.takeData();
+
+  // generate decision diagnostics from input diagnostics
+  for (const auto & function : target_functions_) {
+    const auto it = std::find_if(
+      diag_queue_.begin(), diag_queue_.end(),
+      [&function](const std::pair<diagnostic_msgs::msg::DiagnosticStatus, rclcpp::Time> & p) {
+        return p.first.name.find(function) != std::string::npos;
+      });
+    if (it == diag_queue_.end()) {
+      continue;
+    }
+    // generate each decision diagnostics
+    // - AEB decision
+    if (it->first.name.find("autonomous_emergency_braking") != std::string::npos) {
+      metrics_msg.status.push_back(generateAEBDiagnosticStatus(it->first));
+    }
+  }
+
+  // calculate deviation metrics
+  if (odom && traj && !traj->points.empty()) {
+    const Pose ego_pose = odom->pose.pose;
+    metrics_msg.status.push_back(
+      generateLateralDeviationDiagnosticStatus(*traj, ego_pose.position));
+    metrics_msg.status.push_back(generateYawDeviationDiagnosticStatus(*traj, ego_pose));
+  }
+
+  getRouteData();
+  if (odom && route_handler_.isHandlerReady()) {
+    const Pose ego_pose = odom->pose.pose;
+    metrics_msg.status.push_back(generateLaneletDiagnosticStatus(ego_pose));
+  }
+
+  if (odom && acc) {
+    metrics_msg.status.push_back(generateKinematicStateDiagnosticStatus(*odom, *acc));
+  }
+
+  metrics_msg.header.stamp = now();
+  metrics_pub_->publish(metrics_msg);
+}
+}  // namespace control_diagnostics
+
+#include "rclcpp_components/register_node_macro.hpp"
+RCLCPP_COMPONENTS_REGISTER_NODE(control_diagnostics::ControlEvaluatorNode)

--- a/control/autoware_control_evaluator/src/metrics/deviation_metrics.cpp
+++ b/control/autoware_control_evaluator/src/metrics/deviation_metrics.cpp
@@ -1,0 +1,41 @@
+// Copyright 2024 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/control_evaluator/metrics/deviation_metrics.hpp"
+
+#include "autoware/universe_utils/geometry/geometry.hpp"
+#include "autoware/universe_utils/geometry/pose_deviation.hpp"
+#include "tier4_autoware_utils/trajectory/trajectory.hpp"
+
+namespace control_diagnostics
+{
+namespace metrics
+{
+using autoware_planning_msgs::msg::Trajectory;
+
+double calcLateralDeviation(const Trajectory & traj, const Point & point)
+{
+  const size_t nearest_index = tier4_autoware_utils::findNearestIndex(traj.points, point);
+  return std::abs(
+    tier4_autoware_utils::calcLateralDeviation(traj.points[nearest_index].pose, point));
+}
+
+double calcYawDeviation(const Trajectory & traj, const Pose & pose)
+{
+  const size_t nearest_index = tier4_autoware_utils::findNearestIndex(traj.points, pose.position);
+  return std::abs(tier4_autoware_utils::calcYawDeviation(traj.points[nearest_index].pose, pose));
+}
+
+}  // namespace metrics
+}  // namespace control_diagnostics

--- a/control/autoware_control_evaluator/src/metrics/deviation_metrics.cpp
+++ b/control/autoware_control_evaluator/src/metrics/deviation_metrics.cpp
@@ -14,15 +14,15 @@
 
 #include "autoware/control_evaluator/metrics/deviation_metrics.hpp"
 
-#include "autoware/universe_utils/geometry/geometry.hpp"
-#include "autoware/universe_utils/geometry/pose_deviation.hpp"
+#include "tier4_autoware_utils/geometry/geometry.hpp"
+#include "tier4_autoware_utils/geometry/pose_deviation.hpp"
 #include "tier4_autoware_utils/trajectory/trajectory.hpp"
 
 namespace control_diagnostics
 {
 namespace metrics
 {
-using autoware_planning_msgs::msg::Trajectory;
+using autoware_auto_planning_msgs::msg::Trajectory;
 
 double calcLateralDeviation(const Trajectory & traj, const Point & point)
 {

--- a/control/autoware_evaluator_utils/CMakeLists.txt
+++ b/control/autoware_evaluator_utils/CMakeLists.txt
@@ -1,0 +1,13 @@
+cmake_minimum_required(VERSION 3.14)
+project(autoware_evaluator_utils)
+
+find_package(autoware_cmake REQUIRED)
+autoware_package()
+
+ament_auto_add_library(evaluator_utils SHARED
+  src/evaluator_utils.cpp
+)
+
+ament_auto_package(
+  INSTALL_TO_SHARE
+)

--- a/control/autoware_evaluator_utils/README.md
+++ b/control/autoware_evaluator_utils/README.md
@@ -1,0 +1,5 @@
+# Evaluator Utils
+
+## Purpose
+
+This package provides utils functions for other evaluator packages

--- a/control/autoware_evaluator_utils/include/autoware/evaluator_utils/evaluator_utils.hpp
+++ b/control/autoware_evaluator_utils/include/autoware/evaluator_utils/evaluator_utils.hpp
@@ -1,0 +1,45 @@
+// Copyright 2024 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef AUTOWARE__EVALUATOR_UTILS__EVALUATOR_UTILS_HPP_
+#define AUTOWARE__EVALUATOR_UTILS__EVALUATOR_UTILS_HPP_
+
+#include <rclcpp/rclcpp.hpp>
+
+#include <diagnostic_msgs/msg/diagnostic_array.hpp>
+
+#include <deque>
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace autoware::evaluator_utils
+{
+
+using diagnostic_msgs::msg::DiagnosticArray;
+using diagnostic_msgs::msg::DiagnosticStatus;
+using DiagnosticQueue = std::deque<std::pair<DiagnosticStatus, rclcpp::Time>>;
+
+void removeOldDiagnostics(const rclcpp::Time & stamp, DiagnosticQueue & diag_queue);
+void removeDiagnosticsByName(const std::string & name, DiagnosticQueue & diag_queue);
+void addDiagnostic(
+  const DiagnosticStatus & diag, const rclcpp::Time & stamp, DiagnosticQueue & diag_queue);
+void updateDiagnosticQueue(
+  const DiagnosticArray & input_diagnostics, const std::string & function,
+  const rclcpp::Time & stamp, DiagnosticQueue & diag_queue);
+
+}  // namespace autoware::evaluator_utils
+
+#endif  // AUTOWARE__EVALUATOR_UTILS__EVALUATOR_UTILS_HPP_

--- a/control/autoware_evaluator_utils/package.xml
+++ b/control/autoware_evaluator_utils/package.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>autoware_evaluator_utils</name>
+  <version>0.1.0</version>
+  <description>ROS 2 node for evaluating control</description>
+  <maintainer email="daniel.sanchez@tier4.jp">Daniel SANCHEZ</maintainer>
+  <maintainer email="takayuki.murooka@tier4.jp">Takayuki MUROOKA</maintainer>
+  <license>Apache License 2.0</license>
+
+  <author email="daniel.sanchez@tier4.jp">Daniel SANCHEZ</author>
+  <author email="takayuki.murooka@tier4.jp">Takayuki MUROOKA</author>
+
+  <buildtool_depend>ament_cmake_auto</buildtool_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
+
+  <depend>diagnostic_msgs</depend>
+  <depend>rclcpp</depend>
+  <depend>rclcpp_components</depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/control/autoware_evaluator_utils/src/evaluator_utils.cpp
+++ b/control/autoware_evaluator_utils/src/evaluator_utils.cpp
@@ -1,0 +1,66 @@
+// Copyright 2024 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/evaluator_utils/evaluator_utils.hpp"
+
+#include <algorithm>
+
+namespace autoware::evaluator_utils
+{
+void removeOldDiagnostics(const rclcpp::Time & stamp, DiagnosticQueue & diag_queue)
+{
+  constexpr double KEEP_TIME = 1.0;
+  diag_queue.erase(
+    std::remove_if(
+      diag_queue.begin(), diag_queue.end(),
+      [stamp](const std::pair<DiagnosticStatus, rclcpp::Time> & p) {
+        return (stamp - p.second).seconds() > KEEP_TIME;
+      }),
+    diag_queue.end());
+}
+
+void removeDiagnosticsByName(const std::string & name, DiagnosticQueue & diag_queue)
+{
+  diag_queue.erase(
+    std::remove_if(
+      diag_queue.begin(), diag_queue.end(),
+      [&name](const std::pair<DiagnosticStatus, rclcpp::Time> & p) {
+        return p.first.name.find(name) != std::string::npos;
+      }),
+    diag_queue.end());
+}
+
+void addDiagnostic(
+  const DiagnosticStatus & diag, const rclcpp::Time & stamp, DiagnosticQueue & diag_queue)
+{
+  diag_queue.push_back(std::make_pair(diag, stamp));
+}
+
+void updateDiagnosticQueue(
+  const DiagnosticArray & input_diagnostics, const std::string & function,
+  const rclcpp::Time & stamp, DiagnosticQueue & diag_queue)
+{
+  const auto it = std::find_if(
+    input_diagnostics.status.begin(), input_diagnostics.status.end(),
+    [&function](const DiagnosticStatus & diag) {
+      return diag.name.find(function) != std::string::npos;
+    });
+  if (it != input_diagnostics.status.end()) {
+    removeDiagnosticsByName(it->name, diag_queue);
+    addDiagnostic(*it, input_diagnostics.header.stamp, diag_queue);
+  }
+
+  removeOldDiagnostics(stamp, diag_queue);
+}
+}  // namespace autoware::evaluator_utils


### PR DESCRIPTION
## Description
This PR introduces the control evaluator. 

The control evaluator constantly monitors AEB topics and it is used by the driving log replayer V2 when doing scenario evaluations using rosbags. 

requires changes to launch: https://github.com/tier4/autoware_launch.x1.eve/pull/486
## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
