### PR TITLE
fix(lane_change): change stopping logic (RT0-33761)

### DIFF
--- a/planning/behavior_path_lane_change_module/include/behavior_path_lane_change_module/scene.hpp
+++ b/planning/behavior_path_lane_change_module/include/behavior_path_lane_change_module/scene.hpp
@@ -60,6 +60,8 @@ public:
 
   void insertStopPoint(const lanelet::ConstLanelets & lanelets, PathWithLaneId & path) override;
 
+  void insert_stop_point_on_current_lanes(PathWithLaneId & path);
+
   PathWithLaneId getReferencePath() const override;
 
   std::optional<PathWithLaneId> extendPath() override;
@@ -178,7 +180,7 @@ protected:
 
   std::pair<double, double> calcCurrentMinMaxAcceleration() const;
 
-  void setStopPose(const Pose & stop_pose);
+  void set_stop_pose(const double arc_length_to_stop_pose, PathWithLaneId & path);
 
   void updateStopTime();
 

--- a/planning/behavior_path_lane_change_module/include/behavior_path_lane_change_module/utils/utils.hpp
+++ b/planning/behavior_path_lane_change_module/include/behavior_path_lane_change_module/utils/utils.hpp
@@ -290,12 +290,51 @@ double calcPhaseLength(
   const double velocity, const double maximum_velocity, const double acceleration,
   const double time);
 
+/**
+ * @brief Calculates the minimum distance to a stationary object in the current lanes.
+ *
+ * This function determines the closest distance from the ego vehicle to a stationary object
+ * in the current lanes. It checks if the object is within the stopping criteria based on its
+ * velocity and calculates the distance while accounting for the object's size. Only objects
+ * positioned after the specified distance to the target lane's start are considered.
+ *
+ * @param filtered_objects A collection of lane change target objects, including those in the
+ * current lane.
+ * @param bpp_param Parameters for the behavior path planner, such as vehicle dimensions.
+ * @param lc_param Parameters for the lane change process, including the velocity threshold for
+ * stopping.
+ * @param dist_to_target_lane_start The distance from the ego vehicle to the start of the target
+ * lane.
+ * @param ego_pose The current pose of the ego vehicle.
+ * @param path The current path of the ego vehicle, containing path points and lane information.
+ * @return The minimum distance to a stationary object in the current lanes. If no valid object is
+ * found, returns the maximum possible double value.
+ */
 double get_min_dist_to_current_lanes_obj(
   const LaneChangeTargetObjects & filtered_objects, const BehaviorPathPlannerParameters & bpp_param,
   const LaneChangeParameters & lc_param, const double dist_to_target_lane_start, const Pose & pose,
   const PathWithLaneId & path);
 
-bool has_blocking_target_object_for_stopping(
+/**
+ * @brief Checks if there is any stationary object in the target lanes that would affect the lane
+ * change stop decision.
+ *
+ * This function determines whether there are any stationary objects in the target lanes that could
+ * impact the decision to insert a stop point for the ego vehicle. It checks each object's velocity,
+ * position relative to the ego vehicle, and overlap with the target lanes to identify if any object
+ * meets the criteria for being a blocking obstacle.
+ *
+ * @param target_lanes A collection of lanelets representing the target lanes for the lane change.
+ * @param filtered_objects A collection of lane change target objects, including those in the target
+ * lanes.
+ * @param lc_param Parameters for the lane change process, such as the stop velocity threshold.
+ * @param stop_arc_length The arc length at which the ego vehicle is expected to stop.
+ * @param ego_pose The current pose of the ego vehicle.
+ * @param path The current path of the ego vehicle, containing path points and lane information.
+ * @return true if there is a stationary object in the target lanes that meets the criteria for
+ * being a blocking object; otherwise, false.
+ */
+bool has_blocking_target_object(
   const lanelet::ConstLanelets & target_lanes, const LaneChangeTargetObjects & filtered_objects,
   const LaneChangeParameters & lc_param, const double stop_arc_length, const Pose & ego_pose,
   const PathWithLaneId & path);

--- a/planning/behavior_path_lane_change_module/include/behavior_path_lane_change_module/utils/utils.hpp
+++ b/planning/behavior_path_lane_change_module/include/behavior_path_lane_change_module/utils/utils.hpp
@@ -289,5 +289,15 @@ bool isWithinTurnDirectionLanes(const lanelet::ConstLanelet & lanelet, const Pol
 double calcPhaseLength(
   const double velocity, const double maximum_velocity, const double acceleration,
   const double time);
+
+double get_min_dist_to_current_lanes_obj(
+  const LaneChangeTargetObjects & filtered_objects, const BehaviorPathPlannerParameters & bpp_param,
+  const LaneChangeParameters & lc_param, const double dist_to_target_lane_start, const Pose & pose,
+  const PathWithLaneId & path);
+
+bool has_blocking_target_object_for_stopping(
+  const lanelet::ConstLanelets & target_lanes, const LaneChangeTargetObjects & filtered_objects,
+  const LaneChangeParameters & lc_param, const double stop_arc_length, const Pose & ego_pose,
+  const PathWithLaneId & path);
 }  // namespace behavior_path_planner::utils::lane_change
 #endif  // BEHAVIOR_PATH_LANE_CHANGE_MODULE__UTILS__UTILS_HPP_

--- a/planning/behavior_path_lane_change_module/src/scene.cpp
+++ b/planning/behavior_path_lane_change_module/src/scene.cpp
@@ -165,8 +165,7 @@ BehaviorModuleOutput NormalLaneChange::generateOutput()
         output.path.points, output.path.points.front().point.pose.position, getEgoPosition());
       const auto stop_dist =
         -(current_velocity * current_velocity / (2.0 * planner_data_->parameters.min_acc));
