### PR TITLE
fix: cherry pick/pr11104

### DIFF
--- a/launch/tier4_perception_launch/launch/object_recognition/detection/detector/camera_2d_detector.launch.xml
+++ b/launch/tier4_perception_launch/launch/object_recognition/detection/detector/camera_2d_detector.launch.xml
@@ -1,0 +1,199 @@
+<?xml version="1.0"?>
+<launch>
+  <arg name="image_raw0" default="/sensing/camera/camera0/image_raw"/>
+  <arg name="image_raw1" default="/sensing/camera/camera1/image_raw"/>
+  <arg name="image_raw2" default="/sensing/camera/camera2/image_raw"/>
+  <arg name="image_raw3" default="/sensing/camera/camera3/image_raw"/>
+  <arg name="image_raw4" default="/sensing/camera/camera4/image_raw"/>
+  <arg name="image_raw5" default="/sensing/camera/camera5/image_raw"/>
+  <arg name="image_raw6" default="/sensing/camera/camera6/image_raw"/>
+  <arg name="image_raw7" default="/sensing/camera/camera7/image_raw"/>
+  <arg name="image_raw8" default="/sensing/camera/camera8/image_raw"/>
+  <arg name="image_raw9" default="/sensing/camera/camera9/image_raw"/>
+  <arg name="image_number" default="1"/>
+  <arg name="camera_index" default="0"/>
+  <arg name="use_bytetrack" default="true" description="use bytetrack for tracking, if false, only detection is performed"/>
+  <arg name="enable_visualizer" default="false"/>
+  <arg name="tensorrt_yolox_ns" default=""/>
+  <let name="tensorrt_yolox_ns" value="yolox/" if="$(var use_bytetrack)"/>
+
+  <group if="$(eval &quot;$(var image_number)>=1&quot;)">
+    <let name="camera_index" value="0"/>
+    <include file="$(find-pkg-share autoware_tensorrt_yolox)/launch/yolox.launch.xml">
+      <arg name="yolox_node_name" value="tensorrt_yolox$(var camera_index)"/>
+      <arg name="image_transport_decompressor_node_name" value="image_transport_decompressor_node$(var camera_index)"/>
+      <arg name="input/image" value="$(var image_raw0)"/>
+      <arg name="output/objects" value="$(var tensorrt_yolox_ns)rois$(var camera_index)"/>
+    </include>
+
+    <include file="$(find-pkg-share autoware_bytetrack)/launch/bytetrack.launch.xml">
+      <arg name="in_image" value="$(var image_raw0)"/>
+      <arg name="detection_rect" value="$(var tensorrt_yolox_ns)rois$(var camera_index)"/>
+      <arg name="tracked_rect" value="rois$(var camera_index)"/>
+      <arg name="enable_visualizer" value="$(var enable_visualizer)"/>
+      <arg name="camera_index" value="$(var camera_index)"/>
+    </include>
+  </group>
+
+  <group if="$(eval &quot;$(var image_number)>=2&quot;)">
+    <let name="camera_index" value="1"/>
+    <include file="$(find-pkg-share autoware_tensorrt_yolox)/launch/yolox.launch.xml">
+      <arg name="yolox_node_name" value="tensorrt_yolox$(var camera_index)"/>
+      <arg name="image_transport_decompressor_node_name" value="image_transport_decompressor_node$(var camera_index)"/>
+      <arg name="input/image" value="$(var image_raw0)"/>
+      <arg name="output/objects" value="$(var tensorrt_yolox_ns)rois$(var camera_index)"/>
+    </include>
+
+    <include file="$(find-pkg-share autoware_bytetrack)/launch/bytetrack.launch.xml">
+      <arg name="in_image" value="$(var image_raw0)"/>
+      <arg name="detection_rect" value="$(var tensorrt_yolox_ns)rois$(var camera_index)"/>
+      <arg name="tracked_rect" value="rois$(var camera_index)"/>
+      <arg name="enable_visualizer" value="$(var enable_visualizer)"/>
+      <arg name="camera_index" value="$(var camera_index)"/>
+    </include>
+  </group>
+
+  <group if="$(eval &quot;$(var image_number)>=3&quot;)">
+    <let name="camera_index" value="2"/>
+    <include file="$(find-pkg-share autoware_tensorrt_yolox)/launch/yolox.launch.xml">
+      <arg name="yolox_node_name" value="tensorrt_yolox$(var camera_index)"/>
+      <arg name="image_transport_decompressor_node_name" value="image_transport_decompressor_node$(var camera_index)"/>
+      <arg name="input/image" value="$(var image_raw0)"/>
+      <arg name="output/objects" value="$(var tensorrt_yolox_ns)rois$(var camera_index)"/>
+    </include>
+
+    <include file="$(find-pkg-share autoware_bytetrack)/launch/bytetrack.launch.xml">
+      <arg name="in_image" value="$(var image_raw0)"/>
+      <arg name="detection_rect" value="$(var tensorrt_yolox_ns)rois$(var camera_index)"/>
+      <arg name="tracked_rect" value="rois$(var camera_index)"/>
+      <arg name="enable_visualizer" value="$(var enable_visualizer)"/>
+      <arg name="camera_index" value="$(var camera_index)"/>
+    </include>
+  </group>
+
+  <group if="$(eval &quot;$(var image_number)>=4&quot;)">
+    <let name="camera_index" value="3"/>
+    <include file="$(find-pkg-share autoware_tensorrt_yolox)/launch/yolox.launch.xml">
+      <arg name="yolox_node_name" value="tensorrt_yolox$(var camera_index)"/>
+      <arg name="image_transport_decompressor_node_name" value="image_transport_decompressor_node$(var camera_index)"/>
+      <arg name="input/image" value="$(var image_raw0)"/>
+      <arg name="output/objects" value="$(var tensorrt_yolox_ns)rois$(var camera_index)"/>
+    </include>
+
+    <include file="$(find-pkg-share autoware_bytetrack)/launch/bytetrack.launch.xml">
+      <arg name="in_image" value="$(var image_raw0)"/>
+      <arg name="detection_rect" value="$(var tensorrt_yolox_ns)rois$(var camera_index)"/>
+      <arg name="tracked_rect" value="rois$(var camera_index)"/>
+      <arg name="enable_visualizer" value="$(var enable_visualizer)"/>
+      <arg name="camera_index" value="$(var camera_index)"/>
+    </include>
+  </group>
+
+  <group if="$(eval &quot;$(var image_number)>=5&quot;)">
+    <let name="camera_index" value="4"/>
+    <include file="$(find-pkg-share autoware_tensorrt_yolox)/launch/yolox.launch.xml">
+      <arg name="yolox_node_name" value="tensorrt_yolox$(var camera_index)"/>
+      <arg name="image_transport_decompressor_node_name" value="image_transport_decompressor_node$(var camera_index)"/>
+      <arg name="input/image" value="$(var image_raw0)"/>
+      <arg name="output/objects" value="$(var tensorrt_yolox_ns)rois$(var camera_index)"/>
+    </include>
+
+    <include file="$(find-pkg-share autoware_bytetrack)/launch/bytetrack.launch.xml">
+      <arg name="in_image" value="$(var image_raw0)"/>
+      <arg name="detection_rect" value="$(var tensorrt_yolox_ns)rois$(var camera_index)"/>
+      <arg name="tracked_rect" value="rois$(var camera_index)"/>
+      <arg name="enable_visualizer" value="$(var enable_visualizer)"/>
+      <arg name="camera_index" value="$(var camera_index)"/>
+    </include>
+  </group>
+
+  <group if="$(eval &quot;$(var image_number)>=6&quot;)">
+    <let name="camera_index" value="5"/>
+    <include file="$(find-pkg-share autoware_tensorrt_yolox)/launch/yolox.launch.xml">
+      <arg name="yolox_node_name" value="tensorrt_yolox$(var camera_index)"/>
+      <arg name="image_transport_decompressor_node_name" value="image_transport_decompressor_node$(var camera_index)"/>
+      <arg name="input/image" value="$(var image_raw0)"/>
+      <arg name="output/objects" value="$(var tensorrt_yolox_ns)rois$(var camera_index)"/>
+    </include>
+
+    <include file="$(find-pkg-share autoware_bytetrack)/launch/bytetrack.launch.xml">
+      <arg name="in_image" value="$(var image_raw0)"/>
+      <arg name="detection_rect" value="$(var tensorrt_yolox_ns)rois$(var camera_index)"/>
+      <arg name="tracked_rect" value="rois$(var camera_index)"/>
+      <arg name="enable_visualizer" value="$(var enable_visualizer)"/>
+      <arg name="camera_index" value="$(var camera_index)"/>
+    </include>
+  </group>
+
+  <group if="$(eval &quot;$(var image_number)>=7&quot;)">
+    <let name="camera_index" value="6"/>
+    <include file="$(find-pkg-share autoware_tensorrt_yolox)/launch/yolox.launch.xml">
+      <arg name="yolox_node_name" value="tensorrt_yolox$(var camera_index)"/>
+      <arg name="image_transport_decompressor_node_name" value="image_transport_decompressor_node$(var camera_index)"/>
+      <arg name="input/image" value="$(var image_raw0)"/>
+      <arg name="output/objects" value="$(var tensorrt_yolox_ns)rois$(var camera_index)"/>
+    </include>
+
+    <include file="$(find-pkg-share autoware_bytetrack)/launch/bytetrack.launch.xml">
+      <arg name="in_image" value="$(var image_raw0)"/>
+      <arg name="detection_rect" value="$(var tensorrt_yolox_ns)rois$(var camera_index)"/>
+      <arg name="tracked_rect" value="rois$(var camera_index)"/>
+      <arg name="enable_visualizer" value="$(var enable_visualizer)"/>
+      <arg name="camera_index" value="$(var camera_index)"/>
+    </include>
+  </group>
+
+  <group if="$(eval &quot;$(var image_number)>=8&quot;)">
+    <let name="camera_index" value="7"/>
+    <include file="$(find-pkg-share autoware_tensorrt_yolox)/launch/yolox.launch.xml">
+      <arg name="yolox_node_name" value="tensorrt_yolox$(var camera_index)"/>
+      <arg name="image_transport_decompressor_node_name" value="image_transport_decompressor_node$(var camera_index)"/>
+      <arg name="input/image" value="$(var image_raw0)"/>
+      <arg name="output/objects" value="$(var tensorrt_yolox_ns)rois$(var camera_index)"/>
+    </include>
+
+    <include file="$(find-pkg-share autoware_bytetrack)/launch/bytetrack.launch.xml">
+      <arg name="in_image" value="$(var image_raw0)"/>
+      <arg name="detection_rect" value="$(var tensorrt_yolox_ns)rois$(var camera_index)"/>
+      <arg name="tracked_rect" value="rois$(var camera_index)"/>
+      <arg name="enable_visualizer" value="$(var enable_visualizer)"/>
+      <arg name="camera_index" value="$(var camera_index)"/>
+    </include>
+  </group>
+
+  <group if="$(eval &quot;$(var image_number)>=9&quot;)">
+    <let name="camera_index" value="8"/>
+    <include file="$(find-pkg-share autoware_tensorrt_yolox)/launch/yolox.launch.xml">
+      <arg name="yolox_node_name" value="tensorrt_yolox$(var camera_index)"/>
+      <arg name="image_transport_decompressor_node_name" value="image_transport_decompressor_node$(var camera_index)"/>
+      <arg name="input/image" value="$(var image_raw0)"/>
+      <arg name="output/objects" value="$(var tensorrt_yolox_ns)rois$(var camera_index)"/>
+    </include>
+
+    <include file="$(find-pkg-share autoware_bytetrack)/launch/bytetrack.launch.xml">
+      <arg name="in_image" value="$(var image_raw0)"/>
+      <arg name="detection_rect" value="$(var tensorrt_yolox_ns)rois$(var camera_index)"/>
+      <arg name="tracked_rect" value="rois$(var camera_index)"/>
+      <arg name="enable_visualizer" value="$(var enable_visualizer)"/>
+      <arg name="camera_index" value="$(var camera_index)"/>
+    </include>
+  </group>
+
+  <group if="$(eval &quot;$(var image_number)>=10 &quot;)">
+    <let name="camera_index" value="9"/>
+    <include file="$(find-pkg-share autoware_tensorrt_yolox)/launch/yolox.launch.xml">
+      <arg name="yolox_node_name" value="tensorrt_yolox$(var camera_index)"/>
+      <arg name="image_transport_decompressor_node_name" value="image_transport_decompressor_node$(var camera_index)"/>
+      <arg name="input/image" value="$(var image_raw0)"/>
+      <arg name="output/objects" value="$(var tensorrt_yolox_ns)rois$(var camera_index)"/>
+    </include>
+
+    <include file="$(find-pkg-share autoware_bytetrack)/launch/bytetrack.launch.xml">
+      <arg name="in_image" value="$(var image_raw0)"/>
+      <arg name="detection_rect" value="$(var tensorrt_yolox_ns)rois$(var camera_index)"/>
+      <arg name="tracked_rect" value="rois$(var camera_index)"/>
+      <arg name="enable_visualizer" value="$(var enable_visualizer)"/>
+      <arg name="camera_index" value="$(var camera_index)"/>
+    </include>
+  </group>
+</launch>

