### PR TITLE
fix(traffic_light.launch.xml): add lacked params (#10071)

### DIFF
--- a/launch/tier4_perception_launch/launch/traffic_light_recognition/traffic_light.launch.xml
+++ b/launch/tier4_perception_launch/launch/traffic_light_recognition/traffic_light.launch.xml
@@ -58,7 +58,8 @@
   <group>
     <node pkg="autoware_traffic_light_multi_camera_fusion" exec="traffic_light_multi_camera_fusion_node" name="traffic_light_multi_camera_fusion" output="screen">
       <param name="camera_namespaces" value="$(var all_camera_namespaces)"/>
-      <param name="perform_group_fusion" value="true"/>
+      <param name="message_lifespan" value="0.09"/>
+      <param name="approximate_sync" value="false"/>
       <remap from="~/input/vector_map" to="/map/vector_map"/>
       <remap from="~/output/traffic_signals" to="$(var internal/traffic_signals)"/>
     </node>


### PR DESCRIPTION
## Description
This PR cherry-pick the following change.
- https://github.com/autowarefoundation/autoware.universe/pull/10071

## Related links
[TIER IV INTERNAL](https://star4.slack.com/archives/C07K1PPNPTR/p1739775767826769)


## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
