### PR TITLE
fix(default_adapi): subscribe planning factor

### DIFF
--- a/system/autoware_default_adapi/package.xml
+++ b/system/autoware_default_adapi/package.xml
@@ -32,6 +32,7 @@
   <depend>std_srvs</depend>
   <depend>tier4_api_msgs</depend>
   <depend>tier4_control_msgs</depend>
+  <depend>tier4_planning_msgs</depend>
   <depend>tier4_system_msgs</depend>
 
   <exec_depend>python3-flask</exec_depend>

--- a/system/autoware_default_adapi/src/planning.cpp
+++ b/system/autoware_default_adapi/src/planning.cpp
@@ -18,12 +18,40 @@
 
 #include <autoware_adapi_v1_msgs/msg/planning_behavior.hpp>
 
+#include <map>
 #include <memory>
 #include <string>
 #include <vector>
 
 namespace autoware::default_adapi
 {
+
+const std::map<std::uint16_t, std::uint16_t> direction_map = {
+  {PlanningFactor::SHIFT_RIGHT, SteeringFactor::RIGHT},
+  {PlanningFactor::SHIFT_LEFT, SteeringFactor::LEFT},
+  {PlanningFactor::TURN_RIGHT, SteeringFactor::RIGHT},
+  {PlanningFactor::TURN_LEFT, SteeringFactor::LEFT}};
+
+const std::map<std::string, std::string> conversion_map = {
+  {"static_obstacle_avoidance", PlanningBehavior::AVOIDANCE},
+  {"crosswalk", PlanningBehavior::CROSSWALK},
+  {"goal_planner", PlanningBehavior::GOAL_PLANNER},
+  {"intersection", PlanningBehavior::INTERSECTION},
+  {"lane_change_left", PlanningBehavior::LANE_CHANGE},
+  {"lane_change_right", PlanningBehavior::LANE_CHANGE},
+  {"merge_from_private", PlanningBehavior::MERGE},
+  {"no_stopping_area", PlanningBehavior::NO_STOPPING_AREA},
+  {"blind_spot", PlanningBehavior::REAR_CHECK},
+  {"obstacle_cruise_planner", PlanningBehavior::ROUTE_OBSTACLE},
+  {"motion_velocity_planner", PlanningBehavior::ROUTE_OBSTACLE},
+  {"walkway", PlanningBehavior::SIDEWALK},
+  {"start_planner", PlanningBehavior::START_PLANNER},
+  {"stop_line", PlanningBehavior::STOP_SIGN},
+  {"surround_obstacle_checker", PlanningBehavior::SURROUNDING_OBSTACLE},
+  {"traffic_light", PlanningBehavior::TRAFFIC_SIGNAL},
+  {"detection_area", PlanningBehavior::USER_DEFINED_DETECTION_AREA},
+  {"virtual_traffic_light", PlanningBehavior::VIRTUAL_TRAFFIC_LIGHT},
+  {"run_out", PlanningBehavior::RUN_OUT}};
 
 template <class T>
 void concat(std::vector<T> & v1, const std::vector<T> & v2)
@@ -103,6 +131,10 @@ std::vector<SteeringFactor> convert(const std::vector<PlanningFactor> & factors)
     }
 
     if (conversion_map.count(factor.module) == 0) {
+      continue;
+    }
+
+    if (direction_map.count(factor.behavior) == 0) {
       continue;
     }
 

--- a/system/autoware_default_adapi/src/planning.cpp
+++ b/system/autoware_default_adapi/src/planning.cpp
@@ -283,6 +283,13 @@ void PlanningNode::on_timer()
     }
   }
 
+  for (auto & factor : steering.factors) {
+    if ((factor.status == SteeringFactor::UNKNOWN) && (!std::isnan(factor.distance.front()))) {
+      const auto is_turning = factor.distance.front() < 0.0;
+      factor.status = is_turning ? SteeringFactor::TURNING : SteeringFactor::APPROACHING;
+    }
+  }
+
   pub_velocity_factors_->publish(velocity);
   pub_steering_factors_->publish(steering);
 }

