### PR TITLE
fix(surround_obstacle_checker): use tf2::TimePointZero

### DIFF
--- a/planning/surround_obstacle_checker/include/surround_obstacle_checker/node.hpp
+++ b/planning/surround_obstacle_checker/include/surround_obstacle_checker/node.hpp
@@ -99,8 +99,7 @@ private:
   std::optional<Obstacle> getNearestObstacleByDynamicObject() const;
 
   std::optional<geometry_msgs::msg::TransformStamped> getTransform(
-    const std::string & source, const std::string & target, const rclcpp::Time & stamp,
-    double duration_sec) const;
+    const std::string & source, const std::string & target) const;
 
   bool isStopRequired(const bool is_obstacle_found, const bool is_stopped);
 

--- a/planning/surround_obstacle_checker/src/node.cpp
+++ b/planning/surround_obstacle_checker/src/node.cpp
@@ -424,8 +424,7 @@ std::optional<Obstacle> SurroundObstacleCheckerNode::getNearestObstacleByPointCl
     return std::nullopt;
   }
 
-  const auto transform_stamped =
-    getTransform("base_link", pointcloud_ptr_->header.frame_id, pointcloud_ptr_->header.stamp, 0.5);
+  const auto transform_stamped = getTransform("base_link", pointcloud_ptr_->header.frame_id);
 
   if (!transform_stamped) {
     return std::nullopt;
@@ -468,8 +467,7 @@ std::optional<Obstacle> SurroundObstacleCheckerNode::getNearestObstacleByDynamic
 {
   if (!object_ptr_ || !use_dynamic_object_) return std::nullopt;
 
-  const auto transform_stamped =
-    getTransform(object_ptr_->header.frame_id, "base_link", object_ptr_->header.stamp, 0.5);
+  const auto transform_stamped = getTransform(object_ptr_->header.frame_id, "base_link");
 
   if (!transform_stamped) {
     return std::nullopt;
@@ -522,14 +520,12 @@ std::optional<Obstacle> SurroundObstacleCheckerNode::getNearestObstacleByDynamic
 }
 
 std::optional<geometry_msgs::msg::TransformStamped> SurroundObstacleCheckerNode::getTransform(
-  const std::string & source, const std::string & target, const rclcpp::Time & stamp,
-  double duration_sec) const
+  const std::string & source, const std::string & target) const
 {
   geometry_msgs::msg::TransformStamped transform_stamped;
 
   try {
-    transform_stamped =
-      tf_buffer_.lookupTransform(source, target, stamp, tf2::durationFromSec(duration_sec));
+    transform_stamped = tf_buffer_.lookupTransform(source, target, tf2::TimePointZero);
   } catch (tf2::TransformException & ex) {
     return {};
   }


### PR DESCRIPTION
## Description

It seemed that surround obstacle checker took a lot of time to transform process. As a result, other callbacks couldn't recieve topics. In this PR, I fixed the timeout value of `tf2::lookupTransform`.

![image](https://github.com/user-attachments/assets/4835309c-636d-44da-aad9-d20bc2fa90c3)

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
