### PR TITLE
fix(perception): cherry-pick fixes for perception enhancement

### DIFF
--- a/perception/autoware_detected_object_validation/CMakeLists.txt
+++ b/perception/autoware_detected_object_validation/CMakeLists.txt
@@ -53,6 +53,10 @@ ament_auto_add_library(object_lanelet_filter SHARED
   lib/utils/utils.cpp
 )
 
+target_link_libraries(object_lanelet_filter
+  Eigen3::Eigen
+)
+
 ament_auto_add_library(object_position_filter SHARED
   src/position_filter/position_filter.cpp
   lib/utils/utils.cpp

--- a/perception/autoware_detected_object_validation/config/object_lanelet_filter.param.yaml
+++ b/perception/autoware_detected_object_validation/config/object_lanelet_filter.param.yaml
@@ -12,15 +12,20 @@
 
     filter_settings:
       # polygon overlap based filter
-      polygon_overlap_filter:
-       enabled: true
+      lanelet_xy_overlap_filter:
+        enabled: true
+
       # velocity direction based filter
       lanelet_direction_filter:
         enabled: false
         velocity_yaw_threshold: 0.785398 # [rad] (45 deg)
         object_speed_threshold: 3.0 # [m/s]
-      debug: false
+
+      # object's elevation from lanelet based filter
+      lanelet_object_elevation_filter:
+        enabled: false
+        max_elevation_threshold: 5.0 # [m] from a lanelet's surface
+        min_elevation_threshold: 0.0 # [m] from a lanelet's surface
+
       lanelet_extra_margin: 0.0
-      use_height_threshold: false
-      max_height_threshold: 10.0 # [m] from the base_link height in map frame
-      min_height_threshold: -1.0 # [m] from the base_link height in map frame
+      debug: false

--- a/perception/autoware_detected_object_validation/object-lanelet-filter.md
+++ b/perception/autoware_detected_object_validation/object-lanelet-filter.md
@@ -30,13 +30,14 @@ Description of the `filter_settings` in the parameters of the `object_lanelet_fi
 | ------------------------------------------------- | -------- | ------------------------------------------------------------------------------------------------------------------------------------- |
 | `debug`                                           | `bool`   | If `true`, publishes additional debug information, including visualization markers on the `~/debug/marker` topic for tools like RViz. |
 | `lanelet_extra_margin`                            | `double` | If `> 0`, expands the lanelet polygons used for overlap checks by this margin (in meters). If `<= 0`, polygon expansion is disabled.  |
-| `polygon_overlap_filter.enabled`                  | `bool`   | If `true`, enables filtering of objects based on their overlap with lanelet polygons.                                                 |
+| `lanelet_xy_overlap_filter.enabled`               | `bool`   | If `true`, enables filtering of objects based on their overlap with lanelet polygons.                                                 |
 | `lanelet_direction_filter.enabled`                | `bool`   | If `true`, enables filtering of objects based on their velocity direction relative to the lanelet.                                    |
 | `lanelet_direction_filter.velocity_yaw_threshold` | `double` | The yaw angle difference threshold (in radians) between the object’s velocity vector and the lanelet direction.                       |
 | `lanelet_direction_filter.object_speed_threshold` | `double` | The minimum speed (in m/s) of an object required for the direction filter to be applied.                                              |
-| `use_height_threshold`                            | `bool`   | If `true`, enables filtering of objects based on their height relative to the base_link frame.                                        |
-| `max_height_threshold`                            | `double` | The maximum allowable height (in meters) of an object relative to the base_link in the map frame.                                     |
-| `min_height_threshold`                            | `double` | The minimum allowable height (in meters) of an object relative to the base_link in the map frame.                                     |
+| `lanelet_object_elevation_filter.enabled`         | `bool`   | If `true`, enables filtering of objects based on their elevation relative to the nearest lanelet surface.                             |
+| `max_elevation_threshold`                         | `double` | The maximum allowable elevation (in meters) of an object relative to the nearest lanelet surface.                                     |
+| `min_elevation_threshold`                         | `double` | The minimum allowable elevation (in meters) of an object relative to the nearest lanelet surface.                                     |
+| `lanelet_extra_margin`                            | `double` | The margin value that will be added to the lanelet boundaries.                                                                        |
 
 ### Core Parameters
 

--- a/perception/autoware_detected_object_validation/schema/object_lanelet_filter.schema.json
+++ b/perception/autoware_detected_object_validation/schema/object_lanelet_filter.schema.json
@@ -64,7 +64,7 @@
         "filter_settings": {
           "type": "object",
           "properties": {
-            "polygon_overlap_filter": {
+            "lanelet_xy_overlap_filter": {
               "type": "object",
               "properties": {
                 "enabled": {
@@ -96,40 +96,44 @@
               },
               "required": ["enabled", "velocity_yaw_threshold", "object_speed_threshold"]
             },
-            "debug": {
-              "type": "boolean",
-              "default": false,
-              "description": "If true, debug information is enabled."
+            "lanelet_object_elevation_filter": {
+              "type": "object",
+              "properties": {
+                "enabled": {
+                  "type": "boolean",
+                  "default": false,
+                  "description": "If true, the objects not within the elevation range relative to the lanelet surface will be filtered."
+                },
+                "max_elevation_threshold": {
+                  "type": "number",
+                  "default": 5.0,
+                  "description": "Maximum elevation threshold for filtering objects (in meters)."
+                },
+                "min_elevation_threshold": {
+                  "type": "number",
+                  "default": 0.0,
+                  "description": "Minimum elevation threshold for filtering objects (in meters)."
+                }
+              },
+              "required": ["enabled", "max_elevation_threshold", "min_elevation_threshold"]
             },
             "lanelet_extra_margin": {
               "type": "number",
               "default": 0.0,
               "description": "Extra margin added to the lanelet boundaries."
             },
-            "use_height_threshold": {
+            "debug": {
               "type": "boolean",
               "default": false,
-              "description": "If true, height thresholds are used to filter objects."
-            },
-            "max_height_threshold": {
-              "type": "number",
-              "default": 10.0,
-              "description": "Maximum height threshold for filtering objects (in meters)."
-            },
-            "min_height_threshold": {
-              "type": "number",
-              "default": -1.0,
-              "description": "Minimum height threshold for filtering objects (in meters)."
+              "description": "If true, debug information is enabled."
             }
           },
           "required": [
-            "polygon_overlap_filter",
+            "lanelet_xy_overlap_filter",
             "lanelet_direction_filter",
-            "debug",
+            "lanelet_object_elevation_filter",
             "lanelet_extra_margin",
-            "use_height_threshold",
-            "max_height_threshold",
-            "min_height_threshold"
+            "debug"
           ]
         }
       },

--- a/perception/autoware_detected_object_validation/src/lanelet_filter/lanelet_filter.cpp
+++ b/perception/autoware_detected_object_validation/src/lanelet_filter/lanelet_filter.cpp
@@ -18,7 +18,8 @@
 #include "autoware_lanelet2_extension/utility/message_conversion.hpp"
 #include "autoware_lanelet2_extension/utility/query.hpp"
 #include "autoware_utils/geometry/geometry.hpp"
-#include "autoware_utils/system/time_keeper.hpp"
+
+#include <Eigen/Core>
 
 #include <boost/geometry/algorithms/convex_hull.hpp>
 #include <boost/geometry/algorithms/disjoint.hpp>
@@ -30,6 +31,9 @@
 #include <lanelet2_core/geometry/LaneletMap.h>
 #include <lanelet2_core/geometry/Polygon.h>
 
+#include <algorithm>
+#include <cmath>
+#include <limits>
 #include <memory>
 #include <utility>
 #include <vector>
@@ -38,6 +42,8 @@ namespace autoware::detected_object_validation
 {
 namespace lanelet_filter
 {
+using TriangleMesh = std::vector<std::array<Eigen::Vector3d, 3>>;
+
 ObjectLaneletFilterNode::ObjectLaneletFilterNode(const rclcpp::NodeOptions & node_options)
 : Node("object_lanelet_filter_node", node_options),
   tf_buffer_(this->get_clock()),
@@ -54,24 +60,36 @@ ObjectLaneletFilterNode::ObjectLaneletFilterNode(const rclcpp::NodeOptions & nod
   filter_target_.MOTORCYCLE = declare_parameter<bool>("filter_target_label.MOTORCYCLE");
   filter_target_.BICYCLE = declare_parameter<bool>("filter_target_label.BICYCLE");
   filter_target_.PEDESTRIAN = declare_parameter<bool>("filter_target_label.PEDESTRIAN");
+
   // Set filter settings
-  filter_settings_.polygon_overlap_filter =
-    declare_parameter<bool>("filter_settings.polygon_overlap_filter.enabled");
+  filter_settings_.lanelet_xy_overlap_filter =
+    declare_parameter<bool>("filter_settings.lanelet_xy_overlap_filter.enabled");
+
   filter_settings_.lanelet_direction_filter =
     declare_parameter<bool>("filter_settings.lanelet_direction_filter.enabled");
   filter_settings_.lanelet_direction_filter_velocity_yaw_threshold =
     declare_parameter<double>("filter_settings.lanelet_direction_filter.velocity_yaw_threshold");
   filter_settings_.lanelet_direction_filter_object_speed_threshold =
     declare_parameter<double>("filter_settings.lanelet_direction_filter.object_speed_threshold");
-  filter_settings_.debug = declare_parameter<bool>("filter_settings.debug");
+
+  filter_settings_.lanelet_object_elevation_filter =
+    declare_parameter<bool>("filter_settings.lanelet_object_elevation_filter.enabled");
+  filter_settings_.max_elevation_threshold = declare_parameter<double>(
+    "filter_settings.lanelet_object_elevation_filter.max_elevation_threshold");
+  filter_settings_.min_elevation_threshold = declare_parameter<double>(
+    "filter_settings.lanelet_object_elevation_filter.min_elevation_threshold");
+
   filter_settings_.lanelet_extra_margin =
     declare_parameter<double>("filter_settings.lanelet_extra_margin");
-  filter_settings_.use_height_threshold =
-    declare_parameter<bool>("filter_settings.use_height_threshold");
-  filter_settings_.max_height_threshold =
-    declare_parameter<double>("filter_settings.max_height_threshold");
-  filter_settings_.min_height_threshold =
-    declare_parameter<double>("filter_settings.min_height_threshold");
+  filter_settings_.debug = declare_parameter<bool>("filter_settings.debug");
+
+  if (filter_settings_.min_elevation_threshold > filter_settings_.max_elevation_threshold) {
+    RCLCPP_WARN(
+      this->get_logger(),
+      "parameters of object_elevation_filter do not satisfy the relation: "
+      "min_elevation_threshold (%f) <= max_elevation_threshold (%f)",
+      filter_settings_.min_elevation_threshold, filter_settings_.max_elevation_threshold);
+  }
 
   // Set publisher/subscriber
   map_sub_ = this->create_subscription<autoware_map_msgs::msg::LaneletMapBin>(
@@ -101,6 +119,14 @@ bool isInPolygon(
   return boost::geometry::distance(p, polygon) < radius + eps;
 }
 
+bool isInPolygon(
+  const double & x, const double & y, const lanelet::BasicPolygon2d & polygon, const double radius)
+{
+  constexpr double eps = 1.0e-9;
+  const lanelet::BasicPoint2d p(x, y);
+  return boost::geometry::distance(p, polygon) < radius + eps;
+}
+
 LinearRing2d expandPolygon(const LinearRing2d & polygon, double distance)
 {
   autoware_utils::MultiPolygon2d multi_polygon;
@@ -119,6 +145,170 @@ LinearRing2d expandPolygon(const LinearRing2d & polygon, double distance)
   }
 
   return multi_polygon.front().outer();
+}
+
+TriangleMesh createTriangleMeshFromLanelet(const lanelet::ConstLanelet & lanelet)
+{
+  TriangleMesh mesh;
+
+  const lanelet::ConstLineString3d & left = lanelet.leftBound();
+  const lanelet::ConstLineString3d & right = lanelet.rightBound();
+
+  // bounds should have same number of points
+  // if not the same, first check the first shared points then we will check it from the tail
+  // since we don't have the original set of 3 points,
+  // we will approximate the 3d mesh with this way
+  size_t n_left = left.size();
+  size_t n_right = right.size();
+  const size_t n_shared = std::min(n_left, n_right);
+  if (n_shared < 2) return mesh;
+
+  // take 2 points from each side and create 2 triangles
+  for (size_t i = 0; i < n_shared - 1; ++i) {
+    const Eigen::Vector3d a_l(left[i].x(), left[i].y(), left[i].z());
+    const Eigen::Vector3d b_l(left[i + 1].x(), left[i + 1].y(), left[i + 1].z());
+    const Eigen::Vector3d a_r(right[i].x(), right[i].y(), right[i].z());
+    const Eigen::Vector3d b_r(right[i + 1].x(), right[i + 1].y(), right[i + 1].z());
+
+    //
+    // b_l .--. b_r
+    //     |\ |
+    //     | \|
+    //     .--.
+    // a_l      a_r
+    //
+    mesh.push_back({a_l, b_l, a_r});
+    mesh.push_back({b_l, b_r, a_r});
+  }
+
+  // triangulation of the remaining unmatched parts from the tail
+  if (n_left > n_right) {
+    size_t i = n_left - 1;
+    size_t j = n_right - 1;
+    const size_t n_extra = n_left - n_right;
+
+    for (size_t k = 0; k < n_extra; ++k) {
+      // we need at least 2 points from each side
+      if (i < 1 || j < 1) break;
+
+      const Eigen::Vector3d a_l(left[i - 1].x(), left[i - 1].y(), left[i - 1].z());
+      const Eigen::Vector3d b_l(left[i].x(), left[i].y(), left[i].z());
+      const Eigen::Vector3d a_r(right[j - 1].x(), right[j - 1].y(), right[j - 1].z());
+      const Eigen::Vector3d b_r(right[j].x(), right[j].y(), right[j].z());
+
+      mesh.push_back({b_l, a_l, b_r});
+      mesh.push_back({a_l, a_r, b_r});
+
+      --i;
+      --j;
+    }
+  } else if (n_right > n_left) {
+    size_t i = n_left - 1;
+    size_t j = n_right - 1;
+    const size_t n_extra = n_right - n_left;
+
+    for (size_t k = 0; k < n_extra; ++k) {
+      if (i < 1 || j < 1) break;
+
+      const Eigen::Vector3d a_l(left[i - 1].x(), left[i - 1].y(), left[i - 1].z());
+      const Eigen::Vector3d b_l(left[i].x(), left[i].y(), left[i].z());
+      const Eigen::Vector3d a_r(right[j - 1].x(), right[j - 1].y(), right[j - 1].z());
+      const Eigen::Vector3d b_r(right[j].x(), right[j].y(), right[j].z());
+
+      mesh.push_back({b_l, a_l, b_r});
+      mesh.push_back({a_l, a_r, b_r});
+
+      --i;
+      --j;
+    }
+  }
+
+  return mesh;
+}
+
+// compute a normal vector that is pointing the Z+ from given triangle points
+Eigen::Vector3d computeFaceNormal(const std::array<Eigen::Vector3d, 3> & triangle_points)
+{
+  const Eigen::Vector3d v1 = triangle_points[1] - triangle_points[0];
+  const Eigen::Vector3d v2 = triangle_points[2] - triangle_points[0];
+  Eigen::Vector3d normal = v1.cross(v2);
+
+  // ensure the normal is pointing upward (Z+)
+  if (normal.z() < 0) {
+    normal = -normal;
+  }
+
+  return normal.normalized();
+}
+
+// checks whether a point is located above the lanelet triangle plane
+// that is closest in the perpendicular direction
+bool isPointAboveLaneletMesh(
+  const Eigen::Vector3d & point, const lanelet::ConstLanelet & lanelet, const double & offset,
+  const double & min_distance, const double & max_distance)
+{
+  const TriangleMesh mesh = createTriangleMeshFromLanelet(lanelet);
+
+  if (mesh.empty()) return true;
+
+  // for the query point
+  double query_point_min_abs_dist = std::numeric_limits<double>::infinity();
+  // for top and bottom point
+  double top_min_dist = std::numeric_limits<double>::infinity();
+  double top_min_abs_dist = std::numeric_limits<double>::infinity();
+  double bottom_min_dist = std::numeric_limits<double>::infinity();
+  double bottom_min_abs_dist = std::numeric_limits<double>::infinity();
+
+  // search the most nearest surface from the query point
+  for (const auto & tri : mesh) {
+    const Eigen::Vector3d plane_normal_vec = computeFaceNormal(tri);
+
+    // std::cos(M_PI / 3.0) -> 0.5;
+    // in some environment, or more recent c++, it can be constexpr
+    constexpr double cos_threshold = 0.5;
+    const double cos_of_normal_and_z = plane_normal_vec.dot(Eigen::Vector3d::UnitZ());
+
+    // if angle is too steep, consider as above for safety
+    if (cos_of_normal_and_z < cos_threshold) {
+      return true;
+    }
+
+    Eigen::Vector3d vec_to_point = point - tri[0];
+    double signed_dist = plane_normal_vec.dot(vec_to_point);
+
+    double abs_dist = std::abs(signed_dist);
+    if (abs_dist < query_point_min_abs_dist) {
+      query_point_min_abs_dist = abs_dist;
+
+      // check top side
+      vec_to_point = (point + offset * plane_normal_vec) - tri[0];
+      signed_dist = plane_normal_vec.dot(vec_to_point);
+
+      abs_dist = std::abs(signed_dist);
+      if (abs_dist < top_min_abs_dist) {
+        top_min_dist = signed_dist;
+        top_min_abs_dist = abs_dist;
+      }
+
+      // check bottom side
+      vec_to_point = (point - offset * plane_normal_vec) - tri[0];
+      signed_dist = plane_normal_vec.dot(vec_to_point);
+
+      abs_dist = std::abs(signed_dist);
+      if (abs_dist < bottom_min_abs_dist) {
+        bottom_min_dist = signed_dist;
+        bottom_min_abs_dist = abs_dist;
+      }
+    }
+  }
+
+  // if at least one point is within the range, we consider it to be in the range
+  if (
+    (min_distance <= top_min_dist && top_min_dist <= max_distance) ||
+    (min_distance <= bottom_min_dist && bottom_min_dist <= max_distance))
+    return true;
+  else
+    return false;
 }
 
 void ObjectLaneletFilterNode::mapCallback(
@@ -144,24 +334,12 @@ void ObjectLaneletFilterNode::objectCallback(
     RCLCPP_ERROR(get_logger(), "No vector map received.");
     return;
   }
+
   autoware_perception_msgs::msg::DetectedObjects transformed_objects;
   if (!autoware::object_recognition_utils::transformObjects(
         *input_msg, lanelet_frame_id_, tf_buffer_, transformed_objects)) {
     RCLCPP_ERROR(get_logger(), "Failed transform to %s.", lanelet_frame_id_.c_str());
     return;
-  }
-  // vehicle base pose :map -> base_link
-  if (filter_settings_.use_height_threshold) {
-    try {
-      ego_base_height_ = tf_buffer_
-                           .lookupTransform(
-                             lanelet_frame_id_, "base_link", transformed_objects.header.stamp,
-                             rclcpp::Duration::from_seconds(0.5))
-                           .transform.translation.z;
-    } catch (const tf2::TransformException & ex) {
-      RCLCPP_ERROR_STREAM(get_logger(), "Failed to get transform: " << ex.what());
-      return;
-    }
   }
 
   if (!transformed_objects.objects.empty()) {
@@ -216,30 +394,44 @@ bool ObjectLaneletFilterNode::filterObject(
       return false;
     }
 
-    // 0. check height threshold
-    if (filter_settings_.use_height_threshold) {
-      const double object_height = transformed_object.shape.dimensions.z;
-      if (
-        object_height > ego_base_height_ + filter_settings_.max_height_threshold ||
-        object_height < ego_base_height_ + filter_settings_.min_height_threshold) {
-        return false;
+    // create a 2D polygon from the object for querying
+    Polygon2d object_polygon;
+    if (utils::hasBoundingBox(transformed_object)) {
+      const auto footprint = setFootprint(transformed_object);
+      for (const auto & point : footprint.points) {
+        const geometry_msgs::msg::Point32 point_transformed = autoware_utils::transform_point(
+          point, transformed_object.kinematics.pose_with_covariance.pose);
+        object_polygon.outer().emplace_back(point_transformed.x, point_transformed.y);
       }
+      object_polygon.outer().push_back(object_polygon.outer().front());
+    } else {
+      object_polygon = getConvexHullFromObjectFootprint(transformed_object);
     }
+
+    // create a bounding box from polygon for searching the local R-tree
+    bg::model::box<bg::model::d2::point_xy<double>> bbox_of_convex_hull;
+    bg::envelope(object_polygon, bbox_of_convex_hull);
+    std::vector<BoxAndLanelet> candidates;
+    // only use the lanelets that intersect with the object's bounding box
+    local_rtree.query(bgi::intersects(bbox_of_convex_hull), std::back_inserter(candidates));
 
     bool filter_pass = true;
     // 1. is polygon overlap with road lanelets or shoulder lanelets
-    if (filter_settings_.polygon_overlap_filter) {
-      const bool is_polygon_overlap = isObjectOverlapLanelets(transformed_object, local_rtree);
-      filter_pass = filter_pass && is_polygon_overlap;
+    if (filter_settings_.lanelet_xy_overlap_filter) {
+      filter_pass = isObjectOverlapLanelets(transformed_object, object_polygon, candidates);
     }
 
     // 2. check if objects velocity is the same with the lanelet direction
     const bool orientation_not_available =
       transformed_object.kinematics.orientation_availability ==
       autoware_perception_msgs::msg::TrackedObjectKinematics::UNAVAILABLE;
-    if (filter_settings_.lanelet_direction_filter && !orientation_not_available) {
-      const bool is_same_direction = isSameDirectionWithLanelets(transformed_object, local_rtree);
-      filter_pass = filter_pass && is_same_direction;
+    if (filter_settings_.lanelet_direction_filter && !orientation_not_available && filter_pass) {
+      filter_pass = isSameDirectionWithLanelets(transformed_object, candidates);
+    }
+
+    // 3. check if the object is above the lanelets
+    if (filter_settings_.lanelet_object_elevation_filter && filter_pass) {
+      filter_pass = isObjectAboveLanelet(transformed_object, candidates);
     }
 
     // push back to output object
@@ -299,7 +491,7 @@ LinearRing2d ObjectLaneletFilterNode::getConvexHull(
   return convex_hull;
 }
 
-LinearRing2d ObjectLaneletFilterNode::getConvexHullFromObjectFootprint(
+Polygon2d ObjectLaneletFilterNode::getConvexHullFromObjectFootprint(
   const autoware_perception_msgs::msg::DetectedObject & object)
 {
   MultiPoint2d candidate_points;
@@ -310,7 +502,7 @@ LinearRing2d ObjectLaneletFilterNode::getConvexHullFromObjectFootprint(
     candidate_points.emplace_back(p.x + pos.x, p.y + pos.y);
   }
 
-  LinearRing2d convex_hull;
+  Polygon2d convex_hull;
   bg::convex_hull(candidate_points, convex_hull);
 
   return convex_hull;
@@ -377,59 +569,31 @@ lanelet::BasicPolygon2d ObjectLaneletFilterNode::getPolygon(const lanelet::Const
 }
 
 bool ObjectLaneletFilterNode::isObjectOverlapLanelets(
-  const autoware_perception_msgs::msg::DetectedObject & object,
-  const bgi::rtree<BoxAndLanelet, RtreeAlgo> & local_rtree)
+  const autoware_perception_msgs::msg::DetectedObject & object, const Polygon2d & polygon,
+  const std::vector<BoxAndLanelet> & lanelet_candidates)
 {
   // if object has bounding box, use polygon overlap
   if (utils::hasBoundingBox(object)) {
-    Polygon2d polygon;
-    const auto footprint = setFootprint(object);
-    for (const auto & point : footprint.points) {
-      const geometry_msgs::msg::Point32 point_transformed =
-        autoware_utils::transform_point(point, object.kinematics.pose_with_covariance.pose);
-      polygon.outer().emplace_back(point_transformed.x, point_transformed.y);
-    }
-    polygon.outer().push_back(polygon.outer().front());
-
-    return isPolygonOverlapLanelets(polygon, local_rtree);
+    return isPolygonOverlapLanelets(polygon, lanelet_candidates);
   } else {
-    const LinearRing2d object_convex_hull = getConvexHullFromObjectFootprint(object);
-
-    // create bounding box to search in the rtree
-    std::vector<BoxAndLanelet> candidates;
-    bg::model::box<bg::model::d2::point_xy<double>> bbox;
-    bg::envelope(object_convex_hull, bbox);
-    local_rtree.query(bgi::intersects(bbox), std::back_inserter(candidates));
-
-    // if object do not have bounding box, check each footprint is inside polygon
     for (const auto & point : object.shape.footprint.points) {
       const geometry_msgs::msg::Point32 point_transformed =
         autoware_utils::transform_point(point, object.kinematics.pose_with_covariance.pose);
-      geometry_msgs::msg::Pose point2d;
-      point2d.position.x = point_transformed.x;
-      point2d.position.y = point_transformed.y;
 
-      for (const auto & candidate : candidates) {
-        if (isInPolygon(point2d, candidate.second.polygon, 0.0)) {
+      for (const auto & candidate : lanelet_candidates) {
+        if (isInPolygon(point_transformed.x, point_transformed.y, candidate.second.polygon, 0.0)) {
           return true;
         }
       }
     }
-
     return false;
   }
 }
 
 bool ObjectLaneletFilterNode::isPolygonOverlapLanelets(
-  const Polygon2d & polygon, const bgi::rtree<BoxAndLanelet, RtreeAlgo> & local_rtree)
+  const Polygon2d & polygon, const std::vector<BoxAndLanelet> & lanelet_candidates)
 {
-  // create a bounding box from polygon for searching the local R-tree
-  std::vector<BoxAndLanelet> candidates;
-  bg::model::box<bg::model::d2::point_xy<double>> bbox_of_convex_hull;
-  bg::envelope(polygon, bbox_of_convex_hull);
-  local_rtree.query(bgi::intersects(bbox_of_convex_hull), std::back_inserter(candidates));
-
-  for (const auto & box_and_lanelet : candidates) {
+  for (const auto & box_and_lanelet : lanelet_candidates) {
     if (!bg::disjoint(polygon, box_and_lanelet.second.polygon)) {
       return true;
     }
@@ -440,7 +604,7 @@ bool ObjectLaneletFilterNode::isPolygonOverlapLanelets(
 
 bool ObjectLaneletFilterNode::isSameDirectionWithLanelets(
   const autoware_perception_msgs::msg::DetectedObject & object,
-  const bgi::rtree<BoxAndLanelet, RtreeAlgo> & local_rtree)
+  const std::vector<BoxAndLanelet> & lanelet_candidates)
 {
   const double object_yaw = tf2::getYaw(object.kinematics.pose_with_covariance.pose.orientation);
   const double object_velocity_norm = std::hypot(
@@ -455,21 +619,7 @@ bool ObjectLaneletFilterNode::isSameDirectionWithLanelets(
     return true;
   }
 
-  // we can not query by points, so create a small bounding box
-  // eps is not determined by any specific criteria; just a guess
-  constexpr double eps = 1.0e-6;
-  std::vector<BoxAndLanelet> candidates;
-  const Point2d min_corner(
-    object.kinematics.pose_with_covariance.pose.position.x - eps,
-    object.kinematics.pose_with_covariance.pose.position.y - eps);
-  const Point2d max_corner(
-    object.kinematics.pose_with_covariance.pose.position.x + eps,
-    object.kinematics.pose_with_covariance.pose.position.y + eps);
-  const Box bbox(min_corner, max_corner);
-
-  local_rtree.query(bgi::intersects(bbox), std::back_inserter(candidates));
-
-  for (const auto & box_and_lanelet : candidates) {
+  for (const auto & box_and_lanelet : lanelet_candidates) {
     const bool is_in_lanelet =
       isInPolygon(object.kinematics.pose_with_covariance.pose, box_and_lanelet.second.polygon, 0.0);
     if (!is_in_lanelet) {
@@ -488,6 +638,45 @@ bool ObjectLaneletFilterNode::isSameDirectionWithLanelets(
   }
 
   return false;
+}
+
+bool ObjectLaneletFilterNode::isObjectAboveLanelet(
+  const autoware_perception_msgs::msg::DetectedObject & object,
+  const std::vector<BoxAndLanelet> & lanelet_candidates)
+{
+  // assuming the positions are already the center of the cluster (convex hull)
+  // for an exact calculation of the center from the points,
+  // we should use autoware_utils::transform_point before computing the cluster
+  const double cx = object.kinematics.pose_with_covariance.pose.position.x;
+  const double cy = object.kinematics.pose_with_covariance.pose.position.y;
+  const double cz = object.kinematics.pose_with_covariance.pose.position.z;
+  // use the centroid as a query point
+  const Eigen::Vector3d centroid(cx, cy, cz);
+  const double half_dim_z = object.shape.dimensions.z * 0.5;
+
+  lanelet::ConstLanelet nearest_lanelet;
+  double closest_lanelet_z_dist = std::numeric_limits<double>::infinity();
+
+  // search for the nearest lanelet along the z-axis in case roads are layered
+  for (const auto & candidate_lanelet : lanelet_candidates) {
+    const lanelet::ConstLanelet llt = candidate_lanelet.second.lanelet;
+    const lanelet::ConstLineString3d line = llt.leftBound();
+    if (line.empty()) continue;
+
+    // assuming the roads have enough height difference to distinguish each other
+    const double diff_z = cz - line[0].z();
+    const double dist_z = diff_z * diff_z;
+
+    // use the closest lanelet in z axis
+    if (dist_z < closest_lanelet_z_dist) {
+      closest_lanelet_z_dist = dist_z;
+      nearest_lanelet = llt;
+    }
+  }
+
+  return isPointAboveLaneletMesh(
+    centroid, nearest_lanelet, half_dim_z, filter_settings_.min_elevation_threshold,
+    filter_settings_.max_elevation_threshold);
 }
 
 }  // namespace lanelet_filter

--- a/perception/autoware_detected_object_validation/src/lanelet_filter/lanelet_filter.hpp
+++ b/perception/autoware_detected_object_validation/src/lanelet_filter/lanelet_filter.hpp
@@ -92,15 +92,18 @@ private:
   double ego_base_height_ = 0.0;
   struct FilterSettings
   {
-    bool polygon_overlap_filter;
+    bool lanelet_xy_overlap_filter;
+
     bool lanelet_direction_filter;
     double lanelet_direction_filter_velocity_yaw_threshold;
     double lanelet_direction_filter_object_speed_threshold;
-    bool debug;
+
+    bool lanelet_object_elevation_filter;
+    double max_elevation_threshold = std::numeric_limits<double>::infinity();
+    double min_elevation_threshold = -std::numeric_limits<double>::infinity();
+
     double lanelet_extra_margin;
-    bool use_height_threshold;
-    double max_height_threshold = std::numeric_limits<double>::infinity();
-    double min_height_threshold = -std::numeric_limits<double>::infinity();
+    bool debug;
   } filter_settings_;
 
   bool filterObject(
@@ -109,17 +112,20 @@ private:
     const bg::index::rtree<BoxAndLanelet, RtreeAlgo> & local_rtree,
     autoware_perception_msgs::msg::DetectedObjects & output_object_msg);
   LinearRing2d getConvexHull(const autoware_perception_msgs::msg::DetectedObjects &);
-  LinearRing2d getConvexHullFromObjectFootprint(
+  Polygon2d getConvexHullFromObjectFootprint(
     const autoware_perception_msgs::msg::DetectedObject & object);
   std::vector<BoxAndLanelet> getIntersectedLanelets(const LinearRing2d &);
   bool isObjectOverlapLanelets(
-    const autoware_perception_msgs::msg::DetectedObject & object,
-    const bg::index::rtree<BoxAndLanelet, RtreeAlgo> & local_rtree);
+    const autoware_perception_msgs::msg::DetectedObject & object, const Polygon2d & polygon,
+    const std::vector<BoxAndLanelet> & lanelet_candidates);
   bool isPolygonOverlapLanelets(
-    const Polygon2d & polygon, const bgi::rtree<BoxAndLanelet, RtreeAlgo> & local_rtree);
+    const Polygon2d & polygon, const std::vector<BoxAndLanelet> & lanelet_candidates);
   bool isSameDirectionWithLanelets(
     const autoware_perception_msgs::msg::DetectedObject & object,
-    const bgi::rtree<BoxAndLanelet, RtreeAlgo> & local_rtree);
+    const std::vector<BoxAndLanelet> & lanelet_candidates);
+  bool isObjectAboveLanelet(
+    const autoware_perception_msgs::msg::DetectedObject & object,
+    const std::vector<BoxAndLanelet> & lanelet_candidates);
   geometry_msgs::msg::Polygon setFootprint(const autoware_perception_msgs::msg::DetectedObject &);
 
   lanelet::BasicPolygon2d getPolygon(const lanelet::ConstLanelet & lanelet);

--- a/perception/autoware_detection_by_tracker/src/detection_by_tracker_node.cpp
+++ b/perception/autoware_detection_by_tracker/src/detection_by_tracker_node.cpp
@@ -24,6 +24,7 @@
 #include <Eigen/Geometry>
 
 #include <chrono>
+#include <limits>
 #include <memory>
 #include <optional>
 #include <string>
@@ -116,7 +117,8 @@ DetectionByTracker::DetectionByTracker(const rclcpp::NodeOptions & node_options)
 
   shape_estimator_ = std::make_shared<autoware::shape_estimation::ShapeEstimator>(true, true);
   cluster_ = std::make_shared<autoware::euclidean_cluster::VoxelGridBasedEuclideanCluster>(
-    false, 10, 10000, 0.7, 0.3, 0);
+    false, 10, 10000, 0.7, 0.3, 0, std::numeric_limits<int>::max(), std::numeric_limits<int>::max(),
+    10000);
   debugger_ = std::make_shared<Debugger>(this);
   published_time_publisher_ = std::make_unique<autoware_utils::PublishedTimePublisher>(this);
 }
@@ -272,12 +274,18 @@ float DetectionByTracker::optimizeUnderSegmentedObject(
   float cluster_range = initial_cluster_range;
   constexpr float initial_voxel_size = initial_cluster_range / 2.0f;
   float voxel_size = initial_voxel_size;
+  // set clustering parameters to max values to keep the original behavior here
+  constexpr int min_voxel_cluster_size_for_filtering = std::numeric_limits<int>::max();
+  constexpr int max_points_per_voxel_in_large_cluster = std::numeric_limits<int>::max();
+  constexpr int max_voxel_cluster_for_output = 10000;
 
   const auto & label = target_object.classification.front().label;
 
   // initialize clustering parameters
   autoware::euclidean_cluster::VoxelGridBasedEuclideanCluster cluster(
-    false, 4, 10000, initial_cluster_range, initial_voxel_size, 0);
+    false, 4, 10000, initial_cluster_range, initial_voxel_size, 0,
+    min_voxel_cluster_size_for_filtering, max_points_per_voxel_in_large_cluster,
+    max_voxel_cluster_for_output);
 
   // convert to pcl
   pcl::PointCloud<pcl::PointXYZ>::Ptr pcl_cluster(new pcl::PointCloud<pcl::PointXYZ>);

--- a/perception/autoware_euclidean_cluster/README.md
+++ b/perception/autoware_euclidean_cluster/README.md
@@ -48,14 +48,17 @@ This package has two clustering methods: `euclidean_cluster` and `voxel_grid_bas
 
 #### voxel_grid_based_euclidean_cluster
 
-| Name                          | Type  | Description                                                                                  |
-| ----------------------------- | ----- | -------------------------------------------------------------------------------------------- |
-| `use_height`                  | bool  | use point.z for clustering                                                                   |
-| `min_cluster_size`            | int   | the minimum number of points that a cluster needs to contain in order to be considered valid |
-| `max_cluster_size`            | int   | the maximum number of points that a cluster needs to contain in order to be considered valid |
-| `tolerance`                   | float | the spatial cluster tolerance as a measure in the L2 Euclidean space                         |
-| `voxel_leaf_size`             | float | the voxel leaf size of x and y                                                               |
-| `min_points_number_per_voxel` | int   | the minimum number of points for a voxel                                                     |
+| Name                                    | Type  | Description                                                                                                    |
+| --------------------------------------- | ----- | -------------------------------------------------------------------------------------------------------------- |
+| `use_height`                            | bool  | use point.z for clustering                                                                                     |
+| `min_cluster_size`                      | int   | the minimum number of voxels that a cluster needs to contain in order to be considered valid                   |
+| `max_cluster_size`                      | int   | the maximum number of voxels that a cluster needs to contain in order to be considered valid                   |
+| `tolerance`                             | float | the spatial cluster tolerance as a measure in the L2 Euclidean space                                           |
+| `voxel_leaf_size`                       | float | the voxel leaf size of x and y                                                                                 |
+| `min_points_number_per_voxel`           | int   | the minimum number of points for a voxel                                                                       |
+| `min_voxel_cluster_size_for_filtering`  | int   | The minimum voxel cluster size for a cluster to be checked for being a large cluster.                          |
+| `max_points_per_voxel_in_large_cluster` | int   | The maximum points per voxel allowed in large clusters (used for filtering dense clusters).                    |
+| `max_voxel_cluster_for_output`          | int   | The maximum number of voxel clusters to output. If the voxels exceeds this value, the cluster will be skipped. |
 
 ## Assumptions / Known limits
 

--- a/perception/autoware_euclidean_cluster/config/voxel_grid_based_euclidean_cluster.param.yaml
+++ b/perception/autoware_euclidean_cluster/config/voxel_grid_based_euclidean_cluster.param.yaml
@@ -4,7 +4,19 @@
     voxel_leaf_size: 0.3
     min_points_number_per_voxel: 1
     min_cluster_size: 10
-    max_cluster_size: 3000
+    max_cluster_size: 3000  # this is the maximum number of voxels when clustered
+    max_voxel_cluster_for_output: 800  # Maximum number of voxels in a cluster when outputted
+    # Voxel Counts (0.3m*0.3m voxel, ignoring height):
+    # Based on Japanese vehicle size regulations:
+    # - Regular truck: 12m x 2.5m = ~333 voxels
+    # - Semi-trailer: 16.5m x 2.5m = ~458 voxels
+    # - Full trailer: 25m x 2.5m = ~694 voxels
+    # Adding 15% margin for safety: 694 * 1.15 ~ 800
+    min_voxel_cluster_size_for_filtering: 65  # Clusters below this number of voxels are exempt from per-voxel filtering
+    # This threshold is based on a medium-sized truck (5.0m x 1.8m).
+    # Its full footprint covers about 100 voxels (0.3m x 0.3m grid),
+    # but LiDAR typically captures only ~60–70% due to occlusion.
+    max_points_per_voxel_in_large_cluster: 10  # Max points allowed per voxel in a large cluster
     use_height: false
     input_frame: "base_link"
 

--- a/perception/autoware_euclidean_cluster/include/autoware/euclidean_cluster/voxel_grid_based_euclidean_cluster.hpp
+++ b/perception/autoware_euclidean_cluster/include/autoware/euclidean_cluster/voxel_grid_based_euclidean_cluster.hpp
@@ -31,7 +31,9 @@ public:
   VoxelGridBasedEuclideanCluster(bool use_height, int min_cluster_size, int max_cluster_size);
   VoxelGridBasedEuclideanCluster(
     bool use_height, int min_cluster_size, int max_cluster_size, float tolerance,
-    float voxel_leaf_size, int min_points_number_per_voxel);
+    float voxel_leaf_size, int min_points_number_per_voxel,
+    int min_voxel_cluster_size_for_filtering, int max_points_per_voxel_in_large_cluster,
+    int max_voxel_cluster_for_output);
   bool cluster(
     const pcl::PointCloud<pcl::PointXYZ>::ConstPtr & pointcloud,
     std::vector<pcl::PointCloud<pcl::PointXYZ>> & clusters) override;