--- a/launch/tier4_perception_launch/launch/object_recognition/detection/detector/camera_2d_detector.launch.xml
+++ b/launch/tier4_perception_launch/launch/object_recognition/detection/detector/camera_2d_detector.launch.xml
@@ -12,6 +12,12 @@
   <arg name="image_raw9" default="/sensing/camera/camera9/image_raw"/>
   <arg name="image_number" default="1"/>
   <arg name="camera_index" default="0"/>
+  <arg name="yolox_model_dir" default="$(env HOME)/autoware_data/tensorrt_yolox" description="ml models directory"/>
+  <arg
+    name="yolox_model_name"
+    default="yolox-sPlus-opt-pseudoV2-T4-960x960-T4-seg16cls"
+    description="options `yolox-sPlus-T4-960x960-pseudo-finetune.onnx` if only detection is needed, `yolox-sPlus-opt-pseudoV2-T4-960x960-T4-seg16cls.onnx` if sematic segmentation is also needed"
+  />
   <arg name="use_bytetrack" default="true" description="use bytetrack for tracking, if false, only detection is performed"/>
   <arg name="enable_visualizer" default="false"/>
   <arg name="tensorrt_yolox_ns" default=""/>
@@ -24,6 +30,8 @@
       <arg name="image_transport_decompressor_node_name" value="image_transport_decompressor_node$(var camera_index)"/>
       <arg name="input/image" value="$(var image_raw0)"/>
       <arg name="output/objects" value="$(var tensorrt_yolox_ns)rois$(var camera_index)"/>
