### PR TITLE
fix(fusion_node): subscribe from concat info

### DIFF
--- a/build_depends_humble.repos
+++ b/build_depends_humble.repos
@@ -3,7 +3,7 @@ repositories:
   core/autoware_msgs:
     type: git
     url: https://github.com/autowarefoundation/autoware_msgs.git
-    version: 1.9.0
+    version: 1.10.0
   # TODO (isamu-takagi): Use a released version when autoware_universe uses a released version.
   core/autoware_adapi_msgs:
     type: git

--- a/launch/tier4_perception_launch/launch/object_recognition/detection/detection.launch.xml
+++ b/launch/tier4_perception_launch/launch/object_recognition/detection/detection.launch.xml
@@ -75,6 +75,7 @@
   <arg name="input/camera8/image"/>
   <arg name="input/camera8/info"/>
   <arg name="input/camera8/rois"/>
+  <arg name="input/concatenation_info"/>
   <arg name="image_topic_name"/>
   <arg name="segmentation_pointcloud_fusion_camera_ids"/>
   <arg name="input/radar"/>
@@ -205,6 +206,7 @@
       <arg name="input/camera8/image" value="$(var input/camera8/image)"/>
       <arg name="input/camera8/info" value="$(var input/camera8/info)"/>
       <arg name="input/camera8/rois" value="$(var input/camera8/rois)"/>
+      <arg name="input/concatenation_info" value="$(var input/concatenation_info)"/>
       <arg name="input/pointcloud" value="$(var input/pointcloud)"/>
       <arg name="input/pointcloud_map/pointcloud" value="$(var pointcloud_filter/output/pointcloud)"/>
       <arg name="input/obstacle_segmentation/pointcloud" value="$(var input/obstacle_segmentation/pointcloud)"/>
@@ -231,6 +233,7 @@
       <arg name="pipeline_ns" value="$(var irregular_object_detector_ns)"/>
       <arg name="fusion_camera_ids" value="$(var irregular_object_detector_fusion_camera_ids)"/>
       <arg name="image_topic_name" value="$(var image_topic_name)"/>
+      <arg name="input/concatenation_info" value="$(var input/concatenation_info)"/>
       <arg name="input/pointcloud" value="$(var input/pointcloud)"/>
       <arg name="output/objects" value="$(var irregular_object_pipeline/output/objects)"/>
       <arg name="irregular_object_detector_param_path" value="$(var irregular_object_detector_param_path)"/>

--- a/launch/tier4_perception_launch/launch/object_recognition/detection/detector/camera_lidar_detector.launch.xml
+++ b/launch/tier4_perception_launch/launch/object_recognition/detection/detector/camera_lidar_detector.launch.xml
@@ -46,6 +46,8 @@
   <arg name="input/camera8/info"/>
   <arg name="input/camera8/rois"/>
 
+  <arg name="input/concatenation_info"/>
+
   <arg name="segmentation_pointcloud_fusion_camera_ids"/>
   <arg name="image_topic_name"/>
 
@@ -129,6 +131,7 @@
       <arg name="input/image7" value="$(var input/camera7/image)"/>
       <arg name="input/image8" value="$(var input/camera8/image)"/>
       <arg name="input/pointcloud" value="$(var pointpainting/input/pointcloud)"/>
+      <arg name="input/concatenation_info" value="$(var input/concatenation_info)"/>
       <arg name="output/objects" value="$(var pointpainting/output/objects)"/>
 
       <arg name="model_name" value="$(var lidar_detection_model_name)"/>
@@ -145,6 +148,7 @@
   <!-- Image_segmentation based filter, apply for camera0 only-->
   <group>
     <include file="$(find-pkg-share autoware_image_projection_based_fusion)/launch/segmentation_pointcloud_fusion.launch.py" if="$(var use_image_segmentation_based_filter)">
+      <arg name="input/concatenation_info" value="$(var input/concatenation_info)"/>
       <arg name="input/pointcloud" value="$(var segmentation_based_filtered/input/pointcloud)"/>
       <arg name="output/pointcloud" value="$(var segmentation_based_filtered/output/pointcloud)"/>
       <arg name="image_topic_name" value="$(var image_topic_name)"/>
@@ -207,6 +211,7 @@
           <arg name="input/image6" value="$(var input/camera6/image)"/>
           <arg name="input/image7" value="$(var input/camera7/image)"/>
           <arg name="input/image8" value="$(var input/camera8/image)"/>
+          <arg name="input/concatenation_info" value="$(var input/concatenation_info)"/>
           <arg name="input/clusters" value="$(var roi_cluster_fusion/input/clusters)"/>
           <arg name="output/clusters" value="$(var roi_cluster_fusion/output/clusters)"/>
           <arg name="param_path" value="$(var roi_cluster_fusion_param_path)"/>

--- a/launch/tier4_perception_launch/launch/object_recognition/detection/detector/camera_lidar_irregular_object_detector.launch.xml
+++ b/launch/tier4_perception_launch/launch/object_recognition/detection/detector/camera_lidar_irregular_object_detector.launch.xml
@@ -3,6 +3,7 @@
   <!-- Current namespace -->
   <arg name="ns" description="current namespace"/>
   <arg name="pipeline_ns" description="pipeline namespace"/>
+  <arg name="input/concatenation_info"/>
   <arg name="input/pointcloud"/>
   <arg name="fusion_camera_ids" default="[0]" description="camera IDs used for fusion"/>
   <arg name="image_topic_name" default="image_raw" description="topic name of camera image"/>
@@ -12,6 +13,7 @@
     <push-ros-namespace namespace="$(var pipeline_ns)"/>
     <group>
       <include file="$(find-pkg-share tier4_perception_launch)/launch/object_recognition/detection/detector/camera_lidar_irregular_object_detector.launch.py">
+        <arg name="input/concatenation_info" value="$(var input/concatenation_info)"/>
         <arg name="input/pointcloud" value="$(var input/pointcloud)"/>
         <arg name="output_topic" value="clusters"/>
         <arg name="pointcloud_container_name" value="$(var node/pointcloud_container)"/>

--- a/launch/tier4_perception_launch/launch/object_recognition/detection/merger/camera_lidar_merger.launch.xml
+++ b/launch/tier4_perception_launch/launch/object_recognition/detection/merger/camera_lidar_merger.launch.xml
@@ -103,6 +103,7 @@
       <arg name="input/image6" value="$(var input/camera6/image)"/>
       <arg name="input/image7" value="$(var input/camera7/image)"/>
       <arg name="input/image8" value="$(var input/camera8/image)"/>
+      <arg name="input/concatenation_info" value="$(var input/concatenation_info)"/>
       <arg name="input/objects" value="$(var detected_object_roi_filter/input/objects)"/>
       <arg name="output/objects" value="$(var detected_object_roi_filter/output/objects)"/>
       <arg name="param_path" value="$(var roi_detected_object_fusion_param_path)"/>

--- a/launch/tier4_perception_launch/launch/object_recognition/detection/merger/camera_lidar_radar_merger.launch.xml
+++ b/launch/tier4_perception_launch/launch/object_recognition/detection/merger/camera_lidar_radar_merger.launch.xml
@@ -115,6 +115,7 @@
       <arg name="input/image6" value="$(var input/camera6/image)"/>
       <arg name="input/image7" value="$(var input/camera7/image)"/>
       <arg name="input/image8" value="$(var input/camera8/image)"/>
+      <arg name="input/concatenation_info" value="$(var input/concatenation_info)"/>
       <arg name="input/objects" value="$(var detected_object_roi_filter/input/objects)"/>
       <arg name="output/objects" value="$(var detected_object_roi_filter/output/objects)"/>
       <arg name="param_path" value="$(var roi_detected_object_fusion_param_path)"/>

--- a/launch/tier4_perception_launch/launch/perception.launch.xml
+++ b/launch/tier4_perception_launch/launch/perception.launch.xml
@@ -114,6 +114,7 @@
   <arg name="segmentation_pointcloud_fusion_camera_ids" default="[0,1,5]" description="list of camera ids used for segmentation_pointcloud_fusion node"/>
   <arg name="ml_camera_lidar_merger_priority_mode" default="0" description="priority mode for ml and camera_lidar merger, options: `0: Object0`, `1: Object1`, `2: ConfidenceBased`, `3: ClassBased`"/>
   <arg name="pointcloud_container_name" default="pointcloud_container"/>
+  <arg name="input/concatenation_info" default="/sensing/lidar/concatenated/pointcloud_info"/>
 
   <!-- Pipeline junctions -->
   <arg name="use_vector_map" default="true" description="use vector map in prediction"/>
@@ -276,6 +277,7 @@
           <arg name="input/camera8/image" value="$(var image_raw8)"/>
           <arg name="input/camera8/info" value="$(var camera_info8)"/>
           <arg name="input/camera8/rois" value="$(var detection_rois8)"/>
+          <arg name="input/concatenation_info" value="$(var input/concatenation_info)"/>
           <arg name="input/pointcloud" value="$(var perception_pointcloud)"/>
           <arg name="node/pointcloud_container" value="$(var pointcloud_container_name)"/>
           <arg name="input/radar" value="$(var input/radar)"/>

--- a/perception/autoware_image_projection_based_fusion/include/autoware/image_projection_based_fusion/fusion_matching_strategy.hpp
+++ b/perception/autoware_image_projection_based_fusion/include/autoware/image_projection_based_fusion/fusion_matching_strategy.hpp
@@ -18,6 +18,8 @@
 
 #include <rclcpp/rclcpp.hpp>
 
+#include <autoware_sensing_msgs/msg/concatenated_point_cloud_info.hpp>
+
 #include <cstddef>
 #include <list>
 #include <memory>
@@ -124,9 +126,10 @@ public:
     std::shared_ptr<FusionCollector<Msg3D, Msg2D, ExportObj>> & collector,
     const std::shared_ptr<MatchingContextBase> & matching_context) override;
 
-  double get_concatenated_offset(
+  double get_concatenation_offset(
     const double & msg3d_timestamp,
-    const std::optional<std::unordered_map<std::string, std::string>> & concatenated_status);
+    const std::optional<autoware_sensing_msgs::msg::ConcatenatedPointCloudInfo::SharedPtr> &
+      concatenation_info_msg);
 
   double extract_fractional(double timestamp);
   void update_fractional_timestamp_set(double new_timestamp);

--- a/perception/autoware_image_projection_based_fusion/include/autoware/image_projection_based_fusion/fusion_node.hpp
+++ b/perception/autoware_image_projection_based_fusion/include/autoware/image_projection_based_fusion/fusion_node.hpp
@@ -27,8 +27,7 @@
 #include <rclcpp/rclcpp.hpp>
 
 #include <autoware_perception_msgs/msg/detected_objects.hpp>
-#include <diagnostic_msgs/msg/diagnostic_array.hpp>
-#include <diagnostic_msgs/msg/diagnostic_status.hpp>
+#include <autoware_sensing_msgs/msg/concatenated_point_cloud_info.hpp>
 #include <sensor_msgs/msg/camera_info.hpp>
 #include <sensor_msgs/msg/image.hpp>
 #include <sensor_msgs/point_cloud2_iterator.hpp>
@@ -75,8 +74,8 @@ public:
     typename Msg3D::SharedPtr & output_det3d_msg,
     std::unordered_map<std::size_t, double> id_to_stamp_map,
     std::shared_ptr<FusionCollectorInfoBase> collector_info);
-  std::optional<std::unordered_map<std::string, std::string>> find_concatenation_status(
-    double timestamp);
+  std::optional<autoware_sensing_msgs::msg::ConcatenatedPointCloudInfo::SharedPtr>
+  find_concatenation_info(double timestamp);
   void show_diagnostic_message(
     std::unordered_map<std::size_t, double> id_to_stamp_map,
     std::shared_ptr<FusionCollectorInfoBase> collector_info);
@@ -117,7 +116,8 @@ private:
   std::unordered_map<std::size_t, double> id_to_offset_map_;
 
   // timestamp: (key, value)
-  std::unordered_map<double, std::unordered_map<std::string, std::string>> concatenated_status_map_;
+  std::unordered_map<double, autoware_sensing_msgs::msg::ConcatenatedPointCloudInfo::SharedPtr>
+    concatenated_info_map_;
 
   diagnostic_updater::Updater diagnostic_updater_{this};
   std::shared_ptr<FusionCollectorInfoBase> diagnostic_collector_info_;
@@ -141,7 +141,8 @@ protected:
   // callback for rois subscription
   void rois_callback(const typename Msg2D::ConstSharedPtr rois_msg, const std::size_t rois_id);
 
-  void diagnostic_callback(const diagnostic_msgs::msg::DiagnosticArray::SharedPtr diagnostic_msg);
+  void concatenation_info_callback(
+    const autoware_sensing_msgs::msg::ConcatenatedPointCloudInfo::SharedPtr concatenation_info_msg);
 
   // Custom process methods
   virtual void postprocess(const Msg3D & processing_msg, ExportObj & output_msg);
@@ -156,7 +157,8 @@ protected:
 
   // 3d detection subscription
   typename rclcpp::Subscription<Msg3D>::SharedPtr msg3d_sub_;
-  rclcpp::Subscription<diagnostic_msgs::msg::DiagnosticArray>::SharedPtr sub_diag_;
+  rclcpp::Subscription<autoware_sensing_msgs::msg::ConcatenatedPointCloudInfo>::SharedPtr
+    sub_concatenation_info_;
 
   // parameters for out_of_scope filter
   float filter_scope_min_x_;

--- a/perception/autoware_image_projection_based_fusion/launch/roi_cluster_fusion.launch.xml
+++ b/perception/autoware_image_projection_based_fusion/launch/roi_cluster_fusion.launch.xml
@@ -19,6 +19,7 @@
   <arg name="input/rois8" default="rois8"/>
   <arg name="input/camera_info8" default="/camera_info8"/>
   <arg name="input/clusters" default="clusters"/>
+  <arg name="input/concatenation_info" default="/sensing/lidar/concatenated/pointcloud_info"/>
   <arg name="output/clusters" default="labeled_clusters"/>
   <arg name="param_path" default="$(find-pkg-share autoware_image_projection_based_fusion)/config/roi_cluster_fusion.param.yaml"/>
   <arg name="sync_param_path" default="$(find-pkg-share autoware_image_projection_based_fusion)/config/fusion_common.param.yaml"/>
@@ -39,6 +40,7 @@
       <param from="$(var param_path)"/>
       <param from="$(var sync_param_path)"/>
       <remap from="input" to="$(var input/clusters)"/>
