### PR TITLE
revert: "feat(lane_departure_checker): add parameter of footprint_extra_margin"

### DIFF
--- a/control/lane_departure_checker/README.md
+++ b/control/lane_departure_checker/README.md
@@ -43,10 +43,6 @@ This package includes the following features:
 
 2. Expand footprint based on the standard deviation multiplied with `footprint_margin_scale`.
 
-### How to extend footprint by constant
-
-Expand footprint based on the constant defined with `footprint_extra_margin`.
-
 ## Interface
 
 ### Input
@@ -76,7 +72,6 @@ Expand footprint based on the constant defined with `footprint_extra_margin`.
 | Name                       | Type   | Description                                                                        | Default value |
 | :------------------------- | :----- | :--------------------------------------------------------------------------------- | :------------ |
 | footprint_margin_scale     | double | Coefficient for expanding footprint margin. Multiplied by 1 standard deviation.    | 1.0           |
-| footprint_extra_margin     | double | Coefficient for expanding footprint margin. When checking for lane departure.[m]   | 0.0           |
 | resample_interval          | double | Minimum Euclidean distance between points when resample trajectory.[m]             | 0.3           |
 | max_deceleration           | double | Maximum deceleration when calculating braking distance.                            | 2.8           |
 | delay_time                 | double | Delay time which took to actuate brake when calculating braking distance. [second] | 1.3           |

--- a/control/lane_departure_checker/config/lane_departure_checker.param.yaml
+++ b/control/lane_departure_checker/config/lane_departure_checker.param.yaml
@@ -6,7 +6,6 @@
 
     # Core
     footprint_margin_scale: 1.0
-    footprint_extra_margin: 0.0
     resample_interval: 0.3
     max_deceleration: 2.8
     delay_time: 1.3

--- a/control/lane_departure_checker/include/lane_departure_checker/lane_departure_checker.hpp
+++ b/control/lane_departure_checker/include/lane_departure_checker/lane_departure_checker.hpp
@@ -50,7 +50,6 @@ using TrajectoryPoints = std::vector<TrajectoryPoint>;
 struct Param
 {
   double footprint_margin_scale;
-  double footprint_extra_margin;
   double resample_interval;
   double max_deceleration;
   double delay_time;

--- a/control/lane_departure_checker/include/lane_departure_checker/util/create_vehicle_footprint.hpp
+++ b/control/lane_departure_checker/include/lane_departure_checker/util/create_vehicle_footprint.hpp
@@ -89,9 +89,4 @@ inline FootprintMargin calcFootprintMargin(
   return FootprintMargin{Cov_xy_vehicle(0, 0) * scale, Cov_xy_vehicle(1, 1) * scale};
 }
 
-inline FootprintMargin operator+(FootprintMargin fm, const double margin)
-{
-  return FootprintMargin{fm.lon + margin, fm.lat + margin};
-}
-
 #endif  // LANE_DEPARTURE_CHECKER__UTIL__CREATE_VEHICLE_FOOTPRINT_HPP_

--- a/control/lane_departure_checker/src/lane_departure_checker_node/lane_departure_checker.cpp
+++ b/control/lane_departure_checker/src/lane_departure_checker_node/lane_departure_checker.cpp
@@ -219,8 +219,7 @@ std::vector<LinearRing2d> LaneDepartureChecker::createVehicleFootprints(
   const Param & param)
 {
   // Calculate longitudinal and lateral margin based on covariance
-  const auto margin =
-    calcFootprintMargin(covariance, param.footprint_margin_scale) + param.footprint_extra_margin;
+  const auto margin = calcFootprintMargin(covariance, param.footprint_margin_scale);
 
   // Create vehicle footprint in base_link coordinate
   const auto local_vehicle_footprint = createVehicleFootprint(*vehicle_info_ptr_, margin);

--- a/control/lane_departure_checker/src/lane_departure_checker_node/lane_departure_checker_node.cpp
+++ b/control/lane_departure_checker/src/lane_departure_checker_node/lane_departure_checker_node.cpp
@@ -128,7 +128,6 @@ LaneDepartureCheckerNode::LaneDepartureCheckerNode(const rclcpp::NodeOptions & o
   vehicle_length_m_ = vehicle_info.vehicle_length_m;
 
   param_.footprint_margin_scale = declare_parameter("footprint_margin_scale", 1.0);
-  param_.footprint_extra_margin = declare_parameter("footprint_extra_margin", 0.0);
   param_.resample_interval = declare_parameter("resample_interval", 0.3);
   param_.max_deceleration = declare_parameter("max_deceleration", 3.0);
   param_.delay_time = declare_parameter("delay_time", 0.3);
@@ -353,7 +352,6 @@ rcl_interfaces::msg::SetParametersResult LaneDepartureCheckerNode::onParameter(
 
     // Core
     update_param(parameters, "footprint_margin_scale", param_.footprint_margin_scale);
-    update_param(parameters, "footprint_extra_margin", param_.footprint_extra_margin);
     update_param(parameters, "resample_interval", param_.resample_interval);
     update_param(parameters, "max_deceleration", param_.max_deceleration);
     update_param(parameters, "delay_time", param_.delay_time);


### PR DESCRIPTION
## Description

<!-- Write a brief description of this PR. -->
Reverts tier4/autoware.universe#1565

現時点、自己位置推定ずれ検出機能には「突然眼の前に発生した停止線」に対して自己位置推定のずれがなかった場合においても緊急停止してしまう問題がある。

この問題を孕んだ状態でリリースが難しいというプロジェクト判断により、v0.3.19としては自己位置推定ずれ検出機能のlaunch実装（起動設定及びMRM動作設定）を無効化し、次期リリースv0.3.20で正式にリリースする方針とする。

## Related links

<!-- Write the links related to this PR. -->
[管理チケット](https://tier4.atlassian.net/browse/AEAP-1873)

## Tests performed

<!-- Describe how you have tested this PR. -->

### 妥当性確認
githubのrevert機能を利用していることから、 Revert処理について自動化できているためヒューマンエラーの混入リスクを防止できている。

### 検証
他PR適用により削除されることが前提となるため、本PR単体としての機能変更の検証は不要と判断。

## Notes for reviewers

<!-- Write additional information if necessary. It should be written if there are related PRs that should be merged at the same time. -->

## Pre-review checklist for the PR author

The PR author **must** check the checkboxes below when creating the PR.

- [x] I've confirmed the [contribution guidelines].
- [x] The PR follows the [pull request guidelines].

## In-review checklist for the PR reviewers

The PR reviewers **must** check the checkboxes below before approval.

- [ ] The PR follows the [pull request guidelines].
- [ ] The PR has been properly tested.
- [ ] The PR has been reviewed by the code owners.

## Post-review checklist for the PR author

The PR author **must** check the checkboxes below before merging.

- [x] There are no open discussions or they are tracked via tickets.
- [x] The PR is ready for merge.

After all checkboxes are checked, anyone who has write access can merge the PR.

[contribution guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/
[pull request guidelines]: https://autowarefoundation.github.io/autoware-documentation/main/contributing/pull-request-guidelines/