### PR TITLE
chore: remove the scheduled sync workflow

### DIFF
--- a/.github/workflows/sync-awf-latest.yaml
+++ b/.github/workflows/sync-awf-latest.yaml
@@ -1,8 +1,8 @@
 name: sync-awf-latest
 
 on:
-  schedule:
-    - cron: 50 */1 * * * # every 1 hour (**:50)
+  # schedule:
+  #   - cron: 50 */1 * * * # every 1 hour (**:50)
   workflow_dispatch:
 
 jobs:


### PR DESCRIPTION
## Description

Now that the [sync-awf-latest workflow in `auto-evaluator`](https://github.com/tier4/auto-evaluator/actions/workflows/sync-awf-latest.yaml) is working, the sync workflow in this repository is no longer necessary.

Before deleting it completely, I think it is a good idea to keep this file for a while with scheduled execution disabled.

## How was this PR tested?

I cannot test this.

## Notes for reviewers

None.

## Interface changes

None.

## Effects on system behavior

None.
