### PR TITLE
fix: revert customized hazard status converter

### DIFF
--- a/launch/tier4_system_launch/launch/system.launch.xml
+++ b/launch/tier4_system_launch/launch/system.launch.xml
@@ -39,10 +39,6 @@
   <arg name="launch_rqt_robot_monitor" default="false"/>
   <arg name="launch_rqt_runtime_monitor_err" default="false"/>
 
-  <!-- Hazard Status Converter -->
-  <arg name="report_only_diag" default="false"/>
-  <arg name="report_safe_fault" default="false"/>
-
   <group>
     <push-ros-namespace namespace="/system"/>
 
@@ -124,10 +120,7 @@
 
     <!-- Hazard Status Converter -->
     <group unless="$(var use_emergency_handler)">
-      <include file="$(find-pkg-share hazard_status_converter)/launch/hazard_status_converter.launch.xml">
-        <arg name="report_only_diag" value="$(var report_only_diag)"/>
-        <arg name="report_safe_fault" value="$(var report_safe_fault)"/>
-      </include>
+      <include file="$(find-pkg-share hazard_status_converter)/launch/hazard_status_converter.launch.xml"/>
     </group>
 
     <!-- MRM Handler -->

--- a/launch/tier4_system_launch/launch/system.launch.xml
+++ b/launch/tier4_system_launch/launch/system.launch.xml
@@ -41,6 +41,7 @@
 
   <!-- Hazard Status Converter -->
   <arg name="report_only_diag" default="false"/>
+  <arg name="report_safe_fault" default="false"/>
 
   <group>
     <push-ros-namespace namespace="/system"/>
@@ -125,6 +126,7 @@
     <group unless="$(var use_emergency_handler)">
       <include file="$(find-pkg-share hazard_status_converter)/launch/hazard_status_converter.launch.xml">
         <arg name="report_only_diag" value="$(var report_only_diag)"/>
+        <arg name="report_safe_fault" value="$(var report_safe_fault)"/>
       </include>
     </group>
 

--- a/system/hazard_status_converter/launch/hazard_status_converter.launch.xml
+++ b/system/hazard_status_converter/launch/hazard_status_converter.launch.xml
@@ -1,10 +1,6 @@
 <launch>
-  <arg name="report_only_diag" default="false"/>
-  <arg name="report_safe_fault" default="false"/>
   <node pkg="hazard_status_converter" exec="converter" name="hazard_status_converter">
     <remap from="~/diagnostics_graph" to="/diagnostics_graph"/>
     <remap from="~/hazard_status" to="/system/emergency/hazard_status"/>
-    <param name="report_only_diag" value="$(var report_only_diag)"/>
-    <param name="report_safe_fault" value="$(var report_safe_fault)"/>
   </node>
 </launch>

--- a/system/hazard_status_converter/launch/hazard_status_converter.launch.xml
+++ b/system/hazard_status_converter/launch/hazard_status_converter.launch.xml
@@ -1,8 +1,10 @@
 <launch>
   <arg name="report_only_diag" default="false"/>
+  <arg name="report_safe_fault" default="false"/>
   <node pkg="hazard_status_converter" exec="converter" name="hazard_status_converter">
     <remap from="~/diagnostics_graph" to="/diagnostics_graph"/>
     <remap from="~/hazard_status" to="/system/emergency/hazard_status"/>
     <param name="report_only_diag" value="$(var report_only_diag)"/>
+    <param name="report_safe_fault" value="$(var report_safe_fault)"/>
   </node>
 </launch>

--- a/system/hazard_status_converter/src/converter.cpp
+++ b/system/hazard_status_converter/src/converter.cpp
@@ -95,7 +95,7 @@ void Converter::on_update(DiagGraph::ConstSharedPtr graph)
   const auto get_hazards_vector = [](HazardStatus & status, HazardLevel level) {
     if (level == HazardStatus::SINGLE_POINT_FAULT) return &status.diag_single_point_fault;
     if (level == HazardStatus::LATENT_FAULT) return &status.diag_latent_fault;
-    if (level == HazardStatus::SAFE_FAULT) return &status.diag_latent_fault;
+    if (level == HazardStatus::SAFE_FAULT) return &status.diag_safe_fault;
     if (level == HazardStatus::NO_FAULT) return &status.diag_no_fault;
     return static_cast<std::vector<DiagnosticStatus> *>(nullptr);
   };

