### PR TITLE
fix(planning_validator): update QoS settings for operational mode state subscriber (#11401)

### DIFF
--- a/planning/planning_validator/autoware_planning_validator/include/autoware/planning_validator/node.hpp
+++ b/planning/planning_validator/autoware_planning_validator/include/autoware/planning_validator/node.hpp
@@ -91,7 +91,7 @@ private:
   autoware_utils::InterProcessPollingSubscriber<AccelWithCovarianceStamped> sub_acceleration_{
     this, "~/input/acceleration"};
   autoware_utils::InterProcessPollingSubscriber<OperationModeState> sub_operational_state_{
-    this, "~/input/operational_mode_state"};
+    this, "~/input/operational_mode_state", rclcpp::QoS{1}.transient_local()};
   autoware_utils::InterProcessPollingSubscriber<TrafficLightGroupArray> sub_traffic_signals_{
     this, "~/input/traffic_signals"};
 

--- a/planning/planning_validator/autoware_planning_validator_trajectory_checker/test/test_trajectory_checker_diag.cpp
+++ b/planning/planning_validator/autoware_planning_validator_trajectory_checker/test/test_trajectory_checker_diag.cpp
@@ -73,7 +73,7 @@ public:
       "/planning_validator_node/input/acceleration", 1);
     pointcloud_pub_ = create_publisher<PointCloud2>("/planning_validator_node/input/pointcloud", 1);
     operational_mode_pub_ = create_publisher<OperationModeState>(
-      "/planning_validator_node/input/operational_mode_state", 1);
+      "/planning_validator_node/input/operational_mode_state", rclcpp::QoS(1).transient_local());
     diag_sub_ = create_subscription<DiagnosticArray>(
       "/diagnostics", 1,
       [this](const DiagnosticArray::ConstSharedPtr msg) { received_diags_.push_back(msg); });


### PR DESCRIPTION
cherry pick pr for 
https://github.com/autowarefoundation/autoware_universe/pull/11401

OperationModeState の publisher が transient_local に設定されているが、 planning_validator 側で定義されている subscriber が transient_local の設定されていないため、ポリシーの互換性を保持するため設定。