+      <arg name="model_dir" value="$(var yolox_model_dir)"/>
+      <arg name="model_name" value="$(var yolox_model_name)"/>
     </include>
 
     <include file="$(find-pkg-share autoware_bytetrack)/launch/bytetrack.launch.xml">
@@ -42,6 +50,8 @@
       <arg name="image_transport_decompressor_node_name" value="image_transport_decompressor_node$(var camera_index)"/>
       <arg name="input/image" value="$(var image_raw0)"/>
       <arg name="output/objects" value="$(var tensorrt_yolox_ns)rois$(var camera_index)"/>
+      <arg name="model_dir" value="$(var yolox_model_dir)"/>
+      <arg name="model_name" value="$(var yolox_model_name)"/>
     </include>
 
     <include file="$(find-pkg-share autoware_bytetrack)/launch/bytetrack.launch.xml">
@@ -60,6 +70,8 @@
       <arg name="image_transport_decompressor_node_name" value="image_transport_decompressor_node$(var camera_index)"/>
       <arg name="input/image" value="$(var image_raw0)"/>
       <arg name="output/objects" value="$(var tensorrt_yolox_ns)rois$(var camera_index)"/>
+      <arg name="model_dir" value="$(var yolox_model_dir)"/>
+      <arg name="model_name" value="$(var yolox_model_name)"/>
     </include>
 
     <include file="$(find-pkg-share autoware_bytetrack)/launch/bytetrack.launch.xml">
@@ -78,6 +90,8 @@
       <arg name="image_transport_decompressor_node_name" value="image_transport_decompressor_node$(var camera_index)"/>
       <arg name="input/image" value="$(var image_raw0)"/>
       <arg name="output/objects" value="$(var tensorrt_yolox_ns)rois$(var camera_index)"/>
+      <arg name="model_dir" value="$(var yolox_model_dir)"/>
+      <arg name="model_name" value="$(var yolox_model_name)"/>
     </include>
 
     <include file="$(find-pkg-share autoware_bytetrack)/launch/bytetrack.launch.xml">
@@ -96,6 +110,8 @@
       <arg name="image_transport_decompressor_node_name" value="image_transport_decompressor_node$(var camera_index)"/>
       <arg name="input/image" value="$(var image_raw0)"/>
       <arg name="output/objects" value="$(var tensorrt_yolox_ns)rois$(var camera_index)"/>
+      <arg name="model_dir" value="$(var yolox_model_dir)"/>
+      <arg name="model_name" value="$(var yolox_model_name)"/>
     </include>
 
     <include file="$(find-pkg-share autoware_bytetrack)/launch/bytetrack.launch.xml">
@@ -114,6 +130,8 @@
       <arg name="image_transport_decompressor_node_name" value="image_transport_decompressor_node$(var camera_index)"/>
       <arg name="input/image" value="$(var image_raw0)"/>
       <arg name="output/objects" value="$(var tensorrt_yolox_ns)rois$(var camera_index)"/>
+      <arg name="model_dir" value="$(var yolox_model_dir)"/>
+      <arg name="model_name" value="$(var yolox_model_name)"/>
     </include>
 
     <include file="$(find-pkg-share autoware_bytetrack)/launch/bytetrack.launch.xml">
@@ -132,6 +150,8 @@
       <arg name="image_transport_decompressor_node_name" value="image_transport_decompressor_node$(var camera_index)"/>
       <arg name="input/image" value="$(var image_raw0)"/>
       <arg name="output/objects" value="$(var tensorrt_yolox_ns)rois$(var camera_index)"/>