@@ -50,6 +52,9 @@ private:
   float tolerance_;
   float voxel_leaf_size_;
   int min_points_number_per_voxel_;
+  int min_voxel_cluster_size_for_filtering_;
+  int max_points_per_voxel_in_large_cluster_;
+  int max_voxel_cluster_for_output_;
 };
 
 }  // namespace autoware::euclidean_cluster

--- a/perception/autoware_euclidean_cluster/lib/voxel_grid_based_euclidean_cluster.cpp
+++ b/perception/autoware_euclidean_cluster/lib/voxel_grid_based_euclidean_cluster.cpp
@@ -17,6 +17,9 @@
 #include <pcl/kdtree/kdtree.h>
 #include <pcl/segmentation/extract_clusters.h>
 
+#include <algorithm>
+#include <random>
+#include <string>
 #include <unordered_map>
 #include <vector>
 
@@ -34,11 +37,15 @@ VoxelGridBasedEuclideanCluster::VoxelGridBasedEuclideanCluster(
 
 VoxelGridBasedEuclideanCluster::VoxelGridBasedEuclideanCluster(
   bool use_height, int min_cluster_size, int max_cluster_size, float tolerance,
-  float voxel_leaf_size, int min_points_number_per_voxel)
+  float voxel_leaf_size, int min_points_number_per_voxel, int min_voxel_cluster_size_for_filtering,
+  int max_points_per_voxel_in_large_cluster, int max_voxel_cluster_for_output)
 : EuclideanClusterInterface(use_height, min_cluster_size, max_cluster_size),
   tolerance_(tolerance),
   voxel_leaf_size_(voxel_leaf_size),
