### PR TITLE
fix(recovery_node): recover from MRM even duaring manual driving

### DIFF
--- a/system/diagnostic_graph_utils/src/node/recovery.cpp
+++ b/system/diagnostic_graph_utils/src/node/recovery.cpp
@@ -22,15 +22,10 @@ namespace diagnostic_graph_utils
 RecoveryNode::RecoveryNode(const rclcpp::NodeOptions & options) : Node("dump", options)
 {
   using std::placeholders::_1;
-  const auto qos_aw_state = rclcpp::QoS(1);
   const auto qos_mrm_state = rclcpp::QoS(1);
 
   sub_graph_.register_update_callback(std::bind(&RecoveryNode::on_graph_update, this, _1));
   sub_graph_.subscribe(*this, 1);
-
-  const auto callback_aw_state = std::bind(&RecoveryNode::on_aw_state, this, _1);
-  sub_aw_state_ =
-    create_subscription<AutowareState>("/autoware/state", qos_aw_state, callback_aw_state);
 
   const auto callback_mrm_state = std::bind(&RecoveryNode::on_mrm_state, this, _1);
   sub_mrm_state_ =
@@ -63,11 +58,6 @@ void RecoveryNode::on_graph_update(DiagGraph::ConstSharedPtr graph)
   }
 }
 
-void RecoveryNode::on_aw_state(const AutowareState::ConstSharedPtr msg)
-{
-  auto_driving_ = msg->state == AutowareState::DRIVING;
-}
-
 void RecoveryNode::on_mrm_state(const MrmState::ConstSharedPtr msg)
 {
   // set flag if mrm happened by fatal error
@@ -82,8 +72,7 @@ void RecoveryNode::on_mrm_state(const MrmState::ConstSharedPtr msg)
   // 1. Not emergency
   // 2. Non-recoverable MRM have not happened
   // 3. on MRM
-  // 4. on autonomous driving
-  if (autonomous_available_ && !mrm_by_fatal_error_ && mrm_occur_ && auto_driving_) {
+  if (autonomous_available_ && !mrm_by_fatal_error_ && mrm_occur_) {
     clear_mrm();
   }
 }

--- a/system/diagnostic_graph_utils/src/node/recovery.hpp
+++ b/system/diagnostic_graph_utils/src/node/recovery.hpp
@@ -25,7 +25,6 @@
 #include <component_interface_utils/rclcpp.hpp>
 
 #include <autoware_adapi_v1_msgs/msg/mrm_state.hpp>
-#include <autoware_system_msgs/msg/autoware_state.hpp>
 #include <std_msgs/msg/string.hpp>
 #include <std_srvs/srv/trigger.hpp>
 
@@ -44,17 +43,14 @@ public:
   explicit RecoveryNode(const rclcpp::NodeOptions & options);
 
 private:
-  using AutowareState = autoware_system_msgs::msg::AutowareState;
   using MrmState = autoware_adapi_v1_msgs::msg::MrmState;
   using DiagnosticStatus = diagnostic_msgs::msg::DiagnosticStatus;
 
   bool fatal_error_;
   bool autonomous_available_;
   bool mrm_occur_;
-  bool auto_driving_;
   bool mrm_by_fatal_error_;
   DiagGraphSubscription sub_graph_;
-  rclcpp::Subscription<AutowareState>::SharedPtr sub_aw_state_;
   rclcpp::Subscription<MrmState>::SharedPtr sub_mrm_state_;
 
   // service
@@ -64,7 +60,6 @@ private:
   rclcpp::CallbackGroup::SharedPtr callback_group_;
 
   void on_graph_update(DiagGraph::ConstSharedPtr graph);
-  void on_aw_state(const AutowareState::ConstSharedPtr msg);
   void on_mrm_state(const MrmState::ConstSharedPtr msg);
 
   void clear_mrm();


### PR DESCRIPTION
## Description
> [!WARNING]
>  This change is not merged in main branch because this feature is only used in the specific version.

現状はclear_mrm serviceの呼び出しが自動走行中に限定されているため、
MRM発生 -> OR -> MRMが解消される
となった場合に、clear_mrm serviceが呼び出されずにMRMが解除されない課題があります。
これを解消するため、自動運転中という条件を削除しました。

ロジックの変更としてはこの部分のみで、これ以外は不要となった自動運転状態かどうかを取得する部分の削除です。
![image](https://github.com/user-attachments/assets/b7261d2e-d7fb-4727-a68b-1185f816c4f1)


## Related links
[INTERNAL JIRA](https://tier4.atlassian.net/browse/RT0-35089)

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?
simple planning simulatorで確認しました。

### Before
diag error発生後に`Autoware Control`をOFFにして、**diag errorを解除したが、MRMが継続している。**

https://github.com/user-attachments/assets/5edbc3d1-daa3-41b6-8dbd-91dd89083caf

### After
diag error発生後に`Autoware Control`をOFFにして、**diag errorを解除することで、MRMが解消されている。**
> [!NOTE]
>  Motionがチャタリングしているのは別の既知課題

https://github.com/user-attachments/assets/85339f34-fa34-4739-a933-bdaa468b4f17


## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
