### PR TITLE
feat: customize hazard status converter

### DIFF
--- a/launch/tier4_system_launch/launch/system.launch.xml
+++ b/launch/tier4_system_launch/launch/system.launch.xml
@@ -39,6 +39,10 @@
   <arg name="launch_rqt_robot_monitor" default="false"/>
   <arg name="launch_rqt_runtime_monitor_err" default="false"/>
 
+  <!-- Hazard Status Converter -->
+  <arg name="report_only_diag" default="false"/>
+  <arg name="report_safe_fault" default="false"/>
+
   <group>
     <push-ros-namespace namespace="/system"/>
 
@@ -120,7 +124,10 @@
 
     <!-- Hazard Status Converter -->
     <group unless="$(var use_emergency_handler)">
-      <include file="$(find-pkg-share hazard_status_converter)/launch/hazard_status_converter.launch.xml"/>
+      <include file="$(find-pkg-share hazard_status_converter)/launch/hazard_status_converter.launch.xml">
+        <arg name="report_only_diag" value="$(var report_only_diag)"/>
+        <arg name="report_safe_fault" value="$(var report_safe_fault)"/>
+      </include>
     </group>
 
     <!-- MRM Handler -->

--- a/launch/tier4_system_launch/launch/system.launch.xml
+++ b/launch/tier4_system_launch/launch/system.launch.xml
@@ -41,7 +41,6 @@
 
   <!-- Hazard Status Converter -->
   <arg name="report_only_diag" default="false"/>
-  <arg name="report_safe_fault" default="false"/>
 
   <group>
     <push-ros-namespace namespace="/system"/>
@@ -126,7 +125,6 @@
     <group unless="$(var use_emergency_handler)">
       <include file="$(find-pkg-share hazard_status_converter)/launch/hazard_status_converter.launch.xml">
         <arg name="report_only_diag" value="$(var report_only_diag)"/>
-        <arg name="report_safe_fault" value="$(var report_safe_fault)"/>
       </include>
     </group>
 

--- a/system/hazard_status_converter/launch/hazard_status_converter.launch.xml
+++ b/system/hazard_status_converter/launch/hazard_status_converter.launch.xml
@@ -1,6 +1,10 @@
 <launch>
+  <arg name="report_only_diag" default="false"/>
+  <arg name="report_safe_fault" default="false"/>
   <node pkg="hazard_status_converter" exec="converter" name="hazard_status_converter">
     <remap from="~/diagnostics_graph" to="/diagnostics_graph"/>
     <remap from="~/hazard_status" to="/system/emergency/hazard_status"/>
+    <param name="report_only_diag" value="$(var report_only_diag)"/>
+    <param name="report_safe_fault" value="$(var report_safe_fault)"/>
   </node>
 </launch>

--- a/system/hazard_status_converter/launch/hazard_status_converter.launch.xml
+++ b/system/hazard_status_converter/launch/hazard_status_converter.launch.xml
@@ -1,10 +1,8 @@
 <launch>
   <arg name="report_only_diag" default="false"/>
-  <arg name="report_safe_fault" default="false"/>
   <node pkg="hazard_status_converter" exec="converter" name="hazard_status_converter">
     <remap from="~/diagnostics_graph" to="/diagnostics_graph"/>
     <remap from="~/hazard_status" to="/system/emergency/hazard_status"/>
     <param name="report_only_diag" value="$(var report_only_diag)"/>
-    <param name="report_safe_fault" value="$(var report_safe_fault)"/>
   </node>
 </launch>

--- a/system/hazard_status_converter/src/converter.cpp
+++ b/system/hazard_status_converter/src/converter.cpp
@@ -95,7 +95,7 @@ void Converter::on_update(DiagGraph::ConstSharedPtr graph)
   const auto get_hazards_vector = [](HazardStatus & status, HazardLevel level) {
     if (level == HazardStatus::SINGLE_POINT_FAULT) return &status.diag_single_point_fault;
     if (level == HazardStatus::LATENT_FAULT) return &status.diag_latent_fault;
-    if (level == HazardStatus::SAFE_FAULT) return &status.diag_safe_fault;
+    if (level == HazardStatus::SAFE_FAULT) return &status.diag_latent_fault;
     if (level == HazardStatus::NO_FAULT) return &status.diag_no_fault;
     return static_cast<std::vector<DiagnosticStatus> *>(nullptr);
   };

--- a/system/hazard_status_converter/src/converter.cpp
+++ b/system/hazard_status_converter/src/converter.cpp
@@ -122,7 +122,9 @@ void Converter::on_update(DiagGraph::ConstSharedPtr graph)
   hazard.status.level = get_system_level(hazard.status);
   hazard.status.emergency = hazard.status.level == HazardStatus::SINGLE_POINT_FAULT;
   if (report_safe_fault_)
-    hazard.status.emergency &= hazard.status.level == HazardStatus::SAFE_FAULT;
+    hazard.status.emergency &=
+      (hazard.status.level == HazardStatus::SAFE_FAULT ||
+       hazard.status.level == HazardStatus::LATENT_FAULT);
   hazard.status.emergency_holding = false;
   pub_hazard_->publish(hazard);
 }

--- a/system/hazard_status_converter/src/converter.cpp
+++ b/system/hazard_status_converter/src/converter.cpp
@@ -29,7 +29,6 @@ Converter::Converter(const rclcpp::NodeOptions & options) : Node("converter", op
   sub_graph_.subscribe(*this, 1);
 
   report_only_diag_ = declare_parameter<bool>("report_only_diag", false);
-  report_safe_fault_ = declare_parameter<bool>("report_safe_fault", false);
 }
 
 void Converter::on_create(DiagGraph::ConstSharedPtr graph)
@@ -121,10 +120,6 @@ void Converter::on_update(DiagGraph::ConstSharedPtr graph)
   hazard.stamp = graph->updated_stamp();
   hazard.status.level = get_system_level(hazard.status);
   hazard.status.emergency = hazard.status.level == HazardStatus::SINGLE_POINT_FAULT;
-  if (report_safe_fault_)
-    hazard.status.emergency &=
-      (hazard.status.level == HazardStatus::SAFE_FAULT ||
-       hazard.status.level == HazardStatus::LATENT_FAULT);
   hazard.status.emergency_holding = false;
   pub_hazard_->publish(hazard);
 }

--- a/system/hazard_status_converter/src/converter.hpp
+++ b/system/hazard_status_converter/src/converter.hpp
@@ -41,6 +41,8 @@ private:
 
   DiagUnit * auto_mode_root_;
   std::unordered_set<DiagUnit *> auto_mode_tree_;
+  bool report_only_diag_;
+  bool report_safe_fault_;
 };
 
 }  // namespace hazard_status_converter

--- a/system/hazard_status_converter/src/converter.hpp
+++ b/system/hazard_status_converter/src/converter.hpp
@@ -42,7 +42,6 @@ private:
   DiagUnit * auto_mode_root_;
   std::unordered_set<DiagUnit *> auto_mode_tree_;
   bool report_only_diag_;
-  bool report_safe_fault_;
 };
 
 }  // namespace hazard_status_converter


### PR DESCRIPTION
## Description
Modifications will be made to the hazard status converter to make it compatible with Tier IV tools.
Change the "diag" included in the hazard status to just the diag type.
Also convert safety faults to latent faults.
## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?
I tested with PSim.
We were able to supress the error content in FMS.
Also, diag that is not linked to MRM can be reported.
![image](https://github.com/user-attachments/assets/323883c2-bb32-4334-a359-b93ad9d6a631)

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
