### PR TITLE
fix(perception): cherry-pick fixes for perception components

### DIFF
--- a/perception/autoware_multi_object_tracker/lib/association/association.cpp
+++ b/perception/autoware_multi_object_tracker/lib/association/association.cpp
@@ -180,7 +180,10 @@ double DataAssociation::calculateScore(
   const double mahalanobis_dist = getMahalanobisDistance(
     measurement_object.pose.position, tracked_object.pose.position,
     getXYCovariance(tracked_object.pose_covariance));
-  if (3.035 /*99%*/ <= mahalanobis_dist) return 0.0;
+  constexpr double mahalanobis_dist_threshold =
+    3.717;  // 99.99% confidence level for 2 degrees of freedom, square root of chi-square critical
+            // value of 13.816
+  if (mahalanobis_dist_threshold <= mahalanobis_dist) return 0.0;
 
   // 2d iou gate
   const double min_iou = config_.min_iou_matrix(tracker_label, measurement_label);

--- a/perception/autoware_multi_object_tracker/lib/object_model/shapes.cpp
+++ b/perception/autoware_multi_object_tracker/lib/object_model/shapes.cpp
@@ -182,17 +182,17 @@ void getNearestCornerOrSurface(
   double anchor_y = 0;
   if (xl > length / 2.0) {
     anchor_x = length / 2.0;
-  } else if (xl > -length / 2.0) {
-    anchor_x = 0;
-  } else {
+  } else if (xl < -length / 2.0) {
     anchor_x = -length / 2.0;
+  } else {
+    anchor_x = 0;
   }
   if (yl > width / 2.0) {
     anchor_y = width / 2.0;
-  } else if (yl > -width / 2.0) {
-    anchor_y = 0;
-  } else {
+  } else if (yl < -width / 2.0) {
     anchor_y = -width / 2.0;
+  } else {
+    anchor_y = 0;
   }
 
   object.anchor_point.x = anchor_x;
@@ -206,7 +206,7 @@ void calcAnchorPointOffset(
   // copy value
   const geometry_msgs::msg::Point anchor_vector = updating_object.anchor_point;
   // invalid anchor
-  if (anchor_vector.x <= 1e-6 && anchor_vector.y <= 1e-6) {
+  if (std::abs(anchor_vector.x) <= 1e-6 && std::abs(anchor_vector.y) <= 1e-6) {
     return;
   }
   double input_yaw = tf2::getYaw(updating_object.pose.orientation);
@@ -217,15 +217,19 @@ void calcAnchorPointOffset(
 
   // update offset
   tracking_offset = Eigen::Vector2d(anchor_vector.x, anchor_vector.y);
-  if (tracking_offset.x() > 0) {
+  if (tracking_offset.x() > 1e-6) {
     tracking_offset.x() -= length / 2.0;
-  } else if (tracking_offset.x() < 0) {
+  } else if (tracking_offset.x() < -1e-6) {
     tracking_offset.x() += length / 2.0;
+  } else {
+    tracking_offset.x() = 0.0;
   }
-  if (tracking_offset.y() > 0) {
+  if (tracking_offset.y() > 1e-6) {
     tracking_offset.y() -= width / 2.0;
-  } else if (tracking_offset.y() < 0) {
+  } else if (tracking_offset.y() < -1e-6) {
     tracking_offset.y() += width / 2.0;
+  } else {
+    tracking_offset.y() = 0.0;
   }
 
   // offset input object


### PR DESCRIPTION
# Perception Bug Fixes

This PR includes several critical fixes for perception components:

1. Updated Mahalanobis distance threshold in multi-object tracker for improved data association accuracy
2. Fixed VRU object orientation handling in map-based prediction
3. Corrected anchor point calculation in multi-object tracker