+      <arg name="model_dir" value="$(var yolox_model_dir)"/>
+      <arg name="model_name" value="$(var yolox_model_name)"/>
     </include>
 
     <include file="$(find-pkg-share autoware_bytetrack)/launch/bytetrack.launch.xml">
@@ -150,6 +170,8 @@
       <arg name="image_transport_decompressor_node_name" value="image_transport_decompressor_node$(var camera_index)"/>
       <arg name="input/image" value="$(var image_raw0)"/>
       <arg name="output/objects" value="$(var tensorrt_yolox_ns)rois$(var camera_index)"/>
+      <arg name="model_dir" value="$(var yolox_model_dir)"/>
+      <arg name="model_name" value="$(var yolox_model_name)"/>
     </include>
 
     <include file="$(find-pkg-share autoware_bytetrack)/launch/bytetrack.launch.xml">
@@ -168,6 +190,8 @@
       <arg name="image_transport_decompressor_node_name" value="image_transport_decompressor_node$(var camera_index)"/>
       <arg name="input/image" value="$(var image_raw0)"/>
       <arg name="output/objects" value="$(var tensorrt_yolox_ns)rois$(var camera_index)"/>
+      <arg name="model_dir" value="$(var yolox_model_dir)"/>
+      <arg name="model_name" value="$(var yolox_model_name)"/>
     </include>
 
     <include file="$(find-pkg-share autoware_bytetrack)/launch/bytetrack.launch.xml">
@@ -186,6 +210,8 @@
       <arg name="image_transport_decompressor_node_name" value="image_transport_decompressor_node$(var camera_index)"/>
       <arg name="input/image" value="$(var image_raw0)"/>
       <arg name="output/objects" value="$(var tensorrt_yolox_ns)rois$(var camera_index)"/>
+      <arg name="model_dir" value="$(var yolox_model_dir)"/>
+      <arg name="model_name" value="$(var yolox_model_name)"/>
     </include>
 
     <include file="$(find-pkg-share autoware_bytetrack)/launch/bytetrack.launch.xml">

--- a/launch/tier4_perception_launch/launch/object_recognition/detection/detector/camera_2d_detector.launch.xml
+++ b/launch/tier4_perception_launch/launch/object_recognition/detection/detector/camera_2d_detector.launch.xml
@@ -34,7 +34,7 @@
       <arg name="model_name" value="$(var yolox_model_name)"/>
     </include>
 
-    <include file="$(find-pkg-share autoware_bytetrack)/launch/bytetrack.launch.xml">
+    <include file="$(find-pkg-share autoware_bytetrack)/launch/bytetrack.launch.xml" if="$(var use_bytetrack)">
       <arg name="in_image" value="$(var image_raw0)"/>
       <arg name="detection_rect" value="$(var tensorrt_yolox_ns)rois$(var camera_index)"/>
       <arg name="tracked_rect" value="rois$(var camera_index)"/>
@@ -54,7 +54,7 @@
       <arg name="model_name" value="$(var yolox_model_name)"/>
     </include>
 
-    <include file="$(find-pkg-share autoware_bytetrack)/launch/bytetrack.launch.xml">
+    <include file="$(find-pkg-share autoware_bytetrack)/launch/bytetrack.launch.xml" if="$(var use_bytetrack)">
       <arg name="in_image" value="$(var image_raw0)"/>
       <arg name="detection_rect" value="$(var tensorrt_yolox_ns)rois$(var camera_index)"/>
       <arg name="tracked_rect" value="rois$(var camera_index)"/>
@@ -74,7 +74,7 @@
       <arg name="model_name" value="$(var yolox_model_name)"/>
     </include>
 
-    <include file="$(find-pkg-share autoware_bytetrack)/launch/bytetrack.launch.xml">
+    <include file="$(find-pkg-share autoware_bytetrack)/launch/bytetrack.launch.xml" if="$(var use_bytetrack)">
       <arg name="in_image" value="$(var image_raw0)"/>
       <arg name="detection_rect" value="$(var tensorrt_yolox_ns)rois$(var camera_index)"/>
       <arg name="tracked_rect" value="rois$(var camera_index)"/>
@@ -94,7 +94,7 @@
       <arg name="model_name" value="$(var yolox_model_name)"/>
     </include>
 
-    <include file="$(find-pkg-share autoware_bytetrack)/launch/bytetrack.launch.xml">
+    <include file="$(find-pkg-share autoware_bytetrack)/launch/bytetrack.launch.xml" if="$(var use_bytetrack)">
       <arg name="in_image" value="$(var image_raw0)"/>
       <arg name="detection_rect" value="$(var tensorrt_yolox_ns)rois$(var camera_index)"/>
       <arg name="tracked_rect" value="rois$(var camera_index)"/>
@@ -114,7 +114,7 @@
       <arg name="model_name" value="$(var yolox_model_name)"/>
     </include>
 
-    <include file="$(find-pkg-share autoware_bytetrack)/launch/bytetrack.launch.xml">
+    <include file="$(find-pkg-share autoware_bytetrack)/launch/bytetrack.launch.xml" if="$(var use_bytetrack)">
       <arg name="in_image" value="$(var image_raw0)"/>
       <arg name="detection_rect" value="$(var tensorrt_yolox_ns)rois$(var camera_index)"/>
       <arg name="tracked_rect" value="rois$(var camera_index)"/>
@@ -134,7 +134,7 @@
       <arg name="model_name" value="$(var yolox_model_name)"/>
     </include>
 
-    <include file="$(find-pkg-share autoware_bytetrack)/launch/bytetrack.launch.xml">
+    <include file="$(find-pkg-share autoware_bytetrack)/launch/bytetrack.launch.xml" if="$(var use_bytetrack)">
       <arg name="in_image" value="$(var image_raw0)"/>
       <arg name="detection_rect" value="$(var tensorrt_yolox_ns)rois$(var camera_index)"/>
       <arg name="tracked_rect" value="rois$(var camera_index)"/>
@@ -154,7 +154,7 @@
       <arg name="model_name" value="$(var yolox_model_name)"/>
     </include>
 
