### PR TITLE
modify(dummy_gear_cmd_publisher): replace gear cmd type

### DIFF
--- a/dummy/dummy_gear_cmd_publisher/package.xml
+++ b/dummy/dummy_gear_cmd_publisher/package.xml
@@ -12,7 +12,7 @@
   <build_depend>autoware_cmake</build_depend>
 
   <!-- depend -->
-  <depend>autoware_auto_vehicle_msgs</depend>
+  <depend>autoware_vehicle_msgs</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
 

--- a/dummy/dummy_gear_cmd_publisher/src/dummy_gear_cmd_publisher.cpp
+++ b/dummy/dummy_gear_cmd_publisher/src/dummy_gear_cmd_publisher.cpp
@@ -26,7 +26,7 @@ DummyGearCmdPublisher::DummyGearCmdPublisher(const rclcpp::NodeOptions & node_op
 
   // Publisher
   pub_gear_cmd_ =
-    create_publisher<autoware_auto_vehicle_msgs::msg::GearCommand>("~/output/gear_cmd", 10);
+    create_publisher<autoware_vehicle_msgs::msg::GearCommand>("~/output/gear_cmd", 10);
 
   // Service
 
@@ -44,9 +44,9 @@ DummyGearCmdPublisher::DummyGearCmdPublisher(const rclcpp::NodeOptions & node_op
 
 void DummyGearCmdPublisher::onTimer()
 {
-  autoware_auto_vehicle_msgs::msg::GearCommand msg;
+  autoware_vehicle_msgs::msg::GearCommand msg;
   msg.stamp = this->now();
-  msg.command = autoware_auto_vehicle_msgs::msg::GearCommand::DRIVE;
+  msg.command = autoware_vehicle_msgs::msg::GearCommand::DRIVE;
 
   pub_gear_cmd_->publish(msg);
 }

--- a/dummy/dummy_gear_cmd_publisher/src/dummy_gear_cmd_publisher.hpp
+++ b/dummy/dummy_gear_cmd_publisher/src/dummy_gear_cmd_publisher.hpp
@@ -18,7 +18,7 @@
 // include
 #include <rclcpp/rclcpp.hpp>
 
-#include <autoware_auto_vehicle_msgs/msg/gear_command.hpp>
+#include <autoware_vehicle_msgs/msg/gear_command.hpp>
 
 namespace dummy_gear_cmd_publisher
 {
@@ -35,7 +35,7 @@ private:
   // Subscriber
 
   // Publisher
-  rclcpp::Publisher<autoware_auto_vehicle_msgs::msg::GearCommand>::SharedPtr pub_gear_cmd_;
+  rclcpp::Publisher<autoware_vehicle_msgs::msg::GearCommand>::SharedPtr pub_gear_cmd_;
 
   // Service
 


### PR DESCRIPTION
## Description
This PR modify gear cmd type in dummy gear cmd publisher
## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