+      <remap from="input/concatenation_info" to="$(var input/concatenation_info)"/>
       <remap from="output" to="$(var output/clusters)"/>
 
       <!-- rois, camera and info -->

--- a/perception/autoware_image_projection_based_fusion/launch/roi_detected_object_fusion.launch.xml
+++ b/perception/autoware_image_projection_based_fusion/launch/roi_detected_object_fusion.launch.xml
@@ -19,6 +19,7 @@
   <arg name="input/rois8" default="rois8"/>
   <arg name="input/camera_info8" default="/camera_info8"/>
   <arg name="input/objects" default="objects"/>
+  <arg name="input/concatenation_info" default="/sensing/lidar/concatenated/pointcloud_info"/>
   <arg name="output/objects" default="fused_objects"/>
   <arg name="param_path" default="$(find-pkg-share autoware_image_projection_based_fusion)/config/roi_detected_object_fusion.param.yaml"/>
   <arg name="sync_param_path" default="$(find-pkg-share autoware_image_projection_based_fusion)/config/fusion_common.param.yaml"/>
@@ -43,6 +44,7 @@
       <param from="$(var sync_param_path)"/>
       <param from="$(var param_path)"/>
       <remap from="input" to="$(var input/objects)"/>
+      <remap from="input/concatenation_info" to="$(var input/concatenation_info)"/>
       <remap from="output" to="$(var output/objects)"/>
 
       <!-- rois, camera and info -->

--- a/perception/autoware_image_projection_based_fusion/launch/roi_pointcloud_fusion.launch.xml
+++ b/perception/autoware_image_projection_based_fusion/launch/roi_pointcloud_fusion.launch.xml
@@ -20,6 +20,7 @@
   <arg name="input/rois8" default="rois8"/>
   <arg name="input/camera_info8" default="/camera_info8"/>
   <arg name="input/pointcloud" default="/perception/object_recognition/detection/pointcloud_map_filtered/pointcloud"/>
+  <arg name="input/concatenation_info" default="/sensing/lidar/concatenated/pointcloud_info"/>
   <arg name="output/clusters" default="output/clusters"/>
   <arg name="debug/clusters" default="roi_pointcloud_fusion/debug/clusters"/>
   <arg name="param_path" default="$(find-pkg-share autoware_image_projection_based_fusion)/config/roi_pointcloud_fusion.param.yaml"/>
@@ -43,6 +44,7 @@
         <param from="$(var param_path)"/>
         <param from="$(var sync_param_path)" allow_substs="true"/>
         <remap from="input" to="$(var input/pointcloud)"/>
+        <remap from="input/concatenation_info" to="$(var input/concatenation_info)"/>
         <remap from="output" to="$(var output/clusters)"/>
         <remap from="debug/clusters" to="$(var debug/clusters)"/>
 

--- a/perception/autoware_image_projection_based_fusion/launch/segmentation_pointcloud_fusion.launch.py
+++ b/perception/autoware_image_projection_based_fusion/launch/segmentation_pointcloud_fusion.launch.py
@@ -92,13 +92,16 @@ class SegmentationPointcloudFusion:
             point_project_to_unrectified_image
         )
 
-    def create_segmentation_pointcloud_fusion_node(self, input_topic, output_topic):
+    def create_segmentation_pointcloud_fusion_node(
+        self, input_topic, concat_info_topic, output_topic
+    ):
         node = Node(
             package="autoware_image_projection_based_fusion",
             executable="segmentation_pointcloud_fusion_node",
             name="segmentation_pointcloud_fusion",
             remappings=[
                 ("input", input_topic),
+                ("input/concatenation_info", concat_info_topic),
                 ("output", output_topic),
             ],
             parameters=[
@@ -112,7 +115,9 @@ class SegmentationPointcloudFusion:
 def launch_setup(context, *args, **kwargs):
     pipeline = SegmentationPointcloudFusion(context)
     segmentation_pointcloud_fusion_node = pipeline.create_segmentation_pointcloud_fusion_node(
-        LaunchConfiguration("input/pointcloud"), LaunchConfiguration("output/pointcloud")
+        LaunchConfiguration("input/pointcloud"),
+        LaunchConfiguration("input/concatenation_info"),
+        LaunchConfiguration("output/pointcloud"),
     )
     # TODO(badai-nguyen): add option of using container
     return [segmentation_pointcloud_fusion_node]
@@ -125,6 +130,7 @@ def generate_launch_description():
         launch_arguments.append(DeclareLaunchArgument(name, default_value=default_value))
 
     add_launch_arg("input/pointcloud", "pointcloud_map_filtered/pointcloud")
+    add_launch_arg("input/concatenation_info", "/sensing/lidar/concatenated/pointcloud_info")
     add_launch_arg("output/pointcloud", "segmentation_based_filtered/pointcloud")
     add_launch_arg("use_intra_process", "True")
     add_launch_arg("use_multithread", "True")

--- a/perception/autoware_image_projection_based_fusion/launch/segmentation_pointcloud_fusion.launch.xml
+++ b/perception/autoware_image_projection_based_fusion/launch/segmentation_pointcloud_fusion.launch.xml
@@ -19,6 +19,7 @@
   <arg name="input/mask8" default="/perception/object_recognition/detection/mask8"/>
   <arg name="input/camera_info8" default="/sensing/camera/camera8/camera_info"/>
   <arg name="input/pointcloud" default="/sensing/lidar/top/outlier_filtered/pointcloud"/>
+  <arg name="input/concatenation_info" default="/sensing/lidar/concatenated/pointcloud_info"/>
   <arg name="output/pointcloud" default="output/pointcloud"/>
   <arg name="sync_param_path" default="$(find-pkg-share autoware_image_projection_based_fusion)/config/fusion_common.param.yaml"/>
   <arg name="semantic_segmentation_based_filter_param_path" default="$(find-pkg-share autoware_image_projection_based_fusion)/config/segmentation_pointcloud_fusion.param.yaml"/>
@@ -37,6 +38,7 @@
       <param from="$(var semantic_segmentation_based_filter_param_path)"/>
       <param from="$(var sync_param_path)"/>
       <remap from="input" to="$(var input/pointcloud)"/>
+      <remap from="input/concatenation_info" to="$(var input/concatenation_info)"/>
       <remap from="output" to="$(var output/pointcloud)"/>
 
       <!-- rois, camera and info -->

--- a/perception/autoware_image_projection_based_fusion/package.xml
+++ b/perception/autoware_image_projection_based_fusion/package.xml
@@ -22,6 +22,8 @@
   <depend>autoware_object_recognition_utils</depend>
   <depend>autoware_perception_msgs</depend>
   <depend>autoware_point_types</depend>
+  <depend>autoware_pointcloud_preprocessor</depend>
+  <depend>autoware_sensing_msgs</depend>
   <depend>autoware_utils</depend>
   <depend>cv_bridge</depend>
   <depend>diagnostic_msgs</depend>

--- a/perception/autoware_image_projection_based_fusion/src/fusion_node.cpp
+++ b/perception/autoware_image_projection_based_fusion/src/fusion_node.cpp
@@ -201,9 +201,11 @@ void FusionNode<Msg3D, Msg2D, ExportObj>::initialize_strategy()
   } else if (matching_strategy_ == "advanced") {
     fusion_matching_strategy_ = std::make_unique<AdvancedMatchingStrategy<Msg3D, Msg2D, ExportObj>>(
       std::dynamic_pointer_cast<FusionNode>(shared_from_this()), id_to_offset_map_);
-    // subscribe diagnostics
-    sub_diag_ = this->create_subscription<diagnostic_msgs::msg::DiagnosticArray>(
-      "/diagnostics", 10, std::bind(&FusionNode::diagnostic_callback, this, std::placeholders::_1));
+    // subscribe concatenation_info
+    sub_concatenation_info_ =
+      this->create_subscription<autoware_sensing_msgs::msg::ConcatenatedPointCloudInfo>(
+        "input/concatenation_info", rclcpp::SensorDataQoS().keep_last(10),
+        std::bind(&FusionNode::concatenation_info_callback, this, std::placeholders::_1));
   } else {
     throw std::runtime_error("Matching strategy must be 'advanced' or 'naive'");
   }
@@ -498,36 +500,22 @@ void FusionNode<Msg3D, Msg2D, ExportObj>::rois_callback(
 }
 
 template <class Msg3D, class Msg2D, class ExportObj>
-void FusionNode<Msg3D, Msg2D, ExportObj>::diagnostic_callback(
-  const diagnostic_msgs::msg::DiagnosticArray::SharedPtr diagnostic_msg)
+void FusionNode<Msg3D, Msg2D, ExportObj>::concatenation_info_callback(
+  const autoware_sensing_msgs::msg::ConcatenatedPointCloudInfo::SharedPtr concatenation_info_msg)
 {
-  for (const auto & status : diagnostic_msg->status) {
-    // Filter for the concatenate_and_time_sync_node diagnostic message
-    if (status.name == std::string_view("concatenate_data: /sensing/lidar/concatenate_data")) {
-      std::optional<double> concatenate_timestamp_opt;
-
-      // First pass: Locate concatenated_cloud_timestamp
-      for (const auto & value : status.values) {
-        if (value.key == std::string_view("Concatenated pointcloud timestamp")) {
-          try {
-            concatenate_timestamp_opt = std::stod(value.value);
-          } catch (const std::exception & e) {
-            RCLCPP_ERROR(get_logger(), "Error parsing concatenated cloud timestamp: %s", e.what());
-          }
-        }
-      }
-
-      // Second pass: Fill key-value map only if timestamp was valid
-      if (concatenate_timestamp_opt.has_value()) {
-        std::unordered_map<std::string, std::string> key_value_map;
-        for (const auto & value : status.values) {
-          key_value_map.emplace(value.key, value.value);
-        }
-
-        concatenated_status_map_.emplace(
-          concatenate_timestamp_opt.value(), std::move(key_value_map));
-      }
-    }
+  if (
+    concatenation_info_msg->matching_strategy ==
+    autoware_sensing_msgs::msg::ConcatenatedPointCloudInfo::STRATEGY_NAIVE) {
+    RCLCPP_WARN_THROTTLE(
+      get_logger(), *get_clock(), 1000,
+      "Set the concatenation node's matching strategy to 'advanced' in "
+      "autoware_pointcloud_preprocessor to enable advanced matching in the fusion node.");
+    return;
+  } else if (
+    concatenation_info_msg->matching_strategy ==
+    autoware_sensing_msgs::msg::ConcatenatedPointCloudInfo::STRATEGY_ADVANCED) {
+    double concatenate_timestamp = rclcpp::Time(concatenation_info_msg->header.stamp).seconds();
+    concatenated_info_map_.emplace(concatenate_timestamp, concatenation_info_msg);
   }
 }
 
@@ -536,13 +524,13 @@ void FusionNode<Msg3D, Msg2D, ExportObj>::manage_concatenated_status_map(double 
 {
   constexpr double threshold_seconds = 1.0;  // Define threshold as a constant
 
-  // Remove old entries from concatenated_status_map_
-  auto it = concatenated_status_map_.begin();
-  while (it != concatenated_status_map_.end()) {
+  // Remove old entries from concatenated_info_map_
+  auto it = concatenated_info_map_.begin();
+  while (it != concatenated_info_map_.end()) {
     if (current_timestamp - it->first > threshold_seconds) {
       RCLCPP_DEBUG(
         get_logger(), "Removing old concatenation status for timestamp: %.9f", it->first);
-      it = concatenated_status_map_.erase(it);
+      it = concatenated_info_map_.erase(it);
     } else {
       ++it;
     }
@@ -627,11 +615,11 @@ void FusionNode<Msg3D, Msg2D, ExportObj>::manage_collector_list()
 }
 
 template <class Msg3D, class Msg2D, class ExportObj>
-std::optional<std::unordered_map<std::string, std::string>>
-FusionNode<Msg3D, Msg2D, ExportObj>::find_concatenation_status(double timestamp)
+std::optional<autoware_sensing_msgs::msg::ConcatenatedPointCloudInfo::SharedPtr>
+FusionNode<Msg3D, Msg2D, ExportObj>::find_concatenation_info(double timestamp)
 {
-  auto it = concatenated_status_map_.find(timestamp);
-  if (it != concatenated_status_map_.end()) {
+  auto it = concatenated_info_map_.find(timestamp);
+  if (it != concatenated_info_map_.end()) {
     return it->second;
   }
   return std::nullopt;

--- a/sensing/autoware_cuda_pointcloud_preprocessor/CMakeLists.txt
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/CMakeLists.txt
@@ -77,6 +77,7 @@ target_link_libraries(cuda_pointcloud_preprocessor_lib
 target_include_directories(cuda_pointcloud_preprocessor_lib SYSTEM PRIVATE
   ${autoware_pointcloud_preprocessor_INCLUDE_DIRS}
   ${autoware_point_types_INCLUDE_DIRS}
+  ${autoware_sensing_msgs_INCLUDE_DIRS}
   ${cuda_blackboard_INCLUDE_DIRS}
   ${diagnostic_msgs_INCLUDE_DIRS}
   ${geometry_msgs_INCLUDE_DIRS}

--- a/sensing/autoware_cuda_pointcloud_preprocessor/include/autoware/cuda_pointcloud_preprocessor/cuda_concatenate_data/cuda_combine_cloud_handler.hpp
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/include/autoware/cuda_pointcloud_preprocessor/cuda_concatenate_data/cuda_combine_cloud_handler.hpp
@@ -50,7 +50,8 @@ public:
   ConcatenatedCloudResult<CudaPointCloud2Traits> combine_pointclouds(
     std::unordered_map<
       std::string, typename CudaPointCloud2Traits::PointCloudMessage::ConstSharedPtr> &
-      topic_to_cloud_map);
+      topic_to_cloud_map,
+    const std::shared_ptr<CollectorInfoBase> & collector_info);
 
   void allocate_pointclouds() override;
 };

--- a/sensing/autoware_cuda_pointcloud_preprocessor/launch/cuda_concatenate_and_time_sync_node.launch.xml
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/launch/cuda_concatenate_and_time_sync_node.launch.xml
@@ -1,11 +1,13 @@
 <launch>
   <arg name="input/twist" default="/sensing/vehicle_velocity_converter/twist_with_covariance"/>
   <arg name="output" default="/sensing/lidar/concatenated/pointcloud"/>
+  <arg name="output_info" default="/sensing/lidar/concatenated/pointcloud_info"/>
   <!-- Parameter -->
   <arg name="param_file" default="$(find-pkg-share autoware_pointcloud_preprocessor)/config/concatenate_and_time_sync_node.param.yaml"/>
   <node pkg="autoware_cuda_pointcloud_preprocessor" exec="cuda_concatenate_and_time_sync_node" name="cuda_concatenate_and_time_sync_node" output="screen">
     <remap from="~/input/twist" to="$(var input/twist)"/>
     <remap from="output" to="$(var output)"/>
+    <remap from="output_info" to="$(var output_info)"/>
     <param from="$(var param_file)"/>
   </node>
 </launch>

--- a/sensing/autoware_cuda_pointcloud_preprocessor/package.xml
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/package.xml
@@ -18,6 +18,7 @@
   <depend>autoware_cuda_utils</depend>
   <depend>autoware_point_types</depend>
   <depend>autoware_pointcloud_preprocessor</depend>
+  <depend>autoware_sensing_msgs</depend>
   <depend>autoware_utils</depend>
   <depend>cuda_blackboard</depend>
   <depend>diagnostic_msgs</depend>

--- a/sensing/autoware_cuda_pointcloud_preprocessor/src/cuda_concatenate_data/cuda_combine_cloud_handler.cpp
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/src/cuda_concatenate_data/cuda_combine_cloud_handler.cpp
@@ -17,7 +17,7 @@
 #include "autoware/cuda_pointcloud_preprocessor/cuda_concatenate_data/cuda_combine_cloud_handler_kernel.hpp"
 #include "autoware/cuda_pointcloud_preprocessor/cuda_concatenate_data/cuda_traits.hpp"
 
-#include <autoware/pointcloud_preprocessor/concatenate_data/concatenation_info.hpp>
+#include <autoware/pointcloud_preprocessor/concatenate_data/concatenation_info_manager.hpp>
 #include <cuda_blackboard/cuda_pointcloud2.hpp>
 
 #include <cuda_runtime.h>
@@ -89,7 +89,8 @@ ConcatenatedCloudResult<CudaPointCloud2Traits>
 CombineCloudHandler<CudaPointCloud2Traits>::combine_pointclouds(
   std::unordered_map<
     std::string, typename CudaPointCloud2Traits::PointCloudMessage::ConstSharedPtr> &
-    topic_to_cloud_map)
+    topic_to_cloud_map,
+  const std::shared_ptr<CollectorInfoBase> & collector_info)
 {
   ConcatenatedCloudResult<CudaPointCloud2Traits> concatenate_cloud_result;
   std::lock_guard<std::mutex> lock(mutex_);
@@ -113,7 +114,7 @@ CombineCloudHandler<CudaPointCloud2Traits>::combine_pointclouds(
     std::make_unique<cuda_blackboard::CudaPointCloud2>();
   concatenate_cloud_result.concatenation_info_ptr =
     std::make_unique<autoware_sensing_msgs::msg::ConcatenatedPointCloudInfo>(
-      concatenation_info_.reset_and_get_base_info());
+      concatenation_info_manager_.reset_and_get_base_info());
 
   // Reserve space based on the total size of the pointcloud data to speed up the concatenation
   // process
@@ -181,7 +182,7 @@ CombineCloudHandler<CudaPointCloud2Traits>::combine_pointclouds(
       reinterpret_cast<PointTypeStruct *>(cloud->data.get()), num_points, transform_struct,
       output_points + concatenated_start_index, stream);
     concatenated_start_index += num_points;
-    concatenation_info_.update_source_from_point_cloud(
+    concatenation_info_manager_.update_source_from_point_cloud(
       *cloud, topic, autoware_sensing_msgs::msg::SourcePointCloudInfo::STATUS_OK,
       *concatenate_cloud_result.concatenation_info_ptr);
   }
@@ -281,7 +282,28 @@ CombineCloudHandler<CudaPointCloud2Traits>::combine_pointclouds(
 
   concatenate_cloud_result.concatenate_cloud_ptr->header.stamp = oldest_stamp;
 
-  concatenation_info_.set_result(
+  if (const auto advanced_info = std::dynamic_pointer_cast<AdvancedCollectorInfo>(collector_info)) {
+    const auto reference_timestamp_min = advanced_info->timestamp - advanced_info->noise_window;
+    const auto reference_timestamp_max = advanced_info->timestamp + advanced_info->noise_window;
+
+    builtin_interfaces::msg::Time reference_timestamp_min_msg;
+    reference_timestamp_min_msg.sec = static_cast<int32_t>(reference_timestamp_min);
+    reference_timestamp_min_msg.nanosec =
+      static_cast<uint32_t>((reference_timestamp_min - reference_timestamp_min_msg.sec) * 1e9);
+
+    builtin_interfaces::msg::Time reference_timestamp_max_msg;
+    reference_timestamp_max_msg.sec = static_cast<int32_t>(reference_timestamp_max);
+    reference_timestamp_max_msg.nanosec =
+      static_cast<uint32_t>((reference_timestamp_max - reference_timestamp_max_msg.sec) * 1e9);
+
+    StrategyAdvancedConfig strategy_config(
+      reference_timestamp_min_msg, reference_timestamp_max_msg);
+    auto serialized_config = strategy_config.serialize();
+    ConcatenationInfoManager::set_config(
+      serialized_config, *concatenate_cloud_result.concatenation_info_ptr);
+  }
+
+  concatenation_info_manager_.set_result(
     *concatenate_cloud_result.concatenate_cloud_ptr,
     *concatenate_cloud_result.concatenation_info_ptr);
 

--- a/sensing/autoware_cuda_pointcloud_preprocessor/src/cuda_concatenate_data/cuda_combine_cloud_handler.cpp
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/src/cuda_concatenate_data/cuda_combine_cloud_handler.cpp
@@ -17,6 +17,7 @@
 #include "autoware/cuda_pointcloud_preprocessor/cuda_concatenate_data/cuda_combine_cloud_handler_kernel.hpp"
 #include "autoware/cuda_pointcloud_preprocessor/cuda_concatenate_data/cuda_traits.hpp"
 
+#include <autoware/pointcloud_preprocessor/concatenate_data/concatenation_info.hpp>
 #include <cuda_blackboard/cuda_pointcloud2.hpp>
 
 #include <cuda_runtime.h>
@@ -110,6 +111,9 @@ CombineCloudHandler<CudaPointCloud2Traits>::combine_pointclouds(
   // Before combining the pointclouds, initialize and reserve space for the concatenated pointcloud
   concatenate_cloud_result.concatenate_cloud_ptr =
     std::make_unique<cuda_blackboard::CudaPointCloud2>();
+  concatenate_cloud_result.concatenation_info_ptr =
+    std::make_unique<autoware_sensing_msgs::msg::ConcatenatedPointCloudInfo>(
+      concatenation_info_.reset_and_get_base_info());
 
   // Reserve space based on the total size of the pointcloud data to speed up the concatenation
   // process
@@ -177,6 +181,9 @@ CombineCloudHandler<CudaPointCloud2Traits>::combine_pointclouds(
       reinterpret_cast<PointTypeStruct *>(cloud->data.get()), num_points, transform_struct,
       output_points + concatenated_start_index, stream);
     concatenated_start_index += num_points;
+    concatenation_info_.update_source_from_point_cloud(
+      *cloud, topic, autoware_sensing_msgs::msg::SourcePointCloudInfo::STATUS_OK,
+      *concatenate_cloud_result.concatenation_info_ptr);
   }
 
   concatenate_cloud_result.concatenate_cloud_ptr->header.frame_id = output_frame_;
@@ -273,6 +280,10 @@ CombineCloudHandler<CudaPointCloud2Traits>::combine_pointclouds(
   }
 
   concatenate_cloud_result.concatenate_cloud_ptr->header.stamp = oldest_stamp;
+
+  concatenation_info_.set_result(
+    *concatenate_cloud_result.concatenate_cloud_ptr,
+    *concatenate_cloud_result.concatenation_info_ptr);
 
   return concatenate_cloud_result;
 }

--- a/sensing/autoware_cuda_pointcloud_preprocessor/src/cuda_concatenate_data/cuda_concatenate_and_time_sync_node.cpp
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/src/cuda_concatenate_data/cuda_concatenate_and_time_sync_node.cpp
@@ -18,6 +18,8 @@
 #include "autoware/cuda_pointcloud_preprocessor/cuda_concatenate_data/cuda_traits.hpp"
 #include "autoware/pointcloud_preprocessor/utility/memory.hpp"
 
+#include <autoware_sensing_msgs/msg/concatenated_point_cloud_info.hpp>
+
 #include <memory>
 #include <sstream>
 #include <string>
@@ -33,6 +35,9 @@ void PointCloudConcatenateDataSynchronizerComponentTemplated<
   concatenated_cloud_publisher_ =
     std::make_shared<cuda_blackboard::CudaBlackboardPublisher<cuda_blackboard::CudaPointCloud2>>(
       *this, "output");
+  concatenation_info_publisher_ =
+    this->create_publisher<autoware_sensing_msgs::msg::ConcatenatedPointCloudInfo>(
+      "output_info", rclcpp::SensorDataQoS().keep_last(params_.maximum_queue_size));
 
   for (auto & topic : params_.input_topics) {
     std::string new_topic =

--- a/sensing/autoware_pointcloud_preprocessor/CMakeLists.txt
+++ b/sensing/autoware_pointcloud_preprocessor/CMakeLists.txt
@@ -81,6 +81,7 @@ target_include_directories(concatenate_data PUBLIC
 ament_target_dependencies(concatenate_data
   SYSTEM
   autoware_point_types
+  autoware_sensing_msgs
   autoware_utils
   autoware_vehicle_msgs
   managed_transform_buffer
@@ -300,10 +301,15 @@ if(BUILD_TESTING)
     test/test_pickup_based_voxel_grid_downsample_filter_node.cpp
   )
 
+  ament_add_gtest(test_concatenation_info
+    test/test_concatenation_info.cpp
+  )
+
   target_link_libraries(test_utilities pointcloud_preprocessor_filter)
   target_link_libraries(test_distortion_corrector_node pointcloud_preprocessor_filter)
   target_link_libraries(test_concatenate_node_unit pointcloud_preprocessor_filter)
   target_link_libraries(test_pickup_based_voxel_grid_downsample_filter_node pointcloud_preprocessor_filter)
+  target_link_libraries(test_concatenation_info concatenate_data)
 
   add_ros_test(
     test/test_concatenate_node_component.py

--- a/sensing/autoware_pointcloud_preprocessor/docs/concatenate-data.md
+++ b/sensing/autoware_pointcloud_preprocessor/docs/concatenate-data.md
@@ -49,9 +49,10 @@ By setting the `input_twist_topic_type` parameter to `twist` or `odom`, the subs
 
 ### Output
 
-| Name              | Type                            | Description               |
-| ----------------- | ------------------------------- | ------------------------- |
-| `~/output/points` | `sensor_msgs::msg::Pointcloud2` | Concatenated point clouds |
+| Name              | Type                                                     | Description                                                                                                 |
+| ----------------- | -------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------- |
+| `~/output/points` | `sensor_msgs::msg::Pointcloud2`                          | Concatenated point clouds                                                                                   |
+| `~/output/info`   | `autoware_sensing_msgs::msg::ConcatenatedPointCloudInfo` | Information about the concatenated point cloud, including extents of source point clouds and their statuses |
 
 ### Core Parameters
 
@@ -108,6 +109,31 @@ From the example above, the noise ranges from 0 to 8 ms, so the user should set 
 The figure below demonstrates how `lidar_timestamp_noise_window` works with the `concatenate_and_time_sync_node`. If the green `X` is within the range of the red triangles, it indicates that the point cloud matches the reference timestamp of the collector.
 
 ![noise_timestamp_offset](./image/noise_timestamp_offset.drawio.svg)
+
+## Meta Information Topic
+
+The concatenation node publishes detailed meta information about the concatenation process through the `~/output/info` topic. For detailed information about the `ConcatenatedPointCloudInfo` message structure, please refer to the [autoware_msgs repository documentation](https://github.com/autowarefoundation/autoware_msgs/tree/main/autoware_sensing_msgs#concatenated-point-cloud-messages).
+
+### Handling Serialized Configuration
+
+The `matching_strategy_config` field contains serialized configuration data for the matching strategy.
+If a strategy has its own configuration, it requires serialization and deserialization implementation based on the `StrategyConfig` class defined in [cloud_info.hpp](../include/autoware/pointcloud_preprocessor/concatenate_data/concatenation_info.hpp).
+
+Here's how to work with serialized configuration for the Advanced strategy:
+
+#### Serialization Example
+
+```cpp
+auto cfg = StrategyAdvancedConfig(reference_timestamp_min, reference_timestamp_max);
+ConcatenationInfo::set_config(cfg.serialize(), concatenation_info_msg);
+```
+
+#### Deserialization Example
+
+```cpp
+std::vector<uint8_t> raw_cfg = concat_info_msg->matching_strategy_config;
+auto cfg = StrategyAdvancedConfig(raw_cfg);
+```
 
 ## Launch
 

--- a/sensing/autoware_pointcloud_preprocessor/docs/concatenate-data.md
+++ b/sensing/autoware_pointcloud_preprocessor/docs/concatenate-data.md
@@ -117,7 +117,7 @@ The concatenation node publishes detailed meta information about the concatenati
 ### Handling Serialized Configuration
 
 The `matching_strategy_config` field contains serialized configuration data for the matching strategy.
-If a strategy has its own configuration, it requires serialization and deserialization implementation based on the `StrategyConfig` class defined in [cloud_info.hpp](../include/autoware/pointcloud_preprocessor/concatenate_data/concatenation_info.hpp).
+If a strategy has its own configuration, it requires serialization and deserialization implementation based on the `StrategyConfig` class defined in [cloud_info.hpp](../include/autoware/pointcloud_preprocessor/concatenate_data/concatenation_info_manager.hpp).
 
 Here's how to work with serialized configuration for the Advanced strategy:
 
@@ -125,7 +125,7 @@ Here's how to work with serialized configuration for the Advanced strategy:
 
 ```cpp
 auto cfg = StrategyAdvancedConfig(reference_timestamp_min, reference_timestamp_max);
-ConcatenationInfo::set_config(cfg.serialize(), concatenation_info_msg);
+ConcatenationInfoManager::set_config(cfg.serialize(), concatenation_info_msg);
 ```
 
 #### Deserialization Example

--- a/sensing/autoware_pointcloud_preprocessor/include/autoware/pointcloud_preprocessor/concatenate_data/cloud_collector.hpp
+++ b/sensing/autoware_pointcloud_preprocessor/include/autoware/pointcloud_preprocessor/concatenate_data/cloud_collector.hpp
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include "collector_info.hpp"
 #include "combine_cloud_handler.hpp"
 
 #include <memory>
@@ -28,29 +29,6 @@ class PointCloudConcatenateDataSynchronizerComponentTemplated;
 
 template <typename MsgTraits>
 class CombineCloudHandler;
-
-struct CollectorInfoBase
-{
-  virtual ~CollectorInfoBase() = default;
-};
-
-struct NaiveCollectorInfo : public CollectorInfoBase
-{
-  double timestamp;
-
-  explicit NaiveCollectorInfo(double timestamp = 0.0) : timestamp(timestamp) {}
-};
-
-struct AdvancedCollectorInfo : public CollectorInfoBase
-{
-  double timestamp;
-  double noise_window;
-
-  explicit AdvancedCollectorInfo(double timestamp = 0.0, double noise_window = 0.0)
-  : timestamp(timestamp), noise_window(noise_window)
-  {
-  }
-};
 
 enum class CollectorStatus { Idle, Processing, Finished };
 template <typename MsgTraits>

--- a/sensing/autoware_pointcloud_preprocessor/include/autoware/pointcloud_preprocessor/concatenate_data/cloud_collector.ipp
+++ b/sensing/autoware_pointcloud_preprocessor/include/autoware/pointcloud_preprocessor/concatenate_data/cloud_collector.ipp
@@ -128,7 +128,7 @@ ConcatenatedCloudResult<MsgTraits> CloudCollector<MsgTraits>::concatenate_pointc
   std::unordered_map<std::string, typename MsgTraits::PointCloudMessage::ConstSharedPtr>
     topic_to_cloud_map)
 {
-  return combine_cloud_handler_->combine_pointclouds(topic_to_cloud_map);
+  return combine_cloud_handler_->combine_pointclouds(topic_to_cloud_map, collector_info_);
 }
 
 template <typename MsgTraits>

--- a/sensing/autoware_pointcloud_preprocessor/include/autoware/pointcloud_preprocessor/concatenate_data/collector_info.hpp
+++ b/sensing/autoware_pointcloud_preprocessor/include/autoware/pointcloud_preprocessor/concatenate_data/collector_info.hpp
@@ -1,0 +1,43 @@
+// Copyright 2025 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+namespace autoware::pointcloud_preprocessor
+{
+
+struct CollectorInfoBase
+{
+  virtual ~CollectorInfoBase() = default;
+};
+
+struct NaiveCollectorInfo : public CollectorInfoBase
+{
+  double timestamp;
+
+  explicit NaiveCollectorInfo(double timestamp = 0.0) : timestamp(timestamp) {}
+};
+
+struct AdvancedCollectorInfo : public CollectorInfoBase
+{
+  double timestamp;
+  double noise_window;
+
+  explicit AdvancedCollectorInfo(double timestamp = 0.0, double noise_window = 0.0)
+  : timestamp(timestamp), noise_window(noise_window)
+  {
+  }
+};
+
+}  // namespace autoware::pointcloud_preprocessor

--- a/sensing/autoware_pointcloud_preprocessor/include/autoware/pointcloud_preprocessor/concatenate_data/combine_cloud_handler.hpp
+++ b/sensing/autoware_pointcloud_preprocessor/include/autoware/pointcloud_preprocessor/concatenate_data/combine_cloud_handler.hpp
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include "collector_info.hpp"
 #include "combine_cloud_handler_base.hpp"
 #include "traits.hpp"
 
@@ -47,11 +48,12 @@ public:
   {
   }
 
-  virtual ~CombineCloudHandler() {}
+  virtual ~CombineCloudHandler() = default;
 
   ConcatenatedCloudResult<PointCloud2Traits> combine_pointclouds(
     std::unordered_map<std::string, typename PointCloud2Traits::PointCloudMessage::ConstSharedPtr> &
-      topic_to_cloud_map);
+      topic_to_cloud_map,
+    const std::shared_ptr<CollectorInfoBase> & collector_info);
 
   void allocate_pointclouds() override {};
 

--- a/sensing/autoware_pointcloud_preprocessor/include/autoware/pointcloud_preprocessor/concatenate_data/combine_cloud_handler_base.hpp
+++ b/sensing/autoware_pointcloud_preprocessor/include/autoware/pointcloud_preprocessor/concatenate_data/combine_cloud_handler_base.hpp
@@ -14,7 +14,7 @@
 
 #pragma once
 
-#include "concatenation_info.hpp"
+#include "concatenation_info_manager.hpp"
 #include "traits.hpp"
 
 #include <deque>
@@ -59,7 +59,8 @@ public:
     publish_synchronized_pointcloud_(publish_synchronized_pointcloud),
     keep_input_frame_in_synchronized_pointcloud_(keep_input_frame_in_synchronized_pointcloud),
     managed_tf_buffer_(std::make_unique<managed_transform_buffer::ManagedTransformBuffer>()),
-    concatenation_info_(node.get_parameter("matching_strategy.type").as_string(), input_topics)
+    concatenation_info_manager_(
+      node.get_parameter("matching_strategy.type").as_string(), input_topics)
   {
   }
 
@@ -83,7 +84,7 @@ protected:
   bool publish_synchronized_pointcloud_;
   bool keep_input_frame_in_synchronized_pointcloud_;
   std::unique_ptr<managed_transform_buffer::ManagedTransformBuffer> managed_tf_buffer_{nullptr};
-  ConcatenationInfo concatenation_info_;
+  ConcatenationInfoManager concatenation_info_manager_;
 
   std::deque<geometry_msgs::msg::TwistStamped> twist_queue_;
 };

--- a/sensing/autoware_pointcloud_preprocessor/include/autoware/pointcloud_preprocessor/concatenate_data/combine_cloud_handler_base.hpp
+++ b/sensing/autoware_pointcloud_preprocessor/include/autoware/pointcloud_preprocessor/concatenate_data/combine_cloud_handler_base.hpp
@@ -14,6 +14,7 @@
 
 #pragma once
 
+#include "concatenation_info.hpp"
 #include "traits.hpp"
 
 #include <deque>
@@ -26,6 +27,7 @@
 // ROS includes
 #include <managed_transform_buffer/managed_transform_buffer.hpp>
 
+#include <autoware_sensing_msgs/msg/concatenated_point_cloud_info.hpp>
 #include <geometry_msgs/msg/twist_stamped.hpp>
 #include <geometry_msgs/msg/twist_with_covariance_stamped.hpp>
 #include <nav_msgs/msg/odometry.hpp>
@@ -37,6 +39,7 @@ template <typename MsgTraits>
 struct ConcatenatedCloudResult
 {
   typename MsgTraits::PointCloudMessage::UniquePtr concatenate_cloud_ptr{nullptr};
+  autoware_sensing_msgs::msg::ConcatenatedPointCloudInfo::UniquePtr concatenation_info_ptr;
   std::optional<std::unordered_map<std::string, typename MsgTraits::PointCloudMessage::UniquePtr>>
     topic_to_transformed_cloud_map;
   std::unordered_map<std::string, double> topic_to_original_stamp_map;
@@ -55,7 +58,8 @@ public:
     is_motion_compensated_(is_motion_compensated),
     publish_synchronized_pointcloud_(publish_synchronized_pointcloud),
     keep_input_frame_in_synchronized_pointcloud_(keep_input_frame_in_synchronized_pointcloud),
-    managed_tf_buffer_(std::make_unique<managed_transform_buffer::ManagedTransformBuffer>())
+    managed_tf_buffer_(std::make_unique<managed_transform_buffer::ManagedTransformBuffer>()),
+    concatenation_info_(node.get_parameter("matching_strategy.type").as_string(), input_topics)
   {
   }
 
@@ -79,6 +83,7 @@ protected:
   bool publish_synchronized_pointcloud_;
   bool keep_input_frame_in_synchronized_pointcloud_;
   std::unique_ptr<managed_transform_buffer::ManagedTransformBuffer> managed_tf_buffer_{nullptr};
+  ConcatenationInfo concatenation_info_;
 
   std::deque<geometry_msgs::msg::TwistStamped> twist_queue_;
 };

--- a/sensing/autoware_pointcloud_preprocessor/include/autoware/pointcloud_preprocessor/concatenate_data/concatenate_and_time_sync_node.hpp
+++ b/sensing/autoware_pointcloud_preprocessor/include/autoware/pointcloud_preprocessor/concatenate_data/concatenate_and_time_sync_node.hpp
@@ -33,6 +33,7 @@
 
 #include <autoware_internal_debug_msgs/msg/int32_stamped.hpp>
 #include <autoware_internal_debug_msgs/msg/string_stamped.hpp>
+#include <autoware_sensing_msgs/msg/concatenated_point_cloud_info.hpp>
 #include <diagnostic_msgs/msg/diagnostic_status.hpp>
 #include <geometry_msgs/msg/twist_stamped.hpp>
 #include <geometry_msgs/msg/twist_with_covariance_stamped.hpp>
@@ -123,6 +124,8 @@ private:
 
   // publishers
   std::shared_ptr<PublisherType> concatenated_cloud_publisher_;
+  rclcpp::Publisher<autoware_sensing_msgs::msg::ConcatenatedPointCloudInfo>::SharedPtr
+    concatenation_info_publisher_;
   std::unordered_map<std::string, std::shared_ptr<PublisherType>>
     topic_to_transformed_cloud_publisher_map_;
   std::unique_ptr<autoware_utils::DebugPublisher> debug_publisher_;

--- a/sensing/autoware_pointcloud_preprocessor/include/autoware/pointcloud_preprocessor/concatenate_data/concatenate_and_time_sync_node.ipp
+++ b/sensing/autoware_pointcloud_preprocessor/include/autoware/pointcloud_preprocessor/concatenate_data/concatenate_and_time_sync_node.ipp
@@ -311,7 +311,6 @@ void PointCloudConcatenateDataSynchronizerComponentTemplated<MsgTraits>::publish
   if (publish_pointcloud) {
     latest_concatenate_cloud_timestamp_ = current_concatenate_cloud_timestamp_;
     concatenated_cloud_publisher_->publish(std::move(concatenated_cloud_result.concatenate_cloud_ptr));
-
     // publish transformed raw pointclouds
     if (
       params_.publish_synchronized_pointcloud &&
@@ -331,7 +330,7 @@ void PointCloudConcatenateDataSynchronizerComponentTemplated<MsgTraits>::publish
       }
     }
   }
-
+  concatenation_info_publisher_->publish(std::move(concatenated_cloud_result.concatenation_info_ptr));
 
   const double processing_time = stop_watch_ptr_->toc("processing_time", true);
   std::unordered_map<std::string, double> topic_to_pipeline_latency_map;

--- a/sensing/autoware_pointcloud_preprocessor/include/autoware/pointcloud_preprocessor/concatenate_data/concatenate_pointclouds.hpp
+++ b/sensing/autoware_pointcloud_preprocessor/include/autoware/pointcloud_preprocessor/concatenate_data/concatenate_pointclouds.hpp
@@ -52,7 +52,7 @@
 #ifndef AUTOWARE__POINTCLOUD_PREPROCESSOR__CONCATENATE_DATA__CONCATENATE_POINTCLOUDS_HPP_
 #define AUTOWARE__POINTCLOUD_PREPROCESSOR__CONCATENATE_DATA__CONCATENATE_POINTCLOUDS_HPP_
 
-#include "concatenation_info.hpp"
+#include "concatenation_info_manager.hpp"
 
 #include <deque>
 #include <map>
@@ -144,7 +144,7 @@ private:
   std::vector<std::string> input_topics_;
 
   std::unique_ptr<managed_transform_buffer::ManagedTransformBuffer> managed_tf_buffer_{nullptr};
-  std::unique_ptr<ConcatenationInfo> concatenation_info_{nullptr};
+  std::unique_ptr<ConcatenationInfoManager> concatenation_info_manager_{nullptr};
 
   std::deque<geometry_msgs::msg::TwistStamped::ConstSharedPtr> twist_ptr_queue_;
 

--- a/sensing/autoware_pointcloud_preprocessor/include/autoware/pointcloud_preprocessor/concatenate_data/concatenate_pointclouds.hpp
+++ b/sensing/autoware_pointcloud_preprocessor/include/autoware/pointcloud_preprocessor/concatenate_data/concatenate_pointclouds.hpp
@@ -52,6 +52,8 @@
 #ifndef AUTOWARE__POINTCLOUD_PREPROCESSOR__CONCATENATE_DATA__CONCATENATE_POINTCLOUDS_HPP_
 #define AUTOWARE__POINTCLOUD_PREPROCESSOR__CONCATENATE_DATA__CONCATENATE_POINTCLOUDS_HPP_
 
+#include "concatenation_info.hpp"
+
 #include <deque>
 #include <map>
 #include <memory>
@@ -70,6 +72,7 @@
 
 #include <autoware_internal_debug_msgs/msg/int32_stamped.hpp>
 #include <autoware_internal_debug_msgs/msg/string_stamped.hpp>
+#include <autoware_sensing_msgs/msg/concatenated_point_cloud_info.hpp>
 #include <autoware_vehicle_msgs/msg/velocity_report.hpp>
 #include <diagnostic_msgs/msg/diagnostic_status.hpp>
 #include <geometry_msgs/msg/twist_stamped.hpp>
@@ -111,6 +114,9 @@ public:
 private:
   /** \brief The output PointCloud publisher. */
   rclcpp::Publisher<PointCloud2>::SharedPtr pub_output_;
+  /** \brief The output ConcatenatedPointCloudInfo publisher. */
+  rclcpp::Publisher<autoware_sensing_msgs::msg::ConcatenatedPointCloudInfo>::SharedPtr
+    pub_output_info_;
   /** \brief Delay Compensated PointCloud publisher*/
   std::map<std::string, rclcpp::Publisher<sensor_msgs::msg::PointCloud2>::SharedPtr>
     transformed_raw_pc_publisher_map_;
@@ -138,6 +144,7 @@ private:
   std::vector<std::string> input_topics_;
 
   std::unique_ptr<managed_transform_buffer::ManagedTransformBuffer> managed_tf_buffer_{nullptr};
+  std::unique_ptr<ConcatenationInfo> concatenation_info_{nullptr};
 
   std::deque<geometry_msgs::msg::TwistStamped::ConstSharedPtr> twist_ptr_queue_;
 
@@ -149,7 +156,9 @@ private:
   std::map<std::string, double> offset_map_;
 
   void checkSyncStatus();
-  void combineClouds(sensor_msgs::msg::PointCloud2::SharedPtr & concat_cloud_ptr);
+  void combineClouds(
+    sensor_msgs::msg::PointCloud2::SharedPtr & concat_cloud_ptr,
+    autoware_sensing_msgs::msg::ConcatenatedPointCloudInfo::SharedPtr & concatenation_info_ptr);
   void publish();
 
   void convertToXYZIRCCloud(

--- a/sensing/autoware_pointcloud_preprocessor/include/autoware/pointcloud_preprocessor/concatenate_data/concatenation_info.hpp
+++ b/sensing/autoware_pointcloud_preprocessor/include/autoware/pointcloud_preprocessor/concatenate_data/concatenation_info.hpp
@@ -1,0 +1,397 @@
+// Copyright 2025 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef AUTOWARE__POINTCLOUD_PREPROCESSOR__CONCATENATE_DATA__CONCATENATION_INFO_HPP_
+#define AUTOWARE__POINTCLOUD_PREPROCESSOR__CONCATENATE_DATA__CONCATENATION_INFO_HPP_
+
+#include <builtin_interfaces/msg/time.hpp>
+
+#include <autoware_sensing_msgs/msg/concatenated_point_cloud_info.hpp>
+#include <autoware_sensing_msgs/msg/source_point_cloud_info.hpp>
+#include <sensor_msgs/msg/point_cloud2.hpp>
+
+#include <cstdint>
+#include <cstring>
+#include <stdexcept>
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+namespace autoware::pointcloud_preprocessor
+{
+
+/**
+ * @brief Abstract base class for concatenation strategy configurations.
+ *
+ * This class provides a common interface for serializing strategy-specific
+ * configuration data that can be stored in concatenated point cloud info messages.
+ */
+struct StrategyConfig
+{
+  /**
+   * @brief Serialize the configuration to a byte vector.
+   * @return Serialized configuration data as a byte vector.
+   */
+  [[nodiscard]] virtual std::vector<uint8_t> serialize() const = 0;
+  virtual ~StrategyConfig() = default;
+};
+
+/**
+ * @brief Configuration for advanced concatenation strategy.
+ *
+ * This structure contains timing constraints for the advanced concatenation strategy,
+ * including minimum and maximum reference timestamps that define the time window
+ * for point cloud matching and concatenation.
+ */
+struct StrategyAdvancedConfig : public StrategyConfig
+{
+  /**
+   * @brief Construct configuration with timestamp constraints.
+   * @param reference_timestamp_min Minimum reference timestamp for concatenation window
+   * @param reference_timestamp_max Maximum reference timestamp for concatenation window
+   */
+  StrategyAdvancedConfig(
+    const builtin_interfaces::msg::Time & reference_timestamp_min,
+    const builtin_interfaces::msg::Time & reference_timestamp_max)
+  : reference_timestamp_min(reference_timestamp_min),
+    reference_timestamp_max(reference_timestamp_max)
+  {
+  }
+
+  /**
+   * @brief Construct configuration from serialized data.
+   * @param serialized_data Previously serialized configuration data
+   * @throws std::invalid_argument if serialized data size is invalid
+   */
+  explicit StrategyAdvancedConfig(const std::vector<uint8_t> & serialized_data)
+  {
+    if (
+      serialized_data.size() != sizeof(reference_timestamp_min) + sizeof(reference_timestamp_max)) {
+      throw std::invalid_argument("Invalid serialized data size for StrategyAdvancedConfig");
+    }
+
+    size_t offset = 0;
+
+    // Deserialize reference_timestamp_min
+    std::memcpy(
+      &reference_timestamp_min, serialized_data.data() + offset, sizeof(reference_timestamp_min));
+    offset += sizeof(reference_timestamp_min);
+
+    // Deserialize reference_timestamp_max
+    std::memcpy(
+      &reference_timestamp_max, serialized_data.data() + offset, sizeof(reference_timestamp_max));
+  }
+
+  /**
+   * @brief Serialize the configuration to a byte vector.
+   * @return Serialized configuration data containing timestamp constraints
+   */
+  [[nodiscard]] std::vector<uint8_t> serialize() const final
+  {
+    std::vector<uint8_t> serialized;
+    serialized.reserve(sizeof(reference_timestamp_min) + sizeof(reference_timestamp_max));
+
+    // Serialize reference_timestamp_min
+    const auto * reference_timestamp_min_ptr =
+      reinterpret_cast<const uint8_t *>(&reference_timestamp_min);
+    serialized.insert(
+      serialized.end(), reference_timestamp_min_ptr,
+      reference_timestamp_min_ptr + sizeof(reference_timestamp_min));
+
+    // Serialize reference_timestamp_max
+    const auto * reference_timestamp_max_ptr =
+      reinterpret_cast<const uint8_t *>(&reference_timestamp_max);
+    serialized.insert(
+      serialized.end(), reference_timestamp_max_ptr,
+      reference_timestamp_max_ptr + sizeof(reference_timestamp_max));
+
+    return serialized;
+  }
+
+  //! Minimum reference timestamp for concatenation time window
+  builtin_interfaces::msg::Time reference_timestamp_min;
+  //! Maximum reference timestamp for concatenation time window
+  builtin_interfaces::msg::Time reference_timestamp_max;
+};
+
+/**
+ * @brief Mapping from strategy name strings to strategy enumeration values.
+ *
+ * Supported strategies:
+ * - "naive": Basic concatenation without temporal constraints
+ * - "advanced": Time-window based concatenation with temporal constraints
+ */
+const std::unordered_map<std::string, uint8_t> matching_strategy_name_map = {
+  {"naive", autoware_sensing_msgs::msg::ConcatenatedPointCloudInfo::STRATEGY_NAIVE},
+  {"advanced", autoware_sensing_msgs::msg::ConcatenatedPointCloudInfo::STRATEGY_ADVANCED},
+};
+
+/**
+ * @brief Manages concatenation information for point cloud preprocessing.
+ *
+ * This class provides functionality for tracking and managing the concatenation
+ * of multiple point cloud sources. It maintains information about each source
+ * including their status, indexing within the concatenated result, and metadata.
+ *
+ * @note This class is designed for single-threaded use and should be reset
+ *       between concatenation cycles using reset_and_get_base_info().
+ */
+class ConcatenationInfo
+{
+public:
+  /**
+   * @brief Construct concatenation info manager.
+   *
+   * @param matching_strategy_name Name of the matching strategy ("naive" or "advanced")
+   * @param input_topics List of input topic names to track for concatenation
+   * @throws std::invalid_argument if matching_strategy_name is not recognized
+   */
+  ConcatenationInfo(
+    const std::string & matching_strategy_name, const std::vector<std::string> & input_topics)
+  : concatenated_point_cloud_info_base_msg_(
+      create_concatenation_info_base(matching_strategy_name, input_topics)),
+    num_expected_sources_(concatenated_point_cloud_info_base_msg_.source_info.size())
+  {
+  }
+  ~ConcatenationInfo() = default;
+
+  /**
+   * @brief Reset internal state and get base concatenation info message.
+   *
+   * This method should be called at the beginning of each concatenation cycle
+   * to reset the valid cloud count and get a fresh base message with all
+   * source topics initialized to default values.
+   *
+   * @return Fresh ConcatenatedPointCloudInfo message with source topics initialized
+   */
+  [[nodiscard]] autoware_sensing_msgs::msg::ConcatenatedPointCloudInfo reset_and_get_base_info()
+  {
+    valid_cloud_count_ = 0;
+    return concatenated_point_cloud_info_base_msg_;
+  }
+
+  /**
+   * @brief Update source information from a point cloud message.
+   *
+   * Updates the source information for a specific topic with data from a point cloud.
+   * This includes header information, status, and if the status is OK, calculates
+   * the proper indexing (idx_begin and length) for the concatenated result.
+   *
+   * @param source_cloud Source point cloud message containing data and header
+   * @param topic Topic name that this point cloud belongs to
+   * @param status Status of this source
+   * @param out_concatenated_point_cloud_info_msg Output message to update
+   * @throws std::runtime_error if topic is not found or already has data
+   */
+  void update_source_from_point_cloud(
+    const sensor_msgs::msg::PointCloud2 & source_cloud, const std::string & topic, uint8_t status,
+    autoware_sensing_msgs::msg::ConcatenatedPointCloudInfo & out_concatenated_point_cloud_info_msg)
+  {
+    auto [target_info, idx_begin] =
+      find_source_info_and_next_idx(topic, out_concatenated_point_cloud_info_msg);
+
+    target_info->header = source_cloud.header;
+    target_info->status = status;
+    if (status != autoware_sensing_msgs::msg::SourcePointCloudInfo::STATUS_OK) return;
+    target_info->idx_begin = idx_begin;
+    target_info->length = source_cloud.width * source_cloud.height;
+    valid_cloud_count_++;
+  }
+
+  /**
+   * @brief Update source information from a header only.
+   *
+   * Updates the source information for a specific topic with header data only.
+   * This is useful when you have timing/frame information but no actual point cloud data.
+   * Note that idx_begin and length are not updated with this method.
+   *
+   * @param header Header message containing timestamp and frame information
+   * @param topic Topic name that this header belongs to
+   * @param status Status of this source
+   * @param out_concatenated_point_cloud_info_msg Output message to update
+   * @throws std::runtime_error if topic is not found or already has data
+   */
+  void update_source_from_header(
+    const std_msgs::msg::Header & header, const std::string & topic, uint8_t status,
+    autoware_sensing_msgs::msg::ConcatenatedPointCloudInfo & out_concatenated_point_cloud_info_msg)
+  {
+    auto [target_info, idx_begin] =
+      find_source_info_and_next_idx(topic, out_concatenated_point_cloud_info_msg);
+    target_info->header = header;
+    target_info->status = status;
+    if (status != autoware_sensing_msgs::msg::SourcePointCloudInfo::STATUS_OK) return;
+    valid_cloud_count_++;
+  }
+
+  /**
+   * @brief Update source status only.
+   *
+   * Updates only the status field for a specific topic. This is useful for
+   * marking sources as failed, timed out, or other status conditions without
+   * modifying header or indexing information.
+   *
+   * @param topic Topic name to update status for
+   * @param status New status value
+   * @param out_concatenated_point_cloud_info_msg Output message to update
+   * @throws std::runtime_error if topic is not found or already has data
+   */
+  void update_source_from_status(
+    const std::string & topic, uint8_t status,
+    autoware_sensing_msgs::msg::ConcatenatedPointCloudInfo & out_concatenated_point_cloud_info_msg)
+  {
+    auto [target_info, idx_begin] =
+      find_source_info_and_next_idx(topic, out_concatenated_point_cloud_info_msg);
+    target_info->status = status;
+    if (status != autoware_sensing_msgs::msg::SourcePointCloudInfo::STATUS_OK) return;
+    valid_cloud_count_++;
+  }
+
+  /**
+   * @brief Set final concatenation result information.
+   *
+   * Updates the output message with the final concatenated point cloud header
+   * and determines whether the concatenation was successful based on whether
+   * all expected sources provided valid data.
+   *
+   * @param concatenated_cloud Final concatenated point cloud result
+   * @param out_concatenated_point_cloud_info_msg Output message to update with result
+   */
+  void set_result(
+    const sensor_msgs::msg::PointCloud2 & concatenated_cloud,
+    autoware_sensing_msgs::msg::ConcatenatedPointCloudInfo & out_concatenated_point_cloud_info_msg)
+    const
+  {
+    out_concatenated_point_cloud_info_msg.header = concatenated_cloud.header;
+    out_concatenated_point_cloud_info_msg.concatenation_success =
+      valid_cloud_count_ == num_expected_sources_;
+  }
+
+  /**
+   * @brief Set strategy-specific configuration data.
+   *
+   * Sets the serialized configuration data for the concatenation strategy.
+   * This is used to store parameters specific to the chosen concatenation strategy.
+   *
+   * @param matching_strategy_config Serialized configuration data
+   * @param out_concatenated_point_cloud_info_msg Output message to update
+   */
+  static void set_config(
+    const std::vector<uint8_t> & matching_strategy_config,
+    autoware_sensing_msgs::msg::ConcatenatedPointCloudInfo & out_concatenated_point_cloud_info_msg)
+  {
+    out_concatenated_point_cloud_info_msg.matching_strategy_config = matching_strategy_config;
+  }
+
+private:
+  /**
+   * @brief Helper struct for source cloud information lookup results.
+   *
+   * Contains a pointer to the target source info structure and the calculated
+   * starting index for concatenation.
+   */
+  struct SourceCloudInfo
+  {
+    //! Pointer to the source info structure to update
+    autoware_sensing_msgs::msg::SourcePointCloudInfo * target_info;
+    //! Starting index in the concatenated point cloud for this source
+    uint32_t idx_begin;
+  };
+
+  /**
+   * @brief Find source info structure and calculate next index for concatenation.
+   *
+   * Locates the source info structure for the given topic and calculates the
+   * appropriate starting index (idx_begin) for this source in the concatenated
+   * point cloud based on previously processed sources.
+   *
+   * @param topic Topic name to find source info for
+   * @param out_concatenated_point_cloud_info_msg Message containing source info structures
+   * @return SourceCloudInfo containing pointer to target info and calculated index
+   * @throws std::runtime_error if topic not found or already has data
+   */
+  [[nodiscard]] SourceCloudInfo find_source_info_and_next_idx(
+    const std::string & topic,
+    autoware_sensing_msgs::msg::ConcatenatedPointCloudInfo & out_concatenated_point_cloud_info_msg)
+    const
+  {
+    autoware_sensing_msgs::msg::SourcePointCloudInfo * target_info = nullptr;
+    uint32_t idx_begin = 0;
+
+    for (auto & info : out_concatenated_point_cloud_info_msg.source_info) {
+      if (info.topic == topic) {
+        target_info = &info;
+      }
+      uint32_t idx_begin_candidate = info.idx_begin + info.length;
+      if (idx_begin_candidate > idx_begin) {
+        idx_begin = idx_begin_candidate;
+      }
+    }
+
+    if (!target_info) {
+      throw std::runtime_error("Topic '" + topic + "' not found in ConcatenatedPointCloudInfo");
+    }
+
+    if (target_info->idx_begin != 0 || target_info->length != 0) {
+      throw std::runtime_error(
+        "ConcatenatedPointCloudInfo already has source info for topic '" + topic + "'");
+    }
+
+    return {target_info, idx_begin};
+  }
+
+  /**
+   * @brief Create base concatenation info message with initialized source topics.
+   *
+   * Creates and initializes the base concatenation info message with the specified
+   * strategy and input topics. All source info structures are initialized with
+   * default values and TIMEOUT status.
+   *
+   * @param matching_strategy_name Name of the matching strategy to use
+   * @param input_topics List of input topic names to initialize
+   * @return Initialized ConcatenatedPointCloudInfo message
+   * @throws std::invalid_argument if strategy name is not recognized
+   */
+  [[nodiscard]] autoware_sensing_msgs::msg::ConcatenatedPointCloudInfo
+  create_concatenation_info_base(
+    const std::string & matching_strategy_name, const std::vector<std::string> & input_topics) const
+  {
+    autoware_sensing_msgs::msg::ConcatenatedPointCloudInfo concatenated_point_cloud_info_base;
+    auto strategy_it = matching_strategy_name_map.find(matching_strategy_name);
+    if (strategy_it == matching_strategy_name_map.end()) {
+      throw std::invalid_argument("Unknown matching strategy: '" + matching_strategy_name + "'");
+    }
+    concatenated_point_cloud_info_base.matching_strategy = strategy_it->second;
+    concatenated_point_cloud_info_base.source_info.reserve(input_topics.size());
+    for (const auto & topic : input_topics) {
+      autoware_sensing_msgs::msg::SourcePointCloudInfo info;
+      info.topic = topic;
+      info.status = autoware_sensing_msgs::msg::SourcePointCloudInfo::STATUS_TIMEOUT;
+      concatenated_point_cloud_info_base.source_info.emplace_back(std::move(info));
+    }
+    return concatenated_point_cloud_info_base;
+  }
+
+  //! Base message template with strategy and topics initialized
+  const autoware_sensing_msgs::msg::ConcatenatedPointCloudInfo
+    concatenated_point_cloud_info_base_msg_;
+  //! Total number of expected source point clouds
+  const size_t num_expected_sources_{0};
+  //! Current count of successfully processed source clouds (status == OK)
+  std::size_t valid_cloud_count_{0};
+};
+
+}  // namespace autoware::pointcloud_preprocessor
+
+#endif  // AUTOWARE__POINTCLOUD_PREPROCESSOR__CONCATENATE_DATA__CONCATENATION_INFO_HPP_

--- a/sensing/autoware_pointcloud_preprocessor/launch/concatenate_and_time_sync_node.launch.xml
+++ b/sensing/autoware_pointcloud_preprocessor/launch/concatenate_and_time_sync_node.launch.xml
@@ -1,11 +1,13 @@
 <launch>
   <arg name="input/twist" default="/sensing/vehicle_velocity_converter/twist_with_covariance"/>
   <arg name="output" default="/sensing/lidar/concatenated/pointcloud"/>
+  <arg name="output_info" default="/sensing/lidar/concatenated/pointcloud_info"/>
   <!-- Parameter -->
   <arg name="param_file" default="$(find-pkg-share autoware_pointcloud_preprocessor)/config/concatenate_and_time_sync_node.param.yaml"/>
   <node pkg="autoware_pointcloud_preprocessor" exec="concatenate_and_time_sync_node" name="concatenate_and_time_sync_node" output="screen">
     <remap from="~/input/twist" to="$(var input/twist)"/>
     <remap from="output" to="$(var output)"/>
+    <remap from="output_info" to="$(var output_info)"/>
     <param from="$(var param_file)"/>
   </node>
 </launch>

--- a/sensing/autoware_pointcloud_preprocessor/launch/concatenate_pointcloud.launch.xml
+++ b/sensing/autoware_pointcloud_preprocessor/launch/concatenate_pointcloud.launch.xml
@@ -1,9 +1,11 @@
 <launch>
   <arg name="output" default="/sensing/lidar/concatenated/pointcloud"/>
+  <arg name="output_info" default="/sensing/lidar/concatenated/pointcloud_info"/>
   <!-- Parameter -->
   <arg name="param_file" default="$(find-pkg-share autoware_pointcloud_preprocessor)/config/concatenate_pointclouds.param.yaml"/>
   <node pkg="autoware_pointcloud_preprocessor" exec="concatenate_pointclouds_node" name="concatenate_pointclouds_node" output="screen">
     <remap from="output" to="$(var output)"/>
+    <remap from="output_info" to="$(var output_info)"/>
     <param from="$(var param_file)"/>
   </node>
 </launch>

--- a/sensing/autoware_pointcloud_preprocessor/launch/preprocessor.launch.py
+++ b/sensing/autoware_pointcloud_preprocessor/launch/preprocessor.launch.py
@@ -64,6 +64,7 @@ def launch_setup(context, *args, **kwargs):
             remappings=[
                 ("~/input/twist", "/sensing/vehicle_velocity_converter/twist_with_covariance"),
                 ("output", "points_raw/concatenated"),
+                ("output_info", "points_raw/concatenated_info"),
             ],
             parameters=[
                 concatenate_and_time_sync_node_param,
@@ -96,7 +97,10 @@ def launch_setup(context, *args, **kwargs):
             package=pkg,
             plugin="autoware::pointcloud_preprocessor::PointCloudConcatenationComponent",
             name="concatenate_filter",
-            remappings=[("output", "points_raw/concatenated")],
+            remappings=[
+                ("output", "points_raw/concatenated"),
+                ("output_info", "points_raw/concatenated_info"),
+            ],
             parameters=[
                 concatenate_pointclouds_node_param,
                 {

--- a/sensing/autoware_pointcloud_preprocessor/package.xml
+++ b/sensing/autoware_pointcloud_preprocessor/package.xml
@@ -31,6 +31,7 @@
   <depend>autoware_lanelet2_extension</depend>
   <depend>autoware_pcl_extensions</depend>
   <depend>autoware_point_types</depend>
+  <depend>autoware_sensing_msgs</depend>
   <depend>autoware_utils</depend>
   <depend>autoware_vehicle_msgs</depend>
   <depend>cgal</depend>

--- a/sensing/autoware_pointcloud_preprocessor/src/concatenate_data/combine_cloud_handler.cpp
+++ b/sensing/autoware_pointcloud_preprocessor/src/concatenate_data/combine_cloud_handler.cpp
@@ -14,6 +14,8 @@
 
 #include "autoware/pointcloud_preprocessor/concatenate_data/combine_cloud_handler.hpp"
 
+#include "autoware/pointcloud_preprocessor/concatenate_data/concatenation_info_manager.hpp"
+
 #include <pcl_ros/transforms.hpp>
 
 #include <sensor_msgs/point_cloud2_iterator.hpp>
@@ -112,10 +114,12 @@ void CombineCloudHandler<PointCloud2Traits>::correct_pointcloud_motion(
     adjust_to_old_data_transform, *transformed_cloud_ptr, *transformed_delay_compensated_cloud_ptr);
 }
 
+// TODO(vividf): refactor this function for readability
 ConcatenatedCloudResult<PointCloud2Traits>
 CombineCloudHandler<PointCloud2Traits>::combine_pointclouds(
   std::unordered_map<std::string, PointCloud2Traits::PointCloudMessage::ConstSharedPtr> &
-    topic_to_cloud_map)
+    topic_to_cloud_map,
+  const std::shared_ptr<CollectorInfoBase> & collector_info)
 {
   ConcatenatedCloudResult<PointCloud2Traits> concatenate_cloud_result;
 
@@ -139,7 +143,7 @@ CombineCloudHandler<PointCloud2Traits>::combine_pointclouds(
     std::make_unique<sensor_msgs::msg::PointCloud2>();
   concatenate_cloud_result.concatenation_info_ptr =
     std::make_unique<autoware_sensing_msgs::msg::ConcatenatedPointCloudInfo>(
-      concatenation_info_.reset_and_get_base_info());
+      concatenation_info_manager_.reset_and_get_base_info());
   {
     // Normally, pcl::concatenatePointCloud() copies the field layout (e.g., XYZIRC)
     // from the non-empty point cloud when given one empty and one non-empty input.
@@ -188,7 +192,7 @@ CombineCloudHandler<PointCloud2Traits>::combine_pointclouds(
       pcl::concatenatePointCloud(
         *concatenate_cloud_result.concatenate_cloud_ptr, *transformed_delay_compensated_cloud_ptr,
         *concatenate_cloud_result.concatenate_cloud_ptr);
-      concatenation_info_.update_source_from_point_cloud(
+      concatenation_info_manager_.update_source_from_point_cloud(
         *transformed_delay_compensated_cloud_ptr, topic,
         autoware_sensing_msgs::msg::SourcePointCloudInfo::STATUS_OK,
         *concatenate_cloud_result.concatenation_info_ptr);
@@ -224,7 +228,29 @@ CombineCloudHandler<PointCloud2Traits>::combine_pointclouds(
     }
   }
   concatenate_cloud_result.concatenate_cloud_ptr->header.stamp = oldest_stamp;
-  concatenation_info_.set_result(
+
+  if (const auto advanced_info = std::dynamic_pointer_cast<AdvancedCollectorInfo>(collector_info)) {
+    const auto reference_timestamp_min = advanced_info->timestamp - advanced_info->noise_window;
+    const auto reference_timestamp_max = advanced_info->timestamp + advanced_info->noise_window;
+
+    builtin_interfaces::msg::Time reference_timestamp_min_msg;
+    reference_timestamp_min_msg.sec = static_cast<int32_t>(reference_timestamp_min);
+    reference_timestamp_min_msg.nanosec =
+      static_cast<uint32_t>((reference_timestamp_min - reference_timestamp_min_msg.sec) * 1e9);
+
+    builtin_interfaces::msg::Time reference_timestamp_max_msg;
+    reference_timestamp_max_msg.sec = static_cast<int32_t>(reference_timestamp_max);
+    reference_timestamp_max_msg.nanosec =
+      static_cast<uint32_t>((reference_timestamp_max - reference_timestamp_max_msg.sec) * 1e9);
+
+    StrategyAdvancedConfig strategy_config(
+      reference_timestamp_min_msg, reference_timestamp_max_msg);
+    auto serialized_config = strategy_config.serialize();
+    ConcatenationInfoManager::set_config(
+      serialized_config, *concatenate_cloud_result.concatenation_info_ptr);
+  }
+
+  concatenation_info_manager_.set_result(
     *concatenate_cloud_result.concatenate_cloud_ptr,
     *concatenate_cloud_result.concatenation_info_ptr);
 

--- a/sensing/autoware_pointcloud_preprocessor/src/concatenate_data/combine_cloud_handler.cpp
+++ b/sensing/autoware_pointcloud_preprocessor/src/concatenate_data/combine_cloud_handler.cpp
@@ -137,6 +137,9 @@ CombineCloudHandler<PointCloud2Traits>::combine_pointclouds(
   // Before combining the pointclouds, initialize and reserve space for the concatenated pointcloud
   concatenate_cloud_result.concatenate_cloud_ptr =
     std::make_unique<sensor_msgs::msg::PointCloud2>();
+  concatenate_cloud_result.concatenation_info_ptr =
+    std::make_unique<autoware_sensing_msgs::msg::ConcatenatedPointCloudInfo>(
+      concatenation_info_.reset_and_get_base_info());
   {
     // Normally, pcl::concatenatePointCloud() copies the field layout (e.g., XYZIRC)
     // from the non-empty point cloud when given one empty and one non-empty input.
@@ -185,6 +188,10 @@ CombineCloudHandler<PointCloud2Traits>::combine_pointclouds(
       pcl::concatenatePointCloud(
         *concatenate_cloud_result.concatenate_cloud_ptr, *transformed_delay_compensated_cloud_ptr,
         *concatenate_cloud_result.concatenate_cloud_ptr);
+      concatenation_info_.update_source_from_point_cloud(
+        *transformed_delay_compensated_cloud_ptr, topic,
+        autoware_sensing_msgs::msg::SourcePointCloudInfo::STATUS_OK,
+        *concatenate_cloud_result.concatenation_info_ptr);
     }
 
     if (publish_synchronized_pointcloud_) {
@@ -217,6 +224,9 @@ CombineCloudHandler<PointCloud2Traits>::combine_pointclouds(
     }
   }
   concatenate_cloud_result.concatenate_cloud_ptr->header.stamp = oldest_stamp;
+  concatenation_info_.set_result(
+    *concatenate_cloud_result.concatenate_cloud_ptr,
+    *concatenate_cloud_result.concatenation_info_ptr);
 
   return concatenate_cloud_result;
 }

--- a/sensing/autoware_pointcloud_preprocessor/src/concatenate_data/concatenate_and_time_sync_node.cpp
+++ b/sensing/autoware_pointcloud_preprocessor/src/concatenate_data/concatenate_and_time_sync_node.cpp
@@ -40,6 +40,9 @@ void PointCloudConcatenateDataSynchronizerComponentTemplated<
   // Publishers
   concatenated_cloud_publisher_ = this->create_publisher<sensor_msgs::msg::PointCloud2>(
     "output", rclcpp::SensorDataQoS().keep_last(params_.maximum_queue_size));
+  concatenation_info_publisher_ =
+    this->create_publisher<autoware_sensing_msgs::msg::ConcatenatedPointCloudInfo>(
+      "output_info", rclcpp::SensorDataQoS().keep_last(params_.maximum_queue_size));
 
   // Transformed Raw PointCloud2 Publisher to publish the transformed pointcloud
   if (params_.publish_synchronized_pointcloud) {

--- a/sensing/autoware_pointcloud_preprocessor/src/concatenate_data/concatenate_pointclouds.cpp
+++ b/sensing/autoware_pointcloud_preprocessor/src/concatenate_data/concatenate_pointclouds.cpp
@@ -98,7 +98,8 @@ PointCloudConcatenationComponent::PointCloudConcatenationComponent(
 
   // Cloud info
   {
-    concatenation_info_ = std::make_unique<ConcatenationInfo>("naive", input_topics_);
+    concatenation_info_manager_ =
+      std::make_unique<ConcatenationInfoManager>("naive", input_topics_);
   }
 
   // Output Publishers
@@ -259,9 +260,9 @@ void PointCloudConcatenationComponent::combineClouds(
       if (concatenation_info_ptr == nullptr) {
         concatenation_info_ptr =
           std::make_shared<autoware_sensing_msgs::msg::ConcatenatedPointCloudInfo>(
-            concatenation_info_->reset_and_get_base_info());
+            concatenation_info_manager_->reset_and_get_base_info());
       }
-      concatenation_info_->update_source_from_point_cloud(
+      concatenation_info_manager_->update_source_from_point_cloud(
         *transformed_cloud_ptr, e.first,
         autoware_sensing_msgs::msg::SourcePointCloudInfo::STATUS_OK, *concatenation_info_ptr);
     } else {
@@ -269,7 +270,7 @@ void PointCloudConcatenationComponent::combineClouds(
     }
   }
   if (concatenation_info_ptr != nullptr && concat_cloud_ptr != nullptr) {
-    concatenation_info_->set_result(*concat_cloud_ptr, *concatenation_info_ptr);
+    concatenation_info_manager_->set_result(*concat_cloud_ptr, *concatenation_info_ptr);
   }
 }
 

--- a/sensing/autoware_pointcloud_preprocessor/test/test_concatenate_node_component.py
+++ b/sensing/autoware_pointcloud_preprocessor/test/test_concatenate_node_component.py
@@ -83,6 +83,7 @@ def generate_test_description():
             remappings=[
                 ("~/input/twist", "/test/sensing/vehicle_velocity_converter/twist_with_covariance"),
                 ("output", "/test/sensing/lidar/concatenated/pointcloud"),
+                ("output_info", "/test/sensing/lidar/concatenated/pointcloud_info"),
             ],
             parameters=[
                 {

--- a/sensing/autoware_pointcloud_preprocessor/test/test_concatenate_node_unit.cpp
+++ b/sensing/autoware_pointcloud_preprocessor/test/test_concatenate_node_unit.cpp
@@ -350,8 +350,9 @@ TEST_F(ConcatenateCloudTest, TestConcatenateClouds)
   topic_to_cloud_map["lidar_left"] = left_pointcloud_ptr;
   topic_to_cloud_map["lidar_right"] = right_pointcloud_ptr;
 
-  auto [concatenate_cloud_ptr, topic_to_transformed_cloud_map, topic_to_original_stamp_map] =
-    collector_->concatenate_pointclouds(topic_to_cloud_map);
+  auto
+    [concatenate_cloud_ptr, concatenation_info_ptr, topic_to_transformed_cloud_map,
+     topic_to_original_stamp_map] = collector_->concatenate_pointclouds(topic_to_cloud_map);
 
   // test output concatenate cloud
   // No input twist, so it will not do the motion compensation

--- a/sensing/autoware_pointcloud_preprocessor/test/test_concatenation_info.cpp
+++ b/sensing/autoware_pointcloud_preprocessor/test/test_concatenation_info.cpp
@@ -1,0 +1,513 @@
+// Copyright 2025 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <autoware/pointcloud_preprocessor/concatenate_data/concatenation_info.hpp>
+#include <builtin_interfaces/msg/time.hpp>
+
+#include <autoware_sensing_msgs/msg/concatenated_point_cloud_info.hpp>
+#include <autoware_sensing_msgs/msg/source_point_cloud_info.hpp>
+#include <sensor_msgs/msg/point_cloud2.hpp>
+#include <std_msgs/msg/header.hpp>
+
+#include <gtest/gtest.h>
+#include <pcl/point_cloud.h>
+#include <pcl/point_types.h>
+#include <pcl_conversions/pcl_conversions.h>
+
+#include <algorithm>
+#include <string>
+#include <vector>
+
+using autoware::pointcloud_preprocessor::ConcatenationInfo;
+using autoware::pointcloud_preprocessor::StrategyAdvancedConfig;
+
+class ConcatenationInfoTest : public ::testing::Test
+{
+protected:
+  void SetUp() override
+  {
+    // Setup test data
+    input_topics_ = {"/topic1", "/topic2", "/topic3"};
+    strategy_name_ = "advanced";
+
+    // Create test header
+    test_header_.frame_id = "base_link";
+    test_header_.stamp.sec = 1234567891;
+    test_header_.stamp.nanosec = 987654321;
+
+    // Create test point clouds
+    pcl::PointXYZ pt(1.0f, 2.0f, 3.0f);
+    pcl::PointCloud<pcl::PointXYZ> pcl_cloud_1;
+    pcl::PointCloud<pcl::PointXYZ> pcl_cloud_2;
+    pcl::PointCloud<pcl::PointXYZ> pcl_cloud_3;
+
+    // Cloud 1
+    pcl_cloud_1.width = 100;
+    pcl_cloud_1.height = 1;
+    pcl_cloud_1.is_dense = false;
+    pcl_cloud_1.points.resize(pcl_cloud_1.width * pcl_cloud_1.height);
+    std::fill(pcl_cloud_1.points.begin(), pcl_cloud_1.points.end(), pt);
+
+    // Cloud 2
+    pcl_cloud_2.width = 150;
+    pcl_cloud_2.height = 1;
+    pcl_cloud_2.is_dense = false;
+    pcl_cloud_2.points.resize(pcl_cloud_2.width * pcl_cloud_2.height);
+    std::fill(pcl_cloud_2.points.begin(), pcl_cloud_2.points.end(), pt);
+
+    // Cloud 3
+    pcl_cloud_3.width = 200;
+    pcl_cloud_3.height = 1;
+    pcl_cloud_3.is_dense = false;
+    pcl_cloud_3.points.resize(pcl_cloud_3.width * pcl_cloud_3.height);
+    std::fill(pcl_cloud_3.points.begin(), pcl_cloud_3.points.end(), pt);
+
+    // Convert to ROS messages
+    pcl::toROSMsg(pcl_cloud_1, test_cloud_1_);
+    pcl::toROSMsg(pcl_cloud_2, test_cloud_2_);
+    pcl::toROSMsg(pcl_cloud_3, test_cloud_3_);
+    test_cloud_1_.header = test_header_;
+    test_cloud_2_.header = test_header_;
+    test_cloud_3_.header = test_header_;
+  }
+
+  std::vector<std::string> input_topics_;
+  std::string strategy_name_;
+  sensor_msgs::msg::PointCloud2 test_cloud_1_;
+  sensor_msgs::msg::PointCloud2 test_cloud_2_;
+  sensor_msgs::msg::PointCloud2 test_cloud_3_;
+  std_msgs::msg::Header test_header_;
+};
+
+TEST_F(ConcatenationInfoTest, ConstructorAndGetConcatInfoBase)
+{
+  ConcatenationInfo concatenation_info(strategy_name_, input_topics_);
+
+  auto concatenated_point_cloud_info_msg = concatenation_info.reset_and_get_base_info();
+
+  // Check that source_info is populated with correct topics
+  ASSERT_EQ(concatenated_point_cloud_info_msg.source_info.size(), input_topics_.size());
+
+  for (size_t i = 0; i < input_topics_.size(); ++i) {
+    EXPECT_EQ(concatenated_point_cloud_info_msg.source_info.at(i).topic, input_topics_.at(i));
+    EXPECT_EQ(
+      concatenated_point_cloud_info_msg.source_info.at(i).status,
+      autoware_sensing_msgs::msg::SourcePointCloudInfo::STATUS_TIMEOUT);
+    EXPECT_EQ(concatenated_point_cloud_info_msg.source_info.at(i).idx_begin, 0u);
+    EXPECT_EQ(concatenated_point_cloud_info_msg.source_info.at(i).length, 0u);
+  }
+
+  // Check strategy is set correctly
+  EXPECT_EQ(
+    concatenated_point_cloud_info_msg.matching_strategy,
+    autoware_sensing_msgs::msg::ConcatenatedPointCloudInfo::STRATEGY_ADVANCED);
+}
+
+TEST_F(ConcatenationInfoTest, InvalidMatchingStrategy)
+{
+  EXPECT_THROW(
+    ConcatenationInfo concatenation_info("invalid_strategy", input_topics_), std::invalid_argument);
+}
+
+TEST_F(ConcatenationInfoTest, ApplySourceWithPointCloud)
+{
+  ConcatenationInfo concatenation_info(strategy_name_, input_topics_);
+  auto concatenated_point_cloud_info_msg = concatenation_info.reset_and_get_base_info();
+
+  // Apply point cloud to first topic
+  concatenation_info.update_source_from_point_cloud(
+    test_cloud_1_, input_topics_[0], autoware_sensing_msgs::msg::SourcePointCloudInfo::STATUS_OK,
+    concatenated_point_cloud_info_msg);
+
+  // Check that the first topic was updated correctly
+  auto & first_source = concatenated_point_cloud_info_msg.source_info[0];
+  EXPECT_EQ(first_source.topic, input_topics_[0]);
+  EXPECT_EQ(first_source.status, autoware_sensing_msgs::msg::SourcePointCloudInfo::STATUS_OK);
+  EXPECT_EQ(first_source.header.frame_id, test_cloud_1_.header.frame_id);
+  EXPECT_EQ(first_source.header.stamp.sec, test_cloud_1_.header.stamp.sec);
+  EXPECT_EQ(first_source.header.stamp.nanosec, test_cloud_1_.header.stamp.nanosec);
+  EXPECT_EQ(first_source.idx_begin, 0u);
+  EXPECT_EQ(first_source.length, test_cloud_1_.width * test_cloud_1_.height);
+
+  // Apply second point cloud
+  concatenation_info.update_source_from_point_cloud(
+    test_cloud_2_, input_topics_[1], autoware_sensing_msgs::msg::SourcePointCloudInfo::STATUS_OK,
+    concatenated_point_cloud_info_msg);
+
+  // Check that idx_begin is calculated correctly for second topic
+  auto & second_source = concatenated_point_cloud_info_msg.source_info[1];
+  EXPECT_EQ(second_source.idx_begin, test_cloud_1_.width * test_cloud_1_.height);
+  EXPECT_EQ(second_source.length, test_cloud_2_.width * test_cloud_2_.height);
+}
+
+TEST_F(ConcatenationInfoTest, ApplySourceWithPointCloudNonOkStatus)
+{
+  ConcatenationInfo concatenation_info(strategy_name_, input_topics_);
+  auto concatenated_point_cloud_info_msg = concatenation_info.reset_and_get_base_info();
+
+  // Apply point cloud with ERROR status
+  concatenation_info.update_source_from_point_cloud(
+    test_cloud_1_, input_topics_[0],
+    autoware_sensing_msgs::msg::SourcePointCloudInfo::STATUS_INVALID,
+    concatenated_point_cloud_info_msg);
+
+  // Check that header and status are updated, but idx_begin and length are not
+  auto & first_source = concatenated_point_cloud_info_msg.source_info[0];
+  EXPECT_EQ(first_source.status, autoware_sensing_msgs::msg::SourcePointCloudInfo::STATUS_INVALID);
+  EXPECT_EQ(first_source.header.frame_id, test_cloud_1_.header.frame_id);
+  EXPECT_EQ(first_source.idx_begin, 0u);  // Should remain 0
+  EXPECT_EQ(first_source.length, 0u);     // Should remain 0
+}
+
+TEST_F(ConcatenationInfoTest, ApplySourceWithHeader)
+{
+  ConcatenationInfo concatenation_info(strategy_name_, input_topics_);
+  auto concatenated_point_cloud_info_msg = concatenation_info.reset_and_get_base_info();
+
+  concatenation_info.update_source_from_header(
+    test_header_, input_topics_[0],
+    autoware_sensing_msgs::msg::SourcePointCloudInfo::STATUS_INVALID,
+    concatenated_point_cloud_info_msg);
+
+  auto & first_source = concatenated_point_cloud_info_msg.source_info[0];
+  EXPECT_EQ(first_source.status, autoware_sensing_msgs::msg::SourcePointCloudInfo::STATUS_INVALID);
+  EXPECT_EQ(first_source.header.frame_id, test_header_.frame_id);
+  EXPECT_EQ(first_source.header.stamp.sec, test_header_.stamp.sec);
+  EXPECT_EQ(first_source.header.stamp.nanosec, test_header_.stamp.nanosec);
+}
+
+TEST_F(ConcatenationInfoTest, ApplySourceWithStatus)
+{
+  ConcatenationInfo concatenation_info(strategy_name_, input_topics_);
+  auto concatenated_point_cloud_info_msg = concatenation_info.reset_and_get_base_info();
+
+  concatenation_info.update_source_from_status(
+    input_topics_[0], autoware_sensing_msgs::msg::SourcePointCloudInfo::STATUS_TIMEOUT,
+    concatenated_point_cloud_info_msg);
+
+  auto & first_source = concatenated_point_cloud_info_msg.source_info[0];
+  EXPECT_EQ(first_source.status, autoware_sensing_msgs::msg::SourcePointCloudInfo::STATUS_TIMEOUT);
+  EXPECT_EQ(first_source.topic, input_topics_[0]);
+}
+
+TEST_F(ConcatenationInfoTest, UpdateConcatenatedPointCloudConfig)
+{
+  ConcatenationInfo concatenation_info(strategy_name_, input_topics_);
+  auto concatenated_point_cloud_info_msg = concatenation_info.reset_and_get_base_info();
+
+  // Create AdvancedStrategy config with test timestamps
+  builtin_interfaces::msg::Time reference_timestamp_min;
+  reference_timestamp_min.sec = 1234567890;
+  reference_timestamp_min.nanosec = 100000000;
+
+  builtin_interfaces::msg::Time reference_timestamp_max;
+  reference_timestamp_max.sec = 1234567890;
+  reference_timestamp_max.nanosec = 900000000;
+
+  auto cfg = StrategyAdvancedConfig(reference_timestamp_min, reference_timestamp_max);
+  ConcatenationInfo::set_config(cfg.serialize(), concatenated_point_cloud_info_msg);
+
+  // Verify that the config was serialized and stored
+  EXPECT_FALSE(concatenated_point_cloud_info_msg.matching_strategy_config.empty());
+
+  // Verify we can deserialize it back
+  auto deserialized_cfg =
+    StrategyAdvancedConfig(concatenated_point_cloud_info_msg.matching_strategy_config);
+  EXPECT_EQ(deserialized_cfg.reference_timestamp_min.sec, reference_timestamp_min.sec);
+  EXPECT_EQ(deserialized_cfg.reference_timestamp_min.nanosec, reference_timestamp_min.nanosec);
+  EXPECT_EQ(deserialized_cfg.reference_timestamp_max.sec, reference_timestamp_max.sec);
+  EXPECT_EQ(deserialized_cfg.reference_timestamp_max.nanosec, reference_timestamp_max.nanosec);
+}
+
+TEST_F(ConcatenationInfoTest, StrategyAdvancedConfigInvalidSerializedData)
+{
+  // Test with invalid serialized data size
+  std::vector<uint8_t> invalid_data = {0x01, 0x02, 0x03};  // Too small
+
+  EXPECT_THROW(StrategyAdvancedConfig cfg(invalid_data), std::invalid_argument);
+}
+
+TEST_F(ConcatenationInfoTest, ApplySourceWithNonExistentTopic)
+{
+  ConcatenationInfo concatenation_info(strategy_name_, input_topics_);
+  auto concatenated_point_cloud_info_msg = concatenation_info.reset_and_get_base_info();
+
+  EXPECT_THROW(
+    concatenation_info.update_source_from_point_cloud(
+      test_cloud_1_, "/non_existent_topic",
+      autoware_sensing_msgs::msg::SourcePointCloudInfo::STATUS_OK,
+      concatenated_point_cloud_info_msg),
+    std::runtime_error);
+}
+
+TEST_F(ConcatenationInfoTest, NaiveStrategy)
+{
+  ConcatenationInfo concatenation_info("naive", input_topics_);
+  auto concatenated_point_cloud_info_msg = concatenation_info.reset_and_get_base_info();
+
+  EXPECT_EQ(
+    concatenated_point_cloud_info_msg.matching_strategy,
+    autoware_sensing_msgs::msg::ConcatenatedPointCloudInfo::STRATEGY_NAIVE);
+}
+
+TEST_F(ConcatenationInfoTest, MultiplePointCloudIndexing)
+{
+  ConcatenationInfo concatenation_info(strategy_name_, input_topics_);
+  auto concatenated_point_cloud_info_msg = concatenation_info.reset_and_get_base_info();
+
+  // Apply cloud 1
+  concatenation_info.update_source_from_point_cloud(
+    test_cloud_1_, input_topics_[0], autoware_sensing_msgs::msg::SourcePointCloudInfo::STATUS_OK,
+    concatenated_point_cloud_info_msg);
+
+  // Apply cloud 3 (out of order)
+  concatenation_info.update_source_from_point_cloud(
+    test_cloud_3_, input_topics_[2], autoware_sensing_msgs::msg::SourcePointCloudInfo::STATUS_OK,
+    concatenated_point_cloud_info_msg);
+
+  // Apply cloud 2
+  concatenation_info.update_source_from_point_cloud(
+    test_cloud_2_, input_topics_[1], autoware_sensing_msgs::msg::SourcePointCloudInfo::STATUS_OK,
+    concatenated_point_cloud_info_msg);
+
+  // Cloud 1
+  EXPECT_EQ(concatenated_point_cloud_info_msg.source_info[0].idx_begin, 0u);
+  EXPECT_EQ(
+    concatenated_point_cloud_info_msg.source_info[0].length,
+    test_cloud_1_.width * test_cloud_1_.height);
+
+  // Cloud 3 was supposed to be concatenated second, so its idx_begin should be after cloud 1
+  EXPECT_EQ(
+    concatenated_point_cloud_info_msg.source_info[2].idx_begin,
+    test_cloud_1_.width * test_cloud_1_.height);
+  EXPECT_EQ(
+    concatenated_point_cloud_info_msg.source_info[2].length,
+    test_cloud_3_.width * test_cloud_3_.height);
+
+  // Cloud 2 should have idx_begin after cloud 1
+  EXPECT_EQ(
+    concatenated_point_cloud_info_msg.source_info[1].idx_begin,
+    test_cloud_1_.width * test_cloud_1_.height + test_cloud_3_.width * test_cloud_3_.height);
+  EXPECT_EQ(
+    concatenated_point_cloud_info_msg.source_info[1].length,
+    test_cloud_2_.width * test_cloud_2_.height);
+}
+
+TEST_F(ConcatenationInfoTest, EmptyInputTopics)
+{
+  std::vector<std::string> empty_topics;
+  ConcatenationInfo concatenation_info(strategy_name_, empty_topics);
+  auto concatenated_point_cloud_info_msg = concatenation_info.reset_and_get_base_info();
+
+  EXPECT_EQ(concatenated_point_cloud_info_msg.source_info.size(), 0u);
+}
+
+TEST_F(ConcatenationInfoTest, UpdateConcatenatedPointCloudResultCheckSuccess)
+{
+  ConcatenationInfo concatenation_info(strategy_name_, input_topics_);
+  auto concatenated_point_cloud_info_msg = concatenation_info.reset_and_get_base_info();
+
+  // Create concatenated cloud for the result
+  sensor_msgs::msg::PointCloud2 concatenated_cloud;
+  concatenated_cloud.header.frame_id = "concatenated_frame";
+  concatenated_cloud.header.stamp.sec = 1234567892;
+  concatenated_cloud.header.stamp.nanosec = 555666777;
+
+  // Add only 2 out of 3 clouds with STATUS_OK
+  concatenation_info.update_source_from_point_cloud(
+    test_cloud_1_, input_topics_[0], autoware_sensing_msgs::msg::SourcePointCloudInfo::STATUS_OK,
+    concatenated_point_cloud_info_msg);
+
+  concatenation_info.update_source_from_point_cloud(
+    test_cloud_2_, input_topics_[1], autoware_sensing_msgs::msg::SourcePointCloudInfo::STATUS_OK,
+    concatenated_point_cloud_info_msg);
+
+  // Update result - should not be successful since we only have 2/3 clouds
+  concatenation_info.set_result(concatenated_cloud, concatenated_point_cloud_info_msg);
+
+  // Check header is updated
+  EXPECT_EQ(concatenated_point_cloud_info_msg.header.frame_id, concatenated_cloud.header.frame_id);
+  EXPECT_EQ(
+    concatenated_point_cloud_info_msg.header.stamp.sec, concatenated_cloud.header.stamp.sec);
+  EXPECT_EQ(
+    concatenated_point_cloud_info_msg.header.stamp.nanosec,
+    concatenated_cloud.header.stamp.nanosec);
+
+  // Check concatenation is not successful (2/3 clouds)
+  EXPECT_FALSE(concatenated_point_cloud_info_msg.concatenation_success);
+
+  // Now add the third cloud
+  concatenation_info.update_source_from_point_cloud(
+    test_cloud_3_, input_topics_[2], autoware_sensing_msgs::msg::SourcePointCloudInfo::STATUS_OK,
+    concatenated_point_cloud_info_msg);
+
+  // Update result again - should be successful since we now have all 3/3 clouds
+  concatenation_info.set_result(concatenated_cloud, concatenated_point_cloud_info_msg);
+
+  // Check concatenation is now successful (3/3 clouds)
+  EXPECT_TRUE(concatenated_point_cloud_info_msg.concatenation_success);
+}
+
+TEST_F(ConcatenationInfoTest, UpdateConcatenatedPointCloudResultWithMixedStatus)
+{
+  ConcatenationInfo concatenation_info(strategy_name_, input_topics_);
+  auto concatenated_point_cloud_info_msg = concatenation_info.reset_and_get_base_info();
+
+  // Add one cloud with STATUS_OK
+  concatenation_info.update_source_from_point_cloud(
+    test_cloud_1_, input_topics_[0], autoware_sensing_msgs::msg::SourcePointCloudInfo::STATUS_OK,
+    concatenated_point_cloud_info_msg);
+
+  // Add one cloud with STATUS_INVALID (should not count towards valid_cloud_count_)
+  concatenation_info.update_source_from_point_cloud(
+    test_cloud_2_, input_topics_[1],
+    autoware_sensing_msgs::msg::SourcePointCloudInfo::STATUS_INVALID,
+    concatenated_point_cloud_info_msg);
+
+  // Add one cloud with STATUS_TIMEOUT (should not count towards valid_cloud_count_)
+  concatenation_info.update_source_from_status(
+    input_topics_[2], autoware_sensing_msgs::msg::SourcePointCloudInfo::STATUS_TIMEOUT,
+    concatenated_point_cloud_info_msg);
+
+  // Create concatenated cloud for the result
+  sensor_msgs::msg::PointCloud2 concatenated_cloud;
+  concatenated_cloud.header.frame_id = "concatenated_frame";
+  concatenated_cloud.header.stamp.sec = 1234567892;
+  concatenated_cloud.header.stamp.nanosec = 555666777;
+
+  // Update result - should not be successful since we only have 1/3 valid clouds
+  concatenation_info.set_result(concatenated_cloud, concatenated_point_cloud_info_msg);
+
+  // Check concatenation is not successful (1/3 valid clouds)
+  EXPECT_FALSE(concatenated_point_cloud_info_msg.concatenation_success);
+}
+
+TEST_F(ConcatenationInfoTest, ApplySourceTwiceThrows)
+{
+  ConcatenationInfo concatenation_info(strategy_name_, input_topics_);
+  auto concatenated_point_cloud_info_msg = concatenation_info.reset_and_get_base_info();
+
+  // Apply first cloud successfully
+  concatenation_info.update_source_from_point_cloud(
+    test_cloud_1_, input_topics_[0], autoware_sensing_msgs::msg::SourcePointCloudInfo::STATUS_OK,
+    concatenated_point_cloud_info_msg);
+
+  // Try to apply second cloud to same topic - should throw
+  EXPECT_THROW(
+    concatenation_info.update_source_from_point_cloud(
+      test_cloud_1_, input_topics_[0], autoware_sensing_msgs::msg::SourcePointCloudInfo::STATUS_OK,
+      concatenated_point_cloud_info_msg),
+    std::runtime_error);
+}
+
+TEST_F(ConcatenationInfoTest, TwoIterationsOfSettingCloudInfo)
+{
+  ConcatenationInfo concatenation_info(strategy_name_, input_topics_);
+
+  // First iteration - apply only partial clouds (invalid result)
+  auto concatenated_point_cloud_info_msg_1 = concatenation_info.reset_and_get_base_info();
+
+  concatenation_info.update_source_from_point_cloud(
+    test_cloud_1_, input_topics_[0], autoware_sensing_msgs::msg::SourcePointCloudInfo::STATUS_OK,
+    concatenated_point_cloud_info_msg_1);
+
+  concatenation_info.update_source_from_point_cloud(
+    test_cloud_2_, input_topics_[1],
+    autoware_sensing_msgs::msg::SourcePointCloudInfo::STATUS_INVALID,
+    concatenated_point_cloud_info_msg_1);
+
+  concatenation_info.update_source_from_status(
+    input_topics_[2], autoware_sensing_msgs::msg::SourcePointCloudInfo::STATUS_TIMEOUT,
+    concatenated_point_cloud_info_msg_1);
+
+  // Create concatenated cloud for first iteration
+  sensor_msgs::msg::PointCloud2 concatenated_cloud_1;
+  concatenated_cloud_1.header.frame_id = "concatenated_frame_1";
+  concatenated_cloud_1.header.stamp.sec = 1234567892;
+  concatenated_cloud_1.header.stamp.nanosec = 111222333;
+
+  concatenation_info.set_result(concatenated_cloud_1, concatenated_point_cloud_info_msg_1);
+
+  // Check first iteration results - should be invalid (only 1/3 valid clouds)
+  EXPECT_EQ(
+    concatenated_point_cloud_info_msg_1.header.frame_id, concatenated_cloud_1.header.frame_id);
+  EXPECT_EQ(
+    concatenated_point_cloud_info_msg_1.header.stamp.sec, concatenated_cloud_1.header.stamp.sec);
+  EXPECT_EQ(
+    concatenated_point_cloud_info_msg_1.header.stamp.nanosec,
+    concatenated_cloud_1.header.stamp.nanosec);
+  EXPECT_FALSE(concatenated_point_cloud_info_msg_1.concatenation_success);
+
+  // Verify indexing for first iteration
+  EXPECT_EQ(concatenated_point_cloud_info_msg_1.source_info[0].idx_begin, 0u);
+  EXPECT_EQ(
+    concatenated_point_cloud_info_msg_1.source_info[0].length,
+    test_cloud_1_.width * test_cloud_1_.height);
+  EXPECT_EQ(
+    concatenated_point_cloud_info_msg_1.source_info[1].idx_begin,
+    0u);  // Should remain 0 due to INVALID status
+  EXPECT_EQ(
+    concatenated_point_cloud_info_msg_1.source_info[1].length,
+    0u);  // Should remain 0 due to INVALID status
+
+  // Second iteration - fresh start with new concatenated_point_cloud_info_msg (valid result)
+  auto concatenated_point_cloud_info_msg_2 = concatenation_info.reset_and_get_base_info();
+
+  concatenation_info.update_source_from_point_cloud(
+    test_cloud_1_, input_topics_[0], autoware_sensing_msgs::msg::SourcePointCloudInfo::STATUS_OK,
+    concatenated_point_cloud_info_msg_2);
+
+  concatenation_info.update_source_from_point_cloud(
+    test_cloud_2_, input_topics_[1], autoware_sensing_msgs::msg::SourcePointCloudInfo::STATUS_OK,
+    concatenated_point_cloud_info_msg_2);
+
+  concatenation_info.update_source_from_point_cloud(
+    test_cloud_3_, input_topics_[2], autoware_sensing_msgs::msg::SourcePointCloudInfo::STATUS_OK,
+    concatenated_point_cloud_info_msg_2);
+
+  // Create concatenated cloud for second iteration
+  sensor_msgs::msg::PointCloud2 concatenated_cloud_2;
+  concatenated_cloud_2.header.frame_id = "concatenated_frame_2";
+  concatenated_cloud_2.header.stamp.sec = 1234567893;
+  concatenated_cloud_2.header.stamp.nanosec = 444555666;
+
+  concatenation_info.set_result(concatenated_cloud_2, concatenated_point_cloud_info_msg_2);
+
+  // Check second iteration results - should be valid (all 3/3 clouds)
+  EXPECT_EQ(
+    concatenated_point_cloud_info_msg_2.header.frame_id, concatenated_cloud_2.header.frame_id);
+  EXPECT_EQ(
+    concatenated_point_cloud_info_msg_2.header.stamp.sec, concatenated_cloud_2.header.stamp.sec);
+  EXPECT_EQ(
+    concatenated_point_cloud_info_msg_2.header.stamp.nanosec,
+    concatenated_cloud_2.header.stamp.nanosec);
+  EXPECT_TRUE(concatenated_point_cloud_info_msg_2.concatenation_success);
+
+  // Verify that the first iteration results are unchanged
+  EXPECT_EQ(
+    concatenated_point_cloud_info_msg_1.header.frame_id, concatenated_cloud_1.header.frame_id);
+  EXPECT_FALSE(concatenated_point_cloud_info_msg_1.concatenation_success);
+
+  // Verify indexing for second iteration
+  EXPECT_EQ(concatenated_point_cloud_info_msg_2.source_info[0].idx_begin, 0u);
+  EXPECT_EQ(
+    concatenated_point_cloud_info_msg_2.source_info[0].length,
+    test_cloud_1_.width * test_cloud_1_.height);
+  EXPECT_EQ(
+    concatenated_point_cloud_info_msg_2.source_info[1].idx_begin,
+    test_cloud_1_.width * test_cloud_1_.height);
+  EXPECT_EQ(
+    concatenated_point_cloud_info_msg_2.source_info[1].length,
+    test_cloud_2_.width * test_cloud_2_.height);
+}


### PR DESCRIPTION
This PR fixes the high CPU usage in the fusion node by replacing the subscription to /diagnostic with /concatenation_info.
Verified with x2gen2 rosbag.


* https://github.com/tier4/aip_launcher/pull/541
* https://github.com/tier4/autoware_launch.x2/pull/1477