### PR TITLE
chore(autoware_pointcloud_preprocessor): change unnecessary warning message to debug (#8525)

### DIFF
--- a/sensing/pointcloud_preprocessor/src/concatenate_data/concatenate_and_time_sync_nodelet.cpp
+++ b/sensing/pointcloud_preprocessor/src/concatenate_data/concatenate_and_time_sync_nodelet.cpp
@@ -286,7 +286,7 @@ PointCloudConcatenateDataSynchronizerComponent::computeTransformToAdjustForOldTi
 
   // return identity if old_stamp is newer than new_stamp
   if (old_stamp > new_stamp) {
-    RCLCPP_WARN_STREAM_THROTTLE(
+    RCLCPP_DEBUG_STREAM_THROTTLE(
       get_logger(), *get_clock(), std::chrono::milliseconds(10000).count(),
       "old_stamp is newer than new_stamp,");
     return Eigen::Matrix4f::Identity();


### PR DESCRIPTION
## Description

https://github.com/autowarefoundation/autoware.universe/pull/8525 のbackport

## Related links

**Parent Issue:**

- https://tier4.atlassian.net/browse/VEH-1097
- https://star4.slack.com/archives/CRUE57C30/p1729044019642129

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

コンソール出力のレベルの変更のため、コード確認のみ実施した

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
