### PR TITLE
fix(static_obstacle_avoidance): ego doesn't keep stopping in unsafe c…

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/src/scene.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/src/scene.cpp
@@ -1679,7 +1679,7 @@ void StaticObstacleAvoidanceModule::insertReturnDeadLine(
   const auto min_return_distance =
     helper_->getMinAvoidanceDistance(shift_length) + helper_->getNominalPrepareDistance(0.0);
   const auto to_stop_line = data.to_return_point - min_return_distance - buffer;
-  if (to_stop_line < 0.0) {
+  if (to_stop_line < -1.0 * parameters_->stop_buffer) {
     RCLCPP_WARN(getLogger(), "ego overran return shift dead line. do nothing.");
     return;
   }
@@ -1752,7 +1752,7 @@ void StaticObstacleAvoidanceModule::insertWaitPoint(
     return;
   }
 
-  if (data.to_stop_line < 0.0) {
+  if (data.to_stop_line < -1.0 * parameters_->stop_buffer) {
     RCLCPP_WARN(getLogger(), "ego overran avoidance dead line. do nothing.");
     return;
   }


### PR DESCRIPTION
Cherry-pick the following bug fix.
[fix(static_obstacle_avoidance): ego doesn't keep stopping in unsafe condition #10242](https://github.com/autowarefoundation/autoware.universe/pull/10242)

## Description

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
