### PR TITLE
fix: overwrite invalid detection result for gen1

### DIFF
--- a/perception/autoware_crosswalk_traffic_light_estimator/include/autoware_crosswalk_traffic_light_estimator/node.hpp
+++ b/perception/autoware_crosswalk_traffic_light_estimator/include/autoware_crosswalk_traffic_light_estimator/node.hpp
@@ -97,6 +97,8 @@ private:
 
   void removeDuplicateIds(TrafficSignalArray & signal_array) const;
 
+  bool isInvalidDetectionStatus(const TrafficSignal & signal) const;
+
   // Node param
   bool use_last_detect_color_;
   double last_detect_color_hold_time_;

--- a/perception/autoware_crosswalk_traffic_light_estimator/src/node.cpp
+++ b/perception/autoware_crosswalk_traffic_light_estimator/src/node.cpp
@@ -295,6 +295,14 @@ void CrosswalkTrafficLightEstimatorNode::setCrosswalkTrafficSignal(
     if (valid_id2idx_map.count(id)) {
       size_t idx = valid_id2idx_map[id];
       auto signal = msg.traffic_light_groups[idx];
+      if (isInvalidDetectionStatus(signal)) {
+        TrafficSignalElement output_traffic_signal_element;
+        output_traffic_signal_element.color = color;
+        output_traffic_signal_element.shape = TrafficSignalElement::CIRCLE;
+        output_traffic_signal_element.confidence = 1.0;
+        output.traffic_light_groups[idx].elements[0] = output_traffic_signal_element;
+        continue;
+      }
       updateFlashingState(signal);  // check if it is flashing
       // update output msg according to flashing and current state
       output.traffic_light_groups[idx].elements[0].color = updateAndGetColorState(signal);
@@ -309,6 +317,19 @@ void CrosswalkTrafficLightEstimatorNode::setCrosswalkTrafficSignal(
       output.traffic_light_groups.push_back(output_traffic_signal);
     }
   }
+}
+
+bool CrosswalkTrafficLightEstimatorNode::isInvalidDetectionStatus(const TrafficSignal & signal) const
+{
+  // check occlusion, backlight(shape is unknown) and no detection(shape is circle)
+  if (
+    signal.elements.front().color == TrafficSignalElement::UNKNOWN &&
+    signal.elements.front().confidence == 0.0)
+  {
+    return true;
+  }
+
+  return false;
 }
 
 void CrosswalkTrafficLightEstimatorNode::updateFlashingState(const TrafficSignal & signal)

--- a/perception/autoware_crosswalk_traffic_light_estimator/src/node.cpp
+++ b/perception/autoware_crosswalk_traffic_light_estimator/src/node.cpp
@@ -319,13 +319,13 @@ void CrosswalkTrafficLightEstimatorNode::setCrosswalkTrafficSignal(
   }
 }
 
-bool CrosswalkTrafficLightEstimatorNode::isInvalidDetectionStatus(const TrafficSignal & signal) const
+bool CrosswalkTrafficLightEstimatorNode::isInvalidDetectionStatus(
+  const TrafficSignal & signal) const
 {
   // check occlusion, backlight(shape is unknown) and no detection(shape is circle)
   if (
     signal.elements.front().color == TrafficSignalElement::UNKNOWN &&
-    signal.elements.front().confidence == 0.0)
-  {
+    signal.elements.front().confidence == 0.0) {
     return true;
   }
 


### PR DESCRIPTION
## Description
same as https://github.com/tier4/autoware.universe/pull/1705
## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
