### PR TITLE
fix(cuda_pointcloud_preprocessor): use uint64_t and nanoseconds to prevent potential precision loss

### DIFF
--- a/sensing/autoware_cuda_pointcloud_preprocessor/include/autoware/cuda_pointcloud_preprocessor/cuda_pointcloud_preprocessor_node.hpp
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/include/autoware/cuda_pointcloud_preprocessor/cuda_pointcloud_preprocessor_node.hpp
@@ -92,11 +92,11 @@ private:
   // Helper Functions
   [[nodiscard]] bool validatePointcloudLayout(
     const sensor_msgs::msg::PointCloud2 & input_pointcloud_msg) const;
-  std::pair<double, std::uint32_t> getFirstPointTimeInfo(
+  std::pair<std::uint64_t, std::uint32_t> getFirstPointTimeInfo(
     const sensor_msgs::msg::PointCloud2 & input_pointcloud_msg);
 
-  void updateTwistQueue(double first_point_stamp);
-  void updateImuQueue(double first_point_stamp);
+  void updateTwistQueue(std::uint64_t first_point_stamp);
+  void updateImuQueue(std::uint64_t first_point_stamp);
   std::optional<geometry_msgs::msg::TransformStamped> lookupTransformToBase(
     const std::string & source_frame);
   std::unique_ptr<cuda_blackboard::CudaPointCloud2> processPointcloud(


### PR DESCRIPTION
cherry-pick https://github.com/autowarefoundation/autoware_universe/pull/11398

fix of problems
https://tier4.atlassian.net/browse/RT0-39571
https://tier4.atlassian.net/browse/RT0-39545