-  min_points_number_per_voxel_(min_points_number_per_voxel)
+  min_points_number_per_voxel_(min_points_number_per_voxel),
+  min_voxel_cluster_size_for_filtering_(min_voxel_cluster_size_for_filtering),
+  max_points_per_voxel_in_large_cluster_(max_points_per_voxel_in_large_cluster),
+  max_voxel_cluster_for_output_(max_voxel_cluster_for_output)
 {
 }
 // TODO(badai-nguyen): remove this function when field copying also implemented for
@@ -57,33 +64,33 @@ bool VoxelGridBasedEuclideanCluster::cluster(
   tier4_perception_msgs::msg::DetectedObjectsWithFeature & objects)
 {
   // TODO(Saito) implement use_height is false version
-
-  // create voxel
+  // 1) Convert ROS PointCloud2 to PCL cloud
   pcl::PointCloud<pcl::PointXYZ>::Ptr pointcloud(new pcl::PointCloud<pcl::PointXYZ>);
   int point_step = pointcloud_msg->point_step;
   pcl::fromROSMsg(*pointcloud_msg, *pointcloud);
+  // 2) Voxel grid filtering
   pcl::PointCloud<pcl::PointXYZ>::Ptr voxel_map_ptr(new pcl::PointCloud<pcl::PointXYZ>);
-  voxel_grid_.setLeafSize(voxel_leaf_size_, voxel_leaf_size_, 100000.0);
+  constexpr float Z_AXIS_VOXEL_SIZE = 100000.0f;
+  voxel_grid_.setLeafSize(voxel_leaf_size_, voxel_leaf_size_, Z_AXIS_VOXEL_SIZE);
   voxel_grid_.setMinimumPointsNumberPerVoxel(min_points_number_per_voxel_);
   voxel_grid_.setInputCloud(pointcloud);
   voxel_grid_.setSaveLeafLayout(true);
   voxel_grid_.filter(*voxel_map_ptr);
 
-  // voxel is pressed 2d
+  // 3) Build 2D centroid cloud
   pcl::PointCloud<pcl::PointXYZ>::Ptr pointcloud_2d_ptr(new pcl::PointCloud<pcl::PointXYZ>);
   for (const auto & point : voxel_map_ptr->points) {
     pcl::PointXYZ point2d;
     point2d.x = point.x;
     point2d.y = point.y;
-    point2d.z = 0.0;
+    point2d.z = 0.0;  // Set z to 0.0 for 2D clustering
     pointcloud_2d_ptr->push_back(point2d);
   }
 
-  // create tree
+  // 4) KD-tree + clustering
   pcl::search::KdTree<pcl::PointXYZ>::Ptr tree(new pcl::search::KdTree<pcl::PointXYZ>);
   tree->setInputCloud(pointcloud_2d_ptr);
-
-  // clustering
+  // Perform clustering using EuclideanClusterExtraction
   std::vector<pcl::PointIndices> cluster_indices;
   pcl::EuclideanClusterExtraction<pcl::PointXYZ> pcl_euclidean_cluster;
   pcl_euclidean_cluster.setClusterTolerance(tolerance_);
@@ -93,8 +100,9 @@ bool VoxelGridBasedEuclideanCluster::cluster(
   pcl_euclidean_cluster.setInputCloud(pointcloud_2d_ptr);
   pcl_euclidean_cluster.extract(cluster_indices);
 
-  // create map to search cluster index from voxel grid index
-  std::unordered_map</* voxel grid index */ int, /* cluster index */ int> map;
+  // 5) Buffer preparation
+  // Map to store the mapping between voxel grid indices and their corresponding cluster indices
+  std::unordered_map</* voxel grid index */ int, /* cluster index */ int> voxel_to_cluster_map;
   std::vector<sensor_msgs::msg::PointCloud2> temporary_clusters;  // no check about cluster size
   std::vector<size_t> clusters_data_size;
   temporary_clusters.resize(cluster_indices.size());
@@ -102,7 +110,7 @@ bool VoxelGridBasedEuclideanCluster::cluster(
     const auto & cluster = cluster_indices.at(cluster_idx);
     auto & temporary_cluster = temporary_clusters.at(cluster_idx);
     for (const auto & point_idx : cluster.indices) {
-      map[point_idx] = cluster_idx;
+      voxel_to_cluster_map[point_idx] = cluster_idx;
     }
     temporary_cluster.height = pointcloud_msg->height;
     temporary_cluster.fields = pointcloud_msg->fields;
@@ -110,26 +118,55 @@ bool VoxelGridBasedEuclideanCluster::cluster(
     temporary_cluster.data.resize(cluster.indices.size() * point_step);
     clusters_data_size.push_back(0);
   }
+  // Precompute which clusters are large enough based on the voxel threshold.
+  // This avoids repeatedly checking the size during per-point processing.
+  std::vector<bool> is_large_cluster(cluster_indices.size(), false);
+  std::vector<bool> is_extreme_large_cluster(cluster_indices.size(), false);
 
-  // create vector of point cloud cluster. vector index is voxel grid index.
-  for (size_t i = 0; i < pointcloud->points.size(); ++i) {
-    const auto & point = pointcloud->points.at(i);
-    const int index =
+  for (size_t cluster_idx = 0; cluster_idx < cluster_indices.size(); ++cluster_idx) {
+    const int cluster_size = static_cast<int>(cluster_indices[cluster_idx].indices.size());
+    is_large_cluster[cluster_idx] = cluster_size > min_voxel_cluster_size_for_filtering_;
+    is_extreme_large_cluster[cluster_idx] = cluster_size > max_voxel_cluster_for_output_;
+  }
+
+  // 6) Data copy
+  // Initialize a map to track how many points each voxel has per cluster.
+  // Key: cluster index -> (Key: voxel index -> value: point count)
+  std::unordered_map<int, std::unordered_map<int, int>> point_counts_per_voxel_per_cluster;
+  std::vector<size_t> random_indices(pointcloud->points.size());
+  static std::default_random_engine rng(42);
+  std::iota(random_indices.begin(), random_indices.end(), 0);
+  std::shuffle(random_indices.begin(), random_indices.end(), rng);
+  for (size_t i = 0; i < random_indices.size(); ++i) {
+    const size_t random_index = random_indices[i];
+    const auto & point = pointcloud->points.at(random_index);
+    // for (size_t i = 0; i < pointcloud->points.size(); ++i) {
+    // const auto & point = pointcloud->points.at(i);
+    const int voxel_index =
       voxel_grid_.getCentroidIndexAt(voxel_grid_.getGridCoordinates(point.x, point.y, point.z));
-    if (map.find(index) != map.end()) {
-      auto & cluster_data_size = clusters_data_size.at(map[index]);
-      if (
-        cluster_data_size >
-        static_cast<std::size_t>(max_cluster_size_) * static_cast<std::size_t>(point_step)) {
+    auto voxel_to_cluster_map_it = voxel_to_cluster_map.find(voxel_index);
+    if (voxel_to_cluster_map_it != voxel_to_cluster_map.end()) {
+      // Track point count per voxel per cluster
+      int cluster_idx = voxel_to_cluster_map_it->second;
+      if (is_extreme_large_cluster[cluster_idx]) {
         continue;
       }
+      if (is_large_cluster[cluster_idx]) {
+        int & voxel_point_count = point_counts_per_voxel_per_cluster[cluster_idx][voxel_index];
+        if (voxel_point_count >= max_points_per_voxel_in_large_cluster_) {
+          continue;  // Skip adding this point
+        }
+        voxel_point_count++;
+      }
+
+      auto & cluster_data_size = clusters_data_size.at(voxel_to_cluster_map_it->second);
       std::memcpy(
-        &temporary_clusters.at(map[index]).data[cluster_data_size],
-        &pointcloud_msg->data[i * point_step], point_step);
+        &temporary_clusters.at(voxel_to_cluster_map_it->second).data[cluster_data_size],
+        &pointcloud_msg->data[random_index * point_step], point_step);
       cluster_data_size += point_step;
-      if (cluster_data_size == temporary_clusters.at(map[index]).data.size()) {
-        temporary_clusters.at(map[index])
-          .data.resize(temporary_clusters.at(map[index]).data.size() * 2);
+      if (cluster_data_size == temporary_clusters.at(voxel_to_cluster_map_it->second).data.size()) {
+        temporary_clusters.at(voxel_to_cluster_map_it->second)
+          .data.resize(temporary_clusters.at(voxel_to_cluster_map_it->second).data.size() * 2);
       }
     }
   }
@@ -138,8 +175,10 @@ bool VoxelGridBasedEuclideanCluster::cluster(
   {
     for (size_t i = 0; i < temporary_clusters.size(); ++i) {
       auto & i_cluster_data_size = clusters_data_size.at(i);
-      if (!(min_cluster_size_ <= static_cast<int>(i_cluster_data_size / point_step) &&
-            static_cast<int>(i_cluster_data_size / point_step) <= max_cluster_size_)) {
+
+      int cluster_size = static_cast<int>(i_cluster_data_size / point_step);
+      if (cluster_size < min_cluster_size_) {
+        // Cluster size is below the minimum threshold; skip without messaging.
         continue;
       }
       const auto & cluster = temporary_clusters.at(i);

--- a/perception/autoware_euclidean_cluster/src/voxel_grid_based_euclidean_cluster_node.cpp
+++ b/perception/autoware_euclidean_cluster/src/voxel_grid_based_euclidean_cluster_node.cpp
@@ -18,7 +18,6 @@
 
 #include <memory>
 #include <vector>
-
 namespace autoware::euclidean_cluster
 {
 VoxelGridBasedEuclideanClusterNode::VoxelGridBasedEuclideanClusterNode(
@@ -31,9 +30,16 @@ VoxelGridBasedEuclideanClusterNode::VoxelGridBasedEuclideanClusterNode(
   const float tolerance = this->declare_parameter("tolerance", 1.0);
   const float voxel_leaf_size = this->declare_parameter("voxel_leaf_size", 0.5);
   const int min_points_number_per_voxel = this->declare_parameter("min_points_number_per_voxel", 3);
+  const int min_voxel_cluster_size_for_filtering =
+    this->declare_parameter("min_voxel_cluster_size_for_filtering", 150);
+  const int max_points_per_voxel_in_large_cluster =
+    this->declare_parameter("max_points_per_voxel_in_large_cluster", 10);
+  const int max_voxel_cluster_for_output =
+    this->declare_parameter("max_voxel_cluster_for_output", 800);
   cluster_ = std::make_shared<VoxelGridBasedEuclideanCluster>(
     use_height, min_cluster_size, max_cluster_size, tolerance, voxel_leaf_size,
-    min_points_number_per_voxel);
+    min_points_number_per_voxel, min_voxel_cluster_size_for_filtering,
+    max_points_per_voxel_in_large_cluster, max_voxel_cluster_for_output);
 
   using std::placeholders::_1;
   pointcloud_sub_ = this->create_subscription<sensor_msgs::msg::PointCloud2>(


### PR DESCRIPTION
# Perception Enhancement

## Description
Adds new parameters to control large cluster filtering in the VoxelGridBasedEuclideanCluster implementation. This improves handling of large clusters and optimizes point cloud processing.
Adds 3D filtering to the lanelet filter that will filter objects under the lanelets.


## Changes
- Added `max_voxel_cluster_for_output` parameter
- Removed redundant `max_num_points_per_cluster` parameter
- Updated documentation and tests