### PR TITLE
feat: introducing co-pilot-auto in tier4/universe

### DIFF
--- a/.github/workflows/co-pilot-auto-client.yaml
+++ b/.github/workflows/co-pilot-auto-client.yaml
@@ -6,16 +6,49 @@ on:
 
 jobs:
   analyze-comment:
-    # Only run on PR comments that contain the trigger phrase
-    if: ${{ github.event.issue.pull_request && contains(github.event.comment.body, '@co-pilot-auto') }}
+    # Only run on PR comments that start with the trigger phrase
+    if: |
+      github.event.issue.pull_request &&
+      startsWith(github.event.comment.body, '@co-pilot-auto')
     runs-on: ubuntu-latest
     permissions:
       contents: read
       pull-requests: write
 
     steps:
+      - name: Debug PR reviewer information
+        uses: actions/github-script@v7
+        with:
+          script: |
+            console.log('Comment author:', context.payload.comment.user.login);
+            console.log('PR author:', context.payload.issue.user.login);
+
+            // Get PR details to see reviewers
+            const prNumber = context.payload.issue.number;
+            const { data: prData } = await github.rest.pulls.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              pull_number: prNumber
+            });
+
+            console.log('Requested reviewers:', JSON.stringify(prData.requested_reviewers));
+
+            const reviewerLogins = prData.requested_reviewers.map(reviewer => reviewer.login);
+            console.log('Reviewer logins:', reviewerLogins);
+
+            const isCommentFromPRAuthor = context.payload.comment.user.login === context.payload.issue.user.login;
+            const isCommentFromReviewer = reviewerLogins.includes(context.payload.comment.user.login);
+
+            console.log('Is comment from PR author?', isCommentFromPRAuthor);
+            console.log('Is comment from reviewer?', isCommentFromReviewer);
+            console.log('Should proceed?', isCommentFromPRAuthor || isCommentFromReviewer);
+
+            // Store this information for later steps
+            core.exportVariable('SHOULD_PROCEED', isCommentFromPRAuthor || isCommentFromReviewer);
+
       - name: Generate token
         id: generate-token
+        if: env.SHOULD_PROCEED == 'true'
         uses: actions/create-github-app-token@v1
         with:
           app_id: ${{ secrets.APP_ID }}
@@ -23,9 +56,11 @@ jobs:
           owner: ${{ github.repository_owner }}
 
       - name: Checkout repository
+        if: env.SHOULD_PROCEED == 'true'
         uses: actions/checkout@v4
 
       - name: Call PR analysis workflow
+        if: env.SHOULD_PROCEED == 'true'
         uses: actions/github-script@v7
         with:
           github-token: ${{ steps.generate-token.outputs.token }}


### PR DESCRIPTION
## Co-pilot-auto introduction
[Readme](https://github.com/tier4/llm_pr_analyzer/blob/pilot-auto-branch/docs_copilot_auto/readme_pr_commentor.md)

1. On repos registered with PrivateBot, installing the client is enough.
2. On any PR, users can ask `@co-pilot-auto` to trigger a query after the default branch is installed with the client action.

### Best Prompting Practice
- Simply query with natural language: `@co-pilot-auto review/summarize the PR`
- Co-pilot-auto will try to infer the language to use from the context, but it is encouraged to explicitly tell the model what language to use


## Example

[Internal PR 1](https://github.com/tier4/edge-auto-jetson.xx1/pull/11)

[Internal PR 2](https://github.com/tier4/llm_pr_analyzer/pull/6#issuecomment-3326386379)

## For LLM agent developer

Different from Gemini-CLI and Microsoft Copilot.

- There is sufficient freedom in the [context_manager](https://github.com/tier4/llm_pr_analyzer/blob/pilot-auto-branch/llm_pr_analyzer/context_manager/context_manager.py) and [the system prompt](https://github.com/tier4/llm_pr_analyzer/blob/pilot-auto-branch/prompts/single_reviewer_agent_prompts/system_prompt.txt) to embed an almost unlimited amount of rule-based knowledge from the TIER IV company, feel free to update with that.
- Currently, there will be, at most, only two LLM calls per query, so that the cost will be much lower.
- Unlike Gemini-CLI, which is super-powerful in handling all parts of PR, this agent can only perform review and suggestion; all developments and discussions should be done by the engineer.