### PR TITLE
feat(detection_area)!: suppression of giving up stopping

### DIFF
--- a/planning/behavior_velocity_planner/include/scene_module/detection_area/scene.hpp
+++ b/planning/behavior_velocity_planner/include/scene_module/detection_area/scene.hpp
@@ -58,6 +58,8 @@ public:
     double dead_line_margin;
     bool use_pass_judge_line;
     double state_clear_time;
+    double distance_to_judge_over_stop_line;
+    bool suppress_pass_judge_when_stopping;
   };
 
 public:
@@ -82,7 +84,8 @@ private:
 
   bool isOverLine(
     const autoware_auto_planning_msgs::msg::PathWithLaneId & path,
-    const geometry_msgs::msg::Pose & self_pose, const geometry_msgs::msg::Pose & line_pose) const;
+    const geometry_msgs::msg::Pose & self_pose, const geometry_msgs::msg::Pose & line_pose,
+    const double margin) const;
 
   bool hasEnoughBrakingDistance(
     const geometry_msgs::msg::Pose & self_pose, const geometry_msgs::msg::Pose & line_pose) const;

--- a/planning/behavior_velocity_planner/src/scene_module/detection_area/manager.cpp
+++ b/planning/behavior_velocity_planner/src/scene_module/detection_area/manager.cpp
@@ -69,6 +69,10 @@ DetectionAreaModuleManager::DetectionAreaModuleManager(rclcpp::Node & node)
   planner_param_.dead_line_margin = node.declare_parameter(ns + ".dead_line_margin", 5.0);
   planner_param_.use_pass_judge_line = node.declare_parameter(ns + ".use_pass_judge_line", false);
   planner_param_.state_clear_time = node.declare_parameter(ns + ".state_clear_time", 2.0);
+  planner_param_.distance_to_judge_over_stop_line =
+    node.declare_parameter(ns + ".distance_to_judge_over_stop_line", 0.0);
+  planner_param_.suppress_pass_judge_when_stopping =
+    node.declare_parameter(ns + ".suppress_pass_judge_when_stopping", false);
 }
 
 void DetectionAreaModuleManager::launchNewModules(


### PR DESCRIPTION
## Description
This PR implements functionality to enable stopping when obstacles are detected within the DA (Detection Area) after passing the stop line. 

The implemented code leverages existing features from autowarefoundation to meet the requirements specified in the [documentation](https://docs.google.com/presentation/d/1_OSWKhMmRUf1QYhQGOVd9jnOLOWl8S7rGE-5VcO04zk/edit#slide=id.g315595f3e6d_0_10363).

This PR is implemented with reference to the following PRs:
- https://github.com/autowarefoundation/autoware.universe/pull/3114
- https://github.com/autowarefoundation/autoware.universe/pull/9255

### Implementation Details

The correspondence between design requirements and implementation is as follows:

|Requirement|Implementation Location|
|:--|:--|
|Add Param for margin in StopLine override judgment|https://github.com/tier4/autoware.universe/pull/1631/files#diff-eab2555cc9571b6c90cacb8122131e12d7bd9258aaf241781c4e7cf3287b7b73R61|
|Add Param for DA judgment time extension setting|https://github.com/tier4/autoware.universe/pull/1631/files#diff-eab2555cc9571b6c90cacb8122131e12d7bd9258aaf241781c4e7cf3287b7b73R62|
|When DA judgment time extension is enabled, extend DA stop judgment time until (vehicle speed > 0) is observed|https://github.com/tier4/autoware.universe/pull/1631/files#diff-45a0b8c1f68a13b18e90d3b03a96d5572006228360e908ee749b333fa7acb7e5R234-R238|
|Add margin to StopLine override judgment|https://github.com/tier4/autoware.universe/pull/1631/files#diff-45a0b8c1f68a13b18e90d3b03a96d5572006228360e908ee749b333fa7acb7e5R374-R375|

## Related links

**Parent Issue:**
- [Link](https://tier4.atlassian.net/browse/AEAP-1903?focusedCommentId=194502)
- https://github.com/tier4/autoware_launch.x1.eve/pull/511


## How was this PR tested?

Since there are no changes to the Interface*, we determined that functional testing of this DetectionAreaModule using the following Test criteria is sufficient:

- Test criteria: https://docs.google.com/presentation/d/1_OSWKhMmRUf1QYhQGOVd9jnOLOWl8S7rGE-5VcO04zk/edit#slide=id.g315595f3e6d_0_12942
- Test results: https://tier4.atlassian.net/browse/AEAP-1903?focusedCommentId=194502

I confirm that the specified tests have passed and no critical defects were found in the specified design.

*) Topic names, Msg definitions, SceneModuleInterface

## Notes for reviewers

None.

## Interface changes

None.



## Effects on system behavior

None.
