### PR TITLE
fix(system_error_monitor): data_ready_timeout Increase

### DIFF
--- a/system/system_error_monitor/launch/system_error_monitor.launch.xml
+++ b/system/system_error_monitor/launch/system_error_monitor.launch.xml
@@ -2,7 +2,7 @@
   <arg name="config_file" default="$(find-pkg-share system_error_monitor)/config/system_error_monitor.param.yaml"/>
   <arg name="ignore_missing_diagnostics" default="false"/>
   <arg name="add_leaf_diagnostics" default="true"/>
-  <arg name="data_ready_timeout" default="30.0"/>
+  <arg name="data_ready_timeout" default="300.0"/>
   <arg name="data_heartbeat_timeout" default="1.0"/>
   <arg name="diag_timeout_sec" default="1.0"/>
   <arg name="hazard_recovery_timeout" default="5.0"/>


### PR DESCRIPTION
## Description

本PRは、Web.Agentを直接モードで起動する場合に、
Web.Agentの起動時間が長くなる事で、Agentの起動完了する前に、初期位置設定がtimeoutする問題を
対策するためのPRです。

本設定により、timeoutの閾値を、30[sec]から300[sec]に延長する事で、
Agentの起動完了時間を確保する事ができ、初期位置未設定によるtimeoutは解消されます。

本修正を適用しない場合は、「Psim+FMSによる初期位置設定」のケースのみ、EMが発生します。
本問題は、実車には影響がありまねせん。

※timeout時間：
　検証結果より120[sec]にする事で、現象が改善する事は確認済み。だが、余裕をもって、300[sec]とする

## Related links

[Internal link](https://tier4.atlassian.net/browse/AEAP-1906)

## How was this PR tested?

- Psimを用いて、Autoware起動してから、120[sec]に初期値を設定してもEMにならないことを確認済み。
- Psimを用いて、Autoware起動してから、300[sec]後にEMになることを確認済み。

## Notes for reviewers

Web.Agentを用いた、FMSとの通信に関しては、リリース評価で検証をする。

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
