### PR TITLE
qBv0191+relax unknown stop

### DIFF
--- a/planning/obstacle_cruise_planner/config/obstacle_cruise_planner.param.yaml
+++ b/planning/obstacle_cruise_planner/config/obstacle_cruise_planner.param.yaml
@@ -222,3 +222,5 @@
           sudden_object_acc_threshold: -1.1 # If a stop can be achieved by a deceleration smaller than this value, it is not considered as “sudden stop".
           sudden_object_dist_threshold: 1000.0 # If a stop distance is longer than this value, it is not considered as “sudden stop".
           abandon_to_stop: false # If true, the planner gives up to stop when it cannot avoid to run over while maintaining the deceleration limit.
+      limit_margin_for_unknown: 3.0
+      preffered_acc_for_unknown: -3.0

--- a/planning/obstacle_cruise_planner/include/obstacle_cruise_planner/node.hpp
+++ b/planning/obstacle_cruise_planner/include/obstacle_cruise_planner/node.hpp
@@ -110,6 +110,8 @@ private:
   double additional_safe_distance_margin_on_curve_;
   double min_safe_distance_margin_on_curve_;
   bool suppress_sudden_obstacle_stop_;
+  double limit_margin_for_unknown_;
+  double preffered_acc_for_unknown_;
 
   std::vector<int> stop_obstacle_types_;
   std::vector<int> inside_cruise_obstacle_types_;

--- a/planning/obstacle_cruise_planner/include/obstacle_cruise_planner/planner_interface.hpp
+++ b/planning/obstacle_cruise_planner/include/obstacle_cruise_planner/planner_interface.hpp
@@ -65,7 +65,8 @@ public:
     const bool enable_debug_info, const bool enable_calculation_time_info,
     const double min_behavior_stop_margin, const double enable_approaching_on_curve,
     const double additional_safe_distance_margin_on_curve,
-    const double min_safe_distance_margin_on_curve, const bool suppress_sudden_obstacle_stop)
+    const double min_safe_distance_margin_on_curve, const bool suppress_sudden_obstacle_stop,
+    const double limit_margin_for_unknown, const double preffered_acc_for_unknown)
   {
     enable_debug_info_ = enable_debug_info;
     enable_calculation_time_info_ = enable_calculation_time_info;
@@ -74,6 +75,8 @@ public:
     additional_safe_distance_margin_on_curve_ = additional_safe_distance_margin_on_curve;
     min_safe_distance_margin_on_curve_ = min_safe_distance_margin_on_curve;
     suppress_sudden_obstacle_stop_ = suppress_sudden_obstacle_stop;
+    limit_margin_for_unknown_ = limit_margin_for_unknown;
+    preffered_acc_for_unknown_ = preffered_acc_for_unknown;
   }
 
   std::vector<TrajectoryPoint> generateStopTrajectory(
@@ -123,6 +126,8 @@ protected:
   double additional_safe_distance_margin_on_curve_;
   double min_safe_distance_margin_on_curve_;
   bool suppress_sudden_obstacle_stop_;
+  double limit_margin_for_unknown_;
+  double preffered_acc_for_unknown_;
 
   // stop watch
   tier4_autoware_utils::StopWatch<

--- a/planning/obstacle_cruise_planner/src/node.cpp
+++ b/planning/obstacle_cruise_planner/src/node.cpp
@@ -452,7 +452,6 @@ ObstacleCruisePlannerNode::ObstacleCruisePlannerNode(const rclcpp::NodeOptions &
       enable_approaching_on_curve_, additional_safe_distance_margin_on_curve_,
       min_safe_distance_margin_on_curve_, suppress_sudden_obstacle_stop_, limit_margin_for_unknown_,
       preffered_acc_for_unknown_);
-
   }
 
   {  // stop/cruise/slow down obstacle type

--- a/planning/obstacle_cruise_planner/src/node.cpp
+++ b/planning/obstacle_cruise_planner/src/node.cpp
@@ -445,10 +445,14 @@ ObstacleCruisePlannerNode::ObstacleCruisePlannerNode(const rclcpp::NodeOptions &
       declare_parameter<double>("common.stop_on_curve.min_safe_distance_margin");
     suppress_sudden_obstacle_stop_ =
       declare_parameter<bool>("common.suppress_sudden_obstacle_stop");
+    limit_margin_for_unknown_ = declare_parameter<double>("stop.limit_margin_for_unknown");
+    preffered_acc_for_unknown_ = declare_parameter<double>("stop.preffered_acc_for_unknown");
     planner_ptr_->setParam(
       enable_debug_info_, enable_calculation_time_info_, min_behavior_stop_margin_,
       enable_approaching_on_curve_, additional_safe_distance_margin_on_curve_,
-      min_safe_distance_margin_on_curve_, suppress_sudden_obstacle_stop_);
+      min_safe_distance_margin_on_curve_, suppress_sudden_obstacle_stop_, limit_margin_for_unknown_,
+      preffered_acc_for_unknown_);
+
   }
 
   {  // stop/cruise/slow down obstacle type
@@ -496,11 +500,16 @@ rcl_interfaces::msg::SetParametersResult ObstacleCruisePlannerNode::onParam(
   tier4_autoware_utils::updateParam<double>(
     parameters, "common.stop_on_curve.min_safe_distance_margin",
     min_safe_distance_margin_on_curve_);
+  tier4_autoware_utils::updateParam<double>(
+    parameters, "stop.limit_margin_for_unknown", limit_margin_for_unknown_);
+  tier4_autoware_utils::updateParam<double>(
+    parameters, "stop.preffered_acc_for_unknown", preffered_acc_for_unknown_);
 
   planner_ptr_->setParam(
     enable_debug_info_, enable_calculation_time_info_, min_behavior_stop_margin_,
     enable_approaching_on_curve_, additional_safe_distance_margin_on_curve_,
-    min_safe_distance_margin_on_curve_, suppress_sudden_obstacle_stop_);
+    min_safe_distance_margin_on_curve_, suppress_sudden_obstacle_stop_, limit_margin_for_unknown_,
+    preffered_acc_for_unknown_);
 
   tier4_autoware_utils::updateParam<bool>(
     parameters, "common.enable_slow_down_planning", enable_slow_down_planning_);

--- a/planning/obstacle_cruise_planner/src/planner_interface.cpp
+++ b/planning/obstacle_cruise_planner/src/planner_interface.cpp
@@ -323,7 +323,6 @@ std::vector<TrajectoryPoint> PlannerInterface::generateStopTrajectory(
             planner_data.ego_vel, longitudinal_info_.limit_max_accel,
             stop_param_.getParam(stop_obstacle.classification).sudden_object_acc_threshold),
           stop_param_.getParam(stop_obstacle.classification).sudden_object_dist_threshold);
