### PR TITLE
fix(lane_departure_checker): fix trajectory resampling logic to keep …

### DIFF
--- a/control/autoware_lane_departure_checker/src/lane_departure_checker_node/utils.cpp
+++ b/control/autoware_lane_departure_checker/src/lane_departure_checker_node/utils.cpp
@@ -120,9 +120,8 @@ TrajectoryPoints resampleTrajectory(const Trajectory & trajectory, const double 
 
     if (boost::geometry::distance(prev_point.to_2d(), next_point.to_2d()) >= interval) {
       resampled.push_back(traj_point);
+      prev_point = next_point;
     }
-
-    prev_point = next_point;
   }
   resampled.push_back(trajectory.points.back());
 

--- a/control/autoware_lane_departure_checker/test/test_resample_trajectory.cpp
+++ b/control/autoware_lane_departure_checker/test/test_resample_trajectory.cpp
@@ -92,5 +92,10 @@ INSTANTIATE_TEST_SUITE_P(
       "IntervalIsGreaterThanDistance",
       {{1.0, 0.0, 0.0}, {2.0, 0.0, 0.0}, {3.0, 0.0, 0.0}},
       1.5,
-      {{1.0, 0.0, 0.0}, {3.0, 0.0, 0.0}}}),
+      {{1.0, 0.0, 0.0}, {3.0, 0.0, 0.0}}},
+    ResampleTrajectoryTestParam{
+      "ConsecutiveSmallDistancesFollowedByLargeDistance",
+      {{0.0, 0.0, 0.0}, {0.7, 0.0, 0.0}, {1.3, 0.0, 0.0}, {3.0, 0.0, 0.0}},
+      1.0,
+      {{0.0, 0.0, 0.0}, {1.3, 0.0, 0.0}, {3.0, 0.0, 0.0}}}),
   ::testing::PrintToStringParamName());


### PR DESCRIPTION
## Description
Cherry-pick the following bug fix.
- https://github.com/autowarefoundation/autoware.universe/pull/10221

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
