### PR TITLE
feat(boundary_departure): on time buffer for critical departure (#11126)

### DIFF
--- a/planning/motion_velocity_planner/autoware_motion_velocity_boundary_departure_prevention_module/config/boundary_departure_prevention.param.yaml
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_boundary_departure_prevention_module/config/boundary_departure_prevention.param.yaml
@@ -14,7 +14,9 @@
         near_boundary: 3.5
         departure: 2.0
 
-      on_time_buffer_s: 0.15
+      on_time_buffer_s:
+        near_boundary: 0.15
+        critical_departure: 0.15
       off_time_buffer_s: 0.15
 
       abnormality:

--- a/planning/motion_velocity_planner/autoware_motion_velocity_boundary_departure_prevention_module/schema/boundary_departure_prevention.schema.json
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_boundary_departure_prevention_module/schema/boundary_departure_prevention.schema.json
@@ -72,9 +72,21 @@
         },
 
         "on_time_buffer_s": {
-          "type": "number",
-          "description": "Continuous detection time threshold to insert departure point into departure interval. [s]",
-          "default": 0.15
+          "type": "object",
+          "properties": {
+            "near_boundary": {
+              "type": "number",
+              "description": "Continuous detection time threshold to insert departure point into departure interval. [s]",
+              "default": 0.15
+            },
+            "critical_departure": {
+              "type": "number",
+              "description": "Continuous detection time required to accept new critical departure point. [s]",
+              "default": 0.15
+            }
+          },
+          "required": ["near_boundary", "critical_departure"],
+          "additionalProperties": false
         },
 
         "off_time_buffer_s": {

--- a/planning/motion_velocity_planner/autoware_motion_velocity_boundary_departure_prevention_module/src/boundary_departure_prevention_module.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_boundary_departure_prevention_module/src/boundary_departure_prevention_module.cpp
@@ -86,8 +86,9 @@ void BoundaryDeparturePreventionModule::init(
 
       stat.summary(lvl, msg);
     });
-  last_found_time_ptr_ = std::make_unique<double>(clock_ptr_->now().seconds());
-  last_lost_time_ptr_ = std::make_unique<double>(clock_ptr_->now().seconds());
+  last_abnormality_fp_no_overlap_bound_time_ = clock_ptr_->now().seconds();
+  last_abnormality_fp_overlap_bound_time_ = clock_ptr_->now().seconds();
+  last_no_critical_dpt_time_ = clock_ptr_->now().seconds();
 }
 
 void BoundaryDeparturePreventionModule::update_parameters(
@@ -489,11 +490,8 @@ BoundaryDeparturePreventionModule::plan_slow_down_intervals(
     output_.closest_projections_to_bound, lon_offset_m(planner_data->is_driving_forward));
   toc_curr_watch("get_departure_points");
 
-  utils::update_critical_departure_points(
-    output_.departure_points, output_.critical_departure_points, *ref_traj_pts_opt,
-    node_param_.bdc_param.th_point_merge_distance_m,
-    ego_dist_on_traj_with_offset_m(!planner_data->is_driving_forward),
-    node_param_.th_pt_shift_dist_m, node_param_.th_pt_shift_angle_rad);
+  // update output_.critical_departure_points
+  update_critical_departure_points(*ref_traj_pts_opt, ego_dist_on_traj_m);
   toc_curr_watch("update_critical_departure_points");
 
   const auto is_departure_persist = std::invoke([&]() {
@@ -503,12 +501,12 @@ BoundaryDeparturePreventionModule::plan_slow_down_intervals(
       });
 
     if (!is_found) {
-      *last_lost_time_ptr_ = clock_ptr_->now().seconds();
+      last_abnormality_fp_overlap_bound_time_ = clock_ptr_->now().seconds();
       return false;
     }
 
-    const auto t_diff = clock_ptr_->now().seconds() - *last_lost_time_ptr_;
-    return t_diff >= node_param_.on_time_buffer_s;
+    const auto t_diff = clock_ptr_->now().seconds() - last_abnormality_fp_overlap_bound_time_;
+    return t_diff >= node_param_.on_time_buffer_s.near_boundary;
   });
 
   if (output_.departure_intervals.empty() && is_departure_persist) {
@@ -528,10 +526,10 @@ BoundaryDeparturePreventionModule::plan_slow_down_intervals(
         [&](const auto side_key) { return !output_.departure_points[side_key].empty(); });
 
       if (is_departure_found) {
-        *last_found_time_ptr_ = clock_ptr_->now().seconds();
+        last_abnormality_fp_no_overlap_bound_time_ = clock_ptr_->now().seconds();
         return false;
       }
-      const auto t_diff = clock_ptr_->now().seconds() - *last_found_time_ptr_;
+      const auto t_diff = clock_ptr_->now().seconds() - last_abnormality_fp_no_overlap_bound_time_;
       return t_diff >= node_param_.off_time_buffer_s;
     });
 
