### PR TITLE
fix(obstacle_cruise_planner): use planning factor interface

### DIFF
--- a/planning/autoware_obstacle_cruise_planner/src/node.cpp
+++ b/planning/autoware_obstacle_cruise_planner/src/node.cpp
@@ -726,6 +726,7 @@ void ObstacleCruisePlannerNode::onTrajectory(const Trajectory::ConstSharedPtr ms
   // 8. Publish debug data
   published_time_publisher_->publish_if_subscribed(trajectory_pub_, output_traj.header.stamp);
   planner_ptr_->publishMetrics(now());
+  planner_ptr_->publishPlanningFactors();
   publishDebugMarker();
   publishDebugInfo();
   objects_of_interest_marker_interface_.publishMarkerArray();

--- a/planning/autoware_obstacle_cruise_planner/src/pid_based_planner/pid_based_planner.cpp
+++ b/planning/autoware_obstacle_cruise_planner/src/pid_based_planner/pid_based_planner.cpp
@@ -335,6 +335,10 @@ std::vector<TrajectoryPoint> PIDBasedPlanner::planCruise(
       debug_data_ptr_->obstacles_to_cruise.push_back(cruise_obstacle_info->obstacle);
       debug_data_ptr_->cruise_metrics = makeMetrics("PIDBasedPlanner", "cruise", planner_data);
 
+      planning_factor_interface_->add(
+        stop_traj_points, planner_data.ego_pose, stop_traj_points.at(wall_idx).pose,
+        tier4_planning_msgs::msg::PlanningFactor::NONE,
+        tier4_planning_msgs::msg::SafetyFactorArray{});
       velocity_factors_pub_->publish(obstacle_cruise_utils::makeVelocityFactorArray(
         planner_data.current_time, PlanningBehavior::ADAPTIVE_CRUISE,
         stop_traj_points.at(wall_idx).pose));

--- a/planning/autoware_obstacle_cruise_planner/src/planner_interface.cpp
+++ b/planning/autoware_obstacle_cruise_planner/src/planner_interface.cpp
@@ -338,6 +338,10 @@ std::vector<TrajectoryPoint> PlannerInterface::generateStopTrajectory(
     const auto stop_pose = output_traj_points.at(*zero_vel_idx).pose;
     velocity_factors_pub_->publish(obstacle_cruise_utils::makeVelocityFactorArray(
       planner_data.current_time, PlanningBehavior::ROUTE_OBSTACLE, stop_pose));
+    planning_factor_interface_->add(
+      output_traj_points, planner_data.ego_pose, stop_pose,
+      tier4_planning_msgs::msg::PlanningFactor::STOP,
+      tier4_planning_msgs::msg::SafetyFactorArray{});
     // Store stop reason debug data
     debug_data_ptr_->stop_metrics =
       makeMetrics("PlannerInterface", "stop", planner_data, stop_pose, *determined_stop_obstacle);
@@ -594,6 +598,13 @@ std::vector<TrajectoryPoint> PlannerInterface::generateSlowDownTrajectory(
         planner_data.current_time, PlanningBehavior::ROUTE_OBSTACLE,
         slow_down_traj_points.at(slow_down_wall_idx).pose));
       autoware::universe_utils::appendMarkerArray(markers, &debug_data_ptr_->slow_down_wall_marker);
+      planning_factor_interface_->add(
+        slow_down_traj_points, planner_data.ego_pose,
+        slow_down_traj_points.at(*slow_down_start_idx).pose,
+        slow_down_traj_points.at(*slow_down_end_idx).pose,
+        tier4_planning_msgs::msg::PlanningFactor::SLOW_DOWN,
+        tier4_planning_msgs::msg::SafetyFactorArray{}, planner_data.is_driving_forward,
+        stable_slow_down_vel);
     }
 
     // add debug virtual wall


### PR DESCRIPTION
## Description

Add `PlanningFactorInterface` to output planning factor.

## Related links

**Parent Issue:**

- https://github.com/autowarefoundation/autoware.universe/pull/9676
- https://github.com/tier4/tier4_autoware_msgs/pull/155

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

1. launch Psim.
2. put Ego and Goal on Rviz.
3. put obstacle arround the path.
4. check the topic by echo command.

![Screenshot from 2024-12-20 09-18-12](https://github.com/user-attachments/assets/50ecef3d-8fcc-4eb1-a1b0-a9f59c7212fe)
![Screenshot from 2024-12-20 09-17-48](https://github.com/user-attachments/assets/534dc4d3-63c7-42f2-b95b-6554d5fede0f)


## Notes for reviewers

None.

## Interface changes

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| New     | Pub | `/planing/planning_factors/obstacle_cruise_planner` | `tier4_planning_msgs/PlanningFactorArray` | Topic description |

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.