### PR TITLE
feat: remove max rois limit in the image projection based fusion (#9596)

### DIFF
--- a/perception/image_projection_based_fusion/src/fusion_node.cpp
+++ b/perception/image_projection_based_fusion/src/fusion_node.cpp
@@ -54,8 +54,8 @@ FusionNode<TargetMsg3D, ObjType, Msg2D>::FusionNode(
   }
   if (rois_number_ > 8) {
     RCLCPP_WARN(
-      this->get_logger(), "maximum rois_number is 8. current rois_number is %zu", rois_number_);
-    rois_number_ = 8;
+      this->get_logger(),
+      "Current rois_number is %zu. Large rois number may cause performance issue.", rois_number_);
   }
 
   // Set parameters


### PR DESCRIPTION
## Description

camera_lidar_fusionの最大数が8になっている制限の撤廃

## Related links

**Private Links:**

https://tier4.atlassian.net/browse/RT1-8582?atlOrigin=eyJpIjoiYWUyM2QwOWYwOGM1NDg0NTk3OGJmMTMyY2U3Y2M4MGYiLCJwIjoiamlyYS1zbGFjay1pbnQifQ



<!-- ⬇️🟢

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