@@ -543,7 +541,7 @@ BoundaryDeparturePreventionModule::plan_slow_down_intervals(
       node_param_.slow_down_types, is_reset_interval, is_departure_persist);
 
     if (is_reset_interval) {
-      *last_found_time_ptr_ = clock_ptr_->now().seconds();
+      last_abnormality_fp_no_overlap_bound_time_ = clock_ptr_->now().seconds();
     }
     const auto reset_lost_time =
       std::any_of(g_side_keys.begin(), g_side_keys.end(), [&](const auto side_key) {
@@ -551,7 +549,7 @@ BoundaryDeparturePreventionModule::plan_slow_down_intervals(
       });
 
     if (reset_lost_time) {
-      *last_lost_time_ptr_ = clock_ptr_->now().seconds();
+      last_abnormality_fp_overlap_bound_time_ = clock_ptr_->now().seconds();
     }
   }
 
@@ -614,6 +612,83 @@ BoundaryDeparturePreventionModule::plan_slow_down_intervals(
   return result;
 }
 
+void BoundaryDeparturePreventionModule::update_critical_departure_points(
+  const trajectory::Trajectory<TrajectoryPoint> & aw_ref_traj, const double offset_from_ego)
+{
+  for (auto & crit_dpt_pt_mut : output_.critical_departure_points) {
+    crit_dpt_pt_mut.dist_on_traj =
+      trajectory::closest(aw_ref_traj, crit_dpt_pt_mut.point_on_prev_traj);
+
+    if (crit_dpt_pt_mut.dist_on_traj < offset_from_ego) {
+      crit_dpt_pt_mut.can_be_removed = true;
+      continue;
+    }
+
+    const auto updated_point = aw_ref_traj.compute(crit_dpt_pt_mut.dist_on_traj);
+    if (
+      const auto is_shifted_opt = utils::is_point_shifted(
+        crit_dpt_pt_mut.point_on_prev_traj.pose, updated_point.pose, node_param_.th_pt_shift_dist_m,
+        node_param_.th_pt_shift_angle_rad)) {
+      crit_dpt_pt_mut.can_be_removed = true;
+    }
+  }
+
+  utils::remove_if(
+    output_.critical_departure_points, [](const DeparturePoint & pt) { return pt.can_be_removed; });
+
+  if (!is_continuous_critical_departure()) {
+    return;
+  }
+
+  auto new_critical_departure_point = utils::find_new_critical_departure_points(
+    output_.departure_points, output_.critical_departure_points, aw_ref_traj,
+    node_param_.bdc_param.th_point_merge_distance_m);
+
+  if (new_critical_departure_point.empty()) {
+    return;
+  }
+
+  std::move(
+    new_critical_departure_point.begin(), new_critical_departure_point.end(),
+    std::back_inserter(output_.critical_departure_points));
+
+  std::sort(output_.critical_departure_points.begin(), output_.critical_departure_points.end());
+}
+
+CriticalDeparturePoints find_new_critical_departure_points(
+  const Side<DeparturePoints> & new_departure_points,
+  const CriticalDeparturePoints & critical_departure_points,
+  const trajectory::Trajectory<TrajectoryPoint> & aw_ref_traj,
+  const double th_point_merge_distance_m)
+{
+  CriticalDeparturePoints new_critical_departure_points;
+  for (const auto side_key : g_side_keys) {
+    for (const auto & dpt_pt : new_departure_points[side_key]) {
+      if (dpt_pt.departure_type != DepartureType::CRITICAL_DEPARTURE) {
+        continue;
+      }
+
+      if (dpt_pt.can_be_removed) {
+        continue;
+      }
+
+      const auto is_near_curr_pts = std::any_of(
+        critical_departure_points.begin(), critical_departure_points.end(),
+        [&](const CriticalDeparturePoint & crit_pt) {
+          return std::abs(dpt_pt.dist_on_traj - crit_pt.dist_on_traj) < th_point_merge_distance_m;
+        });
+
+      if (is_near_curr_pts) {
+        continue;
+      }
+
+      CriticalDeparturePoint crit_pt(dpt_pt);
+      crit_pt.point_on_prev_traj = aw_ref_traj.compute(crit_pt.dist_on_traj);
+      new_critical_departure_points.push_back(crit_pt);
+    }
+  }
+  return new_critical_departure_points;
+}
 std::unordered_map<DepartureType, bool> BoundaryDeparturePreventionModule::get_diagnostics(
   const double curr_vel, const double dist_with_offset_m)
 {
@@ -655,6 +730,25 @@ std::unordered_map<DepartureType, bool> BoundaryDeparturePreventionModule::get_d
     });
 
   return diag;
