### PR TITLE
fix(mpc_lateral_controller): prevent unstable steering command while stopped

### DIFF
--- a/control/autoware_mpc_lateral_controller/include/autoware/mpc_lateral_controller/mpc.hpp
+++ b/control/autoware_mpc_lateral_controller/include/autoware/mpc_lateral_controller/mpc.hpp
@@ -522,8 +522,6 @@ public:
    * @param clock The shared pointer to the RCLCPP clock.
    */
   inline void setClock(rclcpp::Clock::SharedPtr clock) { m_clock = clock; }
-
-  inline double get_wheelbase_length() { return m_vehicle_model_ptr->getWheelbase(); }
 };  // class MPC
 }  // namespace autoware::motion::control::mpc_lateral_controller
 

--- a/control/autoware_mpc_lateral_controller/include/autoware/mpc_lateral_controller/mpc.hpp
+++ b/control/autoware_mpc_lateral_controller/include/autoware/mpc_lateral_controller/mpc.hpp
@@ -522,6 +522,8 @@ public:
    * @param clock The shared pointer to the RCLCPP clock.
    */
   inline void setClock(rclcpp::Clock::SharedPtr clock) { m_clock = clock; }
+
+  inline double get_wheelbase_length() { return m_vehicle_model_ptr->getWheelbase(); }
 };  // class MPC
 }  // namespace autoware::motion::control::mpc_lateral_controller
 

--- a/control/autoware_mpc_lateral_controller/src/mpc_lateral_controller.cpp
+++ b/control/autoware_mpc_lateral_controller/src/mpc_lateral_controller.cpp
@@ -419,7 +419,7 @@ bool MpcLateralController::isStoppedState() const
     m_current_trajectory.points, m_current_kinematic_state.pose.pose, m_ego_nearest_dist_threshold,
     m_ego_nearest_yaw_threshold);
 
-  const auto wheelbase_length = m_mpc->get_wheelbase_length();
+  static constexpr double distance_margin = 1.0;
   const double target_vel = std::invoke([&]() -> double {
     auto min_vel = m_current_trajectory.points.at(nearest).longitudinal_velocity_mps;
     auto covered_distance = 0.0;
@@ -427,7 +427,7 @@ bool MpcLateralController::isStoppedState() const
       min_vel = std::min(min_vel, m_current_trajectory.points.at(i).longitudinal_velocity_mps);
       covered_distance += autoware::universe_utils::calcDistance2d(
         m_current_trajectory.points.at(i - 1).pose, m_current_trajectory.points.at(i).pose);
-      if (covered_distance > wheelbase_length) break;
+      if (covered_distance > distance_margin) break;
     }
     return min_vel;
   });

--- a/control/autoware_mpc_lateral_controller/src/mpc_lateral_controller.cpp
+++ b/control/autoware_mpc_lateral_controller/src/mpc_lateral_controller.cpp
@@ -399,9 +399,16 @@ Lateral MpcLateralController::getInitialControlCommand() const
 
 bool MpcLateralController::isStoppedState() const
 {
+  const double current_vel = m_current_kinematic_state.twist.twist.linear.x;
   // If the nearest index is not found, return false
-  if (m_current_trajectory.points.empty()) {
+  if (
+    m_current_trajectory.points.empty() || std::fabs(current_vel) > m_stop_state_entry_ego_speed) {
     return false;
+  }
+
+  const auto latest_published_cmd = m_ctrl_cmd_prev;  // use prev_cmd as a latest published command
+  if (m_keep_steer_control_until_converged && !isSteerConverged(latest_published_cmd)) {
+    return false;  // not stopState: keep control
   }
 
   // Note: This function used to take into account the distance to the stop line
@@ -412,21 +419,20 @@ bool MpcLateralController::isStoppedState() const
     m_current_trajectory.points, m_current_kinematic_state.pose.pose, m_ego_nearest_dist_threshold,
     m_ego_nearest_yaw_threshold);
 
-  const double current_vel = m_current_kinematic_state.twist.twist.linear.x;
-  const double target_vel = m_current_trajectory.points.at(nearest).longitudinal_velocity_mps;
+  const auto wheelbase_length = m_mpc->get_wheelbase_length();
+  const double target_vel = std::invoke([&]() -> double {
+    auto min_vel = m_current_trajectory.points.at(nearest).longitudinal_velocity_mps;
+    auto covered_distance = 0.0;
+    for (auto i = nearest + 1; i < m_current_trajectory.points.size(); ++i) {
+      min_vel = std::min(min_vel, m_current_trajectory.points.at(i).longitudinal_velocity_mps);
+      covered_distance += autoware::universe_utils::calcDistance2d(
+        m_current_trajectory.points.at(i - 1).pose, m_current_trajectory.points.at(i).pose);
+      if (covered_distance > wheelbase_length) break;
+    }
+    return min_vel;
+  });
 
-  const auto latest_published_cmd = m_ctrl_cmd_prev;  // use prev_cmd as a latest published command
-  if (m_keep_steer_control_until_converged && !isSteerConverged(latest_published_cmd)) {
-    return false;  // not stopState: keep control
-  }
-
-  if (
-    std::fabs(current_vel) < m_stop_state_entry_ego_speed &&
-    std::fabs(target_vel) < m_stop_state_entry_target_speed) {
-    return true;
-  } else {
-    return false;
-  }
+  return std::fabs(target_vel) < m_stop_state_entry_target_speed;
 }
 
 Lateral MpcLateralController::createCtrlCmdMsg(const Lateral & ctrl_cmd)

--- a/control/autoware_mpc_lateral_controller/src/mpc_lateral_controller.cpp
+++ b/control/autoware_mpc_lateral_controller/src/mpc_lateral_controller.cpp
@@ -419,6 +419,9 @@ bool MpcLateralController::isStoppedState() const
     m_current_trajectory.points, m_current_kinematic_state.pose.pose, m_ego_nearest_dist_threshold,
     m_ego_nearest_yaw_threshold);
 
+  // It is possible that stop is executed earlier than stop point, and velocity controller
+  // will not start when the distance from ego to stop point is less than 0.5 meter.
+  // So we use a distance margin to ensure we can detect stopped state.
   static constexpr double distance_margin = 1.0;
   const double target_vel = std::invoke([&]() -> double {
     auto min_vel = m_current_trajectory.points.at(nearest).longitudinal_velocity_mps;


### PR DESCRIPTION
## Description
Cherry pick to fix unstable lateral controller steering command
fix(mpc_lateral_controller): prevent unstable steering command while stopped(https://github.com/autowarefoundation/autoware.universe/pull/9690)

## Related links

**Parent Issue:**

- https://tier4.atlassian.net/browse/RT0-34623?focusedCommentId=200855&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-200855
- https://star4.slack.com/archives/CRUE57C30/p1733911916093339

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?
- PSIM

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

Prevent unstable steering command when Ego is stopped.
