### PR TITLE
fix(multi_object_tracker): correct area calculation for cylinder shape in getArea function (#10790)

### DIFF
--- a/perception/autoware_multi_object_tracker/lib/object_model/types.cpp
+++ b/perception/autoware_multi_object_tracker/lib/object_model/types.cpp
@@ -119,7 +119,7 @@ double getArea(const autoware_perception_msgs::msg::Shape & shape)
     case autoware_perception_msgs::msg::Shape::BOUNDING_BOX:
       return shape.dimensions.x * shape.dimensions.y;
     case autoware_perception_msgs::msg::Shape::CYLINDER:
-      return shape.dimensions.x * shape.dimensions.x * M_PI;
+      return shape.dimensions.x * shape.dimensions.x * M_PI * 0.25;
     case autoware_perception_msgs::msg::Shape::POLYGON: {
       double area = 0.0;
       for (size_t i = 0; i < shape.footprint.points.size(); ++i) {


### PR DESCRIPTION

fix(multi_object_tracker): correct area calculation for CYLINDER shape in getArea function

Updated the area calculation for the CYLINDER shape to use a quarter of the cylinder's base area, ensuring accurate area representation in the multi-object tracker.

original PR https://github.com/autowarefoundation/autoware_universe/pull/10790