### PR TITLE
fix(autoware_trajectory_follower, autoware_mission_planner_universe, autoware_scenario_selector): use transient_local for operation_mode_state

### DIFF
--- a/control/autoware_trajectory_follower_node/include/autoware/trajectory_follower_node/controller_node.hpp
+++ b/control/autoware_trajectory_follower_node/include/autoware/trajectory_follower_node/controller_node.hpp
@@ -102,7 +102,7 @@ private:
     sub_accel_{this, "~/input/current_accel"};
 
   autoware_utils::InterProcessPollingSubscriber<OperationModeState> sub_operation_mode_{
-    this, "~/input/current_operation_mode"};
+    this, "~/input/current_operation_mode", rclcpp::QoS{1}.transient_local()};
 
   // Publishers
   rclcpp::Publisher<autoware_control_msgs::msg::Control>::SharedPtr control_cmd_pub_;

--- a/control/autoware_trajectory_follower_node/test/test_controller_node.cpp
+++ b/control/autoware_trajectory_follower_node/test/test_controller_node.cpp
@@ -177,7 +177,9 @@ public:
     fnf->create_publisher<AccelWithCovarianceStamped>("controller/input/current_accel");
 
   rclcpp::Publisher<OperationModeState>::SharedPtr operation_mode_pub =
-    fnf->create_publisher<OperationModeState>("controller/input/current_operation_mode");
+    fnf->create_publisher<OperationModeState>(
+      "controller/input/current_operation_mode", std::chrono::milliseconds{100},
+      rclcpp::QoS(1).transient_local());
 
   rclcpp::Subscription<Control>::SharedPtr cmd_sub = fnf->create_subscription<Control>(
     "controller/output/control_cmd", *fnf->get_fake_node(), [this](const Control::SharedPtr msg) {

--- a/planning/autoware_mission_planner_universe/src/mission_planner/mission_planner.cpp
+++ b/planning/autoware_mission_planner_universe/src/mission_planner/mission_planner.cpp
@@ -82,7 +82,7 @@ MissionPlanner::MissionPlanner(const rclcpp::NodeOptions & options)
   sub_odometry_ = create_subscription<Odometry>(
     "~/input/odometry", rclcpp::QoS(1), std::bind(&MissionPlanner::on_odometry, this, _1));
   sub_operation_mode_state_ = create_subscription<OperationModeState>(
-    "~/input/operation_mode_state", rclcpp::QoS(1),
+    "~/input/operation_mode_state", rclcpp::QoS{1}.transient_local(),
     std::bind(&MissionPlanner::on_operation_mode_state, this, _1));
   sub_vector_map_ = create_subscription<LaneletMapBin>(
     "~/input/vector_map", durable_qos, std::bind(&MissionPlanner::on_map, this, _1));

--- a/planning/autoware_scenario_selector/src/node.cpp
+++ b/planning/autoware_scenario_selector/src/node.cpp
@@ -476,7 +476,7 @@ ScenarioSelectorNode::ScenarioSelectorNode(const rclcpp::NodeOptions & node_opti
 
   sub_operation_mode_state_ =
     decltype(sub_operation_mode_state_)::element_type::create_subscription(
-      this, "input/operation_mode_state", rclcpp::QoS{1});
+      this, "input/operation_mode_state", rclcpp::QoS{1}.transient_local());
 
   // Output
   pub_scenario_ = this->create_publisher<autoware_internal_planning_msgs::msg::Scenario>(


### PR DESCRIPTION
Cherry-picked from https://github.com/autowarefoundation/autoware_universe/pull/11101
https://star4.slack.com/archives/C07GU9S7NVC/p1755752797551849?thread_ts=1755731134.154809&cid=C07GU9S7NVC

シナリオテストで
```
Simulation error [AutowareError]: Simulator waited for the Autoware state to transition to WAITING_FOR_ENGAGE, but time is up. The current Autoware state is PLANNING
```


/system/operation_mode/stateのpublishタイミングによっては、サブスクライバーが取りこぼす場合がありました。
trasient_localに変更することで対応。


related https://github.com/tier4/autoware_core/pull/39


## テスト

before
- https://evaluation.tier4.jp/evaluation/reports/2341cc2d-b806-5000-8ca3-f130546fb634/?project_id=prd_jt
  - 3859 / 3903

after
tmp/test_random_fail_v0.48
- https://evaluation.ci.tier4.jp/evaluation/reports/9e347204-3c3d-5c34-88b8-5b08cafb1da5?project_id=prd_jt
  - 3969/3987
  - state遷移のfail無し。