### PR TITLE
fix: remove ScopedTimeTrack which causes goal planner crash

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/goal_planner_module.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/goal_planner_module.cpp
@@ -1244,8 +1244,6 @@ bool GoalPlannerModule::hasDecidedPath(
   const std::shared_ptr<SafetyCheckParams> & safety_check_params,
   const std::shared_ptr<GoalSearcherBase> goal_searcher) const
 {
-  universe_utils::ScopedTimeTrack st(__func__, *time_keeper_);
-
   return checkDecidingPathStatus(
            planner_data, occupancy_grid_map, parameters, ego_predicted_path_params,
            objects_filtering_params, safety_check_params, goal_searcher)
@@ -1261,8 +1259,6 @@ bool GoalPlannerModule::hasNotDecidedPath(
   const std::shared_ptr<SafetyCheckParams> & safety_check_params,
   const std::shared_ptr<GoalSearcherBase> goal_searcher) const
 {
-  universe_utils::ScopedTimeTrack st(__func__, *time_keeper_);
-
   return checkDecidingPathStatus(
            planner_data, occupancy_grid_map, parameters, ego_predicted_path_params,
            objects_filtering_params, safety_check_params, goal_searcher)
@@ -1278,8 +1274,6 @@ DecidingPathStatusWithStamp GoalPlannerModule::checkDecidingPathStatus(
   const std::shared_ptr<SafetyCheckParams> & safety_check_params,
   const std::shared_ptr<GoalSearcherBase> goal_searcher) const
 {
-  universe_utils::ScopedTimeTrack st(__func__, *time_keeper_);
-
   const auto & prev_status = thread_safe_data_.get_prev_data().deciding_path_status;
   const bool enable_safety_check = parameters.safety_check_params.enable_safety_check;
 
@@ -2375,8 +2369,6 @@ std::pair<bool, bool> GoalPlannerModule::isSafePath(
   const std::shared_ptr<ObjectsFilteringParams> & objects_filtering_params,
   const std::shared_ptr<SafetyCheckParams> & safety_check_params) const
 {
-  universe_utils::ScopedTimeTrack st(__func__, *time_keeper_);
-
   if (!thread_safe_data_.get_pull_over_path()) {
     return {false, false};
   }


### PR DESCRIPTION
## Description
Crash happened in `goal planner` from  X2 v3.1.1.
```
[component_container_mt-6] [ERROR 1729579718.156755464] [lanelet2_extension] getExpandedLanelet(): "Fail to expand lanelet. output may be undesired. Lanelet points interval in map data could be too narrow." at (/home/autoware/autoware.proj/src/autoware/common/tmp/lanelet2_extension/lib/utilities.cpp:L437)
[component_container_mt-6] [ERROR 1729579719.252083043] [lanelet2_extension] getExpandedLanelet(): "Fail to expand lanelet. output may be undesired. Lanelet points interval in map data could be too narrow." at (/home/autoware/autoware.proj/src/autoware/common/tmp/lanelet2_extension/lib/utilities.cpp:L437)
[component_container_mt-6] terminate called after throwing an instance of 'std::runtime_error'
[component_container_mt-6]   what():  You must call end_track(updateData) first, but end_track(isSafePath) is called
[component_container_mt-6] *** Aborted at 1729579720 (unix time) try "date -d @1729579720" if you are using GNU date ***
[component_container_mt-6] PC: @                0x0 (unknown)
[component_container_mt-6] *** SIGABRT (@0x3e80000e170) received by PID 57712 (TID 0x7fdd5a7f4640) from PID 57712; stack trace: ***
[component_container_mt-6]     @     0x7fdd697af4d6 google::(anonymous namespace)::FailureSignalHandler()
[component_container_mt-6]     @     0x7fdd6905f520 (unknown)
[component_container_mt-6]     @     0x7fdd690b39fc pthread_kill
[component_container_mt-6]     @     0x7fdd6905f476 raise
[component_container_mt-6]     @     0x7fdd690457f3 abort
[component_container_mt-6]     @     0x7fdd6930ab9e (unknown)
[component_container_mt-6]     @     0x7fdd6931620c (unknown)
[component_container_mt-6]     @     0x7fdd693151e9 (unknown)
[component_container_mt-6]     @     0x7fdd69315959 __gxx_personality_v0
[component_container_mt-6]     @     0x7fdd6925e884 (unknown)
[component_container_mt-6]     @     0x7fdd6925ef41 _Unwind_RaiseException
[component_container_mt-6]     @     0x7fdd693164cb __cxa_throw
[component_container_mt-6]     @     0x7fdd3bca6a07 _ZN8autoware14universe_utils10TimeKeeper9end_trackERKNSt7__cxx1112basic_stringIcSt11char_traitsIcESaIcEEE.cold
[component_container_mt-6]     @     0x7fdd3bcb9d94 autoware::universe_utils::ScopedTimeTrack::~ScopedTimeTrack()
[component_container_mt-6]     @     0x7fdd3abdfc75 autoware::behavior_path_planner::GoalPlannerModule::isSafePath()
[component_container_mt-6]     @     0x7fdd3abe0d39 autoware::behavior_path_planner::GoalPlannerModule::checkDecidingPathStatus()
[component_container_mt-6]     @     0x7fdd3abe2047 autoware::behavior_path_planner::GoalPlannerModule::hasDecidedPath()
[component_container_mt-6]     @     0x7fdd3abe3d29 autoware::behavior_path_planner::GoalPlannerModule::onTimer()
[component_container_mt-6]     @     0x7fdd3abea995 rclcpp::GenericTimer<>::execute_callback()
[component_container_mt-6]     @     0x7fdd6962cffe rclcpp::Executor::execute_any_executable()
[component_container_mt-6]     @     0x7fdd69633432 rclcpp::executors::MultiThreadedExecutor::run()
[component_container_mt-6]     @     0x7fdd69344253 (unknown)
[component_container_mt-6]     @     0x7fdd690b1ac3 (unknown)
[component_container_mt-6]     @     0x7fdd69143850 (unknown)
[ERROR] [component_container_mt-6]: process has died [pid 57712, exit code -6, cmd '/home/autoware/autoware.proj/install/rclcpp_components/lib/rclcpp_components/component_container_mt --ros-args -r __node:=behavior_planning_container -r __ns:=/planning/scenario_planning/lane_driving/behavior_planning -p use_sim_time:=False -p wheel_radius:=0.3725 -p wheel_width:=0.215 -p wheel_base:=4.76 -p wheel_tread:=1.754 -p front_overhang:=0.9154 -p rear_overhang:=1.498 -p left_overhang:=0.273 -p right_overhang:=0.273 -p vehicle_height:=3.06 -p max_steer_angle:=0.618'].
```
https://github.com/autowarefoundation/autoware.universe/pull/8780
https://github.com/autowarefoundation/autoware.universe/pull/8610
These two PRs above are mentioned by planning team, which are merged into `autoware.universe` from autoware foundation, but not synchronized in `beta/v0.29.0-1` from `tier4/autoware.universe`.

This PR synchronizes `beta/v0.29.0-1` with these two fixes.

## Related links

**Parent Issue:**

[Related ticket](https://tier4.atlassian.net/browse/RT0-33981)

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