-    <include file="$(find-pkg-share autoware_bytetrack)/launch/bytetrack.launch.xml">
+    <include file="$(find-pkg-share autoware_bytetrack)/launch/bytetrack.launch.xml" if="$(var use_bytetrack)">
       <arg name="in_image" value="$(var image_raw0)"/>
       <arg name="detection_rect" value="$(var tensorrt_yolox_ns)rois$(var camera_index)"/>
       <arg name="tracked_rect" value="rois$(var camera_index)"/>
@@ -174,7 +174,7 @@
       <arg name="model_name" value="$(var yolox_model_name)"/>
     </include>
 
-    <include file="$(find-pkg-share autoware_bytetrack)/launch/bytetrack.launch.xml">
+    <include file="$(find-pkg-share autoware_bytetrack)/launch/bytetrack.launch.xml" if="$(var use_bytetrack)">
       <arg name="in_image" value="$(var image_raw0)"/>
       <arg name="detection_rect" value="$(var tensorrt_yolox_ns)rois$(var camera_index)"/>
       <arg name="tracked_rect" value="rois$(var camera_index)"/>
@@ -194,7 +194,7 @@
       <arg name="model_name" value="$(var yolox_model_name)"/>
     </include>
 
-    <include file="$(find-pkg-share autoware_bytetrack)/launch/bytetrack.launch.xml">
+    <include file="$(find-pkg-share autoware_bytetrack)/launch/bytetrack.launch.xml" if="$(var use_bytetrack)">
       <arg name="in_image" value="$(var image_raw0)"/>
       <arg name="detection_rect" value="$(var tensorrt_yolox_ns)rois$(var camera_index)"/>
       <arg name="tracked_rect" value="rois$(var camera_index)"/>
@@ -214,7 +214,7 @@
       <arg name="model_name" value="$(var yolox_model_name)"/>
     </include>
 
-    <include file="$(find-pkg-share autoware_bytetrack)/launch/bytetrack.launch.xml">
+    <include file="$(find-pkg-share autoware_bytetrack)/launch/bytetrack.launch.xml" if="$(var use_bytetrack)">
       <arg name="in_image" value="$(var image_raw0)"/>
       <arg name="detection_rect" value="$(var tensorrt_yolox_ns)rois$(var camera_index)"/>
       <arg name="tracked_rect" value="rois$(var camera_index)"/>

--- a/launch/tier4_perception_launch/launch/object_recognition/detection/detector/camera_2d_detector.launch.xml
+++ b/launch/tier4_perception_launch/launch/object_recognition/detection/detector/camera_2d_detector.launch.xml
@@ -48,14 +48,14 @@
     <include file="$(find-pkg-share autoware_tensorrt_yolox)/launch/yolox.launch.xml">
       <arg name="yolox_node_name" value="tensorrt_yolox$(var camera_index)"/>
       <arg name="image_transport_decompressor_node_name" value="image_transport_decompressor_node$(var camera_index)"/>
-      <arg name="input/image" value="$(var image_raw0)"/>
+      <arg name="input/image" value="$(var image_raw1)"/>
       <arg name="output/objects" value="$(var tensorrt_yolox_ns)rois$(var camera_index)"/>
       <arg name="model_dir" value="$(var yolox_model_dir)"/>
       <arg name="model_name" value="$(var yolox_model_name)"/>
     </include>
 
     <include file="$(find-pkg-share autoware_bytetrack)/launch/bytetrack.launch.xml" if="$(var use_bytetrack)">
-      <arg name="in_image" value="$(var image_raw0)"/>
+      <arg name="in_image" value="$(var image_raw1)"/>
       <arg name="detection_rect" value="$(var tensorrt_yolox_ns)rois$(var camera_index)"/>
       <arg name="tracked_rect" value="rois$(var camera_index)"/>
       <arg name="enable_visualizer" value="$(var enable_visualizer)"/>
@@ -68,14 +68,14 @@
     <include file="$(find-pkg-share autoware_tensorrt_yolox)/launch/yolox.launch.xml">
       <arg name="yolox_node_name" value="tensorrt_yolox$(var camera_index)"/>
       <arg name="image_transport_decompressor_node_name" value="image_transport_decompressor_node$(var camera_index)"/>
-      <arg name="input/image" value="$(var image_raw0)"/>
+      <arg name="input/image" value="$(var image_raw2)"/>
       <arg name="output/objects" value="$(var tensorrt_yolox_ns)rois$(var camera_index)"/>
       <arg name="model_dir" value="$(var yolox_model_dir)"/>
       <arg name="model_name" value="$(var yolox_model_name)"/>
     </include>
 
     <include file="$(find-pkg-share autoware_bytetrack)/launch/bytetrack.launch.xml" if="$(var use_bytetrack)">
-      <arg name="in_image" value="$(var image_raw0)"/>
+      <arg name="in_image" value="$(var image_raw2)"/>
       <arg name="detection_rect" value="$(var tensorrt_yolox_ns)rois$(var camera_index)"/>
       <arg name="tracked_rect" value="rois$(var camera_index)"/>
       <arg name="enable_visualizer" value="$(var enable_visualizer)"/>
@@ -88,14 +88,14 @@
     <include file="$(find-pkg-share autoware_tensorrt_yolox)/launch/yolox.launch.xml">
       <arg name="yolox_node_name" value="tensorrt_yolox$(var camera_index)"/>
       <arg name="image_transport_decompressor_node_name" value="image_transport_decompressor_node$(var camera_index)"/>
-      <arg name="input/image" value="$(var image_raw0)"/>
+      <arg name="input/image" value="$(var image_raw3)"/>
       <arg name="output/objects" value="$(var tensorrt_yolox_ns)rois$(var camera_index)"/>
       <arg name="model_dir" value="$(var yolox_model_dir)"/>
       <arg name="model_name" value="$(var yolox_model_name)"/>
     </include>
 
     <include file="$(find-pkg-share autoware_bytetrack)/launch/bytetrack.launch.xml" if="$(var use_bytetrack)">
