### PR TITLE
chore: add grdi map core dependency

### DIFF
--- a/planning/autoware_static_centerline_generator/package.xml
+++ b/planning/autoware_static_centerline_generator/package.xml
@@ -29,9 +29,9 @@
   <depend>geography_utils</depend>
   <depend>geometry_msgs</depend>
   <depend>global_parameter_loader</depend>
+  <depend>grid_map_core</depend>
   <depend>interpolation</depend>
   <depend>lanelet2_extension</depend>
-  <depend>grid_map_core</depend>
   <depend>map_loader</depend>
   <depend>map_projection_loader</depend>
   <depend>osqp_interface</depend>

--- a/planning/autoware_static_centerline_generator/package.xml
+++ b/planning/autoware_static_centerline_generator/package.xml
@@ -31,6 +31,7 @@
   <depend>global_parameter_loader</depend>
   <depend>interpolation</depend>
   <depend>lanelet2_extension</depend>
+  <depend>grid_map_core</depend>
   <depend>map_loader</depend>
   <depend>map_projection_loader</depend>
   <depend>osqp_interface</depend>

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/package.xml
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/package.xml
@@ -46,6 +46,7 @@
   <depend>eigen</depend>
   <depend>geometry_msgs</depend>
   <depend>lanelet2_extension</depend>
+  <depend>grid_map_core</depend>
   <depend>libboost-dev</depend>
   <depend>pcl_conversions</depend>
   <depend>pluginlib</depend>

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/package.xml
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_planner/package.xml
@@ -45,8 +45,8 @@
   <depend>diagnostic_msgs</depend>
   <depend>eigen</depend>
   <depend>geometry_msgs</depend>
-  <depend>lanelet2_extension</depend>
   <depend>grid_map_core</depend>
+  <depend>lanelet2_extension</depend>
   <depend>libboost-dev</depend>
   <depend>pcl_conversions</depend>
   <depend>pluginlib</depend>

--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner_node/package.xml
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner_node/package.xml
@@ -27,8 +27,8 @@
   <depend>diagnostic_msgs</depend>
   <depend>eigen</depend>
   <depend>geometry_msgs</depend>
-  <depend>lanelet2_extension</depend>
   <depend>grid_map_core</depend>
+  <depend>lanelet2_extension</depend>
   <depend>libboost-dev</depend>
   <depend>pcl_conversions</depend>
   <depend>pluginlib</depend>

--- a/planning/motion_velocity_planner/autoware_motion_velocity_planner_node/package.xml
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_planner_node/package.xml
@@ -28,6 +28,7 @@
   <depend>eigen</depend>
   <depend>geometry_msgs</depend>
   <depend>lanelet2_extension</depend>
+  <depend>grid_map_core</depend>
   <depend>libboost-dev</depend>
   <depend>pcl_conversions</depend>
   <depend>pluginlib</depend>


### PR DESCRIPTION
## Description
Add grid map core dependency for these nodes.

- autoware_static_centerline_generator
- autoware_behavior_velocity_planner
- autoware_motion_velocity_planner_node

## Related links

**Parent Issue:**

- https://github.com/autowarefoundation/autoware.universe/pull/10122

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
