### PR TITLE
feat(out_of_lane): ignore lanelets beyond the last path point

### DIFF
--- a/planning/behavior_velocity_out_of_lane_module/src/lanelets_selection.cpp
+++ b/planning/behavior_velocity_out_of_lane_module/src/lanelets_selection.cpp
@@ -93,6 +93,16 @@ lanelet::ConstLanelets calculate_ignored_lanelets(
     const auto is_path_lanelet = contains_lanelet(path_lanelets, l.second.id());
     if (!is_path_lanelet) ignored_lanelets.push_back(l.second);
   }
+  // ignore lanelets beyond the last path pose
+  const auto beyond =
+    planning_utils::calculateOffsetPoint2d(ego_data.path.points.back().point.pose, params.front_offset, 0.0);
+  const lanelet::BasicPoint2d beyond_point(beyond.x(), beyond.y());
+  const auto beyond_lanelets = lanelet::geometry::findWithin2d(
+    route_handler.getLaneletMapPtr()->laneletLayer, beyond_point, 0.0);
+  for (const auto & l : beyond_lanelets) {
+    const auto is_path_lanelet = contains_lanelet(path_lanelets, l.second.id());
+    if (!is_path_lanelet) ignored_lanelets.push_back(l.second);
+  }
   return ignored_lanelets;
 }
 

--- a/planning/behavior_velocity_out_of_lane_module/src/lanelets_selection.cpp
+++ b/planning/behavior_velocity_out_of_lane_module/src/lanelets_selection.cpp
@@ -94,8 +94,8 @@ lanelet::ConstLanelets calculate_ignored_lanelets(
     if (!is_path_lanelet) ignored_lanelets.push_back(l.second);
   }
   // ignore lanelets beyond the last path pose
-  const auto beyond =
-    planning_utils::calculateOffsetPoint2d(ego_data.path.points.back().point.pose, params.front_offset, 0.0);
+  const auto beyond = planning_utils::calculateOffsetPoint2d(
+    ego_data.path.points.back().point.pose, params.front_offset, 0.0);
   const lanelet::BasicPoint2d beyond_point(beyond.x(), beyond.y());
   const auto beyond_lanelets = lanelet::geometry::findWithin2d(
     route_handler.getLaneletMapPtr()->laneletLayer, beyond_point, 0.0);


### PR DESCRIPTION
## Description

Fix issue where the lanelets at the end of the path were considered as "out of lane", causing wrong stops.
An similar fix is being added to the `main` branch with this PR: https://github.com/autowarefoundation/autoware.universe/pull/8870
Because the implementation on `main` is very different (moved from `behavior_velocity_planner` to `motion_velocity_planner`, new logic, etc), this fix cannot be cherry-picked.

## Related links

**Parent Issue:**

**Private Links:**

- [TIER IV JIRA link](https://tier4.atlassian.net/browse/RT0-33630)

## How was this PR tested?
Perception replayer + Psim.

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
