### PR TITLE
fix(trajectory_validator): fix yaw deviation calclation

### DIFF
--- a/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter.cpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter.cpp
@@ -282,7 +282,7 @@ double calc_longitudinal_velocity(const PosePoints & points, const Object & obje
     throw std::invalid_argument("points must not be empty");
   }
 
-  constexpr double min_path_end_to_end_distance = 1e3;
+  constexpr double min_path_end_to_end_distance = 1e-3;
 
   const auto & object_pose = object.kinematics.initial_pose_with_covariance.pose;
   const bool use_path_yaw =

--- a/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter.cpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter.cpp
@@ -14,6 +14,7 @@
 
 #include "autoware/trajectory_validator/filters/safety/collision_check_filter.hpp"
 
+#include <autoware/universe_utils/geometry/pose_deviation.hpp>
 #include <autoware_utils/system/stop_watch.hpp>
 #include <autoware_utils_geometry/boost_polygon_utils.hpp>
 #include <autoware_utils_uuid/uuid_helper.hpp>
@@ -29,6 +30,7 @@
 #include <cmath>
 #include <limits>
 #include <memory>
+#include <stdexcept>
 #include <string>
 #include <unordered_map>
 #include <utility>
@@ -273,18 +275,31 @@ PoseTrajectory compute_pose_trajectory(
   return pose_trajectory;
 }
 
-template <typename Points, typename Object>
-double calc_longitudinal_velocity(const Points & points, const Object & object)
+template <typename PosePoints, typename Object>
+double calc_longitudinal_velocity(const PosePoints & points, const Object & object)
 {
-  const auto & obj_pose = object.kinematics.initial_pose_with_covariance.pose;
-  const Eigen::Rotation2Dd object_orientation_on_points(
-    autoware::motion_utils::calcYawDeviation(points, obj_pose, true));
+  if (points.empty()) {
+    throw std::invalid_argument("points must not be empty");
+  }
 
-  const auto & obj_twist = object.kinematics.initial_twist_with_covariance.twist;
-  const Eigen::Vector2d object_velocity_on_obstacle(obj_twist.linear.x, obj_twist.linear.y);
+  constexpr double min_path_end_to_end_distance = 1e3;
 
-  const auto object_velocity_on_points = object_orientation_on_points * object_velocity_on_obstacle;
-  return object_velocity_on_points.x();
+  const auto & object_pose = object.kinematics.initial_pose_with_covariance.pose;
+  const bool use_path_yaw =
+    points.size() >= 2 && autoware_utils_geometry::calc_distance2d(points.front(), points.back()) >=
+                            min_path_end_to_end_distance;
+  const double object_yaw_relative_to_points =
+    use_path_yaw ? autoware::motion_utils::calcYawDeviation(points, object_pose, true)
+                 : autoware::universe_utils::calcYawDeviation(points.front(), object_pose);
+  const Eigen::Rotation2Dd object_to_points_rotation(object_yaw_relative_to_points);
+
+  const auto & object_twist = object.kinematics.initial_twist_with_covariance.twist;
+  const Eigen::Vector2d object_velocity_in_object_frame(
+    object_twist.linear.x, object_twist.linear.y);
+  const Eigen::Vector2d object_velocity_in_points_frame =
+    object_to_points_rotation * object_velocity_in_object_frame;
+
+  return object_velocity_in_points_frame.x();
 }
 
 TrajectoryData generate_ego_trajectory(


### PR DESCRIPTION
## Description
This PR adds a fallback in calc_longitudinal_velocity() for cases where the input points do not provide a reliable path direction.

When only one point is available, or when the end-to-end distance of the point sequence is too small, the function falls back to the first point's pose instead of estimating yaw from the full point sequence.

This preserves the existing behavior for normal trajectories while improving robustness for point sequences with insufficient spatial extent.


## Test
engage available in psim 
Unit test should be added later


## Issue example
```
Mar 24 10:53:27 main autoware_main_launch[154923]: [autoware_trajectory_validator_node-95] terminate called after throwing an instance of 'std::runtime_error'
Mar 24 10:53:27 main autoware_main_launch[154923]: [autoware_trajectory_validator_node-95]   what():  [autoware_motion_utils] calcYawDeviation Given points size is less than 2. Failed to calculate yaw deviation.
Mar 24 10:53:27 main autoware_main_launch[154923]: [autoware_trajectory_validator_node-95] *** Aborted at 1774317207 (unix time) try "date -d @1774317207" if you are using GNU date ***
Mar 24 10:53:27 main autoware_main_launch[154923]: [autoware_trajectory_validator_node-95] PC: @                0x0 (unknown)
Mar 24 10:53:27 main autoware_main_launch[154923]: [autoware_trajectory_validator_node-95] *** SIGABRT (@0x3e8000264cb) received by PID 156875 (TID 0x7f7c3b071680) from PID 156875; stack trace: ***
Mar 24 10:53:27 main autoware_main_launch[154923]: [autoware_trajectory_validator_node-95]     @     0x7f7c3b9094d6 google::(anonymous namespace)::FailureSignalHandler()
Mar 24 10:53:27 main autoware_main_launch[154923]: [autoware_trajectory_validator_node-95]     @     0x7f7c3ae42520 (unknown)
Mar 24 10:53:27 main autoware_main_launch[154923]: [autoware_trajectory_validator_node-95]     @     0x7f7c3ae969fc pthread_kill
Mar 24 10:53:27 main autoware_main_launch[154923]: [autoware_trajectory_validator_node-95]     @     0x7f7c3ae42476 raise
Mar 24 10:53:27 main autoware_main_launch[154923]: [autoware_trajectory_validator_node-95]     @     0x7f7c3ae287f3 abort
Mar 24 10:53:27 main autoware_main_launch[154923]: [autoware_trajectory_validator_node-95]     @     0x7f7c3b2a2b9e (unknown)
Mar 24 10:53:27 main autoware_main_launch[154923]: [autoware_trajectory_validator_node-95]     @     0x7f7c3b2ae20c (unknown)
Mar 24 10:53:27 main autoware_main_launch[154923]: [autoware_trajectory_validator_node-95]     @     0x7f7c3b2ae277 std::terminate()
Mar 24 10:53:27 main autoware_main_launch[154923]: [autoware_trajectory_validator_node-95]     @     0x7f7c3b2ae4d8 __cxa_throw
Mar 24 10:53:27 main autoware_main_launch[154923]: [autoware_trajectory_validator_node-95]     @     0x7f7c3595f91a autoware::motion_utils::calcYawDeviation<>()
Mar 24 10:53:27 main autoware_main_launch[154923]: [autoware_trajectory_validator_node-95]     @     0x7f7c35959762 autoware::trajectory_validator::plugin::safety::CollisionCheckFilter::compute_rss_deceleration()
Mar 24 10:53:27 main autoware_main_launch[154923]: [autoware_trajectory_validator_node-95]     @     0x7f7c35959f6e autoware::trajectory_validator::plugin::safety::CollisionCheckFilter::is_feasible()

```

