### PR TITLE
fix(behavior_velocity_run_out_module): fix slow_down jerk filter

### DIFF
--- a/planning/behavior_velocity_run_out_module/src/scene.cpp
+++ b/planning/behavior_velocity_run_out_module/src/scene.cpp
@@ -113,11 +113,6 @@ bool RunOutModule::modifyPathVelocity(
     insertStoppingVelocity(dynamic_obstacle, current_pose, current_vel, current_acc, *path);
   }
 
-  // apply max jerk limit if the ego can't stop with specified max jerk and acc
-  if (planner_param_.slow_down_limit.enable) {
-    applyMaxJerkLimit(current_pose, current_vel, current_acc, *path);
-  }
-
   publishDebugValue(
     trim_smoothed_path, partition_excluded_obstacles, dynamic_obstacle, current_pose);
 
@@ -585,7 +580,8 @@ boost::optional<geometry_msgs::msg::Pose> RunOutModule::calcStopPoint(
 
 void RunOutModule::insertStopPoint(
   const boost::optional<geometry_msgs::msg::Pose> stop_point,
-  autoware_auto_planning_msgs::msg::PathWithLaneId & path)
+  autoware_auto_planning_msgs::msg::PathWithLaneId & path,
+  const geometry_msgs::msg::Pose & current_pose, const float current_vel, const float current_acc)
 {
   // no stop point
   if (!stop_point) {
@@ -610,7 +606,14 @@ void RunOutModule::insertStopPoint(
   stop_point_with_lane_id = path.points.at(nearest_seg_idx);
   stop_point_with_lane_id.point.pose = *stop_point;
 
-  planning_utils::insertVelocity(path, stop_point_with_lane_id, 0.0, insert_idx);
+  double stop_point_velocity = 0.0;
+  // apply max jerk limit if the ego can't stop with specified max jerk and acc
+  if (planner_param_.slow_down_limit.enable) {
+    stop_point_velocity =
+      calcMaxJerkLimitedVelocity(current_pose, current_vel, current_acc, path, *stop_point);
+  }
+
+  planning_utils::insertVelocity(path, stop_point_with_lane_id, stop_point_velocity, insert_idx);
 }
 
 void RunOutModule::insertVelocityForState(
@@ -679,7 +682,7 @@ void RunOutModule::insertStoppingVelocity(
 {
   const auto stop_point =
     calcStopPoint(dynamic_obstacle, output_path, current_pose, current_vel, current_acc);
-  insertStopPoint(stop_point, output_path);
+  insertStopPoint(stop_point, output_path, current_pose, current_vel, current_acc);
 }
 
 void RunOutModule::insertApproachingVelocity(
@@ -719,26 +722,19 @@ void RunOutModule::insertApproachingVelocity(
   planning_utils::insertVelocity(output_path, stop_point_with_lane_id, 0.0, insert_idx_stop);
 }
 
-void RunOutModule::applyMaxJerkLimit(
+double RunOutModule::calcMaxJerkLimitedVelocity(
   const geometry_msgs::msg::Pose & current_pose, const float current_vel, const float current_acc,
-  PathWithLaneId & path) const
+  PathWithLaneId & path, const geometry_msgs::msg::Pose & stop_point) const
 {
-  const auto stop_point_idx = run_out_utils::findFirstStopPointIdx(path.points);
-  if (!stop_point_idx) {
-    return;
-  }
-
-  const auto stop_point = path.points.at(stop_point_idx.get()).point.pose.position;
   const auto dist_to_stop_point =
-    motion_utils::calcSignedArcLength(path.points, current_pose.position, stop_point);
+    motion_utils::calcSignedArcLength(path.points, current_pose.position, stop_point.position);
 
   // calculate desired velocity with limited jerk
   const auto jerk_limited_vel = planning_utils::calcDecelerationVelocityFromDistanceToTarget(
     planner_param_.slow_down_limit.max_jerk, planner_param_.slow_down_limit.max_acc, current_acc,
     current_vel, dist_to_stop_point);
 
-  // overwrite velocity with limited velocity
-  run_out_utils::insertPathVelocityFromIndex(stop_point_idx.get(), jerk_limited_vel, path.points);
+  return jerk_limited_vel;
 }
 
 std::vector<DynamicObstacle> RunOutModule::excludeObstaclesOutSideOfPartition(

--- a/planning/behavior_velocity_run_out_module/src/scene.hpp
+++ b/planning/behavior_velocity_run_out_module/src/scene.hpp
@@ -113,7 +113,9 @@ private:
 
   void insertStopPoint(
     const boost::optional<geometry_msgs::msg::Pose> stop_point,
-    autoware_auto_planning_msgs::msg::PathWithLaneId & path);
+    autoware_auto_planning_msgs::msg::PathWithLaneId & path,
+    const geometry_msgs::msg::Pose & current_pose, const float current_vel,
+    const float current_acc);
 
   void insertVelocityForState(
     const boost::optional<DynamicObstacle> & dynamic_obstacle, const PlannerData planner_data,
@@ -129,9 +131,9 @@ private:
     const DynamicObstacle & dynamic_obstacle, const geometry_msgs::msg::Pose & current_pose,
     const float approaching_vel, const float approach_margin, PathWithLaneId & output_path);
 
-  void applyMaxJerkLimit(
+  double calcMaxJerkLimitedVelocity(
     const geometry_msgs::msg::Pose & current_pose, const float current_vel, const float current_acc,
-    PathWithLaneId & path) const;
+    PathWithLaneId & path, const geometry_msgs::msg::Pose & stop_point) const;
 
   std::vector<DynamicObstacle> excludeObstaclesOutSideOfPartition(
     const std::vector<DynamicObstacle> & dynamic_obstacles, const PathWithLaneId & path,


### PR DESCRIPTION
## Description
run_outをslow_down_limit.enable = trueで動かすと、JerkFilterによりrun_out以外の停止線も上書きされて無効化されてしまう現象があったため、修正

## Related links

None

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

Before:

- stop_lineによる停止線がrun_outのジャークフィルターによって上書きされてしまっている
(走行中にAutoware ControlをDisableにすることで強制的に停止線前で速度が出ている状況を再現)

https://github.com/user-attachments/assets/582469c9-3dd8-4f80-bd95-422d47589c0c




After:

- 既存の停止線がrun_outのジャークフィルターによって上書きされないように修正
(走行中にAutoware ControlをDisableにすることで強制的に停止線前で速度が出ている状況を再現)

https://github.com/user-attachments/assets/f60b82bd-0ee0-4a0d-ae7f-92e9b0678c00


- 通常のJerk Filterは今までどおり正常に機能している状態。直近のrun_outに対しては強い減速かからず、遠方のrun_outに対しては停止指示がかかっている。
(なお、下記の動画ではrun_outのテストのためにobstacle_cruiseを無効にしている)

https://github.com/user-attachments/assets/55c990b7-4a13-401c-adfc-ddbbcbac327c




## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

None.

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

slow_down_limit.enable = trueでrun)outを起動した際に、他の回避モジュールや一時停止モジュールによる停止線が上書きされて無視されるバグが修正される