-
         if (candidate_zero_vel_dist > distance_to_judge_suddenness) {
           return longitudinal_info_.limit_min_accel;
         }

--- a/planning/obstacle_cruise_planner/src/planner_interface.cpp
+++ b/planning/obstacle_cruise_planner/src/planner_interface.cpp
@@ -263,9 +263,6 @@ std::vector<TrajectoryPoint> PlannerInterface::generateStopTrajectory(
   std::optional<double> determined_zero_vel_dist{};
   std::optional<double> determined_desired_margin{};
 
-  const double limit_margin_for_unknown = 3.0;
-  const double preffered_acc_for_unknown = -3.0;
-
   const auto closest_stop_obstacles =
     obstacle_cruise_utils::getClosestStopObstacles(stop_obstacles);
   for (const auto & stop_obstacle : closest_stop_obstacles) {
@@ -308,9 +305,9 @@ std::vector<TrajectoryPoint> PlannerInterface::generateStopTrajectory(
         motion_utils::calcSignedArcLength(
           planner_data.traj_points, 0, planner_data.ego_pose.position) +
         calcMinimumDistanceToStop(
-          planner_data.ego_vel, longitudinal_info_.limit_max_accel, preffered_acc_for_unknown);
+          planner_data.ego_vel, longitudinal_info_.limit_max_accel, preffered_acc_for_unknown_);
       const double liimit_margin_stop_dist =
-        std::max(0.0, dist_to_collide_on_ref_traj - limit_margin_for_unknown);
+        std::max(0.0, dist_to_collide_on_ref_traj - limit_margin_for_unknown_);
       if (pref_acc_stop_dist > candidate_zero_vel_dist) {
         candidate_zero_vel_dist = std::min(pref_acc_stop_dist, liimit_margin_stop_dist);
       }


### PR DESCRIPTION
## Description
https://star4.slack.com/archives/C015H42UVBK/p1729760774267989 の件
「unknownに対しては、（追記）-3.0m/ssで本来のマージン（6m）を開けた停止位置に止まれなさそうなら、-3.0m/ssで止まれるように停止位置を先に伸ばす。ただし、最低限のマージン（例えば3m）は確保し続ける。」
の変更PRです。

## Related links

**Parent Issue:**

- Link

## How was this PR tested?
psim

## Notes for reviewers

None.

## Interface changes

None.

## Effects on system behavior

None.
