### PR TITLE
fix(traffic_light_utils): prevent accessing nullopt (#9163)

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/utils/traffic_light_utils.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner_common/src/utils/traffic_light_utils.cpp
@@ -34,11 +34,13 @@ double getDistanceToNextTrafficLight(
     lanelet::utils::to2D(lanelet_point).basicPoint());
 
   for (const auto & element : current_lanelet.regulatoryElementsAs<lanelet::TrafficLight>()) {
-    lanelet::ConstLineString3d lanelet_stop_lines = element->stopLine().value();
+    const auto lanelet_stop_lines = element->stopLine();
+
+    if (!lanelet_stop_lines.has_value()) continue;
 
     const auto to_stop_line = lanelet::geometry::toArcCoordinates(
       lanelet::utils::to2D(current_lanelet.centerline()),
-      lanelet::utils::to2D(lanelet_stop_lines).front().basicPoint());
+      lanelet::utils::to2D(lanelet_stop_lines.value()).front().basicPoint());
 
     const auto distance_object_to_stop_line = to_stop_line.length - to_object.length;
 
@@ -61,11 +63,13 @@ double getDistanceToNextTrafficLight(
     }
 
     for (const auto & element : llt.regulatoryElementsAs<lanelet::TrafficLight>()) {
-      lanelet::ConstLineString3d lanelet_stop_lines = element->stopLine().value();
+      const auto lanelet_stop_lines = element->stopLine();
+
+      if (!lanelet_stop_lines.has_value()) continue;
 
       const auto to_stop_line = lanelet::geometry::toArcCoordinates(
         lanelet::utils::to2D(llt.centerline()),
-        lanelet::utils::to2D(lanelet_stop_lines).front().basicPoint());
+        lanelet::utils::to2D(lanelet_stop_lines.value()).front().basicPoint());
 
       return distance + to_stop_line.length - to_object.length;
     }


### PR DESCRIPTION
## Description
Cherry-pick https://github.com/autowarefoundation/autoware.universe/pull/9163

## Related links
https://github.com/autowarefoundation/autoware.universe/pull/9163

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