+}
+
+bool BoundaryDeparturePreventionModule::is_continuous_critical_departure()
+{
+  const auto is_critical_departure_found =
+    std::any_of(g_side_keys.begin(), g_side_keys.end(), [&](const auto side_key) {
+      const auto & closest_projections = output_.closest_projections_to_bound[side_key];
+      return std::any_of(
+        closest_projections.rbegin(), closest_projections.rend(),
+        [](const auto & pt) { return pt.departure_type == DepartureType::CRITICAL_DEPARTURE; });
+    });
+
+  if (!is_critical_departure_found) {
+    last_no_critical_dpt_time_ = clock_ptr_->now().seconds();
+    return false;
+  }
+
+  const auto t_diff = clock_ptr_->now().seconds() - last_no_critical_dpt_time_;
+  return t_diff >= node_param_.on_time_buffer_s.critical_departure;
 }
 }  // namespace autoware::motion_velocity_planner::experimental
 

--- a/planning/motion_velocity_planner/autoware_motion_velocity_boundary_departure_prevention_module/src/boundary_departure_prevention_module.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_boundary_departure_prevention_module/src/boundary_departure_prevention_module.hpp
@@ -60,8 +60,36 @@ private:
   tl::expected<VelocityPlanningResult, std::string> plan_slow_down_intervals(
     const TrajectoryPoints & raw_trajectory_points,
     const std::shared_ptr<const PlannerData> & planner_data);
+
+  /**
+   * @brief Update the list of critical departure points.
+   *
+   * Projects existing critical departure points onto the updated reference trajectory
+   * and removes points that are outdated (i.e., passed by the ego or shifted significantly).
+   *
+   * @param aw_ref_traj Current reference trajectory.
+   * @param offset_from_ego Minimum distance from ego to keep a point; points closer than this are
+   * removed.
+   */
+  void update_critical_departure_points(
+    const trajectory::Trajectory<TrajectoryPoint> & aw_ref_traj, const double offset_from_ego);
+
   std::unordered_map<DepartureType, bool> get_diagnostics(
     const double curr_vel, const double dist_with_offset_m);
+
+  /**
+   * @brief Check if critical departure has been continuously observed.
+   *
+   * Determines whether critical departure points have been continuously present
+   * for longer than the configured buffer time (`on_time_buffer_s.critical_departure`).
+   *
+   * This prevents re-adding critical departure points too frequently due to transient noise.
+   * The last time *found* critical departure is stored to measure the continuous duration.
+   *
+   * @return True if critical departure has been continuously observed long enough, false otherwise.
+   */
+  bool is_continuous_critical_departure();
+
   rclcpp::Clock::SharedPtr clock_ptr_;
 
   std::string module_name_;
@@ -81,8 +109,9 @@ private:
   LaneletRoute::ConstSharedPtr route_ptr_;
   std::unordered_map<std::string, double> processing_times_ms_;
 
-  std::unique_ptr<double> last_lost_time_ptr_;
-  std::unique_ptr<double> last_found_time_ptr_;
+  double last_abnormality_fp_overlap_bound_time_{0.0};
+  double last_abnormality_fp_no_overlap_bound_time_{0.0};
+  double last_no_critical_dpt_time_{0.0};
 
   autoware_utils::InterProcessPollingSubscriber<Trajectory>::SharedPtr ego_pred_traj_polling_sub_;
   autoware_utils::InterProcessPollingSubscriber<Control>::SharedPtr control_cmd_polling_sub_;

--- a/planning/motion_velocity_planner/autoware_motion_velocity_boundary_departure_prevention_module/src/parameters.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_boundary_departure_prevention_module/src/parameters.hpp
@@ -57,8 +57,14 @@ struct NodeParam
   double th_pt_shift_dist_m{1.0};
   double th_pt_shift_angle_rad{autoware_utils_math::deg2rad(2.0)};
   double th_goal_shift_dist_m{1.0};
-  double on_time_buffer_s{0.1};
-  double off_time_buffer_s{0.1};
+  struct
+  {
+    double near_boundary{0.15};
+    double critical_departure{0.15};
+  } on_time_buffer_s;
+
+  double off_time_buffer_s{0.15};
+
   BDCParam bdc_param;
   std::unordered_set<DepartureType> slow_down_types;
   std::unordered_map<DepartureType, int8_t> diagnostic_level;
@@ -84,6 +90,12 @@ struct NodeParam
       get_or_declare_parameter<double>(node, module_name + "th_cutoff_time_s.near_boundary");
     bdc_param.th_cutoff_time_departure_s =
       get_or_declare_parameter<double>(node, module_name + "th_cutoff_time_s.departure");
