### PR TITLE
refactor(autoware_behavior_path_dynamic_obstacle_avoidance_module): simplify static-object avoidance logic

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_dynamic_obstacle_avoidance_module/README.md
+++ b/planning/behavior_path_planner/autoware_behavior_path_dynamic_obstacle_avoidance_module/README.md
@@ -1,134 +1,117 @@
-# Avoidance module for dynamic objects
-
-This module is under development.
+# Dynamic Obstacle Avoidance Module
 
 ## Purpose / Role
 
-This module provides avoidance functions for vehicles, pedestrians, and obstacles in the vicinity of the ego's path in combination with the [autoware_path_optimizer](https://autowarefoundation.github.io/autoware_universe/main/planning/autoware_path_optimizer/).
-Each module performs the following roles.
-Dynamic Avoidance module cuts off the drivable area according to the position and velocity of the target to be avoided.
-Obstacle Avoidance module modifies the path to be followed so that it fits within the received drivable area.
+This module constrains the drivable area around obstacles near the ego path so that downstream path generation stays inside a safer corridor.
 
-Static obstacle's avoidance functions are also provided by the [Static Avoidance module](https://autowarefoundation.github.io/autoware_universe/main/planning/autoware_behavior_path_static_obstacle_avoidance_module/), but these modules have different roles.
-The Static Obstacle Avoidance module performs avoidance through the outside of own lanes but cannot avoid the moving objects.
-On the other hand, this module can avoid moving objects.
-For this reason, the word "dynamic" is used in the module's name.
-The table below lists the avoidance modules that can handle each situation.
+- This module: clips drivable area by adding obstacle polygons.
+- Obstacle Avoidance module: generates a path inside the clipped drivable area.
 
-|                          |                         avoid within the own lane                          | avoid through the outside of own lanes |
-| :----------------------- | :------------------------------------------------------------------------: | :------------------------------------: |
-| avoid not-moving objects | Avoidance Module <br> Dynamic Avoidance Module + Obstacle Avoidance Module |            Avoidance Module            |
-| avoid moving objects     |            Dynamic Avoidance Module + Obstacle Avoidance Module            |     No Module (Under Development)      |
+Although the package name contains `dynamic`, the current implementation is intentionally simplified and focused on **stopped or very low-speed objects**.
 
-## Policy of algorithms
+## Current Scope
 
-Here, we describe the policy of inner algorithms.
-The inner algorithms can be separated into two parts: The first decides whether to avoid the obstacles and the second cuts off the drivable area against the corresponding obstacle.
+### What this module handles
 
-### Select obstacles to avoid
+- Objects close to the ego path and enabled by class filter (`car`, `truck`, `bus`, `trailer`, `unknown`, `bicycle`, `motorcycle`, `pedestrian`).
+- Objects whose speed norm is below `target_object.stopped_object.max_object_vel`.
+- In-lane drivable-area clipping (it does not expand drivable lanes by itself).
 
-To decide whether to avoid an object, both the predicted path and the state (pose and twist) of each object are used.
-The type of objects the user wants this module to avoid is also required.
-Using this information, the module decides to _avoid_ objects that _obstruct the ego's passage_ and _can be avoided_.
+### What this module does not handle
 
-The definition of _obstruct the ego's passage_ is implemented as the object that collides within seconds.
-The other, _can be avoided_ denotes whether it can be avoided without risk to the passengers or the other vehicles.
-For this purpose, the module judges whether the obstacle can be avoided with satisfying the constraints of lateral acceleration and lateral jerk.
-For example, the module decides not to avoid an object that is too close or fast in the lateral direction.
+- Dynamic-object reasoning based on predicted paths.
+- Cut-in / cut-out / crossing classification.
+- Time-to-collision based longitudinal extension.
+- Lateral feasibility checks based on ego lateral acceleration/jerk.
 
-### Cuts off the drivable area against the selected vehicles
+In other words, moving-object avoidance behavior that relied on predictive motion logic is not part of the current module behavior.
 
-For the selected obstacles to be avoided, the module cuts off the drivable area.
-As inputs to decide the shapes of cut-off polygons, poses of the obstacles are mainly used, assuming they move in parallel to the ego's path, instead of its predicted path.
-This design arises from that the predicted path of objects is not accurate enough to use the path modifications (at least currently).
-Furthermore, the output drivable area shape is designed as a rectangular cutout along the ego's path to make the computation scalar rather than planar.
+## Algorithm Overview
 
-#### Determination of lateral dimension
+The processing flow has two stages.
 
-The lateral dimensions of the polygon are calculated as follows.
-The polygon's width to extract from the drivable area is the obstacle width and `drivable_area_generation.lat_offset_from_obstacle`.
-We can limit the lateral shift length by `drivable_area_generation.max_lat_offset_to_avoid`.
+1. Select target objects.
+2. Generate obstacle polygons and subtract them from drivable area.
 
-![drivable_area_extraction_width](./image/drivable_area_extraction_width.drawio.svg)
+### 1) Target object selection
 
-#### Determination of longitudinal dimension
+For each perceived object:
 
-Then, extracting the same directional and opposite directional obstacles from the drivable area will work as follows considering TTC (time to collision).
+- Check object class against target class flags.
+- Check speed threshold with `target_object.stopped_object.max_object_vel`.
+- Check lateral proximity to the ego path using `min_obj_lat_offset_to_ego_path` and `max_obj_lat_offset_to_ego_path`.
 
-Regarding the same directional obstacles, obstacles whose TTC is negative will be ignored (e.g., The obstacle is in front of the ego, and the obstacle's velocity is larger than the ego's velocity.).
+Objects that pass these checks are considered avoidance candidates.
 
-Same directional obstacles (Parameter names may differ from implementation)
-![same_directional_object](./image/same_directional_object.svg)
+### 2) Polygon generation and drivable-area clipping
 
-Opposite directional obstacles (Parameter names may differ from implementation)
-![opposite_directional_object](./image/opposite_directional_object.svg)
+#### Regulated objects (vehicle-like classes)
 
-### Cuts off the drivable area against the selected pedestrians
+- Build a polygon along the ego reference path around the object longitudinal interval.
+- Lateral width is determined from object lateral coverage and:
+  - `drivable_area_generation.lat_offset_from_obstacle`
+  - `drivable_area_generation.max_lat_offset_to_avoid`
+  - `drivable_area_generation.lpf_gain_for_lat_avoid_to_offset`
+  - `target_object.front_object.max_ego_path_lat_cover_ratio`
 
-Then, we describe the logic to generate the drivable areas against pedestrians to be avoided.
-Objects of this type are considered to have priority right of way over the ego's vehicle while ensuring a minimum safety of the ego's vehicle.
-In other words, the module assigns a drivable area to an obstacle with a specific margin based on the predicted paths with specific confidences for a specific time interval, as shown in the following figure.
+The result is a path-aligned clipped region.
 
-<figure>
-    <img src="./image/2024-04-18_15-13-01.png" width="600">
-    <figcaption> Restriction areas are generated from each pedestrian's predicted paths</figcaption>
-</figure>
+#### Unregulated objects (pedestrian-like classes)
 
-Apart from polygons for objects, the module also generates another polygon to ensure the ego's safety, i.e., to avoid abrupt steering or significant changes from the path.
-This is similar to avoidance against the vehicles and takes precedence over keeping a safe distance from the object to be avoided.
-As a result, as shown in the figure below, the polygons around the objects reduced by the secured polygon of the ego are subtracted from the ego's drivable area.
+- Build polygon from the **current object footprint only** (no predicted-path hull).
+- Expand it by `drivable_area_generation.margin_distance_around_pedestrian`.
+- Subtract ego reserve polygon to keep minimum ego corridor.
 
-<figure>
-    <img src="./image/2024-04-18_15-32-03.png" width="600">
-    <figcaption> Ego's minimum requirements are prioritized against object margin</figcaption>
-</figure>
+## Relation to Other Avoidance Modules
 
-## Example
+Compared with [Static Obstacle Avoidance module](https://autowarefoundation.github.io/autoware_universe/main/planning/autoware_behavior_path_static_obstacle_avoidance_module/):
 
-<figure>
-    <img src="./image/image-20230807-151945.png" width="800">
-    <figcaption>Avoidance for the bus departure</figcaption>
-</figure>
+- Static Obstacle Avoidance is responsible for larger path-shift behavior (including outside-lane maneuvering depending on scenario).
+- This module is a drivable-area clipping module around nearby low-speed obstacles.
 
-<figure>  
-    <img src="./image/image-20230807-152835.png" width="800">
-    <figcaption>Avoidance on curve </figcaption>
-</figure>
+Both may contribute to overall avoidance behavior depending on planner configuration.
 
-<figure>
-    <img src="./image/image-20230808-095936.png" width="800">
-    <figcaption>Avoidance against the opposite direction vehicle</figcaption>
-</figure>
+## Limitations
 
-<figure>
-    <img src="./image/image-20230808-152853.png" width="800">
-    <figcaption>Avoidance for multiple vehicle</figcaption>
-</figure>
-
-## Future works
-
-Currently, the path shifting length is limited to 0.5 meters or less by `drivable_area_generation.max_lat_offset_to_avoid`.
-This is caused by the lack of functionality to work with other modules and the structure of the planning component.
-Due to this issue, this module can only handle situations where a small avoidance width is sufficient.
-This issue is the most significant for this module.
-In addition, the ability of this module to extend the drivable area as needed is also required.
+- Moving objects above `stopped_object.max_object_vel` are filtered out by design.
+- The module keeps existing drivable lanes from upstream and does not perform internal lane expansion.
+- `max_lat_offset_to_avoid` limits how much lateral clearance can be enforced in clipping.
 
 ## Parameters
 
-Under development
+All parameters are under `dynamic_avoidance`.
 
-| Name                                                                  | Unit  | Type   | Description                                                | Default value |
-| :-------------------------------------------------------------------- | :---- | :----- | :--------------------------------------------------------- | :------------ |
-| target_object.car                                                     | [-]   | bool   | The flag whether to avoid cars or not                      | true          |
-| target_object.truck                                                   | [-]   | bool   | The flag whether to avoid trucks or not                    | true          |
-| ...                                                                   | [-]   | bool   | ...                                                        | ...           |
-| target_object.min_obstacle_vel                                        | [m/s] | double | Minimum obstacle velocity to avoid                         | 1.0           |
-| drivable_area_generation.lat_offset_from_obstacle                     | [m]   | double | Lateral offset to avoid from obstacles                     | 0.8           |
-| drivable_area_generation.max_lat_offset_to_avoid                      | [m]   | double | Maximum lateral offset to avoid                            | 0.5           |
-| drivable_area_generation.overtaking_object.max_time_to_collision      | [s]   | double | Maximum value when calculating time to collision           | 3.0           |
-| drivable_area_generation.overtaking_object.start_duration_to_avoid    | [s]   | double | Duration to consider avoidance before passing by obstacles | 4.0           |
-| drivable_area_generation.overtaking_object.end_duration_to_avoid      | [s]   | double | Duration to consider avoidance after passing by obstacles  | 5.0           |
-| drivable_area_generation.overtaking_object.duration_to_hold_avoidance | [s]   | double | Duration to hold avoidance after passing by obstacles      | 3.0           |
-| drivable_area_generation.oncoming_object.max_time_to_collision        | [s]   | double | Maximum value when calculating time to collision           | 3.0           |
-| drivable_area_generation.oncoming_object.start_duration_to_avoid      | [s]   | double | Duration to consider avoidance before passing by obstacles | 9.0           |
-| drivable_area_generation.oncoming_object.end_duration_to_avoid        | [s]   | double | Duration to consider avoidance after passing by obstacles  | 0.0           |
+### common
+
+| Name                               | Unit  | Type   | Description                                                     | Default |
+| :--------------------------------- | :---- | :----- | :-------------------------------------------------------------- | :------ |
+| `common.enable_debug_info`         | `[-]` | `bool` | Enable debug logging for this module                            | `false` |
+| `common.use_hatched_road_markings` | `[-]` | `bool` | Enable hatched road marking handling in drivable area utilities | `true`  |
+
+### target_object
+
+| Name                                                                | Unit    | Type     | Description                                                     | Default |
+| :------------------------------------------------------------------ | :------ | :------- | :-------------------------------------------------------------- | :------ |
+| `target_object.car`                                                 | `[-]`   | `bool`   | Avoid cars                                                      | `true`  |
+| `target_object.truck`                                               | `[-]`   | `bool`   | Avoid trucks                                                    | `true`  |
+| `target_object.bus`                                                 | `[-]`   | `bool`   | Avoid buses                                                     | `true`  |
+| `target_object.trailer`                                             | `[-]`   | `bool`   | Avoid trailers                                                  | `true`  |
+| `target_object.unknown`                                             | `[-]`   | `bool`   | Avoid unknown objects                                           | `false` |
+| `target_object.bicycle`                                             | `[-]`   | `bool`   | Avoid bicycles                                                  | `true`  |
+| `target_object.motorcycle`                                          | `[-]`   | `bool`   | Avoid motorcycles                                               | `true`  |
+| `target_object.pedestrian`                                          | `[-]`   | `bool`   | Avoid pedestrians                                               | `true`  |
+| `target_object.successive_num_to_entry_dynamic_avoidance_condition` | `[-]`   | `int`    | Consecutive count to enter valid target state                   | `5`     |
+| `target_object.successive_num_to_exit_dynamic_avoidance_condition`  | `[-]`   | `int`    | Consecutive count threshold to remove valid target state        | `1`     |
+| `target_object.min_obj_lat_offset_to_ego_path`                      | `[m]`   | `double` | Minimum lateral overlap margin to treat object as on ego path   | `0.0`   |
+| `target_object.max_obj_lat_offset_to_ego_path`                      | `[m]`   | `double` | Maximum lateral distance from ego path to consider object       | `1.0`   |
+| `target_object.front_object.max_ego_path_lat_cover_ratio`           | `[-]`   | `double` | Ignore object if it laterally covers too much of ego path width | `0.3`   |
+| `target_object.stopped_object.max_object_vel`                       | `[m/s]` | `double` | Maximum speed treated as stopped/low-speed target               | `0.5`   |
+
+### drivable_area_generation
+
+| Name                                                         | Unit  | Type     | Description                                            | Default |
+| :----------------------------------------------------------- | :---- | :------- | :----------------------------------------------------- | :------ |
+| `drivable_area_generation.lat_offset_from_obstacle`          | `[m]` | `double` | Base lateral clearance margin from obstacle            | `1.0`   |
+| `drivable_area_generation.margin_distance_around_pedestrian` | `[m]` | `double` | Buffer margin for unregulated-object footprint polygon | `2.0`   |
+| `drivable_area_generation.max_lat_offset_to_avoid`           | `[m]` | `double` | Maximum lateral offset reserved for clipping policy    | `0.5`   |
+| `drivable_area_generation.lpf_gain_for_lat_avoid_to_offset`  | `[-]` | `double` | LPF gain for lateral avoidance boundary stabilization  | `0.9`   |

--- a/planning/behavior_path_planner/autoware_behavior_path_dynamic_obstacle_avoidance_module/README.md
+++ b/planning/behavior_path_planner/autoware_behavior_path_dynamic_obstacle_avoidance_module/README.md
@@ -39,7 +39,7 @@ For each perceived object:
 
 - Check object class against target class flags.
 - Check speed threshold with `target_object.stopped_object.max_object_vel`.
-- Check lateral proximity to the ego path using `min_obj_lat_offset_to_ego_path` and `max_obj_lat_offset_to_ego_path`.
+- Check lateral proximity to the ego path using `max_obj_lat_offset_to_ego_path`.
 
 Objects that pass these checks are considered avoidance candidates.
 
@@ -102,7 +102,6 @@ All parameters are under `dynamic_avoidance`.
 | `target_object.pedestrian`                                          | `[-]`   | `bool`   | Avoid pedestrians                                               | `true`  |
 | `target_object.successive_num_to_entry_dynamic_avoidance_condition` | `[-]`   | `int`    | Consecutive count to enter valid target state                   | `5`     |
 | `target_object.successive_num_to_exit_dynamic_avoidance_condition`  | `[-]`   | `int`    | Consecutive count threshold to remove valid target state        | `1`     |
-| `target_object.min_obj_lat_offset_to_ego_path`                      | `[m]`   | `double` | Minimum lateral overlap margin to treat object as on ego path   | `0.0`   |
 | `target_object.max_obj_lat_offset_to_ego_path`                      | `[m]`   | `double` | Maximum lateral distance from ego path to consider object       | `1.0`   |
 | `target_object.front_object.max_ego_path_lat_cover_ratio`           | `[-]`   | `double` | Ignore object if it laterally covers too much of ego path width | `0.3`   |
 | `target_object.stopped_object.max_object_vel`                       | `[m/s]` | `double` | Maximum speed treated as stopped/low-speed target               | `0.5`   |

--- a/planning/behavior_path_planner/autoware_behavior_path_dynamic_obstacle_avoidance_module/config/dynamic_obstacle_avoidance.param.yaml
+++ b/planning/behavior_path_planner/autoware_behavior_path_dynamic_obstacle_avoidance_module/config/dynamic_obstacle_avoidance.param.yaml
@@ -16,68 +16,20 @@
         motorcycle: true
         pedestrian: true
 
-        max_obstacle_vel: 100.0 # [m/s]
-        min_obstacle_vel: 0.0 # [m/s]
-
         successive_num_to_entry_dynamic_avoidance_condition: 5
         successive_num_to_exit_dynamic_avoidance_condition: 1
 
         min_obj_lat_offset_to_ego_path: 0.0 # [m]
         max_obj_lat_offset_to_ego_path: 1.0 # [m]
 
-        cut_in_object:
-          min_time_to_start_cut_in: 1.0 # [s]
-          min_lon_offset_ego_to_object: 0.0 # [m]
-          min_object_vel: 0.5 # [m/s]
-
-        cut_out_object:
-          max_time_from_outside_ego_path: 2.0 # [s]
-          min_object_lat_vel: 0.3 # [m/s]
-          min_object_vel: 0.5 # [m/s]
-
-        crossing_object:
-          min_overtaking_object_vel: 1.0
-          max_overtaking_object_angle: 1.05
-          min_oncoming_object_vel: 1.0
-          max_oncoming_object_angle: 0.523
-          max_pedestrian_crossing_vel: 0.8
-
         front_object:
-          max_object_angle: 0.785
-          min_object_vel: -0.5               # [m/s] The value is negative considering the noisy velocity of the stopped vehicle.
           max_ego_path_lat_cover_ratio: 0.3  # [-] The object will be ignored if the ratio of the object covering the ego's path is higher than this value.
 
         stopped_object:
           max_object_vel: 0.5 # [m/s] The object will be determined as stopped if the velocity is smaller than this value.
 
       drivable_area_generation:
-        expand_drivable_area: false
-        polygon_generation_method: "ego_path_base" # choose "ego_path_base" and "object_path_base"
-        object_path_base:
-          min_longitudinal_polygon_margin: 3.0 # [m]
-
         lat_offset_from_obstacle: 1.0 # [m]
         margin_distance_around_pedestrian: 2.0 # [m]
-        predicted_path:
-          end_time_to_consider: 2.0 # [s]
-          threshold_confidence: 0.0 # [] not probability
         max_lat_offset_to_avoid: 0.5 # [m]
-        max_time_for_object_lat_shift: 0.0 # [s]
         lpf_gain_for_lat_avoid_to_offset: 0.9 # [-]
-
-        max_ego_lat_acc: 0.3        # [m/ss]
-        max_ego_lat_jerk: 0.3       # [m/sss]
-        delay_time_ego_shift: 1.0   # [s]
-
-        # for same directional object
-        overtaking_object:
-          max_time_to_collision: 40.0 # [s]
-          start_duration_to_avoid: 1.0  # [s]
-          end_duration_to_avoid: 1.0  # [s]
-          duration_to_hold_avoidance: 3.0 # [s]
-
-        # for opposite directional object
-        oncoming_object:
-          max_time_to_collision: 40.0 # [s] This value should be the same as overtaking_object's one to suppress chattering of this value for parked vehicles
-          start_duration_to_avoid: 1.0  # [s]
-          end_duration_to_avoid: 0.0  # [s]

--- a/planning/behavior_path_planner/autoware_behavior_path_dynamic_obstacle_avoidance_module/config/dynamic_obstacle_avoidance.param.yaml
+++ b/planning/behavior_path_planner/autoware_behavior_path_dynamic_obstacle_avoidance_module/config/dynamic_obstacle_avoidance.param.yaml
@@ -2,34 +2,33 @@
   ros__parameters:
     dynamic_avoidance:
       common:
-        enable_debug_info: false
-        use_hatched_road_markings: true
+        enable_debug_info: false # Enable verbose debug logs for object filtering and polygon generation.
+        use_hatched_road_markings: true # Keep hatched road markings available in drivable area output handling.
 
       # avoidance is performed for the object type with true
       target_object:
-        car: true
-        truck: true
-        bus: true
-        trailer: true
-        unknown: false
-        bicycle: true
-        motorcycle: true
-        pedestrian: true
+        car: true # Treat CAR as avoidance target.
+        truck: true # Treat TRUCK as avoidance target.
+        bus: true # Treat BUS as avoidance target.
+        trailer: true # Treat TRAILER as avoidance target.
+        unknown: false # Treat UNKNOWN as avoidance target (handled as unregulated object).
+        bicycle: true # Treat BICYCLE as avoidance target (handled as unregulated object).
+        motorcycle: true # Treat MOTORCYCLE as avoidance target.
+        pedestrian: true # Treat PEDESTRIAN as avoidance target (handled as unregulated object).
 
-        successive_num_to_entry_dynamic_avoidance_condition: 5
-        successive_num_to_exit_dynamic_avoidance_condition: 1
+        successive_num_to_entry_dynamic_avoidance_condition: 5 # Consecutive detection count required to activate an object as valid target.
+        successive_num_to_exit_dynamic_avoidance_condition: 1 # Counter threshold to keep an object valid; below this value the object is removed.
 
-        min_obj_lat_offset_to_ego_path: 0.0 # [m]
-        max_obj_lat_offset_to_ego_path: 1.0 # [m]
+        max_obj_lat_offset_to_ego_path: 1.0 # [m] Maximum lateral distance from ego path to consider regulated objects.
 
         front_object:
-          max_ego_path_lat_cover_ratio: 0.3  # [-] The object will be ignored if the ratio of the object covering the ego's path is higher than this value.
+          max_ego_path_lat_cover_ratio: 0.3 # [-] Ignore regulated object when its lateral overlap with ego path exceeds this ratio.
 
         stopped_object:
-          max_object_vel: 0.5 # [m/s] The object will be determined as stopped if the velocity is smaller than this value.
+          max_object_vel: 0.5 # [m/s] Maximum speed magnitude considered as stopped/low-speed target in this module.
 
       drivable_area_generation:
-        lat_offset_from_obstacle: 1.0 # [m]
-        margin_distance_around_pedestrian: 2.0 # [m]
-        max_lat_offset_to_avoid: 0.5 # [m]
-        lpf_gain_for_lat_avoid_to_offset: 0.9 # [-]
+        lat_offset_from_obstacle: 1.0 # [m] Base lateral clearance added around obstacle occupancy for lateral bounds.
+        margin_distance_around_pedestrian: 2.0 # [m] Isotropic buffer for unregulated-object (e.g., pedestrian) final clipping polygon.
+        max_lat_offset_to_avoid: 0.5 # [m] Maximum lateral clipping amount allowed on the ego side.
+        lpf_gain_for_lat_avoid_to_offset: 0.9 # [-] Low-pass filter gain for stabilizing near-side lateral bound between frames.

--- a/planning/behavior_path_planner/autoware_behavior_path_dynamic_obstacle_avoidance_module/include/autoware/behavior_path_dynamic_obstacle_avoidance_module/scene.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_dynamic_obstacle_avoidance_module/include/autoware/behavior_path_dynamic_obstacle_avoidance_module/scene.hpp
@@ -333,6 +333,8 @@ private:
     const DynamicAvoidanceObject & object) const;
   std::optional<autoware_utils::Polygon2d> calcCurrentPoseBasedDynamicObstaclePolygon(
     const DynamicAvoidanceObject & object, const EgoPathReservePoly & ego_path_poly) const;
+  std::optional<autoware_utils::Polygon2d> calcExpandedCurrentPoseObjectPolygon(
+    const DynamicAvoidanceObject & object) const;
   EgoPathReservePoly calcEgoPathReservePoly(const PathWithLaneId & ego_path) const;
 
   std::vector<DynamicObstacleAvoidanceModule::DynamicAvoidanceObject> target_objects_;

--- a/planning/behavior_path_planner/autoware_behavior_path_dynamic_obstacle_avoidance_module/include/autoware/behavior_path_dynamic_obstacle_avoidance_module/scene.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_dynamic_obstacle_avoidance_module/include/autoware/behavior_path_dynamic_obstacle_avoidance_module/scene.hpp
@@ -22,10 +22,6 @@
 
 #include <autoware_internal_planning_msgs/msg/path_with_lane_id.hpp>
 #include <autoware_perception_msgs/msg/predicted_object.hpp>
-#include <autoware_perception_msgs/msg/predicted_path.hpp>
-#include <autoware_vehicle_msgs/msg/turn_indicators_command.hpp>
-#include <tier4_planning_msgs/msg/avoidance_debug_msg.hpp>
-#include <tier4_planning_msgs/msg/avoidance_debug_msg_array.hpp>
 
 #include <algorithm>
 #include <iostream>
@@ -58,7 +54,6 @@ std::vector<T> getAllKeys(const std::unordered_map<T, S> & map)
 namespace autoware::behavior_path_planner
 {
 using autoware_internal_planning_msgs::msg::PathWithLaneId;
-using autoware_perception_msgs::msg::PredictedPath;
 using autoware_utils::Polygon2d;
 
 struct MinMaxValue
@@ -73,11 +68,6 @@ struct MinMaxValue
     return ret;
   };
   void swap() { std::swap(min_value, max_value); }
-};
-
-enum class PolygonGenerationMethod {
-  EGO_PATH_BASE = 0,
-  OBJECT_PATH_BASE,
 };
 
 enum class ObjectType {
@@ -96,8 +86,6 @@ struct DynamicAvoidanceParameters
   bool enable_debug_info{true};
   bool use_hatched_road_markings{true};
 
-  std::string use_lane_type{"opposite_direction_lane"};
-
   // obstacle types to avoid
   bool avoid_car{true};
   bool avoid_truck{true};
@@ -107,69 +95,23 @@ struct DynamicAvoidanceParameters
   bool avoid_bicycle{false};
   bool avoid_motorcycle{false};
   bool avoid_pedestrian{false};
-  double max_obstacle_vel{0.0};
-  double min_obstacle_vel{0.0};
   int successive_num_to_entry_dynamic_avoidance_condition{0};
   int successive_num_to_exit_dynamic_avoidance_condition{0};
 
   double min_obj_lat_offset_to_ego_path{0.0};
   double max_obj_lat_offset_to_ego_path{0.0};
 
-  double min_time_to_start_cut_in{0.0};
-  double min_lon_offset_ego_to_cut_in_object{0.0};
-  double min_cut_in_object_vel{0.0};
-  double max_time_from_outside_ego_path_for_cut_out{0.0};
-  double min_cut_out_object_lat_vel{0.0};
-  double min_cut_out_object_vel{0.0};
-  double max_front_object_angle{0.0};
-  double min_front_object_vel{0.0};
   double max_front_object_ego_path_lat_cover_ratio{0.0};
-  double min_overtaking_crossing_object_vel{0.0};
-  double max_overtaking_crossing_object_angle{0.0};
-  double min_oncoming_crossing_object_vel{0.0};
-  double max_oncoming_crossing_object_angle{0.0};
-  double max_pedestrian_crossing_vel{0.0};
   double max_stopped_object_vel{0.0};
 
   // drivable area generation
-  PolygonGenerationMethod polygon_generation_method{};
-  bool expand_drivable_area;
-  double min_obj_path_based_lon_polygon_margin{0.0};
   double lat_offset_from_obstacle{0.0};
   double margin_distance_around_pedestrian{0.0};
 
-  double end_time_to_consider{0.0};
-  double threshold_confidence{0.0};
-
   double max_lat_offset_to_avoid{0.0};
-  double max_time_for_lat_shift{0.0};
   double lpf_gain_for_lat_avoid_to_offset{0.0};
-
-  double max_ego_lat_acc{0.0};
-  double max_ego_lat_jerk{0.0};
-  double delay_time_ego_shift{0.0};
-
-  double max_time_to_collision_overtaking_object{0.0};
-  double start_duration_to_avoid_overtaking_object{0.0};
-  double end_duration_to_avoid_overtaking_object{0.0};
-  double duration_to_hold_avoidance_overtaking_object{0.0};
-
-  double max_time_to_collision_oncoming_object{0.0};
-  double start_duration_to_avoid_oncoming_object{0.0};
-  double end_duration_to_avoid_oncoming_object{0.0};
 };
 
-struct TimeWhileCollision
-{
-  double time_to_start_collision;
-  double time_to_end_collision;
-};
-
-struct LatFeasiblePaths
-{
-  std::vector<geometry_msgs::msg::Point> left_path;
-  std::vector<geometry_msgs::msg::Point> right_path;
-};
 class DynamicObstacleAvoidanceModule : public SceneModuleInterface
 {
 public:
@@ -180,32 +122,23 @@ public:
   struct DynamicAvoidanceObject
   {
     DynamicAvoidanceObject(
-      const PredictedObject & predicted_object, const double arg_vel, const double arg_lat_vel,
-      const bool arg_is_object_on_ego_path,
+      const PredictedObject & predicted_object, const bool arg_is_object_on_ego_path,
       const std::optional<rclcpp::Time> & arg_latest_time_inside_ego_path)
     : uuid(autoware_utils::to_hex_string(predicted_object.object_id)),
       label(predicted_object.classification.front().label),
       pose(predicted_object.kinematics.initial_pose_with_covariance.pose),
       shape(predicted_object.shape),
-      vel(arg_vel),
-      lat_vel(arg_lat_vel),
       is_object_on_ego_path(arg_is_object_on_ego_path),
       latest_time_inside_ego_path(arg_latest_time_inside_ego_path)
     {
-      for (const auto & path : predicted_object.kinematics.predicted_paths) {
-        predicted_paths.push_back(path);
-      }
     }
 
     std::string uuid{};
     uint8_t label{};
     geometry_msgs::msg::Pose pose{};
     autoware_perception_msgs::msg::Shape shape;
-    double vel{0.0};
-    double lat_vel{0.0};
     bool is_object_on_ego_path{false};
     std::optional<rclcpp::Time> latest_time_inside_ego_path{std::nullopt};
-    std::vector<autoware_perception_msgs::msg::PredictedPath> predicted_paths{};
 
     // NOTE: Previous values of the following are used for low-pass filtering.
     //       Therefore, they has to be initialized as nullopt.
@@ -214,7 +147,6 @@ public:
     bool is_collision_left{false};
     bool should_be_avoided{false};
     std::vector<geometry_msgs::msg::Pose> ref_points_for_obj_poly;
-    LatFeasiblePaths ego_lat_feasible_paths;
 
     // add additional information (not update to the latest data)
     void update(
@@ -244,11 +176,7 @@ public:
     {
       // add/update object
       if (object_map_.count(uuid) != 0) {
-        const auto prev_object = object_map_.at(uuid);
         object_map_.at(uuid) = object;
-        // TODO(murooka) refactor this. Counter can be moved to DynamicObject,
-        //               and TargetObjectsManager can be removed.
-        object_map_.at(uuid).ego_lat_feasible_paths = prev_object.ego_lat_feasible_paths;
       } else {
         object_map_.emplace(uuid, object);
       }
@@ -264,7 +192,7 @@ public:
       current_uuids_.push_back(uuid);
     }
 
-    void finalize(const LatFeasiblePaths & ego_lat_feasible_paths)
+    void finalize()
     {
       // decrease counter for not updated uuids
       std::vector<std::string> not_updated_uuids;
@@ -285,7 +213,6 @@ public:
       for (const auto & counter : counter_map_) {
         if (!isInVector(counter.first, valid_object_uuids_) && max_count_ <= counter.second) {
           valid_object_uuids_.push_back(counter.first);
-          object_map_.at(counter.first).ego_lat_feasible_paths = ego_lat_feasible_paths;
         }
       }
       valid_object_uuids_.erase(
@@ -340,12 +267,6 @@ public:
     std::vector<std::string> valid_object_uuids_{};
   };
 
-  struct DecisionWithReason
-  {
-    bool decision;
-    std::string reason{""};
-  };
-
   DynamicObstacleAvoidanceModule(
     const std::string & name, rclcpp::Node & node,
     std::shared_ptr<DynamicAvoidanceParameters> parameters,
@@ -397,74 +318,31 @@ private:
     const std::vector<DynamicAvoidanceObject> & prev_objects);
   void determineWhetherToAvoidAgainstUnregulatedObjects(
     const std::vector<DynamicAvoidanceObject> & prev_objects);
-  LatFeasiblePaths generateLateralFeasiblePaths(
-    const geometry_msgs::msg::Pose & ego_pose, const double ego_vel) const;
-  void updateRefPathBeforeLaneChange(const std::vector<PathPointWithLaneId> & ego_ref_path_points);
-  bool willObjectCutIn(
-    const std::vector<PathPointWithLaneId> & ego_path, const PredictedPath & predicted_path,
-    const double obj_tangent_vel, const LatLonOffset & lat_lon_offset) const;
-  DecisionWithReason willObjectCutOut(
-    const double obj_tangent_vel, const double obj_normal_vel, const bool is_object_left,
-    const std::optional<DynamicAvoidanceObject> & prev_object) const;
-  bool willObjectBeOutsideEgoChangingPath(
-    const geometry_msgs::msg::Pose & obj_pose,
-    const autoware_perception_msgs::msg::Shape & obj_shape, const double obj_vel) const;
   bool isObjectFarFromPath(
     const PredictedObject & predicted_object, const double obj_dist_to_path) const;
-  TimeWhileCollision calcTimeWhileCollision(
-    const std::vector<PathPointWithLaneId> & ego_path, const double obj_tangent_vel,
-    const LatLonOffset & lat_lon_offset) const;
-  std::optional<std::pair<size_t, size_t>> calcCollisionSection(
-    const std::vector<PathPointWithLaneId> & ego_path, const PredictedPath & obj_path) const;
   LatLonOffset getLateralLongitudinalOffset(
     const std::vector<geometry_msgs::msg::Pose> & ego_points,
     const geometry_msgs::msg::Pose & obj_pose, const size_t obj_seg_idx,
     const autoware_perception_msgs::msg::Shape & obj_shape) const;
-  double calcValidLengthToAvoid(
-    const PredictedPath & obj_path, const geometry_msgs::msg::Pose & obj_pose,
-    const autoware_perception_msgs::msg::Shape & obj_shape,
-    const bool is_object_same_direction) const;
   MinMaxValue calcMinMaxLongitudinalOffsetToAvoid(
     const std::vector<geometry_msgs::msg::Pose> & ref_points_for_obj_poly,
-    const geometry_msgs::msg::Pose & obj_pose, const Polygon2d & obj_points, const double obj_vel,
-    const PredictedPath & obj_path, const autoware_perception_msgs::msg::Shape & obj_shape,
-    const TimeWhileCollision & time_while_collision) const;
+    const geometry_msgs::msg::Pose & obj_pose, const Polygon2d & obj_points) const;
   std::optional<MinMaxValue> calcMinMaxLateralOffsetToAvoidRegulatedObject(
     const std::vector<geometry_msgs::msg::Pose> & ref_points_for_obj_poly,
-    const Polygon2d & obj_points, const geometry_msgs::msg::Point & obj_pos, const double obj_vel,
-    const bool is_collision_left, const double obj_normal_vel,
-    const std::optional<DynamicAvoidanceObject> & prev_object) const;
+    const Polygon2d & obj_points, const geometry_msgs::msg::Point & obj_pos,
+    const bool is_collision_left, const std::optional<DynamicAvoidanceObject> & prev_object) const;
   std::optional<MinMaxValue> calcMinMaxLateralOffsetToAvoidUnregulatedObject(
     const std::vector<geometry_msgs::msg::Pose> & ref_points_for_obj_poly,
     const std::optional<DynamicAvoidanceObject> & prev_object,
     const DynamicAvoidanceObject & object) const;
-  std::pair<lanelet::ConstLanelets, lanelet::ConstLanelets> getAdjacentLanes(
-    const double forward_distance, const double backward_distance) const;
   std::optional<autoware_utils::Polygon2d> calcEgoPathBasedDynamicObstaclePolygon(
     const DynamicAvoidanceObject & object) const;
-  std::optional<autoware_utils::Polygon2d> calcObjectPathBasedDynamicObstaclePolygon(
-    const DynamicAvoidanceObject & object) const;
-  std::optional<autoware_utils::Polygon2d> calcPredictedPathBasedDynamicObstaclePolygon(
+  std::optional<autoware_utils::Polygon2d> calcCurrentPoseBasedDynamicObstaclePolygon(
     const DynamicAvoidanceObject & object, const EgoPathReservePoly & ego_path_poly) const;
   EgoPathReservePoly calcEgoPathReservePoly(const PathWithLaneId & ego_path) const;
-  lanelet::ConstLanelets getCurrentLanesFromPath(
-    const PathWithLaneId & path, const std::shared_ptr<const PlannerData> & planner_data);
-  DrivableLanes generateExpandedDrivableLanes(
-    const lanelet::ConstLanelet & lanelet, const std::shared_ptr<const PlannerData> & planner_data,
-    const std::shared_ptr<DynamicAvoidanceParameters> & parameters);
-
-  void printIgnoreReason(const std::string & obj_uuid, const std::string & reason)
-  {
-    const auto reason_text =
-      "[DynamicAvoidance] Ignore obstacle (%s)" + (reason == "" ? "." : " since " + reason + ".");
-    RCLCPP_INFO_EXPRESSION(
-      getLogger(), parameters_->enable_debug_info, reason_text.c_str(), obj_uuid.c_str());
-  }
 
   std::vector<DynamicObstacleAvoidanceModule::DynamicAvoidanceObject> target_objects_;
   // std::vector<DynamicObstacleAvoidanceModule::DynamicAvoidanceObject> prev_target_objects_;
-  std::optional<std::vector<PathPointWithLaneId>> prev_input_ref_path_points_{std::nullopt};
-  std::optional<std::vector<PathPointWithLaneId>> ref_path_before_lane_change_{std::nullopt};
   std::shared_ptr<DynamicAvoidanceParameters> parameters_;
 
   TargetObjectsManager target_objects_manager_;

--- a/planning/behavior_path_planner/autoware_behavior_path_dynamic_obstacle_avoidance_module/include/autoware/behavior_path_dynamic_obstacle_avoidance_module/scene.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_dynamic_obstacle_avoidance_module/include/autoware/behavior_path_dynamic_obstacle_avoidance_module/scene.hpp
@@ -98,7 +98,6 @@ struct DynamicAvoidanceParameters
   int successive_num_to_entry_dynamic_avoidance_condition{0};
   int successive_num_to_exit_dynamic_avoidance_condition{0};
 
-  double min_obj_lat_offset_to_ego_path{0.0};
   double max_obj_lat_offset_to_ego_path{0.0};
 
   double max_front_object_ego_path_lat_cover_ratio{0.0};
@@ -121,15 +120,11 @@ public:
 
   struct DynamicAvoidanceObject
   {
-    DynamicAvoidanceObject(
-      const PredictedObject & predicted_object, const bool arg_is_object_on_ego_path,
-      const std::optional<rclcpp::Time> & arg_latest_time_inside_ego_path)
+    explicit DynamicAvoidanceObject(const PredictedObject & predicted_object)
     : uuid(autoware_utils::to_hex_string(predicted_object.object_id)),
       label(predicted_object.classification.front().label),
       pose(predicted_object.kinematics.initial_pose_with_covariance.pose),
-      shape(predicted_object.shape),
-      is_object_on_ego_path(arg_is_object_on_ego_path),
-      latest_time_inside_ego_path(arg_latest_time_inside_ego_path)
+      shape(predicted_object.shape)
     {
     }
 
@@ -137,8 +132,6 @@ public:
     uint8_t label{};
     geometry_msgs::msg::Pose pose{};
     autoware_perception_msgs::msg::Shape shape;
-    bool is_object_on_ego_path{false};
-    std::optional<rclcpp::Time> latest_time_inside_ego_path{std::nullopt};
 
     // NOTE: Previous values of the following are used for low-pass filtering.
     //       Therefore, they has to be initialized as nullopt.
@@ -150,8 +143,9 @@ public:
 
     // add additional information (not update to the latest data)
     void update(
-      const MinMaxValue & arg_lon_offset_to_avoid, const MinMaxValue & arg_lat_offset_to_avoid,
-      const bool arg_is_collision_left, const bool arg_should_be_avoided,
+      const std::optional<MinMaxValue> & arg_lon_offset_to_avoid,
+      const std::optional<MinMaxValue> & arg_lat_offset_to_avoid, const bool arg_is_collision_left,
+      const bool arg_should_be_avoided,
       const std::vector<geometry_msgs::msg::Pose> & arg_ref_points_for_obj_poly)
     {
       lon_offset_to_avoid = arg_lon_offset_to_avoid;
@@ -248,8 +242,8 @@ public:
       return valid_objects;
     }
     void updateObjectVariables(
-      const std::string & uuid, const MinMaxValue & lon_offset_to_avoid,
-      const MinMaxValue & lat_offset_to_avoid, const bool is_collision_left,
+      const std::string & uuid, const std::optional<MinMaxValue> & lon_offset_to_avoid,
+      const std::optional<MinMaxValue> & lat_offset_to_avoid, const bool is_collision_left,
       const bool should_be_avoided,
       const std::vector<geometry_msgs::msg::Pose> & ref_points_for_obj_poly)
     {
@@ -312,8 +306,8 @@ private:
   bool canTransitFailureState() override { return false; }
 
   ObjectType getObjectType(const uint8_t label) const;
-  void registerRegulatedObjects(const std::vector<DynamicAvoidanceObject> & prev_objects);
-  void registerUnregulatedObjects(const std::vector<DynamicAvoidanceObject> & prev_objects);
+  void registerRegulatedObjects();
+  void registerUnregulatedObjects();
   void determineWhetherToAvoidAgainstRegulatedObjects(
     const std::vector<DynamicAvoidanceObject> & prev_objects);
   void determineWhetherToAvoidAgainstUnregulatedObjects(

--- a/planning/behavior_path_planner/autoware_behavior_path_dynamic_obstacle_avoidance_module/src/manager.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_dynamic_obstacle_avoidance_module/src/manager.cpp
@@ -52,8 +52,6 @@ void DynamicObstacleAvoidanceModuleManager::init(rclcpp::Node * node)
     p.successive_num_to_exit_dynamic_avoidance_condition =
       node->declare_parameter<int>(ns + "successive_num_to_exit_dynamic_avoidance_condition");
 
-    p.min_obj_lat_offset_to_ego_path =
-      node->declare_parameter<double>(ns + "min_obj_lat_offset_to_ego_path");
     p.max_obj_lat_offset_to_ego_path =
       node->declare_parameter<double>(ns + "max_obj_lat_offset_to_ego_path");
     p.max_front_object_ego_path_lat_cover_ratio =
@@ -107,8 +105,6 @@ void DynamicObstacleAvoidanceModuleManager::updateModuleParams(
       parameters, ns + "successive_num_to_exit_dynamic_avoidance_condition",
       p->successive_num_to_exit_dynamic_avoidance_condition);
 
-    update_param<double>(
-      parameters, ns + "min_obj_lat_offset_to_ego_path", p->min_obj_lat_offset_to_ego_path);
     update_param<double>(
       parameters, ns + "max_obj_lat_offset_to_ego_path", p->max_obj_lat_offset_to_ego_path);
     update_param<double>(

--- a/planning/behavior_path_planner/autoware_behavior_path_dynamic_obstacle_avoidance_module/src/manager.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_dynamic_obstacle_avoidance_module/src/manager.cpp
@@ -24,19 +24,6 @@
 
 namespace autoware::behavior_path_planner
 {
-namespace
-{
-PolygonGenerationMethod convertToPolygonGenerationMethod(const std::string & str)
-{
-  if (str == "ego_path_base") {
-    return PolygonGenerationMethod::EGO_PATH_BASE;
-  } else if (str == "object_path_base") {
-    return PolygonGenerationMethod::OBJECT_PATH_BASE;
-  }
-  throw std::logic_error("The polygon_generation_method's string is invalid.");
-}
-}  // namespace
-
 void DynamicObstacleAvoidanceModuleManager::init(rclcpp::Node * node)
 {
   // init manager interface
@@ -60,8 +47,6 @@ void DynamicObstacleAvoidanceModuleManager::init(rclcpp::Node * node)
     p.avoid_bicycle = node->declare_parameter<bool>(ns + "bicycle");
     p.avoid_motorcycle = node->declare_parameter<bool>(ns + "motorcycle");
     p.avoid_pedestrian = node->declare_parameter<bool>(ns + "pedestrian");
-    p.max_obstacle_vel = node->declare_parameter<double>(ns + "max_obstacle_vel");
-    p.min_obstacle_vel = node->declare_parameter<double>(ns + "min_obstacle_vel");
     p.successive_num_to_entry_dynamic_avoidance_condition =
       node->declare_parameter<int>(ns + "successive_num_to_entry_dynamic_avoidance_condition");
     p.successive_num_to_exit_dynamic_avoidance_condition =
@@ -71,36 +56,8 @@ void DynamicObstacleAvoidanceModuleManager::init(rclcpp::Node * node)
       node->declare_parameter<double>(ns + "min_obj_lat_offset_to_ego_path");
     p.max_obj_lat_offset_to_ego_path =
       node->declare_parameter<double>(ns + "max_obj_lat_offset_to_ego_path");
-
-    p.min_time_to_start_cut_in =
-      node->declare_parameter<double>(ns + "cut_in_object.min_time_to_start_cut_in");
-    p.min_lon_offset_ego_to_cut_in_object =
-      node->declare_parameter<double>(ns + "cut_in_object.min_lon_offset_ego_to_object");
-    p.min_cut_in_object_vel = node->declare_parameter<double>(ns + "cut_in_object.min_object_vel");
-
-    p.max_time_from_outside_ego_path_for_cut_out =
-      node->declare_parameter<double>(ns + "cut_out_object.max_time_from_outside_ego_path");
-    p.min_cut_out_object_lat_vel =
-      node->declare_parameter<double>(ns + "cut_out_object.min_object_lat_vel");
-    p.min_cut_out_object_vel =
-      node->declare_parameter<double>(ns + "cut_out_object.min_object_vel");
-
-    p.max_front_object_angle =
-      node->declare_parameter<double>(ns + "front_object.max_object_angle");
     p.max_front_object_ego_path_lat_cover_ratio =
       node->declare_parameter<double>(ns + "front_object.max_ego_path_lat_cover_ratio");
-    p.min_front_object_vel = node->declare_parameter<double>(ns + "front_object.min_object_vel");
-
-    p.min_overtaking_crossing_object_vel =
-      node->declare_parameter<double>(ns + "crossing_object.min_overtaking_object_vel");
-    p.max_overtaking_crossing_object_angle =
-      node->declare_parameter<double>(ns + "crossing_object.max_overtaking_object_angle");
-    p.min_oncoming_crossing_object_vel =
-      node->declare_parameter<double>(ns + "crossing_object.min_oncoming_object_vel");
-    p.max_oncoming_crossing_object_angle =
-      node->declare_parameter<double>(ns + "crossing_object.max_oncoming_object_angle");
-    p.max_pedestrian_crossing_vel =
-      node->declare_parameter<double>(ns + "crossing_object.max_pedestrian_crossing_vel");
 
     p.max_stopped_object_vel =
       node->declare_parameter<double>(ns + "stopped_object.max_object_vel");
@@ -108,43 +65,12 @@ void DynamicObstacleAvoidanceModuleManager::init(rclcpp::Node * node)
 
   {  // drivable_area_generation
     const std::string ns = "dynamic_avoidance.drivable_area_generation.";
-    p.expand_drivable_area = node->declare_parameter<bool>(ns + "expand_drivable_area");
-    p.polygon_generation_method = convertToPolygonGenerationMethod(
-      node->declare_parameter<std::string>(ns + "polygon_generation_method"));
-    p.min_obj_path_based_lon_polygon_margin =
-      node->declare_parameter<double>(ns + "object_path_base.min_longitudinal_polygon_margin");
     p.lat_offset_from_obstacle = node->declare_parameter<double>(ns + "lat_offset_from_obstacle");
     p.margin_distance_around_pedestrian =
       node->declare_parameter<double>(ns + "margin_distance_around_pedestrian");
-    p.end_time_to_consider =
-      node->declare_parameter<double>(ns + "predicted_path.end_time_to_consider");
-    p.threshold_confidence =
-      node->declare_parameter<double>(ns + "predicted_path.threshold_confidence");
     p.max_lat_offset_to_avoid = node->declare_parameter<double>(ns + "max_lat_offset_to_avoid");
-    p.max_time_for_lat_shift =
-      node->declare_parameter<double>(ns + "max_time_for_object_lat_shift");
     p.lpf_gain_for_lat_avoid_to_offset =
       node->declare_parameter<double>(ns + "lpf_gain_for_lat_avoid_to_offset");
-
-    p.max_ego_lat_acc = node->declare_parameter<double>(ns + "max_ego_lat_acc");
-    p.max_ego_lat_jerk = node->declare_parameter<double>(ns + "max_ego_lat_jerk");
-    p.delay_time_ego_shift = node->declare_parameter<double>(ns + "delay_time_ego_shift");
-
-    p.max_time_to_collision_overtaking_object =
-      node->declare_parameter<double>(ns + "overtaking_object.max_time_to_collision");
-    p.start_duration_to_avoid_overtaking_object =
-      node->declare_parameter<double>(ns + "overtaking_object.start_duration_to_avoid");
-    p.end_duration_to_avoid_overtaking_object =
-      node->declare_parameter<double>(ns + "overtaking_object.end_duration_to_avoid");
-    p.duration_to_hold_avoidance_overtaking_object =
-      node->declare_parameter<double>(ns + "overtaking_object.duration_to_hold_avoidance");
-
-    p.max_time_to_collision_oncoming_object =
-      node->declare_parameter<double>(ns + "oncoming_object.max_time_to_collision");
-    p.start_duration_to_avoid_oncoming_object =
-      node->declare_parameter<double>(ns + "oncoming_object.start_duration_to_avoid");
-    p.end_duration_to_avoid_oncoming_object =
-      node->declare_parameter<double>(ns + "oncoming_object.end_duration_to_avoid");
   }
 
   parameters_ = std::make_shared<DynamicAvoidanceParameters>(p);
@@ -174,9 +100,6 @@ void DynamicObstacleAvoidanceModuleManager::updateModuleParams(
     update_param<bool>(parameters, ns + "motorcycle", p->avoid_motorcycle);
     update_param<bool>(parameters, ns + "pedestrian", p->avoid_pedestrian);
 
-    update_param<double>(parameters, ns + "max_obstacle_vel", p->max_obstacle_vel);
-    update_param<double>(parameters, ns + "min_obstacle_vel", p->min_obstacle_vel);
-
     update_param<int>(
       parameters, ns + "successive_num_to_entry_dynamic_avoidance_condition",
       p->successive_num_to_entry_dynamic_avoidance_condition);
@@ -188,44 +111,9 @@ void DynamicObstacleAvoidanceModuleManager::updateModuleParams(
       parameters, ns + "min_obj_lat_offset_to_ego_path", p->min_obj_lat_offset_to_ego_path);
     update_param<double>(
       parameters, ns + "max_obj_lat_offset_to_ego_path", p->max_obj_lat_offset_to_ego_path);
-
-    update_param<double>(
-      parameters, ns + "cut_in_object.min_time_to_start_cut_in", p->min_time_to_start_cut_in);
-    update_param<double>(
-      parameters, ns + "cut_in_object.min_lon_offset_ego_to_object",
-      p->min_lon_offset_ego_to_cut_in_object);
-    update_param<double>(parameters, ns + "cut_in_object.min_object_vel", p->min_cut_in_object_vel);
-
-    update_param<double>(
-      parameters, ns + "cut_out_object.max_time_from_outside_ego_path",
-      p->max_time_from_outside_ego_path_for_cut_out);
-    update_param<double>(
-      parameters, ns + "cut_out_object.min_object_lat_vel", p->min_cut_out_object_lat_vel);
-    update_param<double>(
-      parameters, ns + "cut_out_object.min_object_vel", p->min_cut_out_object_vel);
-
-    update_param<double>(
-      parameters, ns + "front_object.max_object_angle", p->max_front_object_angle);
     update_param<double>(
       parameters, ns + "front_object.max_ego_path_lat_cover_ratio",
       p->max_front_object_ego_path_lat_cover_ratio);
-    update_param<double>(parameters, ns + "front_object.min_object_vel", p->min_front_object_vel);
-
-    update_param<double>(
-      parameters, ns + "crossing_object.min_overtaking_object_vel",
-      p->min_overtaking_crossing_object_vel);
-    update_param<double>(
-      parameters, ns + "crossing_object.max_overtaking_object_angle",
-      p->max_overtaking_crossing_object_angle);
-    update_param<double>(
-      parameters, ns + "crossing_object.min_oncoming_object_vel",
-      p->min_oncoming_crossing_object_vel);
-    update_param<double>(
-      parameters, ns + "crossing_object.max_oncoming_object_angle",
-      p->max_oncoming_crossing_object_angle);
-    update_param<double>(
-      parameters, ns + "crossing_object.max_pedestrian_crossing_vel",
-      p->max_pedestrian_crossing_vel);
 
     update_param<double>(
       parameters, ns + "stopped_object.max_object_vel", p->max_stopped_object_vel);
@@ -233,55 +121,12 @@ void DynamicObstacleAvoidanceModuleManager::updateModuleParams(
 
   {  // drivable_area_generation
     const std::string ns = "dynamic_avoidance.drivable_area_generation.";
-    std::string polygon_generation_method_str;
-    if (update_param<std::string>(
-          parameters, ns + "polygon_generation_method", polygon_generation_method_str)) {
-      p->polygon_generation_method =
-        convertToPolygonGenerationMethod(polygon_generation_method_str);
-    }
-    update_param<bool>(parameters, ns + "expand_drivable_area", p->expand_drivable_area);
-    update_param<double>(
-      parameters, ns + "object_path_base.min_longitudinal_polygon_margin",
-      p->min_obj_path_based_lon_polygon_margin);
     update_param<double>(parameters, ns + "lat_offset_from_obstacle", p->lat_offset_from_obstacle);
     update_param<double>(
       parameters, ns + "margin_distance_around_pedestrian", p->margin_distance_around_pedestrian);
-    update_param<double>(
-      parameters, ns + "predicted_path.end_time_to_consider", p->end_time_to_consider);
-    update_param<double>(
-      parameters, ns + "predicted_path.threshold_confidence", p->threshold_confidence);
     update_param<double>(parameters, ns + "max_lat_offset_to_avoid", p->max_lat_offset_to_avoid);
     update_param<double>(
-      parameters, ns + "max_time_for_object_lat_shift", p->max_time_for_lat_shift);
-    update_param<double>(
       parameters, ns + "lpf_gain_for_lat_avoid_to_offset", p->lpf_gain_for_lat_avoid_to_offset);
-
-    update_param<double>(parameters, ns + "max_ego_lat_acc", p->max_ego_lat_acc);
-    update_param<double>(parameters, ns + "max_ego_lat_jerk", p->max_ego_lat_jerk);
-    update_param<double>(parameters, ns + "delay_time_ego_shift", p->delay_time_ego_shift);
-
-    update_param<double>(
-      parameters, ns + "overtaking_object.max_time_to_collision",
-      p->max_time_to_collision_overtaking_object);
-    update_param<double>(
-      parameters, ns + "overtaking_object.start_duration_to_avoid",
-      p->start_duration_to_avoid_overtaking_object);
-    update_param<double>(
-      parameters, ns + "overtaking_object.end_duration_to_avoid",
-      p->end_duration_to_avoid_overtaking_object);
-    update_param<double>(
-      parameters, ns + "overtaking_object.duration_to_hold_avoidance",
-      p->duration_to_hold_avoidance_overtaking_object);
-
-    update_param<double>(
-      parameters, ns + "oncoming_object.max_time_to_collision",
-      p->max_time_to_collision_oncoming_object);
-    update_param<double>(
-      parameters, ns + "oncoming_object.start_duration_to_avoid",
-      p->start_duration_to_avoid_oncoming_object);
-    update_param<double>(
-      parameters, ns + "oncoming_object.end_duration_to_avoid",
-      p->end_duration_to_avoid_oncoming_object);
   }
 
   std::for_each(observers_.begin(), observers_.end(), [&p](const auto & observer) {

--- a/planning/behavior_path_planner/autoware_behavior_path_dynamic_obstacle_avoidance_module/src/scene.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_dynamic_obstacle_avoidance_module/src/scene.cpp
@@ -92,13 +92,14 @@ void appendObjectMarker(
   marker_array.markers.push_back(marker);
 }
 
-void appendExtractedPolygonMarker(
-  MarkerArray & marker_array, const autoware_utils::Polygon2d & obj_poly, const double obj_z)
+void appendPolygonMarker(
+  MarkerArray & marker_array, const autoware_utils::Polygon2d & obj_poly, const double obj_z,
+  const std::string & marker_namespace, const std_msgs::msg::ColorRGBA & color)
 {
   auto marker = autoware_utils::create_default_marker(
-    "map", rclcpp::Clock{RCL_ROS_TIME}.now(), "extracted_polygons", marker_array.markers.size(),
+    "map", rclcpp::Clock{RCL_ROS_TIME}.now(), marker_namespace, marker_array.markers.size(),
     visualization_msgs::msg::Marker::LINE_STRIP, autoware_utils::create_marker_scale(0.1, 0.0, 0.0),
-    autoware_utils::create_marker_color(1.0, 0.5, 0.6, 0.8));
+    color);
 
   // NOTE: obj_poly.outer() has already duplicated points to close the polygon.
   for (size_t i = 0; i < obj_poly.outer().size(); ++i) {
@@ -309,6 +310,14 @@ BehaviorModuleOutput DynamicObstacleAvoidanceModule::plan()
   // create obstacles to avoid (= extract from the drivable area)
   std::vector<DrivableAreaInfo::Obstacle> obstacles_for_drivable_area;
   for (const auto & object : target_objects_) {
+    const auto expanded_object_poly_for_debug = [&]() -> std::optional<autoware_utils::Polygon2d> {
+      if (getObjectType(object.label) != ObjectType::UNREGULATED) {
+        return std::nullopt;
+      }
+
+      return calcExpandedCurrentPoseObjectPolygon(object);
+    }();
+
     const auto obstacle_poly = [&]() {
       if (getObjectType(object.label) == ObjectType::UNREGULATED) {
         auto output = calcCurrentPoseBasedDynamicObstaclePolygon(object, ego_path_reserve_poly);
@@ -321,7 +330,14 @@ BehaviorModuleOutput DynamicObstacleAvoidanceModule::plan()
         {object.pose, obstacle_poly.value(), object.is_collision_left});
 
       appendObjectMarker(info_marker_, object);
-      appendExtractedPolygonMarker(debug_marker_, obstacle_poly.value(), object.pose.position.z);
+      if (expanded_object_poly_for_debug) {
+        appendPolygonMarker(
+          debug_marker_, expanded_object_poly_for_debug.value(), object.pose.position.z,
+          "expanded_object_polygons", autoware_utils::create_marker_color(0.2, 0.9, 0.4, 0.9));
+      }
+      appendPolygonMarker(
+        debug_marker_, obstacle_poly.value(), object.pose.position.z, "extracted_polygons",
+        autoware_utils::create_marker_color(1.0, 0.5, 0.6, 0.8));
     }
   }
   // generate drivable lanes
@@ -965,26 +981,12 @@ std::optional<autoware_utils::Polygon2d>
 DynamicObstacleAvoidanceModule::calcCurrentPoseBasedDynamicObstaclePolygon(
   const DynamicAvoidanceObject & object, const EgoPathReservePoly & ego_path_poly) const
 {
-  autoware_utils::Polygon2d obj_poly;
-  boost::geometry::append(
-    obj_poly, autoware_utils::to_footprint(
-                object.pose, object.shape.dimensions.x * 0.5, object.shape.dimensions.x * 0.5,
-                object.shape.dimensions.y * 0.5)
-                .outer());
-  boost::geometry::correct(obj_poly);
-
-  autoware_utils::MultiPolygon2d expanded_poly;
-  namespace strategy = boost::geometry::strategy::buffer;
-  boost::geometry::buffer(
-    obj_poly, expanded_poly,
-    strategy::distance_symmetric<double>(parameters_->margin_distance_around_pedestrian),
-    strategy::side_straight(), strategy::join_round(), strategy::end_flat(),
-    strategy::point_circle());
-  if (expanded_poly.empty()) return {};
+  const auto expanded_poly = calcExpandedCurrentPoseObjectPolygon(object);
+  if (!expanded_poly) return {};
 
   autoware_utils::MultiPolygon2d output_poly;
   boost::geometry::difference(
-    expanded_poly[0],
+    expanded_poly.value(),
     object.is_collision_left ? ego_path_poly.right_avoid : ego_path_poly.left_avoid, output_poly);
 
   if (output_poly.empty()) {
@@ -1003,6 +1005,32 @@ DynamicObstacleAvoidanceModule::calcCurrentPoseBasedDynamicObstaclePolygon(
   }
 
   return output_poly[0];
+}
+
+std::optional<autoware_utils::Polygon2d>
+DynamicObstacleAvoidanceModule::calcExpandedCurrentPoseObjectPolygon(
+  const DynamicAvoidanceObject & object) const
+{
+  autoware_utils::Polygon2d obj_poly;
+  boost::geometry::append(
+    obj_poly, autoware_utils::to_footprint(
+                object.pose, object.shape.dimensions.x * 0.5, object.shape.dimensions.x * 0.5,
+                object.shape.dimensions.y * 0.5)
+                .outer());
+  boost::geometry::correct(obj_poly);
+
+  autoware_utils::MultiPolygon2d expanded_poly;
+  namespace strategy = boost::geometry::strategy::buffer;
+  boost::geometry::buffer(
+    obj_poly, expanded_poly,
+    strategy::distance_symmetric<double>(parameters_->margin_distance_around_pedestrian),
+    strategy::side_straight(), strategy::join_round(), strategy::end_flat(),
+    strategy::point_circle());
+  if (expanded_poly.empty()) {
+    return std::nullopt;
+  }
+
+  return expanded_poly[0];
 }
 
 // Calculate the driving area required to ensure the safety of the own vehicle.

--- a/planning/behavior_path_planner/autoware_behavior_path_dynamic_obstacle_avoidance_module/src/scene.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_dynamic_obstacle_avoidance_module/src/scene.cpp
@@ -274,8 +274,8 @@ void DynamicObstacleAvoidanceModule::updateData()
   target_objects_manager_.initialize();
 
   // 1. Rough filtering of target objects with small computing cost
-  registerRegulatedObjects(prev_objects);
-  registerUnregulatedObjects(prev_objects);
+  registerRegulatedObjects();
+  registerUnregulatedObjects();
 
   target_objects_manager_.finalize();
 
@@ -386,8 +386,7 @@ ObjectType DynamicObstacleAvoidanceModule::getObjectType(const uint8_t label) co
   return ObjectType::OUT_OF_SCOPE;
 }
 
-void DynamicObstacleAvoidanceModule::registerRegulatedObjects(
-  const std::vector<DynamicAvoidanceObject> & prev_objects)
+void DynamicObstacleAvoidanceModule::registerRegulatedObjects()
 {
   autoware_utils::ScopedTimeTrack st(__func__, *time_keeper_);
 
@@ -401,7 +400,6 @@ void DynamicObstacleAvoidanceModule::registerRegulatedObjects(
     const double obj_vel_norm = std::hypot(
       predicted_object.kinematics.initial_twist_with_covariance.twist.linear.x,
       predicted_object.kinematics.initial_twist_with_covariance.twist.linear.y);
-    const auto prev_object = getObstacleFromUuid(prev_objects, obj_uuid);
     const size_t obj_seg_idx =
       autoware::motion_utils::findNearestSegmentIndex(input_points, obj_pose.position);
     const size_t obj_idx =
@@ -427,47 +425,22 @@ void DynamicObstacleAvoidanceModule::registerRegulatedObjects(
       continue;
     }
 
-    // 1.f. calculate the object is on ego's path or not
-    const bool is_object_on_ego_path =
-      obj_dist_to_path <
-      planner_data_->parameters.vehicle_width / 2.0 + parameters_->min_obj_lat_offset_to_ego_path;
-
-    // 1.g. calculate latest time inside ego's path
-    const auto latest_time_inside_ego_path = [&]() -> std::optional<rclcpp::Time> {
-      if (!prev_object || !prev_object->latest_time_inside_ego_path) {
-        if (is_object_on_ego_path) {
-          return clock_->now();
-        }
-        return std::nullopt;
-      }
-      if (is_object_on_ego_path) {
-        return clock_->now();
-      }
-      return *prev_object->latest_time_inside_ego_path;
-    }();
-
-    const auto target_object =
-      DynamicAvoidanceObject(predicted_object, is_object_on_ego_path, latest_time_inside_ego_path);
+    const auto target_object = DynamicAvoidanceObject(predicted_object);
     target_objects_manager_.updateObject(obj_uuid, target_object);
   }
 }
 
-void DynamicObstacleAvoidanceModule::registerUnregulatedObjects(
-  const std::vector<DynamicAvoidanceObject> & prev_objects)
+void DynamicObstacleAvoidanceModule::registerUnregulatedObjects()
 {
   autoware_utils::ScopedTimeTrack st(__func__, *time_keeper_);
 
-  const auto input_path = getPreviousModuleOutput().path;
-  const auto input_points = toGeometryPoints(input_path.points);  // for efficient computation
   const auto & predicted_objects = planner_data_->dynamic_object->objects;
 
   for (const auto & predicted_object : predicted_objects) {
     const auto obj_uuid = autoware_utils::to_hex_string(predicted_object.object_id);
-    const auto & obj_pose = predicted_object.kinematics.initial_pose_with_covariance.pose;
     const double obj_vel_norm = std::hypot(
       predicted_object.kinematics.initial_twist_with_covariance.twist.linear.x,
       predicted_object.kinematics.initial_twist_with_covariance.twist.linear.y);
-    const auto prev_object = getObstacleFromUuid(prev_objects, obj_uuid);
 
     // 1.a. Check if the obstacle is labeled as pedestrians, bicycle or similar.
     if (getObjectType(predicted_object.classification.front().label) != ObjectType::UNREGULATED) {
@@ -478,33 +451,8 @@ void DynamicObstacleAvoidanceModule::registerUnregulatedObjects(
     if (obj_vel_norm > parameters_->max_stopped_object_vel) {
       continue;
     }
-    // Blocks for compatibility with existing code
-    //  1.e. check if object lateral distance to ego's path is small enough
-    //  1.f. calculate the object is on ego's path or not
-
-    const double dist_obj_center_to_path =
-      std::abs(autoware::motion_utils::calcLateralOffset(input_points, obj_pose.position));
-    const bool is_object_on_ego_path =
-      dist_obj_center_to_path <
-      planner_data_->parameters.vehicle_width / 2.0 + parameters_->min_obj_lat_offset_to_ego_path;
-
-    // 1.g. calculate last time inside ego's path
-    const auto latest_time_inside_ego_path = [&]() -> std::optional<rclcpp::Time> {
-      if (!prev_object || !prev_object->latest_time_inside_ego_path) {
-        if (is_object_on_ego_path) {
-          return clock_->now();
-        }
-        return std::nullopt;
-      }
-      if (is_object_on_ego_path) {
-        return clock_->now();
-      }
-      return *prev_object->latest_time_inside_ego_path;
-    }();
-
     // register the object
-    const auto target_object =
-      DynamicAvoidanceObject(predicted_object, is_object_on_ego_path, latest_time_inside_ego_path);
+    const auto target_object = DynamicAvoidanceObject(predicted_object);
     target_objects_manager_.updateObject(obj_uuid, target_object);
   }
 }
@@ -580,7 +528,7 @@ void DynamicObstacleAvoidanceModule::determineWhetherToAvoidAgainstRegulatedObje
 
     const bool should_be_avoided = true;
     target_objects_manager_.updateObjectVariables(
-      obj_uuid, lon_offset_to_avoid, *lat_offset_to_avoid, is_collision_left, should_be_avoided,
+      obj_uuid, lon_offset_to_avoid, lat_offset_to_avoid, is_collision_left, should_be_avoided,
       ref_points_for_obj_poly);
   }
 }
@@ -631,8 +579,7 @@ void DynamicObstacleAvoidanceModule::determineWhetherToAvoidAgainstUnregulatedOb
       continue;
     }
 
-    // 2.h. calculate longitudinal and lateral offset to avoid to generate object polygon by
-    // "ego_path_base"
+    // 2.h. calculate lateral offset to avoid for target selection and side decision.
     const auto lat_offset_to_avoid = calcMinMaxLateralOffsetToAvoidUnregulatedObject(
       ref_points_for_obj_poly, getObstacleFromUuid(prev_objects, obj_uuid), object);
     if (!lat_offset_to_avoid) {
@@ -645,11 +592,10 @@ void DynamicObstacleAvoidanceModule::determineWhetherToAvoidAgainstUnregulatedOb
     }
 
     const bool is_collision_left = (lat_offset_to_avoid.value().max_value > 0.0);
-    const auto lon_offset_to_avoid = MinMaxValue{0.0, 1.0};  // not used. dummy value
 
     const bool should_be_avoided = true;
     target_objects_manager_.updateObjectVariables(
-      obj_uuid, lon_offset_to_avoid, *lat_offset_to_avoid, is_collision_left, should_be_avoided,
+      obj_uuid, std::nullopt, lat_offset_to_avoid, is_collision_left, should_be_avoided,
       ref_points_for_obj_poly);
   }
 }

--- a/planning/behavior_path_planner/autoware_behavior_path_dynamic_obstacle_avoidance_module/src/scene.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_dynamic_obstacle_avoidance_module/src/scene.cpp
@@ -16,11 +16,8 @@
 
 #include "autoware/behavior_path_planner_common/utils/drivable_area_expansion/static_drivable_area.hpp"
 #include "autoware/behavior_path_planner_common/utils/utils.hpp"
-#include "autoware/object_recognition_utils/predicted_path_utils.hpp"
 #include "autoware/signal_processing/lowpass_filter_1d.hpp"
-#include "autoware_utils/geometry/boost_polygon_utils.hpp"
 
-#include <autoware_lanelet2_extension/utility/utilities.hpp>
 #include <autoware_utils/geometry/geometry.hpp>
 
 #include <boost/geometry/algorithms/buffer.hpp>
@@ -29,11 +26,7 @@
 #include <boost/geometry/algorithms/difference.hpp>
 #include <boost/geometry/algorithms/union.hpp>
 
-#include <lanelet2_core/geometry/Point.h>
-#include <lanelet2_core/geometry/Polygon.h>
-
 #include <algorithm>
-#include <limits>
 #include <memory>
 #include <string>
 #include <unordered_map>
@@ -61,19 +54,40 @@ MinMaxValue getMinMaxValues(const std::vector<double> & vec)
   return MinMaxValue{vec.at(min_idx), vec.at(max_idx)};
 }
 
-MinMaxValue combineMinMaxValues(const MinMaxValue & r1, const MinMaxValue & r2)
-{
-  return MinMaxValue{std::min(r1.min_value, r2.min_value), std::max(r1.max_value, r2.max_value)};
-}
-
-void appendObjectMarker(MarkerArray & marker_array, const geometry_msgs::msg::Pose & obj_pose)
+void appendObjectMarker(
+  MarkerArray & marker_array, const DynamicObstacleAvoidanceModule::DynamicAvoidanceObject & object)
 {
   auto marker = autoware_utils::create_default_marker(
     "map", rclcpp::Clock{RCL_ROS_TIME}.now(), "dynamic_objects_to_avoid",
     marker_array.markers.size(), visualization_msgs::msg::Marker::CUBE,
-    autoware_utils::create_marker_scale(3.0, 1.0, 1.0),
+    autoware_utils::create_marker_scale(0.1, 0.1, 0.1),
     autoware_utils::create_marker_color(1.0, 0.5, 0.6, 0.8));
-  marker.pose = obj_pose;
+
+  marker.pose = object.pose;
+  const auto & shape = object.shape;
+
+  if (shape.type == autoware_perception_msgs::msg::Shape::BOUNDING_BOX) {
+    marker.type = visualization_msgs::msg::Marker::CUBE;
+    marker.scale = autoware_utils::create_marker_scale(
+      std::max(shape.dimensions.x, 0.1), std::max(shape.dimensions.y, 0.1),
+      std::max(shape.dimensions.z, 0.1));
+  } else if (shape.type == autoware_perception_msgs::msg::Shape::CYLINDER) {
+    marker.type = visualization_msgs::msg::Marker::CYLINDER;
+    marker.scale = autoware_utils::create_marker_scale(
+      std::max(shape.dimensions.x, 0.1), std::max(shape.dimensions.x, 0.1),
+      std::max(shape.dimensions.z, 0.1));
+  } else if (shape.type == autoware_perception_msgs::msg::Shape::POLYGON) {
+    marker.type = visualization_msgs::msg::Marker::LINE_STRIP;
+    marker.scale = autoware_utils::create_marker_scale(0.1, 0.0, 0.0);
+    const auto polygon = autoware_utils::to_polygon2d(object.pose, shape);
+    for (const auto & p : polygon.outer()) {
+      geometry_msgs::msg::Point pt;
+      pt.x = p.x();
+      pt.y = p.y();
+      pt.z = object.pose.position.z;
+      marker.points.push_back(pt);
+    }
+  }
 
   marker_array.markers.push_back(marker);
 }
@@ -100,57 +114,12 @@ void appendExtractedPolygonMarker(
   marker_array.markers.push_back(marker);
 }
 
-bool isEndPointsConnected(
-  const lanelet::ConstLanelet & left_lane, const lanelet::ConstLanelet & right_lane)
-{
-  const auto & left_back_point_2d = right_lane.leftBound2d().back().basicPoint();
-  const auto & right_back_point_2d = left_lane.rightBound2d().back().basicPoint();
-
-  constexpr double epsilon = 1e-5;
-  return (right_back_point_2d - left_back_point_2d).norm() < epsilon;
-}
-
-template <typename T>
-void pushUniqueVector(T & base_vector, const T & additional_vector)
-{
-  base_vector.insert(base_vector.end(), additional_vector.begin(), additional_vector.end());
-}
-
-template <typename T>
-std::optional<T> getObjectFromUuid(const std::vector<T> & objects, const std::string & target_uuid)
-{
-  const auto itr = std::find_if(objects.begin(), objects.end(), [&](const auto & object) {
-    return object.uuid == target_uuid;
-  });
-
-  if (itr == objects.end()) {
-    return std::nullopt;
-  }
-  return *itr;
-}
-
-std::pair<double, double> projectObstacleVelocityToTrajectory(
-  const std::vector<PathPointWithLaneId> & path_points, const PredictedObject & object,
-  const size_t obj_idx)
-{
-  const auto & obj_pose = object.kinematics.initial_pose_with_covariance.pose;
-  const double obj_yaw = tf2::getYaw(obj_pose.orientation);
-  const double path_yaw = tf2::getYaw(path_points.at(obj_idx).point.pose.orientation);
-
-  const Eigen::Rotation2Dd R_ego_to_obstacle(obj_yaw - path_yaw);
-  const Eigen::Vector2d obstacle_velocity(
-    object.kinematics.initial_twist_with_covariance.twist.linear.x,
-    object.kinematics.initial_twist_with_covariance.twist.linear.y);
-  const Eigen::Vector2d projected_velocity = R_ego_to_obstacle * obstacle_velocity;
-
-  return std::make_pair(projected_velocity[0], projected_velocity[1]);
-}
-
 double calcObstacleMaxLength(const autoware_perception_msgs::msg::Shape & shape)
 {
   if (shape.type == autoware_perception_msgs::msg::Shape::BOUNDING_BOX) {
     return std::hypot(shape.dimensions.x / 2.0, shape.dimensions.y / 2.0);
-  } else if (shape.type == autoware_perception_msgs::msg::Shape::CYLINDER) {
+  }
+  if (shape.type == autoware_perception_msgs::msg::Shape::CYLINDER) {
     return shape.dimensions.x / 2.0;
   } else if (shape.type == autoware_perception_msgs::msg::Shape::POLYGON) {
     double max_length_to_point = 0.0;
@@ -164,36 +133,6 @@ double calcObstacleMaxLength(const autoware_perception_msgs::msg::Shape & shape)
   }
 
   throw std::logic_error("The shape type is not supported in dynamic_avoidance.");
-}
-
-double calcObstacleWidth(const autoware_perception_msgs::msg::Shape & shape)
-{
-  if (shape.type == autoware_perception_msgs::msg::Shape::BOUNDING_BOX) {
-    return shape.dimensions.y;
-  } else if (shape.type == autoware_perception_msgs::msg::Shape::CYLINDER) {
-    return shape.dimensions.x;
-  } else if (shape.type == autoware_perception_msgs::msg::Shape::POLYGON) {
-    double max_length_to_point = 0.0;
-    for (const auto rel_point : shape.footprint.points) {
-      const double length_to_point = std::hypot(rel_point.x, rel_point.y);
-      if (max_length_to_point < length_to_point) {
-        max_length_to_point = length_to_point;
-      }
-    }
-    return max_length_to_point;
-  }
-  throw std::logic_error("The shape type is not supported in dynamic_avoidance.");
-}
-
-double calcDiffAngleAgainstPath(
-  const std::vector<PathPointWithLaneId> & path_points,
-  const geometry_msgs::msg::Pose & target_pose, const size_t target_idx)
-{
-  const double traj_yaw = tf2::getYaw(path_points.at(target_idx).point.pose.orientation);
-  const double target_yaw = tf2::getYaw(target_pose.orientation);
-
-  const double diff_yaw = autoware_utils::normalize_radian(target_yaw - traj_yaw);
-  return diff_yaw;
 }
 
 double calcDistanceToPath(
@@ -225,10 +164,7 @@ bool isLeft(
     autoware_utils::calc_azimuth_angle(path_points.at(target_idx).point.pose.position, target_pos);
   const double diff_yaw = autoware_utils::normalize_radian(angle_to_target_pos - target_yaw);
 
-  if (0 < diff_yaw) {
-    return true;
-  }
-  return false;
+  return 0 < diff_yaw;
 }
 
 template <typename T>
@@ -245,50 +181,11 @@ std::optional<T> getObstacleFromUuid(
   return *itr;
 }
 
-double calcDistanceToSegment(
-  const geometry_msgs::msg::Point & p1, const geometry_msgs::msg::Point & p2_first,
-  const geometry_msgs::msg::Point & p2_second)
-{
-  const Eigen::Vector2d first_to_target(p1.x - p2_first.x, p1.y - p2_first.y);
-  const Eigen::Vector2d second_to_target(p1.x - p2_second.x, p1.y - p2_second.y);
-  const Eigen::Vector2d first_to_second(p2_second.x - p2_first.x, p2_second.y - p2_first.y);
-
-  if (first_to_target.dot(first_to_second) < 0) {
-    return first_to_target.norm();
-  }
-  if (second_to_target.dot(-first_to_second) < 0) {
-    return second_to_target.norm();
-  }
-
-  const Eigen::Vector2d p2_nearest =
-    Eigen::Vector2d{p2_first.x, p2_first.y} +
-    first_to_second * first_to_target.dot(first_to_second) / std::pow(first_to_second.norm(), 2);
-  return (Eigen::Vector2d{p1.x, p1.y} - p2_nearest).norm();
-}
-
-std::optional<std::pair<size_t, geometry_msgs::msg::Point>> intersectLines(
-  const std::vector<geometry_msgs::msg::Pose> & source_line,
-  const std::vector<geometry_msgs::msg::Point> & target_line)
-{
-  for (int source_seg_idx = 0; source_seg_idx < static_cast<int>(source_line.size()) - 1;
-       ++source_seg_idx) {
-    for (int target_seg_idx = 0; target_seg_idx < static_cast<int>(target_line.size()) - 1;
-         ++target_seg_idx) {
-      const auto intersect_point = autoware_utils::intersect(
-        source_line.at(source_seg_idx).position, source_line.at(source_seg_idx + 1).position,
-        target_line.at(target_seg_idx), target_line.at(target_seg_idx + 1));
-      if (intersect_point) {
-        return std::make_pair(source_seg_idx, *intersect_point);
-      }
-    }
-  }
-  return std::nullopt;
-}
-
 std::vector<geometry_msgs::msg::Point> convertToPoints(
   const std::vector<geometry_msgs::msg::Pose> & poses)
 {
   std::vector<geometry_msgs::msg::Point> points;
+  points.reserve(poses.size());
   for (const auto & pose : poses) {
     points.push_back(pose.position);
   }
@@ -301,6 +198,7 @@ std::vector<geometry_msgs::msg::Pose> toGeometryPoints(
   const std::vector<PathPointWithLaneId> & path_points)
 {
   std::vector<geometry_msgs::msg::Pose> geom_points;
+  geom_points.reserve(path_points.size());
   for (const auto & path_point : path_points) {
     geom_points.push_back(path_point.point.pose);
   }
@@ -379,8 +277,7 @@ void DynamicObstacleAvoidanceModule::updateData()
   registerRegulatedObjects(prev_objects);
   registerUnregulatedObjects(prev_objects);
 
-  const auto & ego_lat_feasible_paths = generateLateralFeasiblePaths(getEgoPose(), getEgoSpeed());
-  target_objects_manager_.finalize(ego_lat_feasible_paths);
+  target_objects_manager_.finalize();
 
   // 2. Precise filtering of target objects and check if they should be avoided
   determineWhetherToAvoidAgainstRegulatedObjects(prev_objects);
@@ -414,38 +311,23 @@ BehaviorModuleOutput DynamicObstacleAvoidanceModule::plan()
   for (const auto & object : target_objects_) {
     const auto obstacle_poly = [&]() {
       if (getObjectType(object.label) == ObjectType::UNREGULATED) {
-        return calcPredictedPathBasedDynamicObstaclePolygon(object, ego_path_reserve_poly);
+        auto output = calcCurrentPoseBasedDynamicObstaclePolygon(object, ego_path_reserve_poly);
+        return output;
       }
-
-      if (parameters_->polygon_generation_method == PolygonGenerationMethod::EGO_PATH_BASE) {
-        return calcEgoPathBasedDynamicObstaclePolygon(object);
-      }
-      if (parameters_->polygon_generation_method == PolygonGenerationMethod::OBJECT_PATH_BASE) {
-        return calcObjectPathBasedDynamicObstaclePolygon(object);
-      }
-      throw std::logic_error("The polygon_generation_method's string is invalid.");
+      return calcEgoPathBasedDynamicObstaclePolygon(object);
     }();
     if (obstacle_poly) {
       obstacles_for_drivable_area.push_back(
         {object.pose, obstacle_poly.value(), object.is_collision_left});
 
-      appendObjectMarker(info_marker_, object.pose);
+      appendObjectMarker(info_marker_, object);
       appendExtractedPolygonMarker(debug_marker_, obstacle_poly.value(), object.pose.position.z);
     }
   }
   // generate drivable lanes
   DrivableAreaInfo current_drivable_area_info;
-  if (parameters_->expand_drivable_area) {
-    auto current_lanelets =
-      getCurrentLanesFromPath(getPreviousModuleOutput().reference_path, planner_data_);
-    std::for_each(current_lanelets.begin(), current_lanelets.end(), [&](const auto & lanelet) {
-      current_drivable_area_info.drivable_lanes.push_back(
-        generateExpandedDrivableLanes(lanelet, planner_data_, parameters_));
-    });
-  } else {
-    current_drivable_area_info.drivable_lanes =
-      getPreviousModuleOutput().drivable_area_info.drivable_lanes;
-  }
+  current_drivable_area_info.drivable_lanes =
+    getPreviousModuleOutput().drivable_area_info.drivable_lanes;
   current_drivable_area_info.obstacles = obstacles_for_drivable_area;
   current_drivable_area_info.enable_expanding_hatched_road_markings =
     parameters_->use_hatched_road_markings;
@@ -520,10 +402,6 @@ void DynamicObstacleAvoidanceModule::registerRegulatedObjects(
       predicted_object.kinematics.initial_twist_with_covariance.twist.linear.x,
       predicted_object.kinematics.initial_twist_with_covariance.twist.linear.y);
     const auto prev_object = getObstacleFromUuid(prev_objects, obj_uuid);
-    const auto obj_path = *std::max_element(
-      predicted_object.kinematics.predicted_paths.begin(),
-      predicted_object.kinematics.predicted_paths.end(),
-      [](const PredictedPath & a, const PredictedPath & b) { return a.confidence < b.confidence; });
     const size_t obj_seg_idx =
       autoware::motion_utils::findNearestSegmentIndex(input_points, obj_pose.position);
     const size_t obj_idx =
@@ -534,32 +412,8 @@ void DynamicObstacleAvoidanceModule::registerRegulatedObjects(
       continue;
     }
 
-    // 1.b. check obstacle velocity
-    const auto [obj_tangent_vel, obj_normal_vel] =
-      projectObstacleVelocityToTrajectory(input_path.points, predicted_object, obj_idx);
-    if (
-      std::abs(obj_tangent_vel) < parameters_->min_obstacle_vel ||
-      parameters_->max_obstacle_vel < std::abs(obj_tangent_vel)) {
-      continue;
-    }
-
-    // 1.c. check if object is not crossing ego's path
-    const double obj_angle = calcDiffAngleAgainstPath(input_path.points, obj_pose, obj_idx);
-    const double max_crossing_object_angle = 0.0 <= obj_tangent_vel
-                                               ? parameters_->max_overtaking_crossing_object_angle
-                                               : parameters_->max_oncoming_crossing_object_angle;
-    const bool is_obstacle_crossing_path = max_crossing_object_angle < std::abs(obj_angle) &&
-                                           max_crossing_object_angle < M_PI - std::abs(obj_angle);
-    const double min_crossing_object_vel = 0.0 <= obj_tangent_vel
-                                             ? parameters_->min_overtaking_crossing_object_vel
-                                             : parameters_->min_oncoming_crossing_object_vel;
-    const bool is_crossing_object_to_ignore =
-      min_crossing_object_vel < obj_vel_norm && is_obstacle_crossing_path;
-    if (is_crossing_object_to_ignore) {
-      RCLCPP_INFO_EXPRESSION(
-        getLogger(), parameters_->enable_debug_info,
-        "[DynamicAvoidance] Ignore obstacle (%s) since it crosses the ego's path.",
-        obj_uuid.c_str());
+    // 1.b. check obstacle velocity (static objects only)
+    if (obj_vel_norm > parameters_->max_stopped_object_vel) {
       continue;
     }
 
@@ -592,9 +446,8 @@ void DynamicObstacleAvoidanceModule::registerRegulatedObjects(
       return *prev_object->latest_time_inside_ego_path;
     }();
 
-    const auto target_object = DynamicAvoidanceObject(
-      predicted_object, obj_tangent_vel, obj_normal_vel, is_object_on_ego_path,
-      latest_time_inside_ego_path);
+    const auto target_object =
+      DynamicAvoidanceObject(predicted_object, is_object_on_ego_path, latest_time_inside_ego_path);
     target_objects_manager_.updateObject(obj_uuid, target_object);
   }
 }
@@ -615,39 +468,16 @@ void DynamicObstacleAvoidanceModule::registerUnregulatedObjects(
       predicted_object.kinematics.initial_twist_with_covariance.twist.linear.x,
       predicted_object.kinematics.initial_twist_with_covariance.twist.linear.y);
     const auto prev_object = getObstacleFromUuid(prev_objects, obj_uuid);
-    const auto obj_path = *std::max_element(
-      predicted_object.kinematics.predicted_paths.begin(),
-      predicted_object.kinematics.predicted_paths.end(),
-      [](const PredictedPath & a, const PredictedPath & b) { return a.confidence < b.confidence; });
-    const size_t obj_seg_idx =
-      autoware::motion_utils::findNearestSegmentIndex(input_points, obj_pose.position);
-    const size_t obj_idx =
-      getNearestIndexFromSegmentIndex(input_points, obj_seg_idx, obj_pose.position);
 
     // 1.a. Check if the obstacle is labeled as pedestrians, bicycle or similar.
     if (getObjectType(predicted_object.classification.front().label) != ObjectType::UNREGULATED) {
       continue;
     }
 
-    // 1.b. Check if the object's velocity is within the module's coverage range.
-    const auto [obj_tangent_vel, obj_normal_vel] =
-      projectObstacleVelocityToTrajectory(input_path.points, predicted_object, obj_idx);
-    if (
-      obj_vel_norm < parameters_->min_obstacle_vel ||
-      obj_vel_norm > parameters_->max_obstacle_vel) {
+    // 1.b. Check if the object's velocity is within the module's coverage range (static only).
+    if (obj_vel_norm > parameters_->max_stopped_object_vel) {
       continue;
     }
-
-    // 1.c. Check if object' lateral velocity is small enough to be avoid.
-    if (std::abs(obj_normal_vel) > parameters_->max_pedestrian_crossing_vel) {
-      RCLCPP_INFO_EXPRESSION(
-        getLogger(), parameters_->enable_debug_info,
-        "[DynamicAvoidance] Ignore obstacle (%s) since it crosses the ego's path with its normal "
-        "vel (%5.2f) m/s.",
-        obj_uuid.c_str(), obj_normal_vel);
-      continue;
-    }
-
     // Blocks for compatibility with existing code
     //  1.e. check if object lateral distance to ego's path is small enough
     //  1.f. calculate the object is on ego's path or not
@@ -673,9 +503,8 @@ void DynamicObstacleAvoidanceModule::registerUnregulatedObjects(
     }();
 
     // register the object
-    const auto target_object = DynamicAvoidanceObject(
-      predicted_object, obj_tangent_vel, obj_normal_vel, is_object_on_ego_path,
-      latest_time_inside_ego_path);
+    const auto target_object =
+      DynamicAvoidanceObject(predicted_object, is_object_on_ego_path, latest_time_inside_ego_path);
     target_objects_manager_.updateObject(obj_uuid, target_object);
   }
 }
@@ -692,12 +521,8 @@ void DynamicObstacleAvoidanceModule::determineWhetherToAvoidAgainstRegulatedObje
     if (getObjectType(object.label) != ObjectType::REGULATED) {
       continue;
     }
-
     const auto obj_uuid = object.uuid;
     const auto prev_object = getObstacleFromUuid(prev_objects, obj_uuid);
-    const auto obj_path = *std::max_element(
-      object.predicted_paths.begin(), object.predicted_paths.end(),
-      [](const PredictedPath & a, const PredictedPath & b) { return a.confidence < b.confidence; });
     const size_t obj_seg_idx =
       autoware::motion_utils::findNearestSegmentIndex(input_points, object.pose.position);
     const size_t obj_idx =
@@ -705,100 +530,13 @@ void DynamicObstacleAvoidanceModule::determineWhetherToAvoidAgainstRegulatedObje
 
     const auto & ref_points_for_obj_poly = input_points;
 
-    // 2.a. check if object is not to be followed by ego
-    const double obj_angle = calcDiffAngleAgainstPath(input_path.points, object.pose, obj_idx);
-    const bool is_object_aligned_to_path =
-      std::abs(obj_angle) < parameters_->max_front_object_angle ||
-      M_PI - parameters_->max_front_object_angle < std::abs(obj_angle);
-    if (
-      object.is_object_on_ego_path && is_object_aligned_to_path &&
-      parameters_->min_front_object_vel < object.vel) {
-      RCLCPP_INFO_EXPRESSION(
-        getLogger(), parameters_->enable_debug_info,
-        "[DynamicAvoidance] Ignore obstacle (%s) since it is to be followed.", obj_uuid.c_str());
-      continue;
-    }
-
     // 2.b. calculate which side object exists against ego's path
     const bool is_object_left = isLeft(input_path.points, object.pose.position, obj_idx);
     const auto lat_lon_offset =
       getLateralLongitudinalOffset(input_points, object.pose, obj_seg_idx, object.shape);
 
-    // 2.c. check if object will not cut in
-    const bool will_object_cut_in =
-      willObjectCutIn(input_path.points, obj_path, object.vel, lat_lon_offset);
-    if (will_object_cut_in) {
-      RCLCPP_INFO_EXPRESSION(
-        getLogger(), parameters_->enable_debug_info,
-        "[DynamicAvoidance] Ignore obstacle (%s) since it will cut in.", obj_uuid.c_str());
-      continue;
-    }
-
-    // 2.d. check if object will not cut out
-    const auto will_object_cut_out =
-      willObjectCutOut(object.vel, object.lat_vel, is_object_left, prev_object);
-    if (will_object_cut_out.decision) {
-      printIgnoreReason(obj_uuid.c_str(), will_object_cut_out.reason);
-      continue;
-    }
-
-    // 2.e. check if the ego will change the lane and the object will be outside the ego's path
-    // const auto will_object_be_outside_ego_changing_path =
-    //   willObjectBeOutsideEgoChangingPath(object.pose, object.shape, object.vel);
-    // if (will_object_be_outside_ego_changing_path) {
-    //   RCLCPP_INFO_EXPRESSION(
-    //     getLogger(), parameters_->enable_debug_info,
-    //     "[DynamicAvoidance] Ignore obstacle (%s) since the object will be outside ego's changing
-    //     path", obj_uuid.c_str());
-    //   continue;
-    // }
-
-    // 2.e. check time to collision
-    const auto time_while_collision =
-      calcTimeWhileCollision(input_path.points, object.vel, lat_lon_offset);
-    const double time_to_collision = time_while_collision.time_to_start_collision;
-    if (parameters_->max_stopped_object_vel < std::hypot(object.vel, object.lat_vel)) {
-      // NOTE: Only not stopped object is filtered by time to collision.
-      if (
-        (0 <= object.vel &&
-         parameters_->max_time_to_collision_overtaking_object < time_to_collision) ||
-        (object.vel <= 0 &&
-         parameters_->max_time_to_collision_oncoming_object < time_to_collision)) {
-        const auto time_to_collision_str = time_to_collision == std::numeric_limits<double>::max()
-                                             ? "infinity"
-                                             : std::to_string(time_to_collision);
-        RCLCPP_INFO_EXPRESSION(
-          getLogger(), parameters_->enable_debug_info,
-          "[DynamicAvoidance] Ignore obstacle (%s) since time to collision (%s) is large.",
-          obj_uuid.c_str(), time_to_collision_str.c_str());
-        continue;
-      }
-      if (time_to_collision < -parameters_->duration_to_hold_avoidance_overtaking_object) {
-        const auto time_to_collision_str = time_to_collision == std::numeric_limits<double>::max()
-                                             ? "infinity"
-                                             : std::to_string(time_to_collision);
-        RCLCPP_INFO_EXPRESSION(
-          getLogger(), parameters_->enable_debug_info,
-          "[DynamicAvoidance] Ignore obstacle (%s) since time to collision (%s) is a small "
-          "negative value.",
-          obj_uuid.c_str(), time_to_collision_str.c_str());
-        continue;
-      }
-    }
-
     // 2.f. calculate which side object will be against ego's path
-    const bool is_collision_left = [&]() {
-      if (0.0 < object.vel) {
-        return is_object_left;
-      }
-      const auto future_obj_pose =
-        autoware::object_recognition_utils::calcInterpolatedPose(obj_path, time_to_collision);
-      const size_t future_obj_idx =
-        autoware::motion_utils::findNearestIndex(input_path.points, future_obj_pose->position);
-
-      return future_obj_pose ? isLeft(input_path.points, future_obj_pose->position, future_obj_idx)
-                             : is_object_left;
-    }();
+    const bool is_collision_left = is_object_left;
 
     // 2.g. check if the ego is not ahead of the object.
     const double signed_dist_ego_to_obj = [&]() {
@@ -826,12 +564,10 @@ void DynamicObstacleAvoidanceModule::determineWhetherToAvoidAgainstRegulatedObje
     // 2.h. calculate longitudinal and lateral offset to avoid to generate object polygon by
     // "ego_path_base"
     const auto obj_points = autoware_utils::to_polygon2d(object.pose, object.shape);
-    const auto lon_offset_to_avoid = calcMinMaxLongitudinalOffsetToAvoid(
-      ref_points_for_obj_poly, object.pose, obj_points, object.vel, obj_path, object.shape,
-      time_while_collision);
+    const auto lon_offset_to_avoid =
+      calcMinMaxLongitudinalOffsetToAvoid(ref_points_for_obj_poly, object.pose, obj_points);
     const auto lat_offset_to_avoid = calcMinMaxLateralOffsetToAvoidRegulatedObject(
-      ref_points_for_obj_poly, obj_points, object.pose.position, object.vel, is_collision_left,
-      object.lat_vel, prev_object);
+      ref_points_for_obj_poly, obj_points, object.pose.position, is_collision_left, prev_object);
 
     if (!lat_offset_to_avoid) {
       RCLCPP_INFO_EXPRESSION(
@@ -847,7 +583,6 @@ void DynamicObstacleAvoidanceModule::determineWhetherToAvoidAgainstRegulatedObje
       obj_uuid, lon_offset_to_avoid, *lat_offset_to_avoid, is_collision_left, should_be_avoided,
       ref_points_for_obj_poly);
   }
-  // prev_input_ref_path_points_ = input_ref_path_points;
 }
 
 void DynamicObstacleAvoidanceModule::determineWhetherToAvoidAgainstUnregulatedObjects(
@@ -919,163 +654,6 @@ void DynamicObstacleAvoidanceModule::determineWhetherToAvoidAgainstUnregulatedOb
   }
 }
 
-LatFeasiblePaths DynamicObstacleAvoidanceModule::generateLateralFeasiblePaths(
-  const geometry_msgs::msg::Pose & ego_pose, const double ego_vel) const
-{
-  const double lat_acc = parameters_->max_ego_lat_acc;
-  const double lat_jerk = parameters_->max_ego_lat_jerk;
-  const double delay_time = parameters_->delay_time_ego_shift;
-
-  LatFeasiblePaths ego_lat_feasible_paths;
-  for (double t = 0; t < 10.0; t += 1.0) {
-    // maybe this equation does not have physical meaning (takagi)
-    const double feasible_lat_offset = lat_acc * std::pow(std::max(t - delay_time, 0.0), 2) / 2.0 +
-                                       lat_jerk * std::pow(std::max(t - delay_time, 0.0), 3) / 6.0 -
-                                       planner_data_->parameters.vehicle_width / 2.0;
-    const double x = t * ego_vel;
-    const double y = feasible_lat_offset;
-
-    const auto feasible_left_bound_point =
-      autoware_utils::calc_offset_pose(ego_pose, x, -y, 0.0).position;
-    ego_lat_feasible_paths.left_path.push_back(feasible_left_bound_point);
-
-    const auto feasible_right_bound_point =
-      autoware_utils::calc_offset_pose(ego_pose, x, y, 0.0).position;
-    ego_lat_feasible_paths.right_path.push_back(feasible_right_bound_point);
-  }
-
-  autoware_utils::append_marker_array(
-    marker_utils::createPointsMarkerArray(
-      ego_lat_feasible_paths.left_path, "ego_lat_feasible_left_path", 0, 0.6, 0.9, 0.9),
-    &debug_marker_);
-  autoware_utils::append_marker_array(
-    marker_utils::createPointsMarkerArray(
-      ego_lat_feasible_paths.right_path, "ego_lat_feasible_right_path", 0, 0.6, 0.9, 0.9),
-    &debug_marker_);
-
-  return ego_lat_feasible_paths;
-}
-
-[[maybe_unused]] void DynamicObstacleAvoidanceModule::updateRefPathBeforeLaneChange(
-  const std::vector<PathPointWithLaneId> & ego_ref_path_points)
-{
-  if (ref_path_before_lane_change_) {
-    // check if the ego is close enough to the current ref path, meaning that lane change ends.
-    const auto ego_pos = getEgoPose().position;
-    const double dist_to_ref_path =
-      std::abs(autoware::motion_utils::calcLateralOffset(ego_ref_path_points, ego_pos));
-
-    constexpr double epsilon_dist_to_ref_path = 0.5;
-    if (dist_to_ref_path < epsilon_dist_to_ref_path) {
-      ref_path_before_lane_change_ = std::nullopt;
-    }
-  } else {
-    // check if the ego is during lane change.
-    if (prev_input_ref_path_points_ && !prev_input_ref_path_points_->empty()) {
-      const double dist_ref_paths = std::abs(autoware::motion_utils::calcLateralOffset(
-        ego_ref_path_points, prev_input_ref_path_points_->front().point.pose.position));
-      constexpr double epsilon_ref_paths_diff = 1.0;
-      if (epsilon_ref_paths_diff < dist_ref_paths) {
-        ref_path_before_lane_change_ = *prev_input_ref_path_points_;
-      }
-    }
-  }
-}
-
-[[maybe_unused]] std::optional<std::pair<size_t, size_t>>
-DynamicObstacleAvoidanceModule::calcCollisionSection(
-  const std::vector<PathPointWithLaneId> & ego_path, const PredictedPath & obj_path) const
-{
-  const size_t ego_idx = planner_data_->findEgoIndex(ego_path);
-  const double ego_vel = getEgoSpeed();
-
-  std::optional<size_t> collision_start_idx{std::nullopt};
-  double lon_dist = 0.0;
-  for (size_t i = ego_idx; i < ego_path.size() - 1; ++i) {
-    lon_dist += autoware_utils::calc_distance2d(ego_path.at(i), ego_path.at(i + 1));
-    const double elapsed_time = lon_dist / ego_vel;
-
-    const auto future_ego_pose = ego_path.at(i);
-    const auto future_obj_pose =
-      autoware::object_recognition_utils::calcInterpolatedPose(obj_path, elapsed_time);
-
-    if (future_obj_pose) {
-      const double dist_ego_to_obj =
-        autoware_utils::calc_distance2d(future_ego_pose, *future_obj_pose);
-      if (dist_ego_to_obj < 1.0) {
-        if (!collision_start_idx) {
-          collision_start_idx = i;
-        }
-        continue;
-      }
-    } else {
-      if (!collision_start_idx) {
-        continue;
-      }
-    }
-
-    return std::make_pair(*collision_start_idx, i - 1);
-  }
-
-  return std::make_pair(*collision_start_idx, ego_path.size() - 1);
-}
-
-TimeWhileCollision DynamicObstacleAvoidanceModule::calcTimeWhileCollision(
-  const std::vector<PathPointWithLaneId> & ego_path, const double obj_tangent_vel,
-  const LatLonOffset & lat_lon_offset) const
-{
-  // Set maximum time-to-collision 0 if the object longitudinally overlaps ego.
-  // NOTE: This is to avoid objects running right beside ego even if time-to-collision is negative.
-  const size_t ego_seg_idx = planner_data_->findEgoSegmentIndex(ego_path);
-  const double lon_offset_ego_to_obj_idx = autoware::motion_utils::calcSignedArcLength(
-    ego_path, getEgoPose().position, ego_seg_idx, lat_lon_offset.nearest_idx);
-  const double relative_velocity = getEgoSpeed() - obj_tangent_vel;
-
-  const double signed_time_to_start_collision = [&]() {
-    const double lon_offset_ego_front_to_obj_back =
-      lon_offset_ego_to_obj_idx + lat_lon_offset.min_lon_offset -
-      (planner_data_->parameters.wheel_base + planner_data_->parameters.front_overhang);
-    const double lon_offset_obj_front_to_ego_back = -lon_offset_ego_to_obj_idx -
-                                                    lat_lon_offset.max_lon_offset -
-                                                    planner_data_->parameters.rear_overhang;
-    if (0.0 < lon_offset_ego_front_to_obj_back) {  // The object is ahead of the ego.
-      return lon_offset_ego_front_to_obj_back / relative_velocity;
-    } else if (0.0 < lon_offset_obj_front_to_ego_back) {  // The ego is ahead of the object.
-      return lon_offset_obj_front_to_ego_back / -relative_velocity;
-    }
-    // The ego and object are colliding.
-    return 0.0;
-  }();
-  const double signed_time_to_end_collision = [&]() {
-    const double lon_offset_ego_back_to_obj_front = lon_offset_ego_to_obj_idx +
-                                                    lat_lon_offset.max_lon_offset +
-                                                    planner_data_->parameters.rear_overhang;
-    const double lon_offset_obj_back_to_ego_front = -lon_offset_ego_to_obj_idx -
-                                                    lat_lon_offset.min_lon_offset +
-                                                    planner_data_->parameters.front_overhang;
-    if (0.0 < relative_velocity) {
-      return lon_offset_ego_back_to_obj_front / relative_velocity;
-    }
-    return lon_offset_obj_back_to_ego_front / -relative_velocity;
-  }();
-
-  // NOTE: In order to make time_to_start_collision continuous around the relative_velocity is zero.
-  const double time_to_start_collision = [&]() {
-    if (signed_time_to_start_collision < 0.0) {
-      return std::numeric_limits<double>::max();
-    }
-    return signed_time_to_start_collision;
-  }();
-  const double time_to_end_collision = [&]() {
-    if (signed_time_to_end_collision < 0.0) {
-      return std::numeric_limits<double>::max();
-    }
-    return signed_time_to_end_collision;
-  }();
-
-  return TimeWhileCollision{time_to_start_collision, time_to_end_collision};
-}
-
 bool DynamicObstacleAvoidanceModule::isObjectFarFromPath(
   const PredictedObject & predicted_object, const double obj_dist_to_path) const
 {
@@ -1084,149 +662,6 @@ bool DynamicObstacleAvoidanceModule::isObjectFarFromPath(
     0.0, obj_dist_to_path - planner_data_->parameters.vehicle_width / 2.0 - obj_max_length);
 
   return parameters_->max_obj_lat_offset_to_ego_path < min_obj_dist_to_path;
-}
-
-bool DynamicObstacleAvoidanceModule::willObjectCutIn(
-  const std::vector<PathPointWithLaneId> & ego_path, const PredictedPath & predicted_path,
-  const double obj_tangent_vel, const LatLonOffset & lat_lon_offset) const
-{
-  // Ignore oncoming object
-  if (obj_tangent_vel < parameters_->min_cut_in_object_vel) {
-    return false;
-  }
-
-  // Check if ego's path and object's path are close.
-  const bool will_object_cut_in = [&]() {
-    for (const auto & predicted_path_point : predicted_path.path) {
-      const double paths_lat_diff =
-        autoware::motion_utils::calcLateralOffset(ego_path, predicted_path_point.position);
-      if (std::abs(paths_lat_diff) < planner_data_->parameters.vehicle_width / 2.0) {
-        return true;
-      }
-    }
-    return false;
-  }();
-  if (!will_object_cut_in) {
-    // The object's path will not cut in
-    return false;
-  }
-
-  // Ignore object longitudinally close to the ego
-  const size_t ego_seg_idx = planner_data_->findEgoSegmentIndex(ego_path);
-  const double relative_velocity = getEgoSpeed() - obj_tangent_vel;
-  const double lon_offset_ego_to_obj =
-    autoware::motion_utils::calcSignedArcLength(
-      ego_path, getEgoPose().position, ego_seg_idx, lat_lon_offset.nearest_idx) +
-    lat_lon_offset.min_lon_offset;
-  if (
-    lon_offset_ego_to_obj < std::max(
-                              parameters_->min_lon_offset_ego_to_cut_in_object,
-                              relative_velocity * parameters_->min_time_to_start_cut_in)) {
-    return false;
-  }
-
-  return true;
-}
-
-DynamicObstacleAvoidanceModule::DecisionWithReason DynamicObstacleAvoidanceModule::willObjectCutOut(
-  const double obj_tangent_vel, const double obj_normal_vel, const bool is_object_left,
-  const std::optional<DynamicAvoidanceObject> & prev_object) const
-{
-  // Ignore oncoming object
-  if (obj_tangent_vel < parameters_->min_cut_out_object_vel) {
-    return DecisionWithReason{false};
-  }
-
-  // Check if previous object is memorized
-  if (!prev_object || !prev_object->latest_time_inside_ego_path) {
-    return DecisionWithReason{false};
-  }
-  if (
-    parameters_->max_time_from_outside_ego_path_for_cut_out <
-    (clock_->now() - *prev_object->latest_time_inside_ego_path).seconds()) {
-    return DecisionWithReason{false};
-  }
-
-  // Check object's lateral velocity
-  std::stringstream reason;
-  reason << "since latest time inside ego's path is small enough ("
-         << (clock_->now() - *prev_object->latest_time_inside_ego_path).seconds() << "<"
-         << parameters_->max_time_from_outside_ego_path_for_cut_out << ")";
-  if (is_object_left) {
-    if (parameters_->min_cut_out_object_lat_vel < obj_normal_vel) {
-      reason << ", and lateral velocity is large enough ("
-             << parameters_->min_cut_out_object_lat_vel << "<abs(" << obj_normal_vel << ")";
-      return DecisionWithReason{true, reason.str()};
-    }
-  } else {
-    if (obj_normal_vel < -parameters_->min_cut_out_object_lat_vel) {
-      reason << ", and lateral velocity is large enough ("
-             << parameters_->min_cut_out_object_lat_vel << "<abs(" << obj_normal_vel << ")";
-      return DecisionWithReason{true, reason.str()};
-    }
-  }
-
-  return DecisionWithReason{false};
-}
-
-[[maybe_unused]] bool DynamicObstacleAvoidanceModule::willObjectBeOutsideEgoChangingPath(
-  const geometry_msgs::msg::Pose & obj_pose, const autoware_perception_msgs::msg::Shape & obj_shape,
-  const double obj_vel) const
-{
-  if (!ref_path_before_lane_change_ || obj_vel < 0.0) {
-    return false;
-  }
-
-  // Check if object is in the lane before ego's lane change.
-  const double dist_to_ref_path_before_lane_change = std::abs(
-    autoware::motion_utils::calcLateralOffset(*ref_path_before_lane_change_, obj_pose.position));
-  const double epsilon_dist_checking_in_lane = calcObstacleWidth(obj_shape);
-  if (epsilon_dist_checking_in_lane < dist_to_ref_path_before_lane_change) {
-    return false;
-  }
-
-  return true;
-}
-
-std::pair<lanelet::ConstLanelets, lanelet::ConstLanelets>
-DynamicObstacleAvoidanceModule::getAdjacentLanes(
-  const double forward_distance, const double backward_distance) const
-{
-  const auto & rh = planner_data_->route_handler;
-
-  lanelet::ConstLanelet current_lane;
-  if (!rh->getClosestLaneletWithinRoute(getEgoPose(), &current_lane)) {
-    RCLCPP_ERROR(
-      rclcpp::get_logger("behavior_path_planner").get_child("dynamic_avoidance"),
-      "failed to find closest lanelet within route!!!");
-    return {};
-  }
-
-  const auto ego_succeeding_lanes =
-    rh->getLaneletSequence(current_lane, getEgoPose(), backward_distance, forward_distance);
-
-  lanelet::ConstLanelets right_lanes;
-  lanelet::ConstLanelets left_lanes;
-  for (const auto & lane : ego_succeeding_lanes) {
-    // left lane
-    const auto opt_left_lane = rh->getLeftLanelet(lane);
-    if (opt_left_lane) {
-      left_lanes.push_back(opt_left_lane.value());
-    }
-
-    // right lane
-    const auto opt_right_lane = rh->getRightLanelet(lane);
-    if (opt_right_lane) {
-      right_lanes.push_back(opt_right_lane.value());
-    }
-
-    const auto right_opposite_lanes = rh->getRightOppositeLanelets(lane);
-    if (!right_opposite_lanes.empty()) {
-      right_lanes.push_back(right_opposite_lanes.front());
-    }
-  }
-
-  return std::make_pair(right_lanes, left_lanes);
 }
 
 DynamicObstacleAvoidanceModule::LatLonOffset
@@ -1291,9 +726,7 @@ DynamicObstacleAvoidanceModule::getLateralLongitudinalOffset(
 
 MinMaxValue DynamicObstacleAvoidanceModule::calcMinMaxLongitudinalOffsetToAvoid(
   const std::vector<geometry_msgs::msg::Pose> & ref_points_for_obj_poly,
-  const geometry_msgs::msg::Pose & obj_pose, const Polygon2d & obj_points, const double obj_vel,
-  const PredictedPath & obj_path, const autoware_perception_msgs::msg::Shape & obj_shape,
-  const TimeWhileCollision & time_while_collision) const
+  const geometry_msgs::msg::Pose & obj_pose, const Polygon2d & obj_points) const
 {
   const size_t obj_seg_idx =
     autoware::motion_utils::findNearestSegmentIndex(ref_points_for_obj_poly, obj_pose.position);
@@ -1311,156 +744,20 @@ MinMaxValue DynamicObstacleAvoidanceModule::calcMinMaxLongitudinalOffsetToAvoid(
     return getMinMaxValues(obj_lon_offset_vec);
   }();
 
-  const double relative_velocity = getEgoSpeed() - obj_vel;
+  constexpr double start_length_to_avoid = 0.0;
+  constexpr double end_length_to_avoid = 0.0;
 
-  // calculate bound start and end length
-  const double start_length_to_avoid = [&]() {
-    if (obj_vel < parameters_->max_stopped_object_vel) {
-      // The ego and object are the opposite directional or the object is parked.
-      return std::min(time_while_collision.time_to_start_collision, 3.5) * std::abs(obj_vel) +
-             std::abs(relative_velocity) * parameters_->start_duration_to_avoid_oncoming_object;
-    }
-    // The ego and object are the same directional.
-    const double obj_acc = -0.5;
-    const double decel_time = 1.0;
-    const double obj_moving_dist =
-      (std::pow(std::max(obj_vel + obj_acc * decel_time, 0.0), 2) - std::pow(obj_vel, 2)) / 2 /
-      obj_acc;
-    const double ego_moving_dist = getEgoSpeed() * decel_time;
-    return std::max(0.0, ego_moving_dist - obj_moving_dist) +
-           std::abs(relative_velocity) * parameters_->start_duration_to_avoid_overtaking_object;
-  }();
-  const double end_length_to_avoid = [&]() {
-    if (obj_vel < parameters_->max_stopped_object_vel) {
-      // The ego and object are the opposite directional or the object is parked.
-      return std::abs(relative_velocity) * parameters_->end_duration_to_avoid_oncoming_object;
-    }
-    // The ego and object are the same directional.
-    return std::min(time_while_collision.time_to_end_collision, 3.0) * obj_vel +
-           std::abs(relative_velocity) * parameters_->end_duration_to_avoid_overtaking_object;
-  }();
-
-  // calculate valid path for the forked object's path from the ego's path
-  if (obj_vel < -parameters_->max_stopped_object_vel) {
-    const bool is_object_same_direction = false;
-    const double valid_length_to_avoid =
-      calcValidLengthToAvoid(obj_path, obj_pose, obj_shape, is_object_same_direction);
-    return MinMaxValue{
-      obj_lon_offset.min_value + std::max(-start_length_to_avoid, -valid_length_to_avoid),
-      obj_lon_offset.max_value + end_length_to_avoid};
-  }
-  if (parameters_->max_stopped_object_vel < obj_vel) {
-    const bool is_object_same_direction = true;
-    const double valid_length_to_avoid =
-      calcValidLengthToAvoid(obj_path, obj_pose, obj_shape, is_object_same_direction);
-    return MinMaxValue{
-      obj_lon_offset.min_value - start_length_to_avoid,
-      obj_lon_offset.max_value + std::min(end_length_to_avoid, valid_length_to_avoid)};
-  }
   return MinMaxValue{
     obj_lon_offset.min_value - start_length_to_avoid,
     obj_lon_offset.max_value + end_length_to_avoid};
-}
-
-double DynamicObstacleAvoidanceModule::calcValidLengthToAvoid(
-  const PredictedPath & obj_path, const geometry_msgs::msg::Pose & obj_pose,
-  const autoware_perception_msgs::msg::Shape & obj_shape, const bool is_object_same_direction) const
-{
-  const auto & input_path_points = getPreviousModuleOutput().path.points;
-  const size_t obj_seg_idx =
-    autoware::motion_utils::findNearestSegmentIndex(input_path_points, obj_pose.position);
-
-  constexpr double dist_threshold_additional_margin = 0.5;
-  const double dist_threshold_paths =
-    planner_data_->parameters.vehicle_width / 2.0 + parameters_->lat_offset_from_obstacle +
-    calcObstacleWidth(obj_shape) / 2.0 + dist_threshold_additional_margin;
-
-  // crop the ego's path by object position
-  std::vector<PathPointWithLaneId> cropped_ego_path_points;
-  if (is_object_same_direction) {
-    cropped_ego_path_points = std::vector<PathPointWithLaneId>{
-      input_path_points.begin() + obj_seg_idx, input_path_points.end()};
-  } else {
-    cropped_ego_path_points = std::vector<PathPointWithLaneId>{
-      input_path_points.begin(), input_path_points.begin() + obj_seg_idx + 1 + 1};
-    std::reverse(cropped_ego_path_points.begin(), cropped_ego_path_points.end());
-  }
-  if (cropped_ego_path_points.size() < 2) {
-    return autoware::motion_utils::calcArcLength(obj_path.path);
-  }
-
-  // calculate where the object's path will be forked from (= far from) the ego's path.
-  std::optional<size_t> last_nearest_ego_path_seg_idx{std::nullopt};
-  const size_t valid_obj_path_end_idx = [&]() {
-    size_t ego_path_seg_idx = 0;
-    for (size_t obj_path_idx = 0; obj_path_idx < obj_path.path.size(); ++obj_path_idx) {
-      bool are_paths_close{false};
-      for (; ego_path_seg_idx < cropped_ego_path_points.size() - 1; ++ego_path_seg_idx) {
-        const double dist_to_segment = calcDistanceToSegment(
-          obj_path.path.at(obj_path_idx).position,
-          cropped_ego_path_points.at(ego_path_seg_idx).point.pose.position,
-          cropped_ego_path_points.at(ego_path_seg_idx + 1).point.pose.position);
-        if (dist_to_segment < dist_threshold_paths) {
-          last_nearest_ego_path_seg_idx = ego_path_seg_idx;
-          are_paths_close = true;
-          break;
-        }
-      }
-
-      if (!are_paths_close) {
-        return obj_path_idx;
-      }
-    }
-    return obj_path.path.size() - 1;
-  }();
-
-  // calculate valid length to avoid
-  if (last_nearest_ego_path_seg_idx && valid_obj_path_end_idx != obj_path.path.size() - 1) {
-    const auto calc_min_dist = [&](const size_t arg_obj_path_idx) -> std::optional<double> {
-      std::optional<double> min_dist{std::nullopt};
-      for (size_t ego_path_seg_idx = *last_nearest_ego_path_seg_idx;
-           ego_path_seg_idx < cropped_ego_path_points.size() - 1; ++ego_path_seg_idx) {
-        const double dist_to_segment = calcDistanceToSegment(
-          obj_path.path.at(arg_obj_path_idx).position,
-          cropped_ego_path_points.at(ego_path_seg_idx).point.pose.position,
-          cropped_ego_path_points.at(ego_path_seg_idx + 1).point.pose.position);
-        if (!min_dist || dist_to_segment < *min_dist) {
-          min_dist = dist_to_segment;
-        }
-        if (min_dist && *min_dist < dist_to_segment) {
-          return *min_dist;
-        }
-      }
-      return min_dist;
-    };
-    const size_t prev_valid_obj_path_end_idx =
-      (valid_obj_path_end_idx == 0) ? valid_obj_path_end_idx : valid_obj_path_end_idx - 1;
-    const size_t next_valid_obj_path_end_idx =
-      (valid_obj_path_end_idx == 0) ? valid_obj_path_end_idx + 1 : valid_obj_path_end_idx;
-    const auto prev_min_dist = calc_min_dist(prev_valid_obj_path_end_idx);
-    const auto next_min_dist = calc_min_dist(next_valid_obj_path_end_idx);
-    if (prev_min_dist && next_min_dist) {
-      const double segment_length = autoware_utils::calc_distance2d(
-        obj_path.path.at(prev_valid_obj_path_end_idx),
-        obj_path.path.at(next_valid_obj_path_end_idx));
-      const double partial_segment_length = segment_length *
-                                            (dist_threshold_paths - *prev_min_dist) /
-                                            (*next_min_dist - *prev_min_dist);
-      return autoware::motion_utils::calcSignedArcLength(
-               obj_path.path, 0, prev_valid_obj_path_end_idx) +
-             partial_segment_length;
-    }
-  }
-  return autoware::motion_utils::calcSignedArcLength(obj_path.path, 0, valid_obj_path_end_idx);
 }
 
 // min value denotes near side, max value denotes far side
 std::optional<MinMaxValue>
 DynamicObstacleAvoidanceModule::calcMinMaxLateralOffsetToAvoidRegulatedObject(
   const std::vector<geometry_msgs::msg::Pose> & ref_points_for_obj_poly,
-  const Polygon2d & obj_points, const geometry_msgs::msg::Point & obj_pos, const double obj_vel,
-  const bool is_collision_left, const double obj_normal_vel,
-  const std::optional<DynamicAvoidanceObject> & prev_object) const
+  const Polygon2d & obj_points, const geometry_msgs::msg::Point & obj_pos,
+  const bool is_collision_left, const std::optional<DynamicAvoidanceObject> & prev_object) const
 {
   const bool enable_lowpass_filter = [&]() {
     if (
@@ -1498,27 +795,21 @@ DynamicObstacleAvoidanceModule::calcMinMaxLateralOffsetToAvoidRegulatedObject(
   const double min_obj_lat_abs_offset = obj_lat_abs_offset.min_value;
   const double max_obj_lat_abs_offset = obj_lat_abs_offset.max_value;
 
-  if (parameters_->min_front_object_vel < obj_vel) {
-    const double obj_width_on_ego_path =
-      std::min(max_obj_lat_abs_offset, planner_data_->parameters.vehicle_width / 2.0) -
-      std::max(min_obj_lat_abs_offset, -planner_data_->parameters.vehicle_width / 2.0);
-    if (
-      planner_data_->parameters.vehicle_width *
-        parameters_->max_front_object_ego_path_lat_cover_ratio <
-      obj_width_on_ego_path) {
-      return std::nullopt;
-    }
+  const double obj_width_on_ego_path =
+    std::min(max_obj_lat_abs_offset, planner_data_->parameters.vehicle_width / 2.0) -
+    std::max(min_obj_lat_abs_offset, -planner_data_->parameters.vehicle_width / 2.0);
+  if (
+    planner_data_->parameters.vehicle_width *
+      parameters_->max_front_object_ego_path_lat_cover_ratio <
+    obj_width_on_ego_path) {
+    return std::nullopt;
   }
 
   // calculate bound min and max lateral offset
   const double min_bound_lat_offset = [&]() {
-    const double lat_abs_offset_to_shift =
-      std::max(0.0, obj_normal_vel * (is_collision_left ? -1.0 : 1.0)) *
-      parameters_->max_time_for_lat_shift;
     const double raw_min_bound_lat_offset =
       (is_collision_left ? min_obj_lat_abs_offset : max_obj_lat_abs_offset) -
-      (parameters_->lat_offset_from_obstacle + lat_abs_offset_to_shift) *
-        (is_collision_left ? 1.0 : -1.0);
+      parameters_->lat_offset_from_obstacle * (is_collision_left ? 1.0 : -1.0);
     const double min_bound_lat_abs_offset_limit =
       planner_data_->parameters.vehicle_width / 2.0 - parameters_->max_lat_offset_to_avoid;
 
@@ -1612,13 +903,10 @@ DynamicObstacleAvoidanceModule::calcMinMaxLateralOffsetToAvoidUnregulatedObject(
         lat_pos_vec.push_back(obj_point_lat_offset);
       }
     }
-    const auto current_pos_area = getMinMaxValues(lat_pos_vec);
-    return combineMinMaxValues(current_pos_area, current_pos_area + object.lat_vel * 3.0);
+    return getMinMaxValues(lat_pos_vec);
   }();
 
-  if (
-    obj_occupancy_region.min_value * obj_occupancy_region.max_value < 0.0 ||
-    obj_occupancy_region.max_value - obj_occupancy_region.min_value < 1e-3) {
+  if (obj_occupancy_region.min_value * obj_occupancy_region.max_value < 0.0) {
     return std::nullopt;
   }
 
@@ -1699,45 +987,8 @@ DynamicObstacleAvoidanceModule::calcEgoPathBasedDynamicObstaclePolygon(
       ref_points_for_obj_poly.at(i), 0.0, object.lat_offset_to_avoid->min_value, 0.0));
   }
 
-  // calculate start index laterally feasible for ego to shift considering maximum lateral jerk and
-  // acceleration
-  const auto obj_inner_bound_start_idx = [&]() -> std::optional<size_t> {
-    const auto & ego_lat_feasible_path = object.is_collision_left
-                                           ? object.ego_lat_feasible_paths.left_path
-                                           : object.ego_lat_feasible_paths.right_path;
-    const auto intersect_result = intersectLines(obj_inner_bound_poses, ego_lat_feasible_path);
-
-    // Check if the object polygon intersects with the ego_lat_feasible_path.
-    if (intersect_result) {
-      const auto & [bound_seg_idx, intersect_point] = *intersect_result;
-      const double lon_offset =
-        autoware_utils::calc_distance2d(obj_inner_bound_poses.at(bound_seg_idx), intersect_point);
-
-      const auto obj_inner_bound_start_idx_opt =
-        autoware::motion_utils::insertTargetPoint(bound_seg_idx, lon_offset, obj_inner_bound_poses);
-      if (obj_inner_bound_start_idx_opt) {
-        return *obj_inner_bound_start_idx_opt;
-      }
-    }
-
-    // Check if the object polygon is fully outside the ego_lat_feasible_path.
-    const double obj_poly_lat_offset = autoware::motion_utils::calcLateralOffset(
-      ego_lat_feasible_path, obj_inner_bound_poses.front().position);
-    if (
-      (!object.is_collision_left && 0 < obj_poly_lat_offset) ||
-      (object.is_collision_left && obj_poly_lat_offset < 0)) {
-      return std::nullopt;
-    }
-
-    return 0;
-  }();
-  if (!obj_inner_bound_start_idx) {
-    return std::nullopt;
-  }
-
-  // calculate feasible inner/outer bound points
-  const auto feasible_obj_inner_bound_poses = std::vector<geometry_msgs::msg::Pose>(
-    obj_inner_bound_poses.begin() + *obj_inner_bound_start_idx, obj_inner_bound_poses.end());
+  // calculate feasible inner/outer bound points (no dynamic lateral feasibility trimming)
+  const auto feasible_obj_inner_bound_poses = obj_inner_bound_poses;
   const auto feasible_obj_inner_bound_points = convertToPoints(feasible_obj_inner_bound_poses);
   std::vector<geometry_msgs::msg::Point> feasible_obj_outer_bound_points;
   for (const auto & feasible_obj_inner_bound_pose : feasible_obj_inner_bound_poses) {
@@ -1763,93 +1014,18 @@ DynamicObstacleAvoidanceModule::calcEgoPathBasedDynamicObstaclePolygon(
   return obj_poly;
 }
 
-// should be replace by the function calcPredictedPathBasedDynamicObstaclePolygon() (takagi)
+// Calculate obstacle polygon from current pose only.
 std::optional<autoware_utils::Polygon2d>
-DynamicObstacleAvoidanceModule::calcObjectPathBasedDynamicObstaclePolygon(
-  const DynamicAvoidanceObject & object) const
-{
-  const auto obj_path = *std::max_element(
-    object.predicted_paths.begin(), object.predicted_paths.end(),
-    [](const PredictedPath & a, const PredictedPath & b) { return a.confidence < b.confidence; });
-
-  // calculate left and right bound
-  std::vector<geometry_msgs::msg::Point> obj_left_bound_points;
-  std::vector<geometry_msgs::msg::Point> obj_right_bound_points;
-  const double obj_path_length = autoware::motion_utils::calcArcLength(obj_path.path);
-  for (size_t i = 0; i < obj_path.path.size(); ++i) {
-    const double lon_offset = [&]() {
-      if (i == 0)
-        return -object.shape.dimensions.x / 2.0 -
-               std::max(
-                 parameters_->min_obj_path_based_lon_polygon_margin,
-                 parameters_->lat_offset_from_obstacle);
-      if (i == obj_path.path.size() - 1)
-        return object.shape.dimensions.x / 2.0 +
-               std::max(
-                 parameters_->min_obj_path_based_lon_polygon_margin - obj_path_length,
-                 parameters_->lat_offset_from_obstacle);
-      return 0.0;
-    }();
-
-    const auto & obj_pose = obj_path.path.at(i);
-    obj_left_bound_points.push_back(
-      autoware_utils::calc_offset_pose(
-        obj_pose, lon_offset,
-        object.shape.dimensions.y / 2.0 + parameters_->lat_offset_from_obstacle, 0.0)
-        .position);
-    obj_right_bound_points.push_back(
-      autoware_utils::calc_offset_pose(
-        obj_pose, lon_offset,
-        -object.shape.dimensions.y / 2.0 - parameters_->lat_offset_from_obstacle, 0.0)
-        .position);
-  }
-
-  // create obj_polygon from inner/outer bound points
-  autoware_utils::Polygon2d obj_poly;
-  for (const auto & bound_point : obj_right_bound_points) {
-    const auto obj_poly_point = autoware_utils::Point2d(bound_point.x, bound_point.y);
-    obj_poly.outer().push_back(obj_poly_point);
-  }
-  std::reverse(obj_left_bound_points.begin(), obj_left_bound_points.end());
-  for (const auto & bound_point : obj_left_bound_points) {
-    const auto obj_poly_point = autoware_utils::Point2d(bound_point.x, bound_point.y);
-    obj_poly.outer().push_back(obj_poly_point);
-  }
-
-  boost::geometry::correct(obj_poly);
-  return obj_poly;
-}
-
-// Calculate polygons according to predicted_path with certain confidence,
-// except for the area required for ego safety.
-// input: an object, the minimum area required for ego safety, and some global params
-std::optional<autoware_utils::Polygon2d>
-DynamicObstacleAvoidanceModule::calcPredictedPathBasedDynamicObstaclePolygon(
+DynamicObstacleAvoidanceModule::calcCurrentPoseBasedDynamicObstaclePolygon(
   const DynamicAvoidanceObject & object, const EgoPathReservePoly & ego_path_poly) const
 {
-  std::vector<geometry_msgs::msg::Pose> obj_poses;
-  for (const auto & predicted_path : object.predicted_paths) {
-    if (predicted_path.confidence < parameters_->threshold_confidence) continue;
-
-    double time_count = 0.0;
-    for (const auto & pose : predicted_path.path) {
-      obj_poses.push_back(pose);
-      time_count += predicted_path.time_step.sec + predicted_path.time_step.nanosec * 1e-9;
-      if (time_count > parameters_->end_time_to_consider + 1e-3) break;
-    }
-  }
-
-  autoware_utils::Polygon2d obj_points_as_poly;
-  for (const auto pose : obj_poses) {
-    boost::geometry::append(
-      obj_points_as_poly, autoware_utils::to_footprint(
-                            pose, object.shape.dimensions.x * 0.5, object.shape.dimensions.x * 0.5,
-                            object.shape.dimensions.y * 0.5)
-                            .outer());
-  }
-  boost::geometry::correct(obj_points_as_poly);
-  Polygon2d obj_poly;
-  boost::geometry::convex_hull(obj_points_as_poly, obj_poly);
+  autoware_utils::Polygon2d obj_poly;
+  boost::geometry::append(
+    obj_poly, autoware_utils::to_footprint(
+                object.pose, object.shape.dimensions.x * 0.5, object.shape.dimensions.x * 0.5,
+                object.shape.dimensions.y * 0.5)
+                .outer());
+  boost::geometry::correct(obj_poly);
 
   autoware_utils::MultiPolygon2d expanded_poly;
   namespace strategy = boost::geometry::strategy::buffer;
@@ -1871,7 +1047,8 @@ DynamicObstacleAvoidanceModule::calcPredictedPathBasedDynamicObstaclePolygon(
       "[DynamicAvoidance] Ignore obstacle (%s) because it stay inside the ego's path.",
       object.uuid.c_str());
     return {};
-  } else if (output_poly.size() >= 2) {
+  }
+  if (output_poly.size() >= 2) {
     RCLCPP_INFO_EXPRESSION(
       getLogger(), parameters_->enable_debug_info,
       "[DynamicAvoidance] Ignore obstacle (%s) because it covers the ego's path.",
@@ -1899,218 +1076,27 @@ DynamicObstacleAvoidanceModule::calcEgoPathReservePoly(const PathWithLaneId & eg
   }
 
   auto calcReservePoly =
-    [&ego_path_lines](
-      const strategy::distance_asymmetric<double> path_expand_strategy,
-      const strategy::distance_asymmetric<double> steer_expand_strategy,
-      const std::vector<geometry_msgs::msg::Point> & outer_body_path) -> autoware_utils::Polygon2d {
-    // reserve area based on the reference path
+    [&ego_path_lines](const strategy::distance_asymmetric<double> path_expand_strategy)
+    -> autoware_utils::Polygon2d {
     autoware_utils::MultiPolygon2d path_poly;
     boost::geometry::buffer(
       ego_path_lines, path_poly, path_expand_strategy, strategy::side_straight(),
       strategy::join_round(), strategy::end_flat(), strategy::point_circle());
-
-    // reserve area steer to the avoidance path
-    autoware_utils::LineString2d steer_lines;
-    for (const auto & point : outer_body_path) {
-      const auto bg_point = autoware_utils::from_msg(point).to_2d();
-      if (boost::geometry::within(bg_point, path_poly)) {
-        if (steer_lines.size() != 0) {
-          ;
-          // boost::geometry::append(steer_lines, bg_point);
-        }
-        break;
-      }
-      // boost::geometry::append(steer_lines, bg_point);
-    }
-    autoware_utils::MultiPolygon2d steer_poly;
-    boost::geometry::buffer(
-      steer_lines, steer_poly, steer_expand_strategy, strategy::side_straight(),
-      strategy::join_round(), strategy::end_flat(), strategy::point_circle());
-
-    autoware_utils::MultiPolygon2d output_poly;
-    boost::geometry::union_(path_poly, steer_poly, output_poly);
-    if (output_poly.size() != 1) {
+    if (path_poly.size() != 1) {
       assert(false);
     }
-    return output_poly[0];
+    return path_poly[0];
   };
-
-  const auto motion_saturated_outer_paths =
-    generateLateralFeasiblePaths(getEgoPose(), getEgoSpeed());
 
   const double vehicle_half_width = planner_data_->parameters.vehicle_width * 0.5;
   const double reserve_width_obj_side = vehicle_half_width - parameters_->max_lat_offset_to_avoid;
 
   const autoware_utils::Polygon2d left_avoid_poly = calcReservePoly(
-    strategy::distance_asymmetric<double>(vehicle_half_width, reserve_width_obj_side),
-    strategy::distance_asymmetric<double>(vehicle_half_width, 0.0),
-    motion_saturated_outer_paths.right_path);
+    strategy::distance_asymmetric<double>(vehicle_half_width, reserve_width_obj_side));
   const autoware_utils::Polygon2d right_avoid_poly = calcReservePoly(
-    strategy::distance_asymmetric<double>(reserve_width_obj_side, vehicle_half_width),
-    strategy::distance_asymmetric<double>(0.0, vehicle_half_width),
-    motion_saturated_outer_paths.left_path);
+    strategy::distance_asymmetric<double>(reserve_width_obj_side, vehicle_half_width));
 
   return {left_avoid_poly, right_avoid_poly};
 }
 
-lanelet::ConstLanelets DynamicObstacleAvoidanceModule::getCurrentLanesFromPath(
-  const PathWithLaneId & path, const std::shared_ptr<const PlannerData> & planner_data)
-{
-  if (path.points.empty()) {
-    throw std::logic_error("empty path.");
-  }
-
-  const auto idx = planner_data->findEgoIndex(path.points);
-
-  if (path.points.at(idx).lane_ids.empty()) {
-    throw std::logic_error("empty lane ids.");
-  }
-
-  const auto start_id = path.points.at(idx).lane_ids.front();
-  const auto start_lane = planner_data->route_handler->getLaneletsFromId(start_id);
-  const auto & p = planner_data->parameters;
-
-  return planner_data->route_handler->getLaneletSequence(
-    start_lane, p.backward_path_length, p.forward_path_length);
-}
-
-DrivableLanes DynamicObstacleAvoidanceModule::generateExpandedDrivableLanes(
-  const lanelet::ConstLanelet & lanelet, const std::shared_ptr<const PlannerData> & planner_data,
-  const std::shared_ptr<DynamicAvoidanceParameters> & parameters)
-{
-  const auto & route_handler = planner_data->route_handler;
-
-  DrivableLanes current_drivable_lanes;
-  current_drivable_lanes.left_lane = lanelet;
-  current_drivable_lanes.right_lane = lanelet;
-
-  if (parameters->use_lane_type == "current_lane") {
-    return current_drivable_lanes;
-  }
-
-  const auto use_opposite_lane = parameters->use_lane_type == "opposite_direction_lane";
-
-  // 1. get left/right side lanes
-  const auto update_left_lanelets = [&](const lanelet::ConstLanelet & target_lane) {
-    const auto all_left_lanelets =
-      route_handler->getAllLeftSharedLinestringLanelets(target_lane, use_opposite_lane, true);
-    if (!all_left_lanelets.empty()) {
-      current_drivable_lanes.left_lane = all_left_lanelets.back();  // leftmost lanelet
-      pushUniqueVector(
-        current_drivable_lanes.middle_lanes,
-        lanelet::ConstLanelets(all_left_lanelets.begin(), all_left_lanelets.end() - 1));
-    }
-  };
-  const auto update_right_lanelets = [&](const lanelet::ConstLanelet & target_lane) {
-    const auto all_right_lanelets =
-      route_handler->getAllRightSharedLinestringLanelets(target_lane, use_opposite_lane, true);
-    if (!all_right_lanelets.empty()) {
-      current_drivable_lanes.right_lane = all_right_lanelets.back();  // rightmost lanelet
-      pushUniqueVector(
-        current_drivable_lanes.middle_lanes,
-        lanelet::ConstLanelets(all_right_lanelets.begin(), all_right_lanelets.end() - 1));
-    }
-  };
-
-  update_left_lanelets(lanelet);
-  update_right_lanelets(lanelet);
-
-  // 2.1 when there are multiple lanes whose previous lanelet is the same
-  const auto get_next_lanes_from_same_previous_lane =
-    [&route_handler](const lanelet::ConstLanelet & lane) {
-      // get previous lane, and return false if previous lane does not exist
-      lanelet::ConstLanelets prev_lanes;
-      if (!route_handler->getPreviousLaneletsWithinRoute(lane, &prev_lanes)) {
-        return lanelet::ConstLanelets{};
-      }
-
-      lanelet::ConstLanelets next_lanes;
-      for (const auto & prev_lane : prev_lanes) {
-        const auto next_lanes_from_prev = route_handler->getNextLanelets(prev_lane);
-        pushUniqueVector(next_lanes, next_lanes_from_prev);
-      }
-      return next_lanes;
-    };
-
-  const auto next_lanes_for_right =
-    get_next_lanes_from_same_previous_lane(current_drivable_lanes.right_lane);
-  const auto next_lanes_for_left =
-    get_next_lanes_from_same_previous_lane(current_drivable_lanes.left_lane);
-
-  // 2.2 look for neighbor lane recursively, where end line of the lane is connected to end line
-  // of the original lane
-  const auto update_drivable_lanes =
-    [&](const lanelet::ConstLanelets & next_lanes, const bool is_left) {
-      for (const auto & next_lane : next_lanes) {
-        const auto & edge_lane =
-          is_left ? current_drivable_lanes.left_lane : current_drivable_lanes.right_lane;
-        if (next_lane.id() == edge_lane.id()) {
-          continue;
-        }
-
-        const auto & left_lane = is_left ? next_lane : edge_lane;
-        const auto & right_lane = is_left ? edge_lane : next_lane;
-        if (!isEndPointsConnected(left_lane, right_lane)) {
-          continue;
-        }
-
-        if (is_left) {
-          current_drivable_lanes.left_lane = next_lane;
-        } else {
-          current_drivable_lanes.right_lane = next_lane;
-        }
-
-        const auto & middle_lanes = current_drivable_lanes.middle_lanes;
-        const auto has_same_lane = std::any_of(
-          middle_lanes.begin(), middle_lanes.end(),
-          [&edge_lane](const auto & lane) { return lane.id() == edge_lane.id(); });
-
-        if (!has_same_lane) {
-          if (is_left) {
-            if (current_drivable_lanes.right_lane.id() != edge_lane.id()) {
-              current_drivable_lanes.middle_lanes.push_back(edge_lane);
-            }
-          } else {
-            if (current_drivable_lanes.left_lane.id() != edge_lane.id()) {
-              current_drivable_lanes.middle_lanes.push_back(edge_lane);
-            }
-          }
-        }
-
-        return true;
-      }
-      return false;
-    };
-
-  const auto expand_drivable_area_recursively =
-    [&](const lanelet::ConstLanelets & next_lanes, const bool is_left) {
-      // NOTE: set max search num to avoid infinity loop for drivable area expansion
-      constexpr size_t max_recursive_search_num = 3;
-      for (size_t i = 0; i < max_recursive_search_num; ++i) {
-        const bool is_update_kept = update_drivable_lanes(next_lanes, is_left);
-        if (!is_update_kept) {
-          break;
-        }
-        if (i == max_recursive_search_num - 1) {
-          RCLCPP_DEBUG(
-            rclcpp::get_logger(logger_namespace), "Drivable area expansion reaches max iteration.");
-        }
-      }
-    };
-  expand_drivable_area_recursively(next_lanes_for_right, false);
-  expand_drivable_area_recursively(next_lanes_for_left, true);
-
-  // 3. update again for new left/right lanes
-  update_left_lanelets(current_drivable_lanes.left_lane);
-  update_right_lanelets(current_drivable_lanes.right_lane);
-
-  // 4. compensate that current_lane is in either of left_lane, right_lane or middle_lanes.
-  if (
-    current_drivable_lanes.left_lane.id() != lanelet.id() &&
-    current_drivable_lanes.right_lane.id() != lanelet.id()) {
-    current_drivable_lanes.middle_lanes.push_back(lanelet);
-  }
-
-  return current_drivable_lanes;
-}
 }  // namespace autoware::behavior_path_planner


### PR DESCRIPTION
## Description

Dynamic obstacle avoidanceの機能の削減，及び有効化を行いました．
X2のL4走行では`dynamic_obstacle_avoidance`を`static_obstacle_avoidance`の補助として使用します．つまり，**dynamic** な物体(動物体)に対する回避ではなく，静止している物体に対する回避を行います．しかし現状の`dynamic_obstacle_avoidance`は動物体に対する回避機能に関するコードが大部分を締めます．
この変更では，それらの機能を実装するコードを削除しました．この変更によって今回の目的に無関係なコードからバグが発生することを防ぎます．

## Test

[Screencast from 03-04-2026 02:22:48 PM.webm](https://github.com/user-attachments/assets/b08703be-8298-4174-ae46-8695d96d973d)

[Screencast from 03-04-2026 03:02:35 PM.webm](https://github.com/user-attachments/assets/03e01153-7a2f-4452-8c9b-d18360007c91)