-      <arg name="in_image" value="$(var image_raw0)"/>
+      <arg name="in_image" value="$(var image_raw3)"/>
       <arg name="detection_rect" value="$(var tensorrt_yolox_ns)rois$(var camera_index)"/>
       <arg name="tracked_rect" value="rois$(var camera_index)"/>
       <arg name="enable_visualizer" value="$(var enable_visualizer)"/>
@@ -108,14 +108,14 @@
     <include file="$(find-pkg-share autoware_tensorrt_yolox)/launch/yolox.launch.xml">
       <arg name="yolox_node_name" value="tensorrt_yolox$(var camera_index)"/>
       <arg name="image_transport_decompressor_node_name" value="image_transport_decompressor_node$(var camera_index)"/>
-      <arg name="input/image" value="$(var image_raw0)"/>
+      <arg name="input/image" value="$(var image_raw4)"/>
       <arg name="output/objects" value="$(var tensorrt_yolox_ns)rois$(var camera_index)"/>
       <arg name="model_dir" value="$(var yolox_model_dir)"/>
       <arg name="model_name" value="$(var yolox_model_name)"/>
     </include>
 
     <include file="$(find-pkg-share autoware_bytetrack)/launch/bytetrack.launch.xml" if="$(var use_bytetrack)">
-      <arg name="in_image" value="$(var image_raw0)"/>
+      <arg name="in_image" value="$(var image_raw4)"/>
       <arg name="detection_rect" value="$(var tensorrt_yolox_ns)rois$(var camera_index)"/>
       <arg name="tracked_rect" value="rois$(var camera_index)"/>
       <arg name="enable_visualizer" value="$(var enable_visualizer)"/>
@@ -128,14 +128,14 @@
     <include file="$(find-pkg-share autoware_tensorrt_yolox)/launch/yolox.launch.xml">
       <arg name="yolox_node_name" value="tensorrt_yolox$(var camera_index)"/>
       <arg name="image_transport_decompressor_node_name" value="image_transport_decompressor_node$(var camera_index)"/>
-      <arg name="input/image" value="$(var image_raw0)"/>
+      <arg name="input/image" value="$(var image_raw5)"/>
       <arg name="output/objects" value="$(var tensorrt_yolox_ns)rois$(var camera_index)"/>
       <arg name="model_dir" value="$(var yolox_model_dir)"/>
       <arg name="model_name" value="$(var yolox_model_name)"/>
     </include>
 
     <include file="$(find-pkg-share autoware_bytetrack)/launch/bytetrack.launch.xml" if="$(var use_bytetrack)">
-      <arg name="in_image" value="$(var image_raw0)"/>
+      <arg name="in_image" value="$(var image_raw5)"/>
       <arg name="detection_rect" value="$(var tensorrt_yolox_ns)rois$(var camera_index)"/>
       <arg name="tracked_rect" value="rois$(var camera_index)"/>
       <arg name="enable_visualizer" value="$(var enable_visualizer)"/>
@@ -148,14 +148,14 @@
     <include file="$(find-pkg-share autoware_tensorrt_yolox)/launch/yolox.launch.xml">
       <arg name="yolox_node_name" value="tensorrt_yolox$(var camera_index)"/>
       <arg name="image_transport_decompressor_node_name" value="image_transport_decompressor_node$(var camera_index)"/>
-      <arg name="input/image" value="$(var image_raw0)"/>
+      <arg name="input/image" value="$(var image_raw5)"/>
       <arg name="output/objects" value="$(var tensorrt_yolox_ns)rois$(var camera_index)"/>
       <arg name="model_dir" value="$(var yolox_model_dir)"/>
       <arg name="model_name" value="$(var yolox_model_name)"/>
     </include>
 
     <include file="$(find-pkg-share autoware_bytetrack)/launch/bytetrack.launch.xml" if="$(var use_bytetrack)">
-      <arg name="in_image" value="$(var image_raw0)"/>
+      <arg name="in_image" value="$(var image_raw6)"/>
       <arg name="detection_rect" value="$(var tensorrt_yolox_ns)rois$(var camera_index)"/>
       <arg name="tracked_rect" value="rois$(var camera_index)"/>
       <arg name="enable_visualizer" value="$(var enable_visualizer)"/>
@@ -168,14 +168,14 @@
     <include file="$(find-pkg-share autoware_tensorrt_yolox)/launch/yolox.launch.xml">
       <arg name="yolox_node_name" value="tensorrt_yolox$(var camera_index)"/>
       <arg name="image_transport_decompressor_node_name" value="image_transport_decompressor_node$(var camera_index)"/>
-      <arg name="input/image" value="$(var image_raw0)"/>
+      <arg name="input/image" value="$(var image_raw7)"/>
       <arg name="output/objects" value="$(var tensorrt_yolox_ns)rois$(var camera_index)"/>
       <arg name="model_dir" value="$(var yolox_model_dir)"/>
       <arg name="model_name" value="$(var yolox_model_name)"/>
     </include>
 
     <include file="$(find-pkg-share autoware_bytetrack)/launch/bytetrack.launch.xml" if="$(var use_bytetrack)">
-      <arg name="in_image" value="$(var image_raw0)"/>
+      <arg name="in_image" value="$(var image_raw7)"/>
       <arg name="detection_rect" value="$(var tensorrt_yolox_ns)rois$(var camera_index)"/>
       <arg name="tracked_rect" value="rois$(var camera_index)"/>
       <arg name="enable_visualizer" value="$(var enable_visualizer)"/>
@@ -188,14 +188,14 @@
     <include file="$(find-pkg-share autoware_tensorrt_yolox)/launch/yolox.launch.xml">
       <arg name="yolox_node_name" value="tensorrt_yolox$(var camera_index)"/>
       <arg name="image_transport_decompressor_node_name" value="image_transport_decompressor_node$(var camera_index)"/>
-      <arg name="input/image" value="$(var image_raw0)"/>
+      <arg name="input/image" value="$(var image_raw8)"/>
       <arg name="output/objects" value="$(var tensorrt_yolox_ns)rois$(var camera_index)"/>
       <arg name="model_dir" value="$(var yolox_model_dir)"/>
       <arg name="model_name" value="$(var yolox_model_name)"/>
     </include>
 
     <include file="$(find-pkg-share autoware_bytetrack)/launch/bytetrack.launch.xml" if="$(var use_bytetrack)">