-      const auto stop_point = utils::insertStopPoint(stop_dist + current_dist, output.path);
-      setStopPose(stop_point.point.pose);
+      set_stop_pose(stop_dist + current_dist, output.path);
     } else {
       insertStopPoint(status_.target_lanes, output.path);
     }
@@ -204,7 +203,7 @@ void NormalLaneChange::extendOutputDrivableArea(BehaviorModuleOutput & output)
 void NormalLaneChange::insertStopPoint(
   const lanelet::ConstLanelets & lanelets, PathWithLaneId & path)
 {
-  if (lanelets.empty() || status_.current_lanes.empty() || status_.target_lanes.empty()) {
+  if (lanelets.empty() || status_.current_lanes.empty()) {
     return;
   }
 
@@ -214,44 +213,57 @@ void NormalLaneChange::insertStopPoint(
     return;
   }
 
-  const auto shift_intervals = route_handler->getLateralIntervalsToPreferredLane(lanelets.back());
+  const auto & current_lanes = status_.current_lanes;
+  const auto is_current_lane = lanelets.front().id() == current_lanes.front().id() &&
+                               lanelets.back().id() == current_lanes.back().id();
 
-  if (shift_intervals.empty()) {
+  // if input is not current lane, we can just insert the points at terminal.
+  if (!is_current_lane) {
+    const auto shift_intervals = route_handler->getLateralIntervalsToPreferredLane(lanelets.back());
+    const auto min_dist_buffer = utils::lane_change::calcMinimumLaneChangeLength(
+      *lane_change_parameters_, shift_intervals, 0.0);
+    const auto backward_length_buffer =
+      lane_change_parameters_->backward_length_buffer_for_end_of_lane;
+    const auto arc_length_to_stop_pose =
+      motion_utils::calcArcLength(path.points) - backward_length_buffer + min_dist_buffer;
+    set_stop_pose(arc_length_to_stop_pose, path);
     return;
   }
 
-  const auto min_single_lc_length = utils::lane_change::calcMinimumLaneChangeLength(
-    *lane_change_parameters_, {shift_intervals.front()}, 0.0);
+  insert_stop_point_on_current_lanes(path);
+}
 
-  const auto getDistanceAlongLanelet = [&](const geometry_msgs::msg::Pose & target) {
-    return utils::getSignedDistance(path.points.front().point.pose, target, lanelets);
+void NormalLaneChange::insert_stop_point_on_current_lanes(PathWithLaneId & path)
+{
+  const auto & path_front_pose = path.points.front().point.pose;
+  const auto & route_handler_ptr = getRouteHandler();
+  const auto & current_lanes = status_.current_lanes;
+  const auto current_path =
+    route_handler_ptr->getCenterLinePath(current_lanes, 0.0, std::numeric_limits<double>::max());
+  const auto & center_line = current_path.points;
+  const auto get_arc_length_along_lanelet = [&](const geometry_msgs::msg::Pose & target) {
+    return motion_utils::calcSignedArcLength(
+      center_line, path_front_pose.position, target.position);
   };
 
-  // If lanelets.back() is in goal route section, get distance to goal.
-  // Otherwise, get distance to end of lane.
   const auto dist_to_terminal = std::invoke([&]() -> double {
-    if (route_handler->isInGoalRouteSection(lanelets.back())) {
-      const auto goal = route_handler->getGoalPose();
-      return getDistanceAlongLanelet(goal);
-    }
-    return utils::getDistanceToEndOfLane(path.points.front().point.pose, lanelets);
+    const auto target_pose = route_handler_ptr->isInGoalRouteSection(current_lanes.back())
+                               ? route_handler_ptr->getGoalPose()
+                               : center_line.back().point.pose;
+    return get_arc_length_along_lanelet(target_pose);
   });
 
-  const auto dist_to_terminal_start = std::invoke([&]() {
-    const auto lane_change_buffer = utils::lane_change::calcMinimumLaneChangeLength(
-      *lane_change_parameters_, shift_intervals, 0.0);
-    const auto stop_point_buffer = lane_change_parameters_->backward_length_buffer_for_end_of_lane;
-    return dist_to_terminal - stop_point_buffer - lane_change_buffer;
-  });
+  const auto shift_intervals =
+    route_handler_ptr->getLateralIntervalsToPreferredLane(current_lanes.back());
+  const auto min_dist_buffer =
+    utils::lane_change::calcMinimumLaneChangeLength(*lane_change_parameters_, shift_intervals, 0.0);
+  const auto backward_length_buffer =
+    lane_change_parameters_->backward_length_buffer_for_end_of_lane;
+  const auto dist_to_terminal_start = dist_to_terminal - min_dist_buffer - backward_length_buffer;
 
-  const auto insert_stop_at_arc_length = [&](const auto & arc_length) {
-    const auto stop_point = utils::insertStopPoint(arc_length, path);
-    setStopPose(stop_point.point.pose);
-  };
-
-  const auto target_objects = getTargetObjects(status_.current_lanes, status_.target_lanes);
-  if (target_objects.current_lane.empty()) {
-    insert_stop_at_arc_length(dist_to_terminal_start);
+  const auto filtered_objects = getTargetObjects(status_.current_lanes, status_.target_lanes);
+  if (filtered_objects.current_lane.empty()) {
+    set_stop_pose(dist_to_terminal_start, path);
     return;
   }
 
@@ -266,47 +278,12 @@ void NormalLaneChange::insertStopPoint(
     tf_quat.setRPY(0, 0, yaw);
     target_front.orientation = tf2::toMsg(tf_quat);
 
-    return getDistanceAlongLanelet(target_front);
+    return get_arc_length_along_lanelet(target_front);
   });
 
-  const auto dist_to_ego = getDistanceAlongLanelet(getEgoPose());
-
-  // calculate minimum distance from path front to the stationary object on the ego lane.
-  const auto arc_length_to_current_obj = std::invoke([&]() -> double {
-    auto min_dist_to_obj = std::numeric_limits<double>::max();
-    for (const auto & object : target_objects.current_lane) {
-      // check if stationary
-      const auto obj_v = std::abs(object.initial_twist.twist.linear.x);
-      if (obj_v > lane_change_parameters_->stop_velocity_threshold) {
-        continue;
-      }
-
-      // provide "estimation" based on size of object
-      const auto dist_to_obj =
-        getDistanceAlongLanelet(object.initial_pose.pose) - (object.shape.dimensions.x / 2);
-
-      if (dist_to_obj < dist_to_target_lane_start || dist_to_obj < dist_to_ego) {
-        continue;
-      }
-
-      // calculate distance from path front to the stationary object polygon on the ego lane.
-      const auto polygon =
-        tier4_autoware_utils::toPolygon2d(object.initial_pose.pose, object.shape).outer();
-      for (const auto & polygon_p : polygon) {
-        const auto p_fp = tier4_autoware_utils::toMsg(polygon_p.to_3d());
-        const auto lateral_fp = motion_utils::calcLateralOffset(path.points, p_fp);
-
-        // ignore if the point is around the ego path
-        if (std::abs(lateral_fp) > planner_data_->parameters.vehicle_width) {
-          continue;
-        }
-
-        const auto current_distance_to_obj = calcSignedArcLength(path.points, 0, p_fp);
-        min_dist_to_obj = std::min(min_dist_to_obj, current_distance_to_obj);
-      }
-    }
-    return min_dist_to_obj;
-  });
+  const auto arc_length_to_current_obj = utils::lane_change::get_min_dist_to_current_lanes_obj(
+    filtered_objects, getCommonParam(), *lane_change_parameters_, dist_to_target_lane_start,
+    getEgoPose(), path);
 
   // margin with leading vehicle
   // consider rss distance when the LC need to avoid obstacles
@@ -314,23 +291,22 @@ void NormalLaneChange::insertStopPoint(
     0.0, lane_change_parameters_->minimum_lane_changing_velocity,
     lane_change_parameters_->rss_params);
 
+  const auto min_single_lc_length = utils::lane_change::calcMinimumLaneChangeLength(
+    *lane_change_parameters_, {shift_intervals.front()}, 0.0);
   const auto stop_margin = min_single_lc_length +
                            lane_change_parameters_->backward_length_buffer_for_blocking_object +
                            rss_dist + getCommonParam().base_link2front;
   const auto stop_arc_length_behind_obj = arc_length_to_current_obj - stop_margin;
 
   if (stop_arc_length_behind_obj < dist_to_target_lane_start) {
-    insert_stop_at_arc_length(dist_to_target_lane_start);
+    set_stop_pose(dist_to_target_lane_start, path);
     return;
   }
 
   if (stop_arc_length_behind_obj > dist_to_terminal_start) {
-    insert_stop_at_arc_length(dist_to_terminal_start);
+    set_stop_pose(dist_to_terminal_start, path);
     return;
   }
-
-  const auto target_lanes_poly =
-    lanelet::utils::combineLaneletsShape(status_.target_lanes).polygon2d().basicPolygon();
 
   //  If the target lane in the lane change section is blocked by a stationary obstacle, there
   //  is no reason for stopping with a lane change margin. Instead, stop right behind the
@@ -340,34 +316,17 @@ void NormalLaneChange::insertStopPoint(
   //  ----------------------------------------------------------
   //    [ego]>          | <--- stop margin --->  [obj]>
   //  ----------------------------------------------------------
-  const auto has_blocking_target_lane_obj = std::any_of(
-    target_objects.target_lane.begin(), target_objects.target_lane.end(),
-    [&](const ExtendedPredictedObject & o) {
-      const auto v = std::abs(o.initial_twist.twist.linear.x);
-      if (v > lane_change_parameters_->stop_velocity_threshold) {
-        return false;
-      }
-
-      // target_objects includes objects out of target lanes, so filter them out
-      if (boost::geometry::disjoint(
-            tier4_autoware_utils::toPolygon2d(o.initial_pose.pose, o.shape).outer(),
-            target_lanes_poly)) {
-        return false;
-      }
-
-      const auto arc_length_to_target_lane_obj = getDistanceAlongLanelet(o.initial_pose.pose);
-      const auto width_margin = o.shape.dimensions.x / 2;
-      const auto upper_bound = arc_length_to_target_lane_obj - width_margin;
-      const auto lower_bound = arc_length_to_target_lane_obj + width_margin;
-      return lower_bound > dist_to_ego && upper_bound < stop_arc_length_behind_obj;
-    });
+  const auto has_blocking_target_lane_obj =
+    utils::lane_change::has_blocking_target_object_for_stopping(
+      status_.target_lanes, filtered_objects, *lane_change_parameters_, stop_arc_length_behind_obj,
+      getEgoPose(), path);
 
   if (has_blocking_target_lane_obj || stop_arc_length_behind_obj <= 0.0) {
-    insert_stop_at_arc_length(dist_to_terminal_start);
+    set_stop_pose(dist_to_terminal_start, path);
     return;
   }
 
-  insert_stop_at_arc_length(stop_arc_length_behind_obj);
+  set_stop_pose(stop_arc_length_behind_obj, path);
 }
 
 PathWithLaneId NormalLaneChange::getReferencePath() const
@@ -1869,9 +1828,10 @@ bool NormalLaneChange::isVehicleStuck(const lanelet::ConstLanelets & current_lan
   return isVehicleStuck(current_lanes, detection_distance);
 }
 
-void NormalLaneChange::setStopPose(const Pose & stop_pose)
+void NormalLaneChange::set_stop_pose(const double arc_length_to_stop_pose, PathWithLaneId & path)
 {
-  lane_change_stop_pose_ = stop_pose;
+  const auto stop_point = utils::insertStopPoint(arc_length_to_stop_pose, path);
+  lane_change_stop_pose_ = stop_point.point.pose;
 }
 
 void NormalLaneChange::updateStopTime()

--- a/planning/behavior_path_lane_change_module/src/scene.cpp
+++ b/planning/behavior_path_lane_change_module/src/scene.cpp
@@ -316,10 +316,9 @@ void NormalLaneChange::insert_stop_point_on_current_lanes(PathWithLaneId & path)
   //  ----------------------------------------------------------
   //    [ego]>          | <--- stop margin --->  [obj]>
   //  ----------------------------------------------------------
-  const auto has_blocking_target_lane_obj =
-    utils::lane_change::has_blocking_target_object_for_stopping(
-      status_.target_lanes, filtered_objects, *lane_change_parameters_, stop_arc_length_behind_obj,
-      getEgoPose(), path);
+  const auto has_blocking_target_lane_obj = utils::lane_change::has_blocking_target_object(
+    status_.target_lanes, filtered_objects, *lane_change_parameters_, stop_arc_length_behind_obj,
+    getEgoPose(), path);
 
   if (has_blocking_target_lane_obj || stop_arc_length_behind_obj <= 0.0) {
     set_stop_pose(dist_to_terminal_start, path);

--- a/planning/behavior_path_lane_change_module/src/utils/utils.cpp
+++ b/planning/behavior_path_lane_change_module/src/utils/utils.cpp
@@ -1256,7 +1256,7 @@ double get_min_dist_to_current_lanes_obj(
       const auto p_fp = tier4_autoware_utils::toMsg(polygon_p.to_3d());
       const auto lateral_fp = motion_utils::calcLateralOffset(path_points, p_fp);
 
-      // ignore if the point is around the ego path
+      // ignore if the point is not on ego path
       if (std::abs(lateral_fp) > (bpp_param.vehicle_width / 2)) {
         continue;
       }

--- a/planning/behavior_path_lane_change_module/src/utils/utils.cpp
+++ b/planning/behavior_path_lane_change_module/src/utils/utils.cpp
@@ -1219,4 +1219,89 @@ double calcPhaseLength(
   const auto length_with_max_velocity = maximum_velocity * duration;
   return std::min(length_with_acceleration, length_with_max_velocity);
 }
+
+double get_min_dist_to_current_lanes_obj(
+  const LaneChangeTargetObjects & filtered_objects, const BehaviorPathPlannerParameters & bpp_param,
+  const LaneChangeParameters & lc_param, const double dist_to_target_lane_start,
+  const Pose & ego_pose, const PathWithLaneId & path)
+{
+  const auto & path_points = path.points;
+
+  auto min_dist_to_obj = std::numeric_limits<double>::max();
+  for (const auto & object : filtered_objects.current_lane) {
+    // check if stationary
+    const auto obj_v = std::abs(object.initial_twist.twist.linear.x);
+    if (obj_v > lc_param.stop_velocity_threshold) {
+      continue;
+    }
+
+    // provide "estimation" based on size of object
+    const auto dist_to_obj =
+      motion_utils::calcSignedArcLength(
+        path_points, path_points.front().point.pose.position, object.initial_pose.pose.position) -
+      (object.shape.dimensions.x / 2);
+
+    const auto dist_to_ego = motion_utils::calcSignedArcLength(
+                               path_points, ego_pose.position, object.initial_pose.pose.position) -
+                             (object.shape.dimensions.x / 2);
+
+    if (dist_to_obj < dist_to_target_lane_start || dist_to_obj < dist_to_ego) {
+      continue;
+    }
+
+    // calculate distance from path front to the stationary object polygon on the ego lane.
+    const auto obj_poly =
+      tier4_autoware_utils::toPolygon2d(object.initial_pose.pose, object.shape).outer();
+    for (const auto & polygon_p : obj_poly) {
+      const auto p_fp = tier4_autoware_utils::toMsg(polygon_p.to_3d());
+      const auto lateral_fp = motion_utils::calcLateralOffset(path_points, p_fp);
+
+      // ignore if the point is around the ego path
+      if (std::abs(lateral_fp) > (bpp_param.vehicle_width / 2)) {
+        continue;
+      }
+
+      const auto current_distance_to_obj = motion_utils::calcSignedArcLength(path_points, 0, p_fp);
+      min_dist_to_obj = std::min(min_dist_to_obj, current_distance_to_obj);
+    }
+  }
+  return min_dist_to_obj;
+}
+
+bool has_blocking_target_object_for_stopping(
+  const lanelet::ConstLanelets & target_lanes, const LaneChangeTargetObjects & filtered_objects,
+  const LaneChangeParameters & lc_param, const double stop_arc_length, const Pose & ego_pose,
+  const PathWithLaneId & path)
+{
+  const auto target_lane_poly =
+    lanelet::utils::combineLaneletsShape(target_lanes).polygon2d().basicPolygon();
+  return std::any_of(
+    filtered_objects.target_lane.begin(), filtered_objects.target_lane.end(),
+    [&](const ExtendedPredictedObject & o) {
+      const auto v = std::abs(o.initial_twist.twist.linear.x);
+      if (v > lc_param.stop_velocity_threshold) {
+        return false;
+      }
+
+      const auto arc_length_to_ego =
+        motion_utils::calcSignedArcLength(
+          path.points, ego_pose.position, o.initial_pose.pose.position) -
+        (o.shape.dimensions.x / 2);
+
+      if (arc_length_to_ego < 0.0) {
+        return false;
+      }
+
+      const auto obj_poly = tier4_autoware_utils::toPolygon2d(o.initial_pose.pose, o.shape);
+      // filtered_objects includes objects out of target lanes, so filter them out
+      if (boost::geometry::disjoint(obj_poly, target_lane_poly)) {
+        return false;
+      }
+
+      const auto arc_length_to_target_lane_obj = motion_utils::calcSignedArcLength(
+        path.points, path.points.front().point.pose.position, o.initial_pose.pose.position);
+      const auto width_margin = o.shape.dimensions.x / 2;
+      return (arc_length_to_target_lane_obj - width_margin) >= stop_arc_length;
+    });
+}
 }  // namespace behavior_path_planner::utils::lane_change


### PR DESCRIPTION
## Description

The lane change module evaluates the validity of the lane change start point. If the start point is determined to be invalid, the module responds by placing a stop point only at the terminal start position.

An invalid start point occurs when it is not located within the target neighboring lane.

However, as highlighted in the `RT0-33761`, checking the start point's validity is impractical in certain scenarios. By the time the start point becomes valid, the expected stop point's position is already behind the ego vehicle. This results in the stop point being incorrectly placed behind the ego vehicle, leading to sudden and unintended deceleration.

The proposed PR addresses this issue by improving how the distance is captured. It ensures that only objects located between the target lane start and the terminal start are detected and considered. This fix prevents the stop point from being inserted behind the ego vehicle, improving lane change behavior and eliminating sudden deceleration.

### Before PR

https://github.com/user-attachments/assets/386bbdf8-3e0e-482c-b40c-5880da545cf5

![image](https://github.com/user-attachments/assets/040789ec-7276-4436-8129-32867463e8cc)


### After PR

https://github.com/user-attachments/assets/d953b12e-ff17-4706-89f4-ab03fa51511d

![image](https://github.com/user-attachments/assets/888abb2d-deea-4a05-96d3-8523aa2ea1c9)



<!--
original flow chart
@startuml
start

if (the number of lanes to the preferred lane is equal to zero) then (yes)
:Do not insert stop pose;
stop
else (no)
:Check if the start point is valid;
if (the start point is not valid) then (yes)
:Insert stop pose at terminal start;
stop
else (no)

if (the distance to the object in the ego lane is less than the distance to the terminal) then (yes)
if (the target lane does not have a blocking object) then (yes)
:Insert stop pose behind object;
stop
else (no)
:Do not insert stop pose;
stop
endif
endif

if (the stopping distance is greater than zero) then (yes)
:Insert a stop point at stopping_distance;
stop
endif

:Do not insert stop pose;

stop
@enduml

@startuml
start
if (NumLaneToPreferredLane is zero) then (yes)
  stop
else (no)
  if (shift_intervals is empty) then (yes)
    stop
  else (no)
    if (stop_arc_length_behind_obj is less than dist_to_target_lane_start) then (yes)
      :Insert stop at dist_to_target_lane_start;
      stop
    else (no)
      if (stop_arc_length_behind_obj is greater than dist_to_terminal_start) then (yes)
        :Insert stop at dist_to_terminal_start;
        stop
      else (no)
        if (has_blocking_target_lane_obj or stop_arc_length_behind_obj is less than or equal to 0.0) then (yes)
          :Insert stop at dist_to_terminal_start;
          stop
        else (no)
          :Insert stop at stop_arc_length_behind_obj;
          stop
        endif
      endif
    endif
endif
@enduml
-->


## Related links

https://github.com/autowarefoundation/autoware.universe/pull/9070

**Parent Issue:**



## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
