### PR TITLE
feat(multi_object_tracker): add object filtering to data association

### DIFF
--- a/perception/multi_object_tracker/include/multi_object_tracker/data_association/data_association.hpp
+++ b/perception/multi_object_tracker/include/multi_object_tracker/data_association/data_association.hpp
@@ -54,6 +54,7 @@ public:
   void assign(
     const Eigen::MatrixXd & src, std::unordered_map<int, int> & direct_assignment,
     std::unordered_map<int, int> & reverse_assignment);
+  void objectFilter(autoware_auto_perception_msgs::msg::DetectedObjects & measurements) const;
   Eigen::MatrixXd calcScoreMatrix(
     const autoware_auto_perception_msgs::msg::DetectedObjects & measurements,
     const std::list<std::shared_ptr<Tracker>> & trackers);

--- a/perception/multi_object_tracker/src/data_association/data_association.cpp
+++ b/perception/multi_object_tracker/src/data_association/data_association.cpp
@@ -146,6 +146,37 @@ void DataAssociation::assign(
   }
 }
 
+void DataAssociation::objectFilter(
+  autoware_auto_perception_msgs::msg::DetectedObjects & measurements) const
+{
+  using Label = autoware_auto_perception_msgs::msg::ObjectClassification;
+
+  for (auto & measurement_object : measurements.objects) {
+    auto & obj_class_list = measurement_object.classification;
+    const std::uint8_t measurement_label =
+      object_recognition_utils::getHighestProbLabel(obj_class_list);
+    bool passed_gate = true;
+    const double max_area = max_area_matrix_(measurement_label, measurement_label);
+    const double min_area = min_area_matrix_(measurement_label, measurement_label);
+    const double area = tier4_autoware_utils::getArea(measurement_object.shape);
+    if (area < min_area || max_area < area) passed_gate = false;
+
+    //
+    if (!passed_gate) {
+      // change top-rate label to unknown, step back the existing labels
+      constexpr float RATE_REDUCED = 0.3f;
+      constexpr float RATE_OVERWRITE = 0.7f;
+      for (auto & obj_class : obj_class_list) {
+        obj_class.probability *= RATE_REDUCED;
+      }
+      Label new_obj_class;
+      new_obj_class.label = Label::UNKNOWN;
+      new_obj_class.probability = RATE_OVERWRITE;
+      obj_class_list.emplace_back(new_obj_class);
+    }
+  }
+}
+
 Eigen::MatrixXd DataAssociation::calcScoreMatrix(
   const autoware_auto_perception_msgs::msg::DetectedObjects & measurements,
   const std::list<std::shared_ptr<Tracker>> & trackers)
@@ -178,13 +209,6 @@ Eigen::MatrixXd DataAssociation::calcScoreMatrix(
         // dist gate
         if (passed_gate) {
           if (max_dist < dist) passed_gate = false;
-        }
-        // area gate
-        if (passed_gate) {
-          const double max_area = max_area_matrix_(tracker_label, measurement_label);
-          const double min_area = min_area_matrix_(tracker_label, measurement_label);
-          const double area = tier4_autoware_utils::getArea(measurement_object.shape);
-          if (area < min_area || max_area < area) passed_gate = false;
         }
         // angle gate
         if (passed_gate) {

--- a/perception/multi_object_tracker/src/multi_object_tracker_core.cpp
+++ b/perception/multi_object_tracker/src/multi_object_tracker_core.cpp
@@ -264,6 +264,8 @@ void MultiObjectTracker::onMeasurement(
     (*itr)->predict(measurement_time);
   }
 
+  data_association_->objectFilter(transformed_objects);
+
   /* global nearest neighbor */
   std::unordered_map<int, int> direct_assignment, reverse_assignment;
   Eigen::MatrixXd score_matrix = data_association_->calcScoreMatrix(


### PR DESCRIPTION
## Description

1. check object size(area) before the association matrix,
2. if the object size is not in the size range, make the label unknown.

## Related links

**Parent Issue:**

- Link


<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->


## How was this PR tested?


Before

https://github.com/user-attachments/assets/b0857ee1-2f55-42ff-a42f-3c850aeac751

After

https://github.com/user-attachments/assets/8a655135-331f-466e-836a-8d0f4920109f


Another Case - After

https://github.com/user-attachments/assets/95daad69-e444-4b07-a553-2d5382e9c3c2




## Notes for reviewers



None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
