### PR TITLE
fix(lidar_centerpoint, pointpainting): increase CAPACITY_POINT to avoid crashing

### DIFF
--- a/perception/image_projection_based_fusion/include/image_projection_based_fusion/pointpainting_fusion/pointpainting_trt.hpp
+++ b/perception/image_projection_based_fusion/include/image_projection_based_fusion/pointpainting_fusion/pointpainting_trt.hpp
@@ -23,7 +23,7 @@
 
 namespace image_projection_based_fusion
 {
-static constexpr size_t CAPACITY_POINT = 1000000;
+static constexpr size_t CAPACITY_POINT = 2000000;
 class PointPaintingTRT : public centerpoint::CenterPointTRT
 {
 public:

--- a/perception/lidar_centerpoint/include/lidar_centerpoint/centerpoint_trt.hpp
+++ b/perception/lidar_centerpoint/include/lidar_centerpoint/centerpoint_trt.hpp
@@ -32,7 +32,7 @@
 
 namespace centerpoint
 {
-static constexpr size_t CAPACITY_POINT = 1000000;
+static constexpr size_t CAPACITY_POINT = 2000000;
 
 class NetworkParam
 {


### PR DESCRIPTION
## Description
This PR increases CAPACITY_POINT to avoid crashing due to the large number of points.

⚠️ This is a temporary workaround for this branch.
Since the following PR also addresses this issue, I tried to cherry-pick it, but there were too many conflicts.
Therefore, I directly changed the CAPACITY_POINT in the current code.
- https://github.com/autowarefoundation/autoware.universe/pull/7936

## Related links

[TIER IV INTERNAL](https://tier4.atlassian.net/browse/RT0-31777)

## How was this PR tested?

I confirmed node doesn't crash on the bench environment.

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
