### PR TITLE
fix(intersection): clamp collision stopline ip index (#11009)

### DIFF
--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/scene_intersection_prepare_data.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_intersection_module/src/scene_intersection_prepare_data.cpp
@@ -435,7 +435,9 @@ std::optional<IntersectionStopLines> IntersectionModule::generateIntersectionSto
     velocity, acceleration, max_accel, max_jerk, delay_response_time);
 
   // collision_stopline
-  const size_t collision_stopline_ip = closest_idx_ip + std::ceil(braking_dist / ds);
+  const size_t collision_stopline_ip = std::clamp<size_t>(
+    closest_idx_ip + std::ceil(braking_dist / ds), 0,
+    static_cast<size_t>(path_ip.points.size()) - 1);
 
   // (3) occlusion peeking stop line position on interpolated path
   int occlusion_peeking_line_ip_int = static_cast<int>(default_stopline_ip);


### PR DESCRIPTION


Cherry-pick from  https://github.com/autowarefoundation/autoware_universe/pull/11009

The unbounded collision_stopline_ip will make node-dead errors in manual tests. Clamp the value to improve stability.