--- a/system/autoware_default_adapi/src/planning.cpp
+++ b/system/autoware_default_adapi/src/planning.cpp
@@ -33,6 +33,7 @@ const std::map<std::uint16_t, std::uint16_t> direction_map = {
   {PlanningFactor::TURN_LEFT, SteeringFactor::LEFT}};
 
 const std::map<std::string, std::string> conversion_map = {
+  {"behavior_path_planner", PlanningBehavior::INTERSECTION},
   {"static_obstacle_avoidance", PlanningBehavior::AVOIDANCE},
   {"crosswalk", PlanningBehavior::CROSSWALK},
   {"goal_planner", PlanningBehavior::GOAL_PLANNER},
@@ -204,6 +205,7 @@ PlanningNode::PlanningNode(const rclcpp::NodeOptions & options) : Node("planning
   stop_checker_ = std::make_unique<VehicleStopChecker>(this, stop_duration_ + 1.0);
 
   std::vector<std::string> factor_topics = {
+    "/planning/planning_factors/behavior_path_planner",
     "/planning/planning_factors/blind_spot",
     "/planning/planning_factors/crosswalk",
     "/planning/planning_factors/detection_area",

--- a/system/autoware_default_adapi/src/planning.hpp
+++ b/system/autoware_default_adapi/src/planning.hpp
@@ -21,7 +21,12 @@
 #include <autoware/motion_utils/vehicle/vehicle_state_checker.hpp>
 #include <rclcpp/rclcpp.hpp>
 
+#include <autoware_adapi_v1_msgs/msg/planning_behavior.hpp>
+#include <tier4_planning_msgs/msg/planning_factor_array.hpp>
+
+#include <map>
 #include <memory>
+#include <string>
 #include <vector>
 
 // This file should be included after messages.
@@ -30,22 +35,53 @@
 namespace autoware::default_adapi
 {
 
+using autoware_adapi_v1_msgs::msg::PlanningBehavior;
+using autoware_adapi_v1_msgs::msg::SteeringFactor;
+using autoware_adapi_v1_msgs::msg::SteeringFactorArray;
+using autoware_adapi_v1_msgs::msg::VelocityFactor;
+using autoware_adapi_v1_msgs::msg::VelocityFactorArray;
+using tier4_planning_msgs::msg::PlanningFactor;
+using tier4_planning_msgs::msg::PlanningFactorArray;
+
+const std::map<std::uint16_t, std::uint16_t> direction_map = {
+  {PlanningFactor::SHIFT_RIGHT, SteeringFactor::RIGHT},
+  {PlanningFactor::SHIFT_LEFT, SteeringFactor::LEFT},
+  {PlanningFactor::TURN_RIGHT, SteeringFactor::RIGHT},
+  {PlanningFactor::TURN_LEFT, SteeringFactor::LEFT}};
+
+const std::map<std::string, std::string> conversion_map = {
+  {"static_obstacle_avoidance", PlanningBehavior::AVOIDANCE},
+  {"crosswalk", PlanningBehavior::CROSSWALK},
+  {"goal_planner", PlanningBehavior::GOAL_PLANNER},
+  {"intersection", PlanningBehavior::INTERSECTION},
+  {"lane_change_left", PlanningBehavior::LANE_CHANGE},
+  {"lane_change_right", PlanningBehavior::LANE_CHANGE},
+  {"merge_from_private", PlanningBehavior::MERGE},
+  {"no_stopping_area", PlanningBehavior::NO_STOPPING_AREA},
+  {"blind_spot", PlanningBehavior::REAR_CHECK},
+  {"obstacle_cruise_planner", PlanningBehavior::ROUTE_OBSTACLE},
+  {"motion_velocity_planner", PlanningBehavior::ROUTE_OBSTACLE},
+  {"walkway", PlanningBehavior::SIDEWALK},
+  {"start_planner", PlanningBehavior::START_PLANNER},
+  {"stop_line", PlanningBehavior::STOP_SIGN},
+  {"surround_obstacle_checker", PlanningBehavior::SURROUNDING_OBSTACLE},
+  {"traffic_light", PlanningBehavior::TRAFFIC_SIGNAL},
+  {"detection_area", PlanningBehavior::USER_DEFINED_DETECTION_AREA},
+  {"virtual_traffic_light", PlanningBehavior::VIRTUAL_TRAFFIC_LIGHT},
+  {"run_out", PlanningBehavior::RUN_OUT}};
+
 class PlanningNode : public rclcpp::Node
 {
 public:
   explicit PlanningNode(const rclcpp::NodeOptions & options);
 
 private:
-  using VelocityFactorArray = autoware_adapi_v1_msgs::msg::VelocityFactorArray;
-  using SteeringFactorArray = autoware_adapi_v1_msgs::msg::SteeringFactorArray;
   Pub<autoware::adapi_specs::planning::VelocityFactors> pub_velocity_factors_;
   Pub<autoware::adapi_specs::planning::SteeringFactors> pub_steering_factors_;
   Sub<autoware::component_interface_specs::planning::Trajectory> sub_trajectory_;
   Sub<autoware::component_interface_specs::localization::KinematicState> sub_kinematic_state_;
-  std::vector<rclcpp::Subscription<VelocityFactorArray>::SharedPtr> sub_velocity_factors_;
-  std::vector<rclcpp::Subscription<SteeringFactorArray>::SharedPtr> sub_steering_factors_;
-  std::vector<VelocityFactorArray::ConstSharedPtr> velocity_factors_;
-  std::vector<SteeringFactorArray::ConstSharedPtr> steering_factors_;
+  std::vector<rclcpp::Subscription<PlanningFactorArray>::SharedPtr> sub_factors_;
+  std::vector<PlanningFactorArray::ConstSharedPtr> factors_;
   rclcpp::TimerBase::SharedPtr timer_;
 
   using VehicleStopChecker = autoware::motion_utils::VehicleStopCheckerBase;

--- a/system/autoware_default_adapi/src/planning.hpp
+++ b/system/autoware_default_adapi/src/planning.hpp
@@ -24,7 +24,6 @@
 #include <autoware_adapi_v1_msgs/msg/planning_behavior.hpp>
 #include <tier4_planning_msgs/msg/planning_factor_array.hpp>
 
-#include <map>
 #include <memory>
 #include <string>
 #include <vector>
@@ -42,33 +41,6 @@ using autoware_adapi_v1_msgs::msg::VelocityFactor;
 using autoware_adapi_v1_msgs::msg::VelocityFactorArray;
 using tier4_planning_msgs::msg::PlanningFactor;
 using tier4_planning_msgs::msg::PlanningFactorArray;
-
-const std::map<std::uint16_t, std::uint16_t> direction_map = {
-  {PlanningFactor::SHIFT_RIGHT, SteeringFactor::RIGHT},
-  {PlanningFactor::SHIFT_LEFT, SteeringFactor::LEFT},
-  {PlanningFactor::TURN_RIGHT, SteeringFactor::RIGHT},
-  {PlanningFactor::TURN_LEFT, SteeringFactor::LEFT}};
-
-const std::map<std::string, std::string> conversion_map = {
-  {"static_obstacle_avoidance", PlanningBehavior::AVOIDANCE},
-  {"crosswalk", PlanningBehavior::CROSSWALK},
-  {"goal_planner", PlanningBehavior::GOAL_PLANNER},
-  {"intersection", PlanningBehavior::INTERSECTION},
-  {"lane_change_left", PlanningBehavior::LANE_CHANGE},
-  {"lane_change_right", PlanningBehavior::LANE_CHANGE},
-  {"merge_from_private", PlanningBehavior::MERGE},
-  {"no_stopping_area", PlanningBehavior::NO_STOPPING_AREA},
-  {"blind_spot", PlanningBehavior::REAR_CHECK},
-  {"obstacle_cruise_planner", PlanningBehavior::ROUTE_OBSTACLE},
-  {"motion_velocity_planner", PlanningBehavior::ROUTE_OBSTACLE},
-  {"walkway", PlanningBehavior::SIDEWALK},
-  {"start_planner", PlanningBehavior::START_PLANNER},
-  {"stop_line", PlanningBehavior::STOP_SIGN},
-  {"surround_obstacle_checker", PlanningBehavior::SURROUNDING_OBSTACLE},
-  {"traffic_light", PlanningBehavior::TRAFFIC_SIGNAL},
-  {"detection_area", PlanningBehavior::USER_DEFINED_DETECTION_AREA},
-  {"virtual_traffic_light", PlanningBehavior::VIRTUAL_TRAFFIC_LIGHT},
-  {"run_out", PlanningBehavior::RUN_OUT}};
 
 class PlanningNode : public rclcpp::Node
 {


### PR DESCRIPTION
## Description

New factor msgs were defined in https://github.com/tier4/tier4_autoware_msgs/pull/155 to output various information of module running state. And, each planning module will use them.

In this PR, I fixed adapi node to convert msg type from `tier4_planning_msgs/PlanningFactorArray` to `autoware_adapi_v1_msgs/VelocityFactorArray(SteeringFactorArray)`.

## Related links

**Parent Issue:**

- https://github.com/autowarefoundation/autoware.universe/pull/9676
- https://github.com/tier4/tier4_autoware_msgs/pull/155

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

![image](https://github.com/user-attachments/assets/01513d89-897a-4fb1-bebb-00630f857510)

1. launch psim.
2. put ego and goal.
3. put object on ego path.
4. check the topic `/api/planning/velocity_factors` by echo command.
5. confirm that the node outputs factor like following one.

```
header:
  stamp:
    sec: 1735008280
    nanosec: 610628888
  frame_id: map
factors:
- pose:
    position:
      x: 61578.199978951016
      y: 56213.78579257302
      z: 78.16299873101634
    orientation:
      x: -3.6191521078641166e-05
      y: -0.0006830251435586911
      z: -0.052912858993544
      w: 0.9985988992182779
  distance: 14.520707130432129
  status: 1
  behavior: route-obstacle
  sequence: ''
  detail: ''
  cooperation: []
```

## Notes for reviewers

None.

## Interface changes

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Sub | `/planing/planning_factors/xxx` | `tier4_planning_msgs/PlanningFactorArray` | Topic description |
| New     | Sub | `/planing/velocity(steering)_factors/xxx` | `autoware_adapi_v1_msgs/VelocityFactorArray(SteeringFactorArray)` | Topic description |

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
