### PR TITLE
fix(boundary_departure): gradual slow down with feasible profile (#11131)

### DIFF
--- a/planning/motion_velocity_planner/autoware_motion_velocity_boundary_departure_prevention_module/src/slow_down_interpolator.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_boundary_departure_prevention_module/src/slow_down_interpolator.hpp
@@ -80,6 +80,10 @@ private:
   static tl::expected<double, std::string> find_reach_time(
     double j, double a, double v0, double dist, double t_min, double t_max);
 
+  static std::optional<double> find_feasible_accel(
+    double gap, double v0, double vt, double a0, double a_comfortable, double a_max,
+    double j_comfortable);
+
   [[nodiscard]] std::optional<double> get_comfort_distance(
     const double lon_dist_to_dpt_pt, const double v_0, const double v_target,
     const double a_0) const;

--- a/planning/motion_velocity_planner/autoware_motion_velocity_boundary_departure_prevention_module/src/utils.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_boundary_departure_prevention_module/src/utils.cpp
@@ -338,8 +338,8 @@ std::vector<std::tuple<Pose, Pose, double>> get_slow_down_intervals(
   std::vector<std::tuple<Pose, Pose, double>> slowdown_intervals;
 
   for (const auto & departure_interval : departure_intervals) {
-    const auto slow_down_dist_on_traj_m = departure_interval.end_dist_on_traj;
-    const auto lon_dist_to_bound_m = slow_down_dist_on_traj_m - ego_dist_on_traj_m;
+    const auto slow_down_dist_on_traj_m = departure_interval.start_dist_on_traj;
+    const auto lon_dist_to_bound_m = (slow_down_dist_on_traj_m - ego_dist_on_traj_m);
 
     const auto & candidates = departure_interval.candidates;
     const auto lat_dist_to_bound_itr = std::min_element(
@@ -363,7 +363,7 @@ std::vector<std::tuple<Pose, Pose, double>> get_slow_down_intervals(
 
     const auto rel_dist_m = vel_opt->rel_dist_m;
     const auto start_pose = std::invoke([&]() {
-      if (ego_dist_on_traj_m + rel_dist_m < lon_dist_to_bound_m) {
+      if (ego_dist_on_traj_m + rel_dist_m < slow_down_dist_on_traj_m) {
         return ref_traj_pts.compute(ego_dist_on_traj_m + rel_dist_m).pose;
       }
       return departure_interval.start.pose;


### PR DESCRIPTION
Backport for boundary departure slow down feature.
This prevents sudden deceleration by computing feasible slow down profile.

https://github.com/autowarefoundation/autoware_universe/pull/11131