-      <arg name="in_image" value="$(var image_raw0)"/>
+      <arg name="in_image" value="$(var image_raw8)"/>
       <arg name="detection_rect" value="$(var tensorrt_yolox_ns)rois$(var camera_index)"/>
       <arg name="tracked_rect" value="rois$(var camera_index)"/>
       <arg name="enable_visualizer" value="$(var enable_visualizer)"/>
@@ -208,14 +208,14 @@
     <include file="$(find-pkg-share autoware_tensorrt_yolox)/launch/yolox.launch.xml">
       <arg name="yolox_node_name" value="tensorrt_yolox$(var camera_index)"/>
       <arg name="image_transport_decompressor_node_name" value="image_transport_decompressor_node$(var camera_index)"/>
-      <arg name="input/image" value="$(var image_raw0)"/>
+      <arg name="input/image" value="$(var image_raw9)"/>
       <arg name="output/objects" value="$(var tensorrt_yolox_ns)rois$(var camera_index)"/>
       <arg name="model_dir" value="$(var yolox_model_dir)"/>
       <arg name="model_name" value="$(var yolox_model_name)"/>
     </include>
 
     <include file="$(find-pkg-share autoware_bytetrack)/launch/bytetrack.launch.xml" if="$(var use_bytetrack)">
-      <arg name="in_image" value="$(var image_raw0)"/>
+      <arg name="in_image" value="$(var image_raw9)"/>
       <arg name="detection_rect" value="$(var tensorrt_yolox_ns)rois$(var camera_index)"/>
       <arg name="tracked_rect" value="rois$(var camera_index)"/>
       <arg name="enable_visualizer" value="$(var enable_visualizer)"/>

--- a/launch/tier4_perception_launch/launch/object_recognition/detection/detector/camera_lidar_detector.launch.xml
+++ b/launch/tier4_perception_launch/launch/object_recognition/detection/detector/camera_lidar_detector.launch.xml
@@ -85,6 +85,8 @@
   <let name="detected_object_feature_remover/output/objects" value="$(var output/rule_detector/objects)"/>
 
   <arg name="enable_2d_detection" default="false" description="true: when 2d detection yolox model run the same machine, false: when it run in separate machine"/>
+  <arg name="yolox_model_dir" default="$(env HOME)/autoware_data/tensorrt_yolox" description="directory path of yolox model file"/>
+  <arg name="yolox_model_name" default="yolox-sPlus-opt-pseudoV2-T4-960x960-T4-seg16cls"/>
   <include file="$(find-pkg-share tier4_perception_launch)/launch/object_recognition/detection/detector/camera_2d_detector.launch.xml" if="$(var enable_2d_detection)">
     <arg name="image_raw0" value="$(var input/camera0/image)"/>
     <arg name="image_raw1" value="$(var input/camera1/image)"/>
@@ -95,6 +97,8 @@
     <arg name="image_raw6" value="$(var input/camera6/image)"/>
     <arg name="image_raw7" value="$(var input/camera7/image)"/>
     <arg name="image_number" value="$(var number_of_cameras)"/>
+    <arg name="yolox_model_dir" value="$(var yolox_model_dir)"/>
+    <arg name="yolox_model_name" value="$(var yolox_model_name)"/>
   </include>
 
   <!-- PointPainting -->

--- a/launch/tier4_perception_launch/launch/object_recognition/detection/detector/camera_lidar_detector.launch.xml
+++ b/launch/tier4_perception_launch/launch/object_recognition/detection/detector/camera_lidar_detector.launch.xml
@@ -85,6 +85,7 @@
   <let name="detected_object_feature_remover/output/objects" value="$(var output/rule_detector/objects)"/>
 
   <arg name="enable_2d_detection" default="false" description="true: when 2d detection yolox model run the same machine, false: when it run in separate machine"/>
+  <arg name="use_bytetrack" default="false" description="if true, Bytetrack is used for 2D tracking. Otherwise, SORT is used."/>
   <arg name="yolox_model_dir" default="$(env HOME)/autoware_data/tensorrt_yolox" description="directory path of yolox model file"/>
   <arg name="yolox_model_name" default="yolox-sPlus-opt-pseudoV2-T4-960x960-T4-seg16cls"/>
   <include file="$(find-pkg-share tier4_perception_launch)/launch/object_recognition/detection/detector/camera_2d_detector.launch.xml" if="$(var enable_2d_detection)">
@@ -99,6 +100,7 @@
     <arg name="image_number" value="$(var number_of_cameras)"/>
     <arg name="yolox_model_dir" value="$(var yolox_model_dir)"/>
     <arg name="yolox_model_name" value="$(var yolox_model_name)"/>
+    <arg name="use_bytetrack" value="$(var use_bytetrack)"/>
   </include>
 
   <!-- PointPainting -->

--- a/launch/tier4_perception_launch/launch/object_recognition/detection/detector/camera_lidar_detector.launch.xml
+++ b/launch/tier4_perception_launch/launch/object_recognition/detection/detector/camera_lidar_detector.launch.xml
@@ -84,8 +84,8 @@
   <let name="detected_object_feature_remover/input/objects_with_feature" value="$(var shape_estimation2/output/objects)"/>
   <let name="detected_object_feature_remover/output/objects" value="$(var output/rule_detector/objects)"/>
 
-  <!-- Jetson AGX -->
-  <!-- <include file="$(find-pkg-share autoware_tensorrt_yolox)/launch/multiple_yolox.launch.xml">
+  <arg name="enable_2d_detection" default="false" description="true: when 2d detection yolox model run the same machine, false: when it run in separate machine"/>
+  <include file="$(find-pkg-share tier4_perception_launch)/launch/object_recognition/detection/detector/camera_2d_detector.launch.xml" if="$(var enable_2d_detection)">
     <arg name="image_raw0" value="$(var input/camera0/image)"/>
     <arg name="image_raw1" value="$(var input/camera1/image)"/>
     <arg name="image_raw2" value="$(var input/camera2/image)"/>
@@ -95,7 +95,7 @@
     <arg name="image_raw6" value="$(var input/camera6/image)"/>
     <arg name="image_raw7" value="$(var input/camera7/image)"/>
     <arg name="image_number" value="$(var number_of_cameras)"/>
-  </include> -->
+  </include>
 
   <!-- PointPainting -->
   <group if="$(eval &quot;'$(var lidar_detection_model_type)'=='pointpainting'&quot;)">

--- a/launch/tier4_perception_launch/package.xml
+++ b/launch/tier4_perception_launch/package.xml
@@ -15,6 +15,7 @@
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
   <exec_depend>autoware_bevfusion</exec_depend>
+  <exec_depend>autoware_bytetrack</exec_depend>
   <exec_depend>autoware_cluster_merger</exec_depend>
   <exec_depend>autoware_compare_map_segmentation</exec_depend>
   <exec_depend>autoware_crosswalk_traffic_light_estimator</exec_depend>

--- a/perception/autoware_bytetrack/launch/bytetrack.launch.xml
+++ b/perception/autoware_bytetrack/launch/bytetrack.launch.xml
@@ -7,15 +7,16 @@
   <arg name="bytetrack_param_path" default="$(find-pkg-share autoware_bytetrack)/config/bytetrack.param.yaml"/>
   <arg name="bytetrack_visualizer_param_path" default="$(find-pkg-share autoware_bytetrack)/config/bytetrack_visualizer.param.yaml"/>
   <arg name="enable_visualizer" default="true"/>
+  <arg name="camera_index" default="0"/>
 
-  <node pkg="autoware_bytetrack" exec="bytetrack_node_exe" output="screen">
+  <node pkg="autoware_bytetrack" exec="bytetrack_node_exe" name="bytetrack$(var camera_index)" output="screen">
     <remap from="~/in/rect" to="$(var detection_rect)"/>
     <remap from="~/out/objects" to="$(var tracked_rect)"/>
     <remap from="~/out/objects/debug/uuid" to="$(var tracked_rect)/debug/uuid"/>
     <param from="$(var bytetrack_param_path)"/>
   </node>
 
-  <node pkg="autoware_bytetrack" exec="bytetrack_visualizer_node_exe" output="screen" if="$(var enable_visualizer)">
+  <node pkg="autoware_bytetrack" exec="bytetrack_visualizer_node_exe" name="bytetrack_visualizer$(var camera_index)" output="screen" if="$(var enable_visualizer)">
     <remap from="~/in/image" to="$(var in_image)"/>
     <remap from="~/in/rect" to="$(var tracked_rect)"/>
     <remap from="~/in/uuid" to="$(var tracked_rect)/debug/uuid"/>

--- a/perception/autoware_tensorrt_yolox/launch/yolox_s_plus_opt.launch.xml
+++ b/perception/autoware_tensorrt_yolox/launch/yolox_s_plus_opt.launch.xml
@@ -4,20 +4,20 @@
   <arg name="yolox_node_name" default="tensorrt_yolox"/>
   <arg name="image_transport_decompressor_node_name" default="image_transport_decompressor_node"/>
 
-  <arg name="data_path" default="$(env HOME)/autoware_data" description="packages data and artifacts directory path"/>
-
+  <arg name="model_dir" default="$(env HOME)/autoware_data/tensorrt_yolox" description="packages data and artifacts directory path"/>
+  <arg
+    name="model_name"
+    default="yolox-sPlus-opt-pseudoV2-T4-960x960-T4-seg16cls"
+    description="options `yolox-sPlus-T4-960x960-pseudo-finetune.onnx` if only detection is needed, `yolox-sPlus-opt-pseudoV2-T4-960x960-T4-seg16cls.onnx` if sematic segmentation is also needed"
+  />
   <arg name="input/image" default="/sensing/camera/camera0/image_rect_color"/>
   <arg name="output/objects" default="/perception/object_recognition/detection/rois0"/>
   <arg name="output/mask" default="/perception/object_recognition/detection/mask0"/>
 
   <arg name="yolox_param_path" default="$(find-pkg-share autoware_tensorrt_yolox)/config/yolox_s_plus_opt.param.yaml"/>
-  <arg
-    name="model_path"
-    default="$(var data_path)/tensorrt_yolox/yolox-sPlus-opt-pseudoV2-T4-960x960-T4-seg16cls.onnx"
-    description="options `yolox-sPlus-T4-960x960-pseudo-finetune.onnx` if only detection is needed, `yolox-sPlus-opt-pseudoV2-T4-960x960-T4-seg16cls.onnx` if sematic segmentation is also needed"
-  />
-  <arg name="label_path" default="$(var data_path)/tensorrt_yolox/label.txt" description="label path"/>
-  <arg name="color_map_path" default="$(var data_path)/tensorrt_yolox/semseg_color_map.csv" description="color map path"/>
+  <arg name="model_path" default="$(var model_dir)/$(var model_name).onnx"/>
+  <arg name="label_path" default="$(var model_dir)/label.txt" description="label path"/>
+  <arg name="color_map_path" default="$(var model_dir)/semseg_color_map.csv" description="color map path"/>
 
   <arg name="use_decompress" default="true" description="use image decompress"/>
   <arg name="build_only" default="false" description="exit after trt engine is built"/>


### PR DESCRIPTION
- SimulatorでTensorrt_yoloxを起動するニーズが高める：
  -  https://star4.slack.com/archives/CRUE57C30/p1757644378632819?thread_ts=1757639076.334349&cid=CRUE57C30
- Evaluator上でTensorrt_yoloxを回せるように必要なCherry-pickです
  - https://github.com/autowarefoundation/autoware_universe/pull/11104 
  - https://github.com/autowarefoundation/autoware_universe/pull/11359
- 必要なPRをリストアップしておきます
  - Pilot-auto.x2: 
    - https://github.com/tier4/pilot-auto.x2/pull/2480
  - DLR: 
    - https://github.com/tier4/driving_log_replayer_v2/pull/212 :merged: 
  - Universe関連：
    - https://github.com/autowarefoundation/autoware_universe/pull/11359
    - Cherry-pick: https://github.com/tier4/autoware_universe/pull/2372
  - autoware_launch:
    - https://github.com/tier4/autoware_launch.x2/pull/1555
