### PR TITLE
feat(diffusion_planner): add planning factor interface (#12387)

### DIFF
--- a/planning/autoware_diffusion_planner/CMakeLists.txt
+++ b/planning/autoware_diffusion_planner/CMakeLists.txt
@@ -62,6 +62,7 @@ if(TRT_AVAIL AND CUDA_AVAIL)
     src/preprocessing/traffic_signals.cpp
     src/utils/utils.cpp
     src/utils/marker_utils.cpp
+    src/utils/planning_factor_utils.cpp
     src/postprocessing/turn_indicator_manager.cpp
     src/inference/tensorrt_inference.cpp
   )
@@ -97,7 +98,8 @@ if(TRT_AVAIL AND CUDA_AVAIL)
       test/agent_edge_case_test.cpp
       test/lanelet_edge_case_test.cpp
       test/diffusion_planner_integration_test.cpp
-      test/rtc_prefix_test.cpp)
+      test/rtc_prefix_test.cpp
+      test/planning_factor_utils_test.cpp)
 
     target_link_libraries(test_diffusion_planner autoware_diffusion_planner_component)
     ament_target_dependencies(test_diffusion_planner

--- a/planning/autoware_diffusion_planner/config/diffusion_planner.param.yaml
+++ b/planning/autoware_diffusion_planner/config/diffusion_planner.param.yaml
@@ -17,6 +17,12 @@
     delay_step: 0
     line_string_max_step_m: 5.0
     use_time_interpolation: false
+    planning_factor:
+      enable_stop: true
+      enable_slowdown: false
+      stop_keep_duration_threshold: 1.0  # [s]
+      stop_velocity_threshold: 0.1       # [m/s]
+      slowdown_accel_threshold: -0.3     # [m/s^2]
     debug_params:
       publish_debug_route: true
       publish_debug_map: false

--- a/planning/autoware_diffusion_planner/include/autoware/diffusion_planner/diffusion_planner_node.hpp
+++ b/planning/autoware_diffusion_planner/include/autoware/diffusion_planner/diffusion_planner_node.hpp
@@ -16,8 +16,10 @@
 #define AUTOWARE__DIFFUSION_PLANNER__DIFFUSION_PLANNER_NODE_HPP_
 
 #include "autoware/diffusion_planner/diffusion_planner_core.hpp"
+#include "autoware/diffusion_planner/utils/planning_factor_utils.hpp"
 
 #include <autoware/lanelet2_utils/conversion.hpp>
+#include <autoware/planning_factor_interface/planning_factor_interface.hpp>
 #include <autoware/vehicle_info_utils/vehicle_info.hpp>
 #include <autoware_utils/ros/polling_subscriber.hpp>
 #include <autoware_utils/ros/update_param.hpp>
@@ -49,6 +51,7 @@ using autoware_planning_msgs::msg::Trajectory;
 using autoware_vehicle_msgs::msg::TurnIndicatorsCommand;
 using HADMapBin = autoware_map_msgs::msg::LaneletMapBin;
 using autoware::vehicle_info_utils::VehicleInfo;
+using autoware_internal_planning_msgs::msg::PlanningFactor;
 using autoware_utils_diagnostics::DiagnosticsInterface;
 using geometry_msgs::msg::Pose;
 using rcl_interfaces::msg::SetParametersResult;
@@ -60,6 +63,13 @@ struct DiffusionPlannerDebugParams
   bool publish_debug_route{true};
   bool publish_debug_map{false};
   bool publish_debug_linestrings{false};
+};
+
+struct DiffusionPlannerPlanningFactorParams
+{
+  bool enable_stop{false};
+  bool enable_slowdown{false};
+  PlanningFactorDetectionConfig detection_config;
 };
 
 /**
@@ -147,6 +157,12 @@ private:
   void publish_first_traffic_light_on_route(const FrameContext & frame_context) const;
 
   /**
+   * @brief Publish planning factors (stop/slowdown) derived from the trajectory.
+   * @param trajectory The planned trajectory.
+   */
+  void publish_planning_factor(const Trajectory & trajectory);
+
+  /**
    * @brief Callback for dynamic parameter updates.
    * @param parameters Updated parameters.
    * @return Result of parameter update.
@@ -198,6 +214,10 @@ private:
 
   std::unique_ptr<DiagnosticsInterface> diagnostics_inference_;
   std::shared_ptr<const lanelet::LaneletMap> lanelet_map_ptr_{nullptr};
+
+  std::unique_ptr<autoware::planning_factor_interface::PlanningFactorInterface>
+    planning_factor_interface_;
+  DiffusionPlannerPlanningFactorParams planning_factor_params_;
 };
 
 }  // namespace autoware::diffusion_planner

--- a/planning/autoware_diffusion_planner/include/autoware/diffusion_planner/utils/planning_factor_utils.hpp
+++ b/planning/autoware_diffusion_planner/include/autoware/diffusion_planner/utils/planning_factor_utils.hpp
@@ -1,0 +1,60 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef AUTOWARE__DIFFUSION_PLANNER__UTILS__PLANNING_FACTOR_UTILS_HPP_
+#define AUTOWARE__DIFFUSION_PLANNER__UTILS__PLANNING_FACTOR_UTILS_HPP_
+
+#include <autoware_planning_msgs/msg/trajectory_point.hpp>
+#include <geometry_msgs/msg/pose.hpp>
+
+#include <optional>
+#include <vector>
+
+namespace autoware::diffusion_planner
+{
+
+struct PlanningFactorDetectionConfig
+{
+  double stop_velocity_threshold{0.1};
+  double stop_keep_duration_threshold{1.0};
+  double slowdown_accel_threshold{-0.3};
+};
+
+struct DetectedStopFactor
+{
+  geometry_msgs::msg::Pose ego_pose;
+  geometry_msgs::msg::Pose stop_pose;
+};
+
+struct DetectedSlowdownFactor
+{
+  geometry_msgs::msg::Pose ego_pose;
+  geometry_msgs::msg::Pose start_pose;
+  geometry_msgs::msg::Pose end_pose;
+  double start_velocity;
+  double end_velocity;
+};
+
+struct PlanningFactorDetectionResult
+{
+  std::optional<DetectedStopFactor> stop;
+  std::optional<DetectedSlowdownFactor> slowdown;
+};
+
+PlanningFactorDetectionResult detect_planning_factors(
+  const std::vector<autoware_planning_msgs::msg::TrajectoryPoint> & points,
+  const PlanningFactorDetectionConfig & config);
+
+}  // namespace autoware::diffusion_planner
+#endif  // AUTOWARE__DIFFUSION_PLANNER__UTILS__PLANNING_FACTOR_UTILS_HPP_

--- a/planning/autoware_diffusion_planner/package.xml
+++ b/planning/autoware_diffusion_planner/package.xml
@@ -24,6 +24,7 @@
   <depend>autoware_motion_utils</depend>
   <depend>autoware_object_recognition_utils</depend>
   <depend>autoware_perception_msgs</depend>
+  <depend>autoware_planning_factor_interface</depend>
   <depend>autoware_planning_msgs</depend>
   <depend>autoware_tensorrt_common</depend>
   <depend>autoware_traffic_light_utils</depend>

--- a/planning/autoware_diffusion_planner/schema/diffusion_planner.schema.json
+++ b/planning/autoware_diffusion_planner/schema/diffusion_planner.schema.json
@@ -111,6 +111,43 @@
           "default": false,
           "description": "Whether to interpolate ego past trajectory at regular time intervals"
         },
+        "planning_factor": {
+          "type": "object",
+          "properties": {
+            "enable_stop": {
+              "type": "boolean",
+              "default": false,
+              "description": "Enable stop planning factor"
+            },
+            "enable_slowdown": {
+              "type": "boolean",
+              "default": false,
+              "description": "Enable slowdown planning factor"
+            },
+            "stop_velocity_threshold": {
+              "type": "number",
+              "default": 0.1,
+              "description": "Velocity threshold to detect a stop [m/s]"
+            },
+            "stop_keep_duration_threshold": {
+              "type": "number",
+              "default": 1.0,
+              "description": "Duration threshold to validate a stop [s]"
+            },
+            "slowdown_accel_threshold": {
+              "type": "number",
+              "default": -0.3,
+              "description": "Acceleration threshold to detect a slowdown [m/s^2]"
+            }
+          },
+          "required": [
+            "enable_stop",
+            "enable_slowdown",
+            "stop_velocity_threshold",
+            "stop_keep_duration_threshold",
+            "slowdown_accel_threshold"
+          ]
+        },
         "debug_params": {
           "type": "object",
           "properties": {
@@ -144,6 +181,7 @@
         "stopping_threshold",
         "turn_indicator_keep_offset",
         "turn_indicator_hold_duration",
+        "planning_factor",
         "debug_params"
       ]
     }

--- a/planning/autoware_diffusion_planner/src/diffusion_planner_node.cpp
+++ b/planning/autoware_diffusion_planner/src/diffusion_planner_node.cpp
@@ -60,6 +60,10 @@ DiffusionPlanner::DiffusionPlanner(const rclcpp::NodeOptions & options)
   // Create core instance
   core_ = std::make_unique<DiffusionPlannerCore>(params_, vehicle_info_);
 
+  planning_factor_interface_ =
+    std::make_unique<autoware::planning_factor_interface::PlanningFactorInterface>(
+      this, "diffusion_planner");
+
   diagnostics_inference_ = std::make_unique<DiagnosticsInterface>(this, "inference_status");
   try {
     load_model();
@@ -120,6 +124,18 @@ void DiffusionPlanner::set_up_params()
   params_.delay_step = this->declare_parameter<int64_t>("delay_step", 0);
   params_.line_string_max_step_m = this->declare_parameter<double>("line_string_max_step_m", 5.0);
   params_.use_time_interpolation = this->declare_parameter<bool>("use_time_interpolation", false);
+
+  // planning factor params
+  planning_factor_params_.enable_stop =
+    this->declare_parameter<bool>("planning_factor.enable_stop", false);
+  planning_factor_params_.enable_slowdown =
+    this->declare_parameter<bool>("planning_factor.enable_slowdown", false);
+  planning_factor_params_.detection_config.stop_velocity_threshold =
+    this->declare_parameter<double>("planning_factor.stop_velocity_threshold", 0.1);
+  planning_factor_params_.detection_config.stop_keep_duration_threshold =
+    this->declare_parameter<double>("planning_factor.stop_keep_duration_threshold", 1.0);
+  planning_factor_params_.detection_config.slowdown_accel_threshold =
+    this->declare_parameter<double>("planning_factor.slowdown_accel_threshold", -0.3);
 
   // debug params
   debug_params_.publish_debug_map =
@@ -373,8 +389,34 @@ void DiffusionPlanner::on_timer()
   pub_objects_->publish(planner_output.predicted_objects);
   pub_turn_indicators_->publish(planner_output.turn_indicator_command);
 
+  publish_planning_factor(planner_output.trajectory);
+
   // Publish diagnostics
   diagnostics_inference_->publish(frame_time);
+}
+
+void DiffusionPlanner::publish_planning_factor(const Trajectory & trajectory)
+{
+  const auto & points = trajectory.points;
+  const auto detection_result =
+    detect_planning_factors(points, planning_factor_params_.detection_config);
+
+  if (planning_factor_params_.enable_stop && detection_result.stop) {
+    const auto & stop = *detection_result.stop;
+    planning_factor_interface_->add(
+      points, stop.ego_pose, stop.stop_pose, PlanningFactor::STOP,
+      autoware_internal_planning_msgs::msg::SafetyFactorArray{});
+  }
+
+  if (planning_factor_params_.enable_slowdown && detection_result.slowdown) {
+    const auto & slowdown = *detection_result.slowdown;
+    planning_factor_interface_->add(
+      points, slowdown.ego_pose, slowdown.start_pose, slowdown.end_pose, PlanningFactor::SLOW_DOWN,
+      autoware_internal_planning_msgs::msg::SafetyFactorArray{}, true, slowdown.start_velocity,
+      slowdown.end_velocity);
+  }
+
+  planning_factor_interface_->publish();
 }
 
 void DiffusionPlanner::on_map(const HADMapBin::ConstSharedPtr map_msg)

--- a/planning/autoware_diffusion_planner/src/utils/planning_factor_utils.cpp
+++ b/planning/autoware_diffusion_planner/src/utils/planning_factor_utils.cpp
@@ -1,0 +1,102 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/diffusion_planner/utils/planning_factor_utils.hpp"
+
+#include <rclcpp/duration.hpp>
+
+#include <vector>
+
+namespace autoware::diffusion_planner
+{
+
+using autoware_planning_msgs::msg::TrajectoryPoint;
+
+std::optional<DetectedStopFactor> detect_stop_factor(
+  const std::vector<TrajectoryPoint> & points, const PlanningFactorDetectionConfig & config)
+{
+  std::optional<size_t> stop_idx;
+  rclcpp::Duration stop_start_time(0, 0);
+  bool is_valid_stop = true;
+
+  for (size_t i = 0; i < points.size(); ++i) {
+    if (!stop_idx && points[i].longitudinal_velocity_mps <= config.stop_velocity_threshold) {
+      stop_idx = i;
+      stop_start_time = rclcpp::Duration(points[i].time_from_start);
+    }
+    if (
+      stop_idx &&
+      (rclcpp::Duration(points[i].time_from_start) - stop_start_time).seconds() <
+        config.stop_keep_duration_threshold &&
+      points[i].longitudinal_velocity_mps > config.stop_velocity_threshold) {
+      is_valid_stop = false;
+    }
+  }
+
+  if (!stop_idx || !is_valid_stop) {
+    return std::nullopt;
+  }
+
+  DetectedStopFactor stop;
+  stop.ego_pose = points[0].pose;
+  stop.stop_pose = points[*stop_idx].pose;
+  return stop;
+}
+
+std::optional<DetectedSlowdownFactor> detect_slowdown_factor(
+  const std::vector<TrajectoryPoint> & points, const PlanningFactorDetectionConfig & config)
+{
+  std::optional<size_t> slowdown_start_idx;
+  std::optional<size_t> slowdown_end_idx;
+
+  for (size_t i = 0; i < points.size(); ++i) {
+    if (points[i].acceleration_mps2 < config.slowdown_accel_threshold) {
+      if (!slowdown_start_idx) slowdown_start_idx = i;
+    } else if (slowdown_start_idx && !slowdown_end_idx) {
+      slowdown_end_idx = i;
+    }
+  }
+
+  if (slowdown_start_idx && !slowdown_end_idx) {
+    slowdown_end_idx = points.size() - 1;
+  }
+
+  if (!slowdown_start_idx) {
+    return std::nullopt;
+  }
+
+  DetectedSlowdownFactor slowdown;
+  slowdown.ego_pose = points[0].pose;
+  slowdown.start_pose = points[*slowdown_start_idx].pose;
+  slowdown.end_pose = points[*slowdown_end_idx].pose;
+  slowdown.start_velocity = points[*slowdown_start_idx].longitudinal_velocity_mps;
+  slowdown.end_velocity = points[*slowdown_end_idx].longitudinal_velocity_mps;
+  return slowdown;
+}
+
+PlanningFactorDetectionResult detect_planning_factors(
+  const std::vector<TrajectoryPoint> & points, const PlanningFactorDetectionConfig & config)
+{
+  PlanningFactorDetectionResult result;
+
+  if (points.empty()) {
+    return result;
+  }
+
+  result.stop = detect_stop_factor(points, config);
+  result.slowdown = detect_slowdown_factor(points, config);
+  return result;
+}
+
+}  // namespace autoware::diffusion_planner

--- a/planning/autoware_diffusion_planner/test/planning_factor_utils_test.cpp
+++ b/planning/autoware_diffusion_planner/test/planning_factor_utils_test.cpp
@@ -1,0 +1,178 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/diffusion_planner/utils/planning_factor_utils.hpp"
+
+#include <gtest/gtest.h>
+
+#include <vector>
+
+namespace autoware::diffusion_planner::test
+{
+
+using autoware_planning_msgs::msg::TrajectoryPoint;
+
+namespace
+{
+
+TrajectoryPoint make_point(
+  const double time_from_start_sec, const double x, const float velocity, const float accel)
+{
+  TrajectoryPoint p;
+  p.time_from_start.sec = static_cast<int32_t>(time_from_start_sec);
+  p.time_from_start.nanosec =
+    static_cast<uint32_t>((time_from_start_sec - static_cast<int32_t>(time_from_start_sec)) * 1e9);
+  p.pose.position.x = x;
+  p.pose.position.y = 0.0;
+  p.pose.position.z = 0.0;
+  p.longitudinal_velocity_mps = velocity;
+  p.acceleration_mps2 = accel;
+  return p;
+}
+
+}  // namespace
+
+class PlanningFactorUtilsTest : public ::testing::Test
+{
+protected:
+  PlanningFactorDetectionConfig config_;
+
+  void SetUp() override
+  {
+    config_.stop_velocity_threshold = 0.1;
+    config_.stop_keep_duration_threshold = 1.0;
+    config_.slowdown_accel_threshold = -0.3;
+  }
+};
+
+TEST_F(PlanningFactorUtilsTest, EmptyPoints)
+{
+  std::vector<TrajectoryPoint> points;
+  const auto result = detect_planning_factors(points, config_);
+  EXPECT_FALSE(result.stop.has_value());
+  EXPECT_FALSE(result.slowdown.has_value());
+}
+
+TEST_F(PlanningFactorUtilsTest, NoStopNoSlowdown)
+{
+  std::vector<TrajectoryPoint> points;
+  for (int i = 0; i < 10; ++i) {
+    points.push_back(make_point(i * 0.5, i * 1.0, 5.0f, 0.0f));
+  }
+  const auto result = detect_planning_factors(points, config_);
+  EXPECT_FALSE(result.stop.has_value());
+  EXPECT_FALSE(result.slowdown.has_value());
+}
+
+TEST_F(PlanningFactorUtilsTest, StopDetected)
+{
+  std::vector<TrajectoryPoint> points;
+  points.push_back(make_point(0.0, 0.0, 3.0f, 0.0f));
+  points.push_back(make_point(0.5, 1.0, 2.0f, -0.2f));
+  points.push_back(make_point(1.0, 2.0, 1.0f, -0.2f));
+  points.push_back(make_point(1.5, 3.0, 0.05f, -0.1f));  // below threshold
+  points.push_back(make_point(2.0, 4.0, 0.0f, 0.0f));
+  points.push_back(make_point(2.5, 5.0, 0.0f, 0.0f));
+  points.push_back(make_point(3.0, 6.0, 0.0f, 0.0f));
+
+  const auto result = detect_planning_factors(points, config_);
+  ASSERT_TRUE(result.stop.has_value());
+  EXPECT_DOUBLE_EQ(result.stop->ego_pose.position.x, 0.0);
+  EXPECT_DOUBLE_EQ(result.stop->stop_pose.position.x, 3.0);
+  EXPECT_FALSE(result.slowdown.has_value());
+}
+
+TEST_F(PlanningFactorUtilsTest, StopInvalidatedByVelocityResume)
+{
+  std::vector<TrajectoryPoint> points;
+  points.push_back(make_point(0.0, 0.0, 3.0f, 0.0f));
+  points.push_back(make_point(0.5, 1.0, 0.05f, -0.1f));  // below threshold
+  points.push_back(make_point(0.8, 2.0, 0.5f, 0.1f));    // above threshold, within 1.0s
+  points.push_back(make_point(1.0, 3.0, 2.0f, 0.1f));
+
+  const auto result = detect_planning_factors(points, config_);
+  EXPECT_FALSE(result.stop.has_value());
+}
+
+TEST_F(PlanningFactorUtilsTest, SlowdownDetected)
+{
+  std::vector<TrajectoryPoint> points;
+  points.push_back(make_point(0.0, 0.0, 5.0f, 0.0f));
+  points.push_back(make_point(0.5, 1.0, 4.5f, -0.1f));
+  points.push_back(make_point(1.0, 2.0, 3.5f, -0.5f));  // below slowdown threshold
+  points.push_back(make_point(1.5, 3.0, 2.5f, -0.5f));  // below slowdown threshold
+  points.push_back(make_point(2.0, 4.0, 2.0f, -0.1f));  // above threshold -> end
+  points.push_back(make_point(2.5, 5.0, 2.0f, 0.0f));
+
+  const auto result = detect_planning_factors(points, config_);
+  EXPECT_FALSE(result.stop.has_value());
+  ASSERT_TRUE(result.slowdown.has_value());
+  EXPECT_DOUBLE_EQ(result.slowdown->ego_pose.position.x, 0.0);
+  EXPECT_DOUBLE_EQ(result.slowdown->start_pose.position.x, 2.0);
+  EXPECT_DOUBLE_EQ(result.slowdown->end_pose.position.x, 4.0);
+  EXPECT_DOUBLE_EQ(result.slowdown->start_velocity, 3.5);
+  EXPECT_DOUBLE_EQ(result.slowdown->end_velocity, 2.0);
+}
+
+TEST_F(PlanningFactorUtilsTest, BothStopAndSlowdown)
+{
+  std::vector<TrajectoryPoint> points;
+  points.push_back(make_point(0.0, 0.0, 5.0f, 0.0f));
+  points.push_back(make_point(0.5, 1.0, 3.0f, -0.5f));  // slowdown start
+  points.push_back(make_point(1.0, 2.0, 1.0f, -0.5f));
+  points.push_back(make_point(1.5, 3.0, 0.5f, -0.1f));    // slowdown end
+  points.push_back(make_point(2.0, 4.0, 0.05f, -0.05f));  // stop detected
+  points.push_back(make_point(2.5, 5.0, 0.0f, 0.0f));
+  points.push_back(make_point(3.0, 6.0, 0.0f, 0.0f));
+  points.push_back(make_point(3.5, 7.0, 0.0f, 0.0f));
+
+  const auto result = detect_planning_factors(points, config_);
+
+  ASSERT_TRUE(result.stop.has_value());
+  EXPECT_DOUBLE_EQ(result.stop->stop_pose.position.x, 4.0);
+
+  ASSERT_TRUE(result.slowdown.has_value());
+  EXPECT_DOUBLE_EQ(result.slowdown->start_pose.position.x, 1.0);
+  EXPECT_DOUBLE_EQ(result.slowdown->end_pose.position.x, 3.0);
+}
+
+TEST_F(PlanningFactorUtilsTest, SlowdownWithoutEnd)
+{
+  // Deceleration starts but never ends
+  std::vector<TrajectoryPoint> points;
+  points.push_back(make_point(0.0, 0.0, 5.0f, 0.0f));
+  points.push_back(make_point(0.5, 1.0, 3.0f, -0.5f));
+  points.push_back(make_point(1.0, 2.0, 1.0f, -0.5f));
+  points.push_back(make_point(1.5, 3.0, 0.5f, -0.5f));
+
+  const auto result = detect_planning_factors(points, config_);
+  ASSERT_TRUE(result.slowdown.has_value());
+  EXPECT_DOUBLE_EQ(result.slowdown->start_pose.position.x, 1.0);
+  EXPECT_DOUBLE_EQ(result.slowdown->end_pose.position.x, 3.0);
+  EXPECT_DOUBLE_EQ(result.slowdown->start_velocity, 3.0);
+  EXPECT_DOUBLE_EQ(result.slowdown->end_velocity, 0.5);
+}
+
+TEST_F(PlanningFactorUtilsTest, SingleStoppedPoint)
+{
+  std::vector<TrajectoryPoint> points;
+  points.push_back(make_point(0.0, 0.0, 0.0f, 0.0f));
+
+  const auto result = detect_planning_factors(points, config_);
+  ASSERT_TRUE(result.stop.has_value());
+  EXPECT_DOUBLE_EQ(result.stop->ego_pose.position.x, 0.0);
+  EXPECT_DOUBLE_EQ(result.stop->stop_pose.position.x, 0.0);
+}
+
+}  // namespace autoware::diffusion_planner::test


### PR DESCRIPTION
- cherry-pick https://github.com/autowarefoundation/autoware_universe/pull/12387

After merging this, I'll open the follow-up PRs to remove planning factor interface from `trajectory_adapter` and update launch parameter and rviz config.