### PR TITLE
chore: add cuda backward support 12.0~ to match AWF patch

### DIFF
--- a/e2e/autoware_tensorrt_vad/CMakeLists.txt
+++ b/e2e/autoware_tensorrt_vad/CMakeLists.txt
@@ -64,6 +64,7 @@ if(TRT_AVAIL AND CUDA_AVAIL)
   endif()
 
   # CUDA architecture settings
+  list(APPEND CUDA_NVCC_FLAGS "-gencode arch=compute_75,code=sm_75")
   list(APPEND CUDA_NVCC_FLAGS "-gencode arch=compute_86,code=sm_86")
   list(APPEND CUDA_NVCC_FLAGS "-gencode arch=compute_87,code=sm_87")
   list(APPEND CUDA_NVCC_FLAGS "-gencode arch=compute_89,code=sm_89")
@@ -75,6 +76,8 @@ if(TRT_AVAIL AND CUDA_AVAIL)
     endif()
     list(APPEND CUDA_NVCC_FLAGS "-gencode arch=compute_120,code=sm_120")
     list(APPEND CUDA_NVCC_FLAGS "-gencode arch=compute_120,code=compute_120")
+  else()
+    list(APPEND CUDA_NVCC_FLAGS "-gencode arch=compute_89,code=compute_89")
   endif()
 
   cuda_add_library(${PROJECT_NAME}_cuda_lib SHARED

--- a/perception/autoware_bevfusion/CMakeLists.txt
+++ b/perception/autoware_bevfusion/CMakeLists.txt
@@ -81,6 +81,7 @@ if(TRT_AVAIL AND CUDA_AVAIL AND SPCONV_AVAIL)
 
   # cSpell:ignore expt
   list(APPEND CUDA_NVCC_FLAGS "--expt-relaxed-constexpr -diag-suppress 1675 --extended-lambda")
+  list(APPEND CUDA_NVCC_FLAGS "-gencode arch=compute_75,code=sm_75")
   list(APPEND CUDA_NVCC_FLAGS "-gencode arch=compute_86,code=sm_86")
   list(APPEND CUDA_NVCC_FLAGS "-gencode arch=compute_87,code=sm_87")
   list(APPEND CUDA_NVCC_FLAGS "-gencode arch=compute_89,code=sm_89")
@@ -92,6 +93,8 @@ if(TRT_AVAIL AND CUDA_AVAIL AND SPCONV_AVAIL)
     endif()
     list(APPEND CUDA_NVCC_FLAGS "-gencode arch=compute_120,code=sm_120")
     list(APPEND CUDA_NVCC_FLAGS "-gencode arch=compute_120,code=compute_120")
+  else()
+    list(APPEND CUDA_NVCC_FLAGS "-gencode arch=compute_89,code=compute_89")
   endif()
 
   cuda_add_library(${PROJECT_NAME}_cuda_lib SHARED

--- a/perception/autoware_ground_segmentation_cuda/CMakeLists.txt
+++ b/perception/autoware_ground_segmentation_cuda/CMakeLists.txt
@@ -35,6 +35,7 @@ include_directories(
 
 # cSpell: ignore expt
 list(APPEND CUDA_NVCC_FLAGS "--expt-relaxed-constexpr -diag-suppress 20012")
+list(APPEND CUDA_NVCC_FLAGS "-gencode arch=compute_75,code=sm_75")
 list(APPEND CUDA_NVCC_FLAGS "-gencode arch=compute_86,code=sm_86")
 list(APPEND CUDA_NVCC_FLAGS "-gencode arch=compute_87,code=sm_87")
 list(APPEND CUDA_NVCC_FLAGS "-gencode arch=compute_89,code=sm_89")
@@ -46,6 +47,8 @@ if(CUDA_VERSION VERSION_GREATER_EQUAL "12.8")
   endif()
   list(APPEND CUDA_NVCC_FLAGS "-gencode arch=compute_120,code=sm_120")
   list(APPEND CUDA_NVCC_FLAGS "-gencode arch=compute_120,code=compute_120")
+else()
+  list(APPEND CUDA_NVCC_FLAGS "-gencode arch=compute_89,code=compute_89")
 endif()
 
 #################### cuda_ground_segmentation ##################

--- a/perception/autoware_image_projection_based_fusion/CMakeLists.txt
+++ b/perception/autoware_image_projection_based_fusion/CMakeLists.txt
@@ -115,6 +115,7 @@ if(TRT_AVAIL AND CUDA_AVAIL)
     src/pointpainting_fusion/voxel_generator.cpp
   )
 
+  list(APPEND CUDA_NVCC_FLAGS "-gencode arch=compute_75,code=sm_75")
   list(APPEND CUDA_NVCC_FLAGS "-gencode arch=compute_86,code=sm_86")
   list(APPEND CUDA_NVCC_FLAGS "-gencode arch=compute_87,code=sm_87")
   list(APPEND CUDA_NVCC_FLAGS "-gencode arch=compute_89,code=sm_89")
@@ -126,6 +127,8 @@ if(TRT_AVAIL AND CUDA_AVAIL)
     endif()
     list(APPEND CUDA_NVCC_FLAGS "-gencode arch=compute_120,code=sm_120")
     list(APPEND CUDA_NVCC_FLAGS "-gencode arch=compute_120,code=compute_120")
+  else()
+    list(APPEND CUDA_NVCC_FLAGS "-gencode arch=compute_89,code=compute_89")
   endif()
 
   cuda_add_library(pointpainting_cuda_lib SHARED

--- a/perception/autoware_lidar_centerpoint/CMakeLists.txt
+++ b/perception/autoware_lidar_centerpoint/CMakeLists.txt
@@ -69,6 +69,7 @@ if(TRT_AVAIL AND CUDA_AVAIL)
     lib/preprocess/voxel_generator.cpp
   )
 
+  list(APPEND CUDA_NVCC_FLAGS "-gencode arch=compute_75,code=sm_75")
   list(APPEND CUDA_NVCC_FLAGS "-gencode arch=compute_86,code=sm_86")
   list(APPEND CUDA_NVCC_FLAGS "-gencode arch=compute_87,code=sm_87")
   list(APPEND CUDA_NVCC_FLAGS "-gencode arch=compute_89,code=sm_89")
@@ -80,6 +81,8 @@ if(TRT_AVAIL AND CUDA_AVAIL)
     endif()
     list(APPEND CUDA_NVCC_FLAGS "-gencode arch=compute_120,code=sm_120")
     list(APPEND CUDA_NVCC_FLAGS "-gencode arch=compute_120,code=compute_120")
+  else()
+    list(APPEND CUDA_NVCC_FLAGS "-gencode arch=compute_89,code=compute_89")
   endif()
 
   cuda_add_library(${PROJECT_NAME}_cuda_lib SHARED

--- a/perception/autoware_lidar_frnet/CMakeLists.txt
+++ b/perception/autoware_lidar_frnet/CMakeLists.txt
@@ -68,6 +68,7 @@ if(TRT_AVAIL AND CUDA_AVAIL)
 
   # cSpell:ignore expt
   list(APPEND CUDA_NVCC_FLAGS "--expt-relaxed-constexpr -diag-suppress 1675 --extended-lambda")
+  list(APPEND CUDA_NVCC_FLAGS "-gencode arch=compute_75,code=sm_75")
   list(APPEND CUDA_NVCC_FLAGS "-gencode arch=compute_86,code=sm_86")
   list(APPEND CUDA_NVCC_FLAGS "-gencode arch=compute_87,code=sm_87")
   list(APPEND CUDA_NVCC_FLAGS "-gencode arch=compute_89,code=sm_89")
@@ -79,6 +80,8 @@ if(TRT_AVAIL AND CUDA_AVAIL)
     endif()
     list(APPEND CUDA_NVCC_FLAGS "-gencode arch=compute_120,code=sm_120")
     list(APPEND CUDA_NVCC_FLAGS "-gencode arch=compute_120,code=compute_120")
+  else()
+    list(APPEND CUDA_NVCC_FLAGS "-gencode arch=compute_89,code=compute_89")
   endif()
 
   cuda_add_library(${PROJECT_NAME}_cuda_lib SHARED

--- a/perception/autoware_lidar_transfusion/CMakeLists.txt
+++ b/perception/autoware_lidar_transfusion/CMakeLists.txt
@@ -71,6 +71,7 @@ if(TRT_AVAIL AND CUDA_AVAIL)
     lib/transfusion_trt.cpp
   )
 
+  list(APPEND CUDA_NVCC_FLAGS "-gencode arch=compute_75,code=sm_75")
   list(APPEND CUDA_NVCC_FLAGS "-gencode arch=compute_86,code=sm_86")
   list(APPEND CUDA_NVCC_FLAGS "-gencode arch=compute_87,code=sm_87")
   list(APPEND CUDA_NVCC_FLAGS "-gencode arch=compute_89,code=sm_89")
@@ -82,6 +83,8 @@ if(TRT_AVAIL AND CUDA_AVAIL)
     endif()
     list(APPEND CUDA_NVCC_FLAGS "-gencode arch=compute_120,code=sm_120")
     list(APPEND CUDA_NVCC_FLAGS "-gencode arch=compute_120,code=compute_120")
+  else()
+    list(APPEND CUDA_NVCC_FLAGS "-gencode arch=compute_89,code=compute_89")
   endif()
 
   cuda_add_library(${PROJECT_NAME}_cuda_lib SHARED

--- a/perception/autoware_probabilistic_occupancy_grid_map/CMakeLists.txt
+++ b/perception/autoware_probabilistic_occupancy_grid_map/CMakeLists.txt
@@ -30,6 +30,7 @@ if(${CUDA_FOUND})
 
   # cSpell: ignore expt
   list(APPEND CUDA_NVCC_FLAGS --expt-relaxed-constexpr -diag-suppress 20012 --compiler-options -fPIC)
+  list(APPEND CUDA_NVCC_FLAGS "-gencode arch=compute_75,code=sm_75")
   list(APPEND CUDA_NVCC_FLAGS -gencode arch=compute_86,code=sm_86)
   list(APPEND CUDA_NVCC_FLAGS -gencode arch=compute_87,code=sm_87)
   list(APPEND CUDA_NVCC_FLAGS -gencode arch=compute_89,code=sm_89)
@@ -41,6 +42,8 @@ if(${CUDA_FOUND})
     endif()
     list(APPEND CUDA_NVCC_FLAGS -gencode arch=compute_120,code=sm_120)
     list(APPEND CUDA_NVCC_FLAGS -gencode arch=compute_120,code=compute_120)
+  else()
+    list(APPEND CUDA_NVCC_FLAGS "-gencode arch=compute_89,code=compute_89")
   endif()
 
   set(CUDA_SEPARABLE_COMPILATION ON)

--- a/perception/autoware_ptv3/CMakeLists.txt
+++ b/perception/autoware_ptv3/CMakeLists.txt
@@ -63,6 +63,7 @@ if(TRT_AVAIL AND CUDA_AVAIL)
 
   # cSpell:ignore expt
   list(APPEND CUDA_NVCC_FLAGS "--expt-relaxed-constexpr -diag-suppress 1675 --extended-lambda")
+  list(APPEND CUDA_NVCC_FLAGS "-gencode arch=compute_75,code=sm_75")
   list(APPEND CUDA_NVCC_FLAGS "-gencode arch=compute_86,code=sm_86")
   list(APPEND CUDA_NVCC_FLAGS "-gencode arch=compute_87,code=sm_87")
   list(APPEND CUDA_NVCC_FLAGS "-gencode arch=compute_89,code=sm_89")
@@ -74,6 +75,8 @@ if(TRT_AVAIL AND CUDA_AVAIL)
     endif()
     list(APPEND CUDA_NVCC_FLAGS "-gencode arch=compute_120,code=sm_120")
     list(APPEND CUDA_NVCC_FLAGS "-gencode arch=compute_120,code=compute_120")
+  else()
+    list(APPEND CUDA_NVCC_FLAGS "-gencode arch=compute_89,code=compute_89")
   endif()
 
   cuda_add_library(${PROJECT_NAME}_cuda_lib SHARED

--- a/perception/autoware_tensorrt_bevformer/CMakeLists.txt
+++ b/perception/autoware_tensorrt_bevformer/CMakeLists.txt
@@ -62,6 +62,7 @@ if(TRT_AVAIL AND CUDA_AVAIL)
 
   # CUDA flags
   set(CUDA_NVCC_FLAGS "${CUDA_NVCC_FLAGS} --expt-relaxed-constexpr -diag-suppress 1675 --extended-lambda")
+  list(APPEND CUDA_NVCC_FLAGS "-gencode arch=compute_75,code=sm_75")
   list(APPEND CUDA_NVCC_FLAGS "-gencode arch=compute_86,code=sm_86")
   list(APPEND CUDA_NVCC_FLAGS "-gencode arch=compute_87,code=sm_87")
   list(APPEND CUDA_NVCC_FLAGS "-gencode arch=compute_89,code=sm_89")
@@ -73,6 +74,8 @@ if(TRT_AVAIL AND CUDA_AVAIL)
     endif()
     list(APPEND CUDA_NVCC_FLAGS "-gencode arch=compute_120,code=sm_120")
     list(APPEND CUDA_NVCC_FLAGS "-gencode arch=compute_120,code=compute_120")
+  else()
+    list(APPEND CUDA_NVCC_FLAGS "-gencode arch=compute_89,code=compute_89")
   endif()
 
   # Build TensorRT plugin library

--- a/perception/autoware_tensorrt_classifier/CMakeLists.txt
+++ b/perception/autoware_tensorrt_classifier/CMakeLists.txt
@@ -27,6 +27,7 @@ ament_target_dependencies(${PROJECT_NAME}
   OpenCV
 )
 
+list(APPEND CUDA_NVCC_FLAGS "-gencode arch=compute_75,code=sm_75")
 list(APPEND CUDA_NVCC_FLAGS "-gencode arch=compute_86,code=sm_86")
 list(APPEND CUDA_NVCC_FLAGS "-gencode arch=compute_87,code=sm_87")
 list(APPEND CUDA_NVCC_FLAGS "-gencode arch=compute_89,code=sm_89")
@@ -38,6 +39,8 @@ if(CUDA_VERSION VERSION_GREATER_EQUAL "12.8")
   endif()
   list(APPEND CUDA_NVCC_FLAGS "-gencode arch=compute_120,code=sm_120")
   list(APPEND CUDA_NVCC_FLAGS "-gencode arch=compute_120,code=compute_120")
+else()
+    list(APPEND CUDA_NVCC_FLAGS "-gencode arch=compute_89,code=compute_89")
 endif()
 
 cuda_add_library(${PROJECT_NAME}_gpu_preprocess

--- a/perception/autoware_tensorrt_plugins/CMakeLists.txt
+++ b/perception/autoware_tensorrt_plugins/CMakeLists.txt
@@ -85,6 +85,7 @@ if(TRT_AVAIL AND CUDA_AVAIL AND SPCONV_AVAIL)
 
   # cSpell:ignore expt
   list(APPEND CUDA_NVCC_FLAGS "--expt-relaxed-constexpr -diag-suppress 1675 --extended-lambda")
+  list(APPEND CUDA_NVCC_FLAGS "-gencode arch=compute_75,code=sm_75")
   list(APPEND CUDA_NVCC_FLAGS "-gencode arch=compute_86,code=sm_86")
   list(APPEND CUDA_NVCC_FLAGS "-gencode arch=compute_87,code=sm_87")
   list(APPEND CUDA_NVCC_FLAGS "-gencode arch=compute_89,code=sm_89")
@@ -96,6 +97,8 @@ if(TRT_AVAIL AND CUDA_AVAIL AND SPCONV_AVAIL)
     endif()
     list(APPEND CUDA_NVCC_FLAGS "-gencode arch=compute_120,code=sm_120")
     list(APPEND CUDA_NVCC_FLAGS "-gencode arch=compute_120,code=compute_120")
+  else()
+    list(APPEND CUDA_NVCC_FLAGS "-gencode arch=compute_89,code=compute_89")
   endif()
 
   cuda_add_library(cuda_ops SHARED

--- a/perception/autoware_tensorrt_yolox/CMakeLists.txt
+++ b/perception/autoware_tensorrt_yolox/CMakeLists.txt
@@ -81,6 +81,7 @@ if(TRT_AVAIL AND CUDA_AVAIL)
   # but nvcc assume comma separated as argument of `-Xcompiler` option).
   # That is why `cuda_add_library` is used here.
 
+  list(APPEND CUDA_NVCC_FLAGS "-gencode arch=compute_75,code=sm_75")
   list(APPEND CUDA_NVCC_FLAGS "-gencode arch=compute_86,code=sm_86")
   list(APPEND CUDA_NVCC_FLAGS "-gencode arch=compute_87,code=sm_87")
   list(APPEND CUDA_NVCC_FLAGS "-gencode arch=compute_89,code=sm_89")
@@ -92,6 +93,8 @@ if(TRT_AVAIL AND CUDA_AVAIL)
     endif()
     list(APPEND CUDA_NVCC_FLAGS "-gencode arch=compute_120,code=sm_120")
     list(APPEND CUDA_NVCC_FLAGS "-gencode arch=compute_120,code=compute_120")
+  else()
+    list(APPEND CUDA_NVCC_FLAGS "-gencode arch=compute_89,code=compute_89")
   endif()
 
   cuda_add_library(${PROJECT_NAME}_gpu_preprocess

--- a/sensing/autoware_calibration_status_classifier/CMakeLists.txt
+++ b/sensing/autoware_calibration_status_classifier/CMakeLists.txt
@@ -66,6 +66,7 @@ if(TRT_AVAIL AND CUDA_AVAIL)
 
   # cSpell:ignore expt
   list(APPEND CUDA_NVCC_FLAGS "--expt-relaxed-constexpr")
+  list(APPEND CUDA_NVCC_FLAGS "-gencode arch=compute_75,code=sm_75")
   list(APPEND CUDA_NVCC_FLAGS "-gencode arch=compute_86,code=sm_86")
   list(APPEND CUDA_NVCC_FLAGS "-gencode arch=compute_87,code=sm_87")
   list(APPEND CUDA_NVCC_FLAGS "-gencode arch=compute_89,code=sm_89")
@@ -77,6 +78,8 @@ if(TRT_AVAIL AND CUDA_AVAIL)
     endif()
     list(APPEND CUDA_NVCC_FLAGS "-gencode arch=compute_120,code=sm_120")
     list(APPEND CUDA_NVCC_FLAGS "-gencode arch=compute_120,code=compute_120")
+  else()
+    list(APPEND CUDA_NVCC_FLAGS "-gencode arch=compute_89,code=compute_89")
   endif()
 
   cuda_add_library(${PROJECT_NAME}_cuda_lib SHARED

--- a/sensing/autoware_cuda_pointcloud_preprocessor/CMakeLists.txt
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/CMakeLists.txt
@@ -50,6 +50,7 @@ include_directories(
 
 # cSpell: ignore expt
 list(APPEND CUDA_NVCC_FLAGS "--expt-relaxed-constexpr -diag-suppress 20012")
+list(APPEND CUDA_NVCC_FLAGS "-gencode arch=compute_75,code=sm_75")
 list(APPEND CUDA_NVCC_FLAGS "-gencode arch=compute_86,code=sm_86")
 list(APPEND CUDA_NVCC_FLAGS "-gencode arch=compute_87,code=sm_87")
 list(APPEND CUDA_NVCC_FLAGS "-gencode arch=compute_89,code=sm_89")
@@ -61,6 +62,8 @@ if(CUDA_VERSION VERSION_GREATER_EQUAL "12.8")
   endif()
   list(APPEND CUDA_NVCC_FLAGS "-gencode arch=compute_120,code=sm_120")
   list(APPEND CUDA_NVCC_FLAGS "-gencode arch=compute_120,code=compute_120")
+else()
+  list(APPEND CUDA_NVCC_FLAGS "-gencode arch=compute_89,code=compute_89")
 endif()
 
 # __host__ or __device__ annotation on lambda requires --extended-lambda nvcc flag


### PR DESCRIPTION
## Description

restore Turing arch and add else() branch for CMakeLists.txt, as in https://github.com/autowarefoundation/autoware_universe/pull/12194 and many similar PRs.

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
