### PR TITLE
feat(tracker): adjust generalized IoU threshold based on target object speed

### DIFF
--- a/perception/autoware_multi_object_tracker/config/multi_object_tracker_node.param.yaml
+++ b/perception/autoware_multi_object_tracker/config/multi_object_tracker_node.param.yaml
@@ -28,6 +28,9 @@
     pruning_generalized_iou_thresholds:
       # UNKNOWN,  CAR, TRUCK,  BUS, TRAILER, MOTORCYCLE, BICYCLE, PEDESTRIAN
       [    -0.3, -0.4,  -0.6, -0.6,    -0.6,       -0.1,    -0.1,       -0.1]
+    pruning_static_object_speed: 1.38  # [m/s]
+    pruning_moving_object_speed: 5.5   # [m/s]
+    pruning_static_iou_threshold: 0.0  # [ratio]
     pruning_distance_thresholds:
       # UNKNOWN, CAR, TRUCK, BUS, TRAILER, MOTORCYCLE, BICYCLE, PEDESTRIAN
       [     9.0, 5.0,   9.0, 9.0,     9.0,        4.0,     3.0,        2.0]

--- a/perception/autoware_multi_object_tracker/schema/multi_object_tracker_node.schema.json
+++ b/perception/autoware_multi_object_tracker/schema/multi_object_tracker_node.schema.json
@@ -101,6 +101,21 @@
           "description": "Generalized IoU threshold for each class.",
           "default": [-0.3, -0.4, -0.6, -0.6, -0.6, -0.1, -0.1, -0.1]
         },
+        "prune_static_object_speed": {
+          "type": "number",
+          "description": "Speed threshold to consider an object as static. Below this speed, nearby unknown objects should always be detected.",
+          "default": 1.38
+        },
+        "prune_moving_object_speed": {
+          "type": "number",
+          "description": "Speed threshold to consider an object as moving. Above this speed, nearby unknown objects should always be merged to avoid false unknown detections.",
+          "default": 5.5
+        },
+        "prune_static_iou_threshold": {
+          "type": "number",
+          "description": "Generalized IoU threshold for a static object.",
+          "default": 0.0
+        },
         "overlap_distance_thresholds": {
           "type": "array",
           "items": {

--- a/perception/autoware_multi_object_tracker/src/multi_object_tracker_node.cpp
+++ b/perception/autoware_multi_object_tracker/src/multi_object_tracker_node.cpp
@@ -206,6 +206,10 @@ MultiObjectTracker::MultiObjectTracker(const rclcpp::NodeOptions & node_options)
         const auto label = static_cast<LabelType>(i);
         config.pruning_giou_thresholds[label] = pruning_giou_thresholds.at(i);
       }
+      config.pruning_static_object_speed = declare_parameter<double>("pruning_static_object_speed");
+      config.pruning_moving_object_speed = declare_parameter<double>("pruning_moving_object_speed");
+      config.pruning_static_iou_threshold =
+        declare_parameter<double>("pruning_static_iou_threshold");
 
       // Declare parameters for overlap distance threshold
       std::vector<double> pruning_distance_threshold_list =

--- a/perception/autoware_multi_object_tracker/src/processor/processor.hpp
+++ b/perception/autoware_multi_object_tracker/src/processor/processor.hpp
@@ -47,6 +47,9 @@ struct TrackerProcessorConfig
   bool enable_unknown_object_motion_output;
   std::unordered_map<LabelType, double> pruning_giou_thresholds;
   std::unordered_map<LabelType, double> pruning_distance_thresholds;  // [m]
+  double pruning_static_object_speed;                                 // [m/s]
+  double pruning_moving_object_speed;                                 // [m/s]
+  double pruning_static_iou_threshold;                                // [ratio]
 };
 
 class TrackerProcessor

--- a/perception/autoware_multi_object_tracker/test/test_bench.cpp
+++ b/perception/autoware_multi_object_tracker/test/test_bench.cpp
@@ -61,6 +61,9 @@ autoware::multi_object_tracker::TrackerProcessorConfig createProcessorConfig()
     {ObjectClassification::TRAILER, -0.6}, {ObjectClassification::MOTORCYCLE, -0.1},
     {ObjectClassification::BICYCLE, -0.1}, {ObjectClassification::PEDESTRIAN, -0.1}};
 
+  config.pruning_moving_object_speed = 5.5;   // [m/s]
+  config.pruning_static_object_speed = 1.38;  // [m/s]
+  config.pruning_static_iou_threshold = 0.0;  // [ratio]
   // overlap distance threshold for each class
   config.pruning_distance_thresholds = {
     {ObjectClassification::UNKNOWN, 9.0}, {ObjectClassification::CAR, 5.0},


### PR DESCRIPTION
Need to merge with https://github.com/tier4/autoware_launch/pull/1094

Cherry-pick of #11237

## Description
**Improvement of Tracking Merging Process**

This PR enhances the merging process in the tracker, addressing cases where Unknown objects were not being tracked correctly.

Verified that improvements can be observed in the following problem tickets:

- https://tier4.atlassian.net/browse/RT0-38856
- https://tier4.atlassian.net/browse/RT0-38857

### Detaills
This pull request enhances the logic for merging overlapped trackers in the multi-object tracker by introducing a dynamic threshold for the generalized IoU metric that adapts based on the speed of the tracked object. This change aims to improve the accuracy of tracker pruning, especially for objects with unknown classifications, by making the overlap criteria more sensitive to object motion.

