### PR TITLE
feat(obstacle_stop, motion_velocity_planner_common, motion_utils): pointcloud stop, update lat margin

### DIFF
--- a/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_slow_down_module/src/parameters.hpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_obstacle_slow_down_module/src/parameters.hpp
@@ -57,7 +57,6 @@ struct CommonParam
 
 struct ObstacleFilteringParam
 {
-  PointcloudObstacleFilteringParam pointcloud_obstacle_filtering_param;
   std::vector<uint8_t> object_types{};
 
   bool use_pointcloud{false};


### PR DESCRIPTION
無印へのバックポートの実験ブランチへの取り込み
https://star4.slack.com/archives/C07K1PPNPTR/p1756103982678259