### PR TITLE
fix(segmentation_pointcloud_fusion): set valid pointcloud field for output pointcloud (#10196)

### DIFF
--- a/perception/autoware_image_projection_based_fusion/src/segmentation_pointcloud_fusion/node.cpp
+++ b/perception/autoware_image_projection_based_fusion/src/segmentation_pointcloud_fusion/node.cpp
@@ -151,6 +151,7 @@ void SegmentPointCloudFusionNode::postprocess(
   std::unique_ptr<ScopedTimeTrack> st_ptr;
   if (time_keeper_) st_ptr = std::make_unique<ScopedTimeTrack>(__func__, *time_keeper_);
 
+  output_msg = pointcloud_msg;
   output_msg.header = pointcloud_msg.header;
   output_msg.data.clear();
   output_msg.data.resize(pointcloud_msg.data.size());
@@ -165,8 +166,14 @@ void SegmentPointCloudFusionNode::postprocess(
   }
 
   output_msg.data.resize(output_pointcloud_size);
-  output_msg.row_step = output_pointcloud_size / output_msg.height;
-  output_msg.width = output_pointcloud_size / output_msg.point_step / output_msg.height;
+  if (output_msg.height != 0 && output_msg.point_step != 0) {
+    output_msg.row_step = output_pointcloud_size / output_msg.height;
+    output_msg.width = output_pointcloud_size / output_msg.point_step / output_msg.height;
+  } else {
+    RCLCPP_ERROR(this->get_logger(), "output_msg.height or output_msg.point_step is 0");
+    output_msg.row_step = 0;
+    output_msg.width = 0;
+  }
 
   filter_global_offset_set_.clear();
   return;


### PR DESCRIPTION
## Description

Cherry-pick

- https://github.com/autowarefoundation/autoware.universe/pull/10196

## How was this PR tested?

- [x] `planning_simulator` with [sample_map](https://autowarefoundation.github.io/autoware-documentation/main/tutorials/ad-hoc-simulation/planning-simulation/)
- [x] `logging_simulator` with [sample_rosbag](https://autowarefoundation.github.io/autoware-documentation/main/tutorials/ad-hoc-simulation/rosbag-replay-simulation/)
- [x] `logging_simulator` with [awsim_gt_data(TIER IV INTERNAL)](https://drive.google.com/file/d/1BtH3Ry5lu-h85GHM-sYq_jNJLw-s0re6/view?usp=drive_link)
- [x] `e2e_simulator` with [AWSIM v1.3.1](https://github.com/tier4/AWSIM/releases/tag/v1.3.1)
- [ ] the issue rosbag -> Skip!

## Notes for reviewers

None.

## Interface changes

None.

## Effects on system behavior

Fix a bug.
