### PR TITLE
Feat/v0.19.2/multi tracker sanitize update

### DIFF
--- a/perception/multi_object_tracker/src/multi_object_tracker_core.cpp
+++ b/perception/multi_object_tracker/src/multi_object_tracker_core.cpp
@@ -419,35 +419,33 @@ void MultiObjectTracker::sanitizeTracker(
       const auto iou = object_recognition_utils::get2dIoU(object1, object2, min_union_iou_area);
       const auto & label1 = sorted_list_tracker[i]->getHighestProbLabel();
       const auto & label2 = sorted_list_tracker[j]->getHighestProbLabel();
-      bool should_delete_tracker2 = false;
+      bool delete_candidate_tracker = false;
 
       // If at least one of them is UNKNOWN, delete the one with lower IOU. Because the UNKNOWN
       // objects are not reliable.
       if (label1 == Label::UNKNOWN || label2 == Label::UNKNOWN) {
         if (min_iou_for_unknown_object < iou) {
           if (label2 == Label::UNKNOWN) {
-            /* erase only when prioritized one has a measurement or the other one doesn't */
-            if (sorted_list_tracker[i]->getNoMeasurementCount() <= 0 or 
-                sorted_list_tracker[j]->getNoMeasurementCount() > 0) {
-              should_delete_tracker2 = true;
-            }
+            delete_candidate_tracker = true;
           }
         }
       } else {  // If neither is UNKNOWN, delete the one with lower IOU.
         if (min_iou < iou) {
           /* erase only when prioritized one has a measurement */
-          if (sorted_list_tracker[i]->getNoMeasurementCount() <= 0) {
-            should_delete_tracker2 = true;
-          }
+          delete_candidate_tracker = true;
         }
       }
 
-      if (should_delete_tracker2) {
-        // Remove from original list_tracker
-        list_tracker.remove(sorted_list_tracker[j]);
-        // Remove from sorted list
-        sorted_list_tracker.erase(sorted_list_tracker.begin() + j);
-        --j;
+      if (delete_candidate_tracker) {
+        /* erase only when prioritized one has a measurement or the other one doesn't */
+        if (sorted_list_tracker[i]->getNoMeasurementCount() <= 0 or 
+            sorted_list_tracker[j]->getNoMeasurementCount() > 0) {
+          // Remove from original list_tracker
+          list_tracker.remove(sorted_list_tracker[j]);
+          // Remove from sorted list
+          sorted_list_tracker.erase(sorted_list_tracker.begin() + j);
+          --j;
+        }
       }
     }
   }

--- a/perception/multi_object_tracker/src/multi_object_tracker_core.cpp
+++ b/perception/multi_object_tracker/src/multi_object_tracker_core.cpp
@@ -435,7 +435,10 @@ void MultiObjectTracker::sanitizeTracker(
         }
       } else {  // If neither is UNKNOWN, delete the one with lower IOU.
         if (min_iou < iou) {
-          should_delete_tracker2 = true;
+          /* erase only when prioritized one has a measurement */
+          if (sorted_list_tracker[i]->getNoMeasurementCount() <= 0) {
+            should_delete_tracker2 = true;
+          }
         }
       }
 

--- a/perception/multi_object_tracker/src/multi_object_tracker_core.cpp
+++ b/perception/multi_object_tracker/src/multi_object_tracker_core.cpp
@@ -437,9 +437,9 @@ void MultiObjectTracker::sanitizeTracker(
       }
 
       if (delete_candidate_tracker) {
-        /* erase only when prioritized one has a measurement or the other one doesn't */
-        if (sorted_list_tracker[i]->getNoMeasurementCount() <= 0 or 
-            sorted_list_tracker[j]->getNoMeasurementCount() > 0) {
+        /* erase only when prioritized one has later(or equal time) meas than the other's */
+        if (sorted_list_tracker[i]->getElapsedTimeFromLastUpdate(time) <= 
+            sorted_list_tracker[j]->getElapsedTimeFromLastUpdate(time)) {
           // Remove from original list_tracker
           list_tracker.remove(sorted_list_tracker[j]);
           // Remove from sorted list

--- a/perception/multi_object_tracker/src/multi_object_tracker_core.cpp
+++ b/perception/multi_object_tracker/src/multi_object_tracker_core.cpp
@@ -401,10 +401,6 @@ void MultiObjectTracker::sanitizeTracker(
 
   /* delete collision tracker */
   for (size_t i = 0; i < sorted_list_tracker.size(); ++i) {
-    /* block erasing if no measurement */
-    if (sorted_list_tracker[i]->getNoMeasurementCount() > 0) {
-      continue;
-    }
     autoware_auto_perception_msgs::msg::TrackedObject object1;
     sorted_list_tracker[i]->getTrackedObject(time, object1);
     for (size_t j = i + 1; j < sorted_list_tracker.size(); ++j) {
@@ -430,7 +426,11 @@ void MultiObjectTracker::sanitizeTracker(
       if (label1 == Label::UNKNOWN || label2 == Label::UNKNOWN) {
         if (min_iou_for_unknown_object < iou) {
           if (label2 == Label::UNKNOWN) {
-            should_delete_tracker2 = true;
+            /* erase only when prioritized one has a measurement or the other one doesn't */
+            if (sorted_list_tracker[i]->getNoMeasurementCount() <= 0 or 
+                sorted_list_tracker[j]->getNoMeasurementCount() > 0) {
+              should_delete_tracker2 = true;
+            }
           }
         }
       } else {  // If neither is UNKNOWN, delete the one with lower IOU.

--- a/perception/multi_object_tracker/src/multi_object_tracker_core.cpp
+++ b/perception/multi_object_tracker/src/multi_object_tracker_core.cpp
@@ -386,13 +386,30 @@ void MultiObjectTracker::sanitizeTracker(
   constexpr float min_iou = 0.1;
   constexpr float min_iou_for_unknown_object = 0.001;
   constexpr double distance_threshold = 5.0;
+
+  // Create sorted list with non-UNKNOWN objects first, then by measurement count
+  std::vector<std::shared_ptr<Tracker>> sorted_list_tracker(list_tracker.begin(), list_tracker.end());
+  std::sort(sorted_list_tracker.begin(), sorted_list_tracker.end(),
+    [](const std::shared_ptr<Tracker>& a, const std::shared_ptr<Tracker>& b) {
+      bool a_unknown = (a->getHighestProbLabel() == Label::UNKNOWN);
+      bool b_unknown = (b->getHighestProbLabel() == Label::UNKNOWN);
+      if (a_unknown != b_unknown) {
+        return b_unknown;  // Put non-UNKNOWN objects first
+      }
+      return a->getTotalMeasurementCount() > b->getTotalMeasurementCount();  // Then sort by measurement count
+    });
+
   /* delete collision tracker */
-  for (auto itr1 = list_tracker.begin(); itr1 != list_tracker.end(); ++itr1) {
+  for (size_t i = 0; i < sorted_list_tracker.size(); ++i) {
+    /* block erasing if no measurement */
+    if (sorted_list_tracker[i]->getNoMeasurementCount() > 0) {
+      continue;
+    }
     autoware_auto_perception_msgs::msg::TrackedObject object1;
-    (*itr1)->getTrackedObject(time, object1);
-    for (auto itr2 = std::next(itr1); itr2 != list_tracker.end(); ++itr2) {
+    sorted_list_tracker[i]->getTrackedObject(time, object1);
+    for (size_t j = i + 1; j < sorted_list_tracker.size(); ++j) {
       autoware_auto_perception_msgs::msg::TrackedObject object2;
-      (*itr2)->getTrackedObject(time, object2);
+      sorted_list_tracker[j]->getTrackedObject(time, object2);
       const double distance = std::hypot(
         object1.kinematics.pose_with_covariance.pose.position.x -
           object2.kinematics.pose_with_covariance.pose.position.x,
@@ -404,44 +421,30 @@ void MultiObjectTracker::sanitizeTracker(
 
       const double min_union_iou_area = 1e-2;
       const auto iou = object_recognition_utils::get2dIoU(object1, object2, min_union_iou_area);
-      const auto & label1 = (*itr1)->getHighestProbLabel();
-      const auto & label2 = (*itr2)->getHighestProbLabel();
-      bool should_delete_tracker1 = false;
+      const auto & label1 = sorted_list_tracker[i]->getHighestProbLabel();
+      const auto & label2 = sorted_list_tracker[j]->getHighestProbLabel();
       bool should_delete_tracker2 = false;
 
       // If at least one of them is UNKNOWN, delete the one with lower IOU. Because the UNKNOWN
       // objects are not reliable.
       if (label1 == Label::UNKNOWN || label2 == Label::UNKNOWN) {
         if (min_iou_for_unknown_object < iou) {
-          if (label1 == Label::UNKNOWN && label2 == Label::UNKNOWN) {
-            if ((*itr1)->getTotalMeasurementCount() < (*itr2)->getTotalMeasurementCount()) {
-              should_delete_tracker1 = true;
-            } else {
-              should_delete_tracker2 = true;
-            }
-          } else if (label1 == Label::UNKNOWN) {
-            should_delete_tracker1 = true;
-          } else if (label2 == Label::UNKNOWN) {
+          if (label2 == Label::UNKNOWN) {
             should_delete_tracker2 = true;
           }
         }
       } else {  // If neither is UNKNOWN, delete the one with lower IOU.
         if (min_iou < iou) {
-          if ((*itr1)->getTotalMeasurementCount() < (*itr2)->getTotalMeasurementCount()) {
-            should_delete_tracker1 = true;
-          } else {
-            should_delete_tracker2 = true;
-          }
+          should_delete_tracker2 = true;
         }
       }
 
-      if (should_delete_tracker1) {
-        itr1 = list_tracker.erase(itr1);
-        --itr1;
-        break;
-      } else if (should_delete_tracker2) {
-        itr2 = list_tracker.erase(itr2);
-        --itr2;
+      if (should_delete_tracker2) {
+        // Remove from original list_tracker
+        list_tracker.remove(sorted_list_tracker[j]);
+        // Remove from sorted list
+        sorted_list_tracker.erase(sorted_list_tracker.begin() + j);
+        --j;
       }
     }
   }

--- a/perception/multi_object_tracker/src/multi_object_tracker_core.cpp
+++ b/perception/multi_object_tracker/src/multi_object_tracker_core.cpp
@@ -388,15 +388,18 @@ void MultiObjectTracker::sanitizeTracker(
   constexpr double distance_threshold = 5.0;
 
   // Create sorted list with non-UNKNOWN objects first, then by measurement count
-  std::vector<std::shared_ptr<Tracker>> sorted_list_tracker(list_tracker.begin(), list_tracker.end());
-  std::sort(sorted_list_tracker.begin(), sorted_list_tracker.end(),
-    [](const std::shared_ptr<Tracker>& a, const std::shared_ptr<Tracker>& b) {
+  std::vector<std::shared_ptr<Tracker>> sorted_list_tracker(
+    list_tracker.begin(), list_tracker.end());
+  std::sort(
+    sorted_list_tracker.begin(), sorted_list_tracker.end(),
+    [](const std::shared_ptr<Tracker> & a, const std::shared_ptr<Tracker> & b) {
       bool a_unknown = (a->getHighestProbLabel() == Label::UNKNOWN);
       bool b_unknown = (b->getHighestProbLabel() == Label::UNKNOWN);
       if (a_unknown != b_unknown) {
         return b_unknown;  // Put non-UNKNOWN objects first
       }
-      return a->getTotalMeasurementCount() > b->getTotalMeasurementCount();  // Then sort by measurement count
+      return a->getTotalMeasurementCount() >
+             b->getTotalMeasurementCount();  // Then sort by measurement count
     });
 
   /* delete collision tracker */
@@ -438,8 +441,9 @@ void MultiObjectTracker::sanitizeTracker(
 
       if (delete_candidate_tracker) {
         /* erase only when prioritized one has later(or equal time) meas than the other's */
-        if (sorted_list_tracker[i]->getElapsedTimeFromLastUpdate(time) <= 
-            sorted_list_tracker[j]->getElapsedTimeFromLastUpdate(time)) {
+        if (
+          sorted_list_tracker[i]->getElapsedTimeFromLastUpdate(time) <=
+          sorted_list_tracker[j]->getElapsedTimeFromLastUpdate(time)) {
           // Remove from original list_tracker
           list_tracker.remove(sorted_list_tracker[j]);
           // Remove from sorted list


### PR DESCRIPTION
## Description
Update sanitization(prune) process to fix the issue of temp lost for a laying adult found in LSim perception test

追加したソートの考え方：
Known objects(NO-UNKNOWN  objs)かどうかを第一条件、meas timeを第二条件としてソートすることで、tracking objの削除が発生する場合は、”必ずインデックスの小さい方が大きい方を消す”ようにして、forループ以後の処理を単純化
(
Added sorting concept:
By sorting with known objects (NO-UNKNOWN objs) as the first condition and mean time as the second condition, when a tracking obj is deleted, the smaller index will always delete the larger one, so that simplifying the processing after the for loop.
)

## Related links
TBD

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?
Minimum test on evaluator to check there is no side effect
https://evaluation.tier4.jp/evaluation/reports/04ac5b9d-1229-5171-8360-f8d67ce2d7fa?project_id=x2_dev

ベンチマークでは98.1->98.6と0.5ptの改善(最後のcommitを取り入れると98.7まで改善)
![image](https://github.com/user-attachments/assets/e27add4d-d29a-4202-8d74-d3b8b3c06d2f)



## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