--- a/system/hazard_status_converter/src/converter.cpp
+++ b/system/hazard_status_converter/src/converter.cpp
@@ -29,6 +29,7 @@ Converter::Converter(const rclcpp::NodeOptions & options) : Node("converter", op
   sub_graph_.subscribe(*this, 1);
 
   report_only_diag_ = declare_parameter<bool>("report_only_diag", false);
+  report_safe_fault_ = declare_parameter<bool>("report_safe_fault", false);
 }
 
 void Converter::on_create(DiagGraph::ConstSharedPtr graph)
@@ -120,6 +121,10 @@ void Converter::on_update(DiagGraph::ConstSharedPtr graph)
   hazard.stamp = graph->updated_stamp();
   hazard.status.level = get_system_level(hazard.status);
   hazard.status.emergency = hazard.status.level == HazardStatus::SINGLE_POINT_FAULT;
+  if (report_safe_fault_)
+    hazard.status.emergency &=
+      (hazard.status.level == HazardStatus::SAFE_FAULT ||
+       hazard.status.level == HazardStatus::LATENT_FAULT);
   hazard.status.emergency_holding = false;
   pub_hazard_->publish(hazard);
 }

--- a/system/hazard_status_converter/src/converter.cpp
+++ b/system/hazard_status_converter/src/converter.cpp
@@ -122,9 +122,7 @@ void Converter::on_update(DiagGraph::ConstSharedPtr graph)
   hazard.status.level = get_system_level(hazard.status);
   hazard.status.emergency = hazard.status.level == HazardStatus::SINGLE_POINT_FAULT;
   if (report_safe_fault_)
-    hazard.status.emergency &=
-      (hazard.status.level == HazardStatus::SAFE_FAULT ||
-       hazard.status.level == HazardStatus::LATENT_FAULT);
+    hazard.status.emergency &= hazard.status.level == HazardStatus::SAFE_FAULT;
   hazard.status.emergency_holding = false;
   pub_hazard_->publish(hazard);
 }

--- a/system/hazard_status_converter/src/converter.cpp
+++ b/system/hazard_status_converter/src/converter.cpp
@@ -27,9 +27,6 @@ Converter::Converter(const rclcpp::NodeOptions & options) : Node("converter", op
   sub_graph_.register_create_callback(std::bind(&Converter::on_create, this, _1));
   sub_graph_.register_update_callback(std::bind(&Converter::on_update, this, _1));
   sub_graph_.subscribe(*this, 1);
-
-  report_only_diag_ = declare_parameter<bool>("report_only_diag", false);
-  report_safe_fault_ = declare_parameter<bool>("report_safe_fault", false);
 }
 
 void Converter::on_create(DiagGraph::ConstSharedPtr graph)
@@ -110,7 +107,6 @@ void Converter::on_update(DiagGraph::ConstSharedPtr graph)
   HazardStatusStamped hazard;
   for (const auto & unit : graph->units()) {
     if (unit->path().empty()) continue;
-    if (report_only_diag_ && unit->type() != "diag") continue;
     const bool is_auto_tree = auto_mode_tree_.count(unit);
     const auto root_level = is_auto_tree ? auto_mode_root_->level() : DiagnosticStatus::OK;
     const auto unit_level = unit->level();
@@ -121,8 +117,6 @@ void Converter::on_update(DiagGraph::ConstSharedPtr graph)
   hazard.stamp = graph->updated_stamp();
   hazard.status.level = get_system_level(hazard.status);
   hazard.status.emergency = hazard.status.level == HazardStatus::SINGLE_POINT_FAULT;
-  if (report_safe_fault_)
-    hazard.status.emergency &= hazard.status.level == HazardStatus::SAFE_FAULT;
   hazard.status.emergency_holding = false;
   pub_hazard_->publish(hazard);
 }

--- a/system/hazard_status_converter/src/converter.hpp
+++ b/system/hazard_status_converter/src/converter.hpp
@@ -41,8 +41,6 @@ private:
 
   DiagUnit * auto_mode_root_;
   std::unordered_set<DiagUnit *> auto_mode_tree_;
-  bool report_only_diag_;
-  bool report_safe_fault_;
 };
 
 }  // namespace hazard_status_converter

--- a/system/hazard_status_converter/src/converter.hpp
+++ b/system/hazard_status_converter/src/converter.hpp
@@ -42,6 +42,7 @@ private:
   DiagUnit * auto_mode_root_;
   std::unordered_set<DiagUnit *> auto_mode_tree_;
   bool report_only_diag_;
+  bool report_safe_fault_;
 };
 
 }  // namespace hazard_status_converter


### PR DESCRIPTION
## Description
Revert this [PR](https://github.com/tier4/autoware.universe/pull/1725) because this change makes Rviz noisy.
## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