+
+    on_time_buffer_s.critical_departure =
+      get_or_declare_parameter<double>(node, module_name + "on_time_buffer_s.critical_departure");
+    on_time_buffer_s.near_boundary =
+      get_or_declare_parameter<double>(node, module_name + "on_time_buffer_s.near_boundary");
+    off_time_buffer_s = get_or_declare_parameter<double>(node, module_name + "off_time_buffer_s");
 
     bdc_param.th_max_lateral_query_num =
       get_or_declare_parameter<int>(node, module_name + "th_max_lateral_query_num");

--- a/planning/motion_velocity_planner/autoware_motion_velocity_boundary_departure_prevention_module/src/utils.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_boundary_departure_prevention_module/src/utils.cpp
@@ -275,32 +275,13 @@ void update_departure_intervals(
   departure_intervals = merge_departure_intervals(departure_intervals);
 }
 
-void update_critical_departure_points(
+CriticalDeparturePoints find_new_critical_departure_points(
   const Side<DeparturePoints> & new_departure_points,
-  CriticalDeparturePoints & critical_departure_points,
+  const CriticalDeparturePoints & critical_departure_points,
   const trajectory::Trajectory<TrajectoryPoint> & aw_ref_traj,
-  const double th_point_merge_distance_m, const double offset_from_ego,
-  const double th_pt_shift_dist_m, const double th_pt_shift_angle_rad)
+  const double th_point_merge_distance_m)
 {
-  for (auto & crit_dpt_pt_mut : critical_departure_points) {
-    crit_dpt_pt_mut.dist_on_traj =
-      trajectory::closest(aw_ref_traj, crit_dpt_pt_mut.point_on_prev_traj);
-    if (crit_dpt_pt_mut.dist_on_traj < offset_from_ego) {
-      crit_dpt_pt_mut.can_be_removed = true;
-      continue;
-    }
-
-    const auto updated_point = aw_ref_traj.compute(crit_dpt_pt_mut.dist_on_traj);
-    if (
-      const auto is_shifted_opt = utils::is_point_shifted(
-        crit_dpt_pt_mut.point_on_prev_traj.pose, updated_point.pose, th_pt_shift_dist_m,
-        th_pt_shift_angle_rad)) {
-      crit_dpt_pt_mut.can_be_removed = true;
-    }
-  }
-  utils::remove_if(
-    critical_departure_points, [](const DeparturePoint & pt) { return pt.can_be_removed; });
-
+  CriticalDeparturePoints new_critical_departure_points;
   for (const auto side_key : g_side_keys) {
     for (const auto & dpt_pt : new_departure_points[side_key]) {
       if (dpt_pt.departure_type != DepartureType::CRITICAL_DEPARTURE) {
@@ -323,10 +304,10 @@ void update_critical_departure_points(
 
       CriticalDeparturePoint crit_pt(dpt_pt);
       crit_pt.point_on_prev_traj = aw_ref_traj.compute(crit_pt.dist_on_traj);
-      critical_departure_points.push_back(crit_pt);
+      new_critical_departure_points.push_back(crit_pt);
     }
   }
-  std::sort(critical_departure_points.begin(), critical_departure_points.end());
+  return new_critical_departure_points;
 }
 
 std::vector<std::tuple<Pose, Pose, double>> get_slow_down_intervals(

--- a/planning/motion_velocity_planner/autoware_motion_velocity_boundary_departure_prevention_module/src/utils.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_boundary_departure_prevention_module/src/utils.hpp
@@ -165,12 +165,11 @@ void update_departure_intervals(
  * @param[in] th_pt_shift_dist_m Threshold distance to detect point drift.
  * @param[in] th_pt_shift_angle_rad Threshold angle to detect pose change.
  */
-void update_critical_departure_points(
+CriticalDeparturePoints find_new_critical_departure_points(
   const Side<DeparturePoints> & new_departure_points,
-  CriticalDeparturePoints & critical_departure_points,
+  const CriticalDeparturePoints & critical_departure_points,
   const trajectory::Trajectory<TrajectoryPoint> & aw_ref_traj,
-  const double th_point_merge_distance_m, const double offset_from_ego,
-  const double th_pt_shift_dist_m, const double th_pt_shift_angle_rad);
+  const double th_point_merge_distance_m);
 
 /**
  * @brief Build slow-down segments ahead of the ego vehicle.


### PR DESCRIPTION
backport PR to add hysteresis for checking critical departure point.
This reduces false positive when predicted path crosses any boundary  unexpectedly.


launcher https://github.com/tier4/autoware_launch/pull/1074

https://github.com/autowarefoundation/autoware_universe/pull/11126