### PR TITLE
build: remove dependency on component_interface_utils

### DIFF
--- a/common/autoware_component_interface_tools/package.xml
+++ b/common/autoware_component_interface_tools/package.xml
@@ -12,7 +12,6 @@
 
   <depend>autoware_adapi_v1_msgs</depend>
   <depend>autoware_system_msgs</depend>
-  <depend>component_interface_utils</depend>
   <depend>diagnostic_msgs</depend>
   <depend>diagnostic_updater</depend>
   <depend>fmt</depend>


### PR DESCRIPTION
## Description

Fix the following error:

```
+ rosdep install -y --from-paths src --ignore-src --rosdistro humble
ERROR: the following packages/stacks could not have their rosdep keys resolved
to system dependencies:
autoware_component_interface_tools: Cannot locate rosdep definition for [component_interface_utils]
```

## Related links

- https://github.com/tier4/autoware.universe/pull/1818

## How was this PR tested?

- [x] `rosdep install`
- [x] Build

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
