### PR TITLE
feat(behavior_path_planner/trajectory_follower_node): replace topic_state_monitor for v4.3.1.2 20260413

### DIFF
--- a/control/autoware_trajectory_follower_node/README.md
+++ b/control/autoware_trajectory_follower_node/README.md
@@ -145,6 +145,11 @@ Giving the longitudinal controller information about steer convergence allows it
   - Each time the node receives lateral and longitudinal commands from each controller, it publishes an `Control` if the following two conditions are met.
     1. Both commands have been received.
     2. The last received commands are not older than defined by `timeout_thr_sec`.
+- `cyclic_message_timeout_thr_sec`: duration in second for monitoring incoming trajectory messages via diagnostic updater (default: 0.9)
+  - The diagnostic updater will report ERROR status if:
+    1. No trajectory message has been received yet.
+    2. The elapsed time since the last trajectory message exceeds this threshold.
+  - This parameter helps monitor the health of the trajectory input stream.
 - `lateral_controller_mode`: `mpc` or `pure_pursuit`
   - (currently there is only `PID` for longitudinal controller)
 - `enable_control_cmd_horizon_pub`: publish `ControlHorizon` or not (default: false)

--- a/control/autoware_trajectory_follower_node/include/autoware/trajectory_follower_node/controller_node.hpp
+++ b/control/autoware_trajectory_follower_node/include/autoware/trajectory_follower_node/controller_node.hpp
@@ -48,6 +48,7 @@
 #include <autoware_internal_debug_msgs/msg/float64_stamped.hpp>
 
 #include <memory>
+#include <optional>
 #include <string>
 #include <utility>
 #include <vector>
@@ -79,6 +80,7 @@ public:
 private:
   rclcpp::TimerBase::SharedPtr timer_control_;
   double timeout_thr_sec_;
+  double cyclic_message_timeout_thr_sec_;
   bool enable_control_cmd_horizon_pub_{false};
   boost::optional<LongitudinalOutput> longitudinal_output_{boost::none};
 
@@ -138,6 +140,7 @@ private:
   void callbackTimerControl();
   bool processData(rclcpp::Clock & clock);
   bool isTimeOut(const LongitudinalOutput & lon_out, const LateralOutput & lat_out);
+  void check_cyclic_message_timeout(diagnostic_updater::DiagnosticStatusWrapper & stat);
   LateralControllerMode getLateralControllerMode(const std::string & algorithm_name) const;
   LongitudinalControllerMode getLongitudinalControllerMode(
     const std::string & algorithm_name) const;

--- a/control/autoware_trajectory_follower_node/param/trajectory_follower_node.param.yaml
+++ b/control/autoware_trajectory_follower_node/param/trajectory_follower_node.param.yaml
@@ -2,3 +2,4 @@
   ros__parameters:
     ctrl_period: 0.03
     timeout_thr_sec: 0.5
+    cyclic_message_timeout_thr_sec: 0.9

--- a/control/autoware_trajectory_follower_node/src/controller_node.cpp
+++ b/control/autoware_trajectory_follower_node/src/controller_node.cpp
@@ -56,6 +56,7 @@ Controller::Controller(const rclcpp::NodeOptions & node_options) : Node("control
 
   const double ctrl_period = declare_parameter<double>("ctrl_period");
   timeout_thr_sec_ = declare_parameter<double>("timeout_thr_sec");
+  cyclic_message_timeout_thr_sec_ = declare_parameter<double>("cyclic_message_timeout_thr_sec");
   // NOTE: It is possible that using control_horizon could be expected to enhance performance,
   // but it is not a formal interface topic, only an experimental one.
   // So it is disabled by default.
@@ -63,6 +64,7 @@ Controller::Controller(const rclcpp::NodeOptions & node_options) : Node("control
     declare_parameter<bool>("enable_control_cmd_horizon_pub", false);
 
   diag_updater_->setHardwareID("trajectory_follower_node");
+  diag_updater_->add("incoming_message_timeout", this, &Controller::check_cyclic_message_timeout);
 
   const auto lateral_controller_mode =
     getLateralControllerMode(declare_parameter<std::string>("lateral_controller_mode"));
@@ -143,6 +145,26 @@ Controller::LongitudinalControllerMode Controller::getLongitudinalControllerMode
   if (controller_mode == "pid") return LongitudinalControllerMode::PID;
 
   return LongitudinalControllerMode::INVALID;
+}
+
+void Controller::check_cyclic_message_timeout(diagnostic_updater::DiagnosticStatusWrapper & stat)
+{
+  const auto traj_timestamp = sub_ref_path_.last_taken_data_timestamp();
+
+  if (!traj_timestamp) {
+    stat.summary(diagnostic_msgs::msg::DiagnosticStatus::ERROR, "timeout");
+    stat.add("trajectory", "no message received");
+    return;
+  }
+
+  const auto elapsed = (this->now() - traj_timestamp.value()).seconds();
+  if (elapsed > cyclic_message_timeout_thr_sec_) {
+    stat.summary(diagnostic_msgs::msg::DiagnosticStatus::ERROR, "timeout");
+    stat.add("trajectory", "timeout (elapsed: " + std::to_string(elapsed) + " sec)");
+  } else {
+    stat.summary(diagnostic_msgs::msg::DiagnosticStatus::OK, "OK");
+    stat.add("trajectory", "OK");
+  }
 }
 
 bool Controller::processData(rclcpp::Clock & clock)

--- a/planning/behavior_path_planner/autoware_behavior_path_planner/config/behavior_path_planner.param.yaml
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner/config/behavior_path_planner.param.yaml
@@ -2,6 +2,11 @@
   ros__parameters:
     traffic_light_signal_timeout: 1.0
 
+    # timeout monitoring
+    # The timeout means the time between source timestamp and current time.
+    cyclic_timeout: 0.90
+    enable_traffic_signal_timeout: false
+
     planning_hz: 10.0
     backward_path_length: 5.0
     forward_path_length: 300.0

--- a/planning/behavior_path_planner/autoware_behavior_path_planner/include/autoware/behavior_path_planner/behavior_path_planner_node.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner/include/autoware/behavior_path_planner/behavior_path_planner_node.hpp
@@ -24,6 +24,7 @@
 #include <autoware/planning_factor_interface/planning_factor_interface.hpp>
 #include <autoware_utils/ros/polling_subscriber.hpp>
 #include <autoware_utils/ros/published_time_publisher.hpp>
+#include <autoware_utils_diagnostics/diagnostics_interface.hpp>
 
 #include <autoware_adapi_v1_msgs/msg/operation_mode_state.hpp>
 #include <autoware_internal_planning_msgs/msg/path_with_lane_id.hpp>
@@ -141,23 +142,23 @@ private:
   std::mutex mutex_pd_;       // mutex for planner_data_
   std::mutex mutex_manager_;  // mutex for bt_manager_ or planner_manager_
 
+  // timeout monitoring
+  double cyclic_message_timeout_;  // seconds
+  bool enable_traffic_signal_timeout_;
+  std::unique_ptr<autoware_utils_diagnostics::DiagnosticsInterface> diagnostics_message_timeout_;
+  enum class DataReadyStatus {
+    SUCCESS,
+    NOT_RECEIVED,
+    TIMEOUT,
+  };
+
   // setup
   void takeData();
-  bool isDataReady();
+  DataReadyStatus isDataReady(const rclcpp::Time & now);
 
-  // callback
-  void onOdometry(const Odometry::ConstSharedPtr msg);
-  void onAcceleration(const AccelWithCovarianceStamped::ConstSharedPtr msg);
-  void onPerception(const PredictedObjects::ConstSharedPtr msg);
-  void onOccupancyGrid(const OccupancyGrid::ConstSharedPtr msg);
-  void onCostMap(const OccupancyGrid::ConstSharedPtr msg);
+  // data processing called from takeData()
   void onTrafficSignals(const TrafficLightGroupArray::ConstSharedPtr msg);
-  void onMap(const LaneletMapBin::ConstSharedPtr map_msg);
-  void onRoute(const LaneletRoute::ConstSharedPtr route_msg);
-  void onOperationMode(const OperationModeState::ConstSharedPtr msg);
   void onLateralOffset(const LateralOffset::ConstSharedPtr msg);
-  void on_external_velocity_limiter(
-    const autoware_internal_planning_msgs::msg::VelocityLimit::ConstSharedPtr msg);
 
   SetParametersResult onSetParam(const std::vector<rclcpp::Parameter> & parameters);
 

--- a/planning/behavior_path_planner/autoware_behavior_path_planner/package.xml
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner/package.xml
@@ -53,9 +53,11 @@
   <depend>autoware_planning_test_manager</depend>
   <depend>autoware_signal_processing</depend>
   <depend>autoware_utils</depend>
+  <depend>autoware_utils_diagnostics</depend>
   <depend>autoware_vehicle_info_utils</depend>
   <depend>autoware_vehicle_msgs</depend>
   <depend>behaviortree_cpp_v3</depend>
+  <depend>diagnostic_msgs</depend>
   <depend>geometry_msgs</depend>
   <depend>libboost-dev</depend>
   <depend>libopencv-dev</depend>

--- a/planning/behavior_path_planner/autoware_behavior_path_planner/src/behavior_path_planner_node.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner/src/behavior_path_planner_node.cpp
@@ -355,6 +355,7 @@ void BehaviorPathPlannerNode::run()
 
   // behavior_path_planner runs only in LANE DRIVING scenario.
   if (current_scenario_->current_scenario != Scenario::LANEDRIVING) {
+    diagnostics_message_timeout_->publish(stamp);
     return;
   }
 

--- a/planning/behavior_path_planner/autoware_behavior_path_planner/src/behavior_path_planner_node.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner/src/behavior_path_planner_node.cpp
@@ -24,6 +24,7 @@
 #include <tier4_planning_msgs/msg/path_change_module_id.hpp>
 
 #include <memory>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -127,6 +128,14 @@ BehaviorPathPlannerNode::BehaviorPathPlannerNode(const rclcpp::NodeOptions & nod
     const auto period_ns = rclcpp::Rate(planning_hz).period();
     timer_ = rclcpp::create_timer(
       this, get_clock(), period_ns, std::bind(&BehaviorPathPlannerNode::run, this));
+  }
+  // Timeout handling
+  {
+    cyclic_message_timeout_ = declare_parameter<double>("cyclic_timeout");
+    enable_traffic_signal_timeout_ = declare_parameter<bool>("enable_traffic_signal_timeout");
+    diagnostics_message_timeout_ =
+      std::make_unique<autoware_utils_diagnostics::DiagnosticsInterface>(
+        this, "incoming_message_timeout");
   }
 
   logger_configure_ = std::make_unique<autoware_utils::LoggerLevelConfigure>(this);
@@ -251,51 +260,75 @@ void BehaviorPathPlannerNode::takeData()
   }
 }
 
-// wait until mandatory data is ready
-bool BehaviorPathPlannerNode::isDataReady()
+// check if mandatory data is ready and check if cyclic data is not timed out.
+BehaviorPathPlannerNode::DataReadyStatus BehaviorPathPlannerNode::isDataReady(
+  const rclcpp::Time & now)
 {
-  const auto missing = [this](const auto & name) {
-    RCLCPP_INFO_SKIPFIRST_THROTTLE(get_logger(), *get_clock(), 5000, "waiting for %s", name);
-    return false;
-  };
+  diagnostics_message_timeout_->clear();
+  DataReadyStatus status = DataReadyStatus::SUCCESS;
 
-  if (!current_scenario_) {
-    return missing("scenario_topic");
+  // 1: Check if mandatory data has been received at least once.
+  {
+    const auto update_reception_diagnostics = [&](const auto & ptr, const std::string & name) {
+      if (!ptr) {
+        RCLCPP_INFO_SKIPFIRST_THROTTLE(
+          get_logger(), *get_clock(), 5000, "waiting for %s", name.c_str());
+        diagnostics_message_timeout_->add_key_value(name, std::string("not received"));
+        status = DataReadyStatus::NOT_RECEIVED;
+        return;
+      }
+      diagnostics_message_timeout_->add_key_value(name, std::string("OK"));
+    };
+
+    update_reception_diagnostics(route_ptr_, "route");
+    update_reception_diagnostics(map_ptr_, "vector_map");
+    update_reception_diagnostics(current_scenario_, "scenario");
+    update_reception_diagnostics(planner_data_->self_acceleration, "acceleration");
+    update_reception_diagnostics(planner_data_->operation_mode, "operation_mode");
   }
 
+  // Step 2: Check if cyclic data is not timed out instead of `topic_state_monitor`.
   {
-    if (!route_ptr_) {
-      return missing("route");
+    const auto update_timeout_diagnostics =
+      [&](const std::optional<rclcpp::Time> & ts, double timeout, const std::string & name) {
+        if (!ts.has_value()) {
+          RCLCPP_INFO_SKIPFIRST_THROTTLE(
+            get_logger(), *get_clock(), 5000, "waiting for %s", name.c_str());
+          diagnostics_message_timeout_->add_key_value(name, std::string("not received"));
+          status = DataReadyStatus::NOT_RECEIVED;
+          return;
+        }
+        if ((now - ts.value()).seconds() > timeout) {
+          diagnostics_message_timeout_->add_key_value(name, std::string("timeout"));
+          if (status == DataReadyStatus::SUCCESS) {
+            status = DataReadyStatus::TIMEOUT;
+          }
+          return;
+        }
+        diagnostics_message_timeout_->add_key_value(name, std::string("OK"));
+      };
+
+    update_timeout_diagnostics(
+      perception_subscriber_.last_taken_data_timestamp(), cyclic_message_timeout_,
+      "perception_objects");
+    update_timeout_diagnostics(
+      velocity_subscriber_.last_taken_data_timestamp(), cyclic_message_timeout_, "odometry");
+    update_timeout_diagnostics(
+      occupancy_grid_subscriber_.last_taken_data_timestamp(), cyclic_message_timeout_,
+      "occupancy_grid_map");
+    if (enable_traffic_signal_timeout_) {
+      update_timeout_diagnostics(
+        traffic_signals_subscriber_.last_taken_data_timestamp(), cyclic_message_timeout_,
+        "traffic_signal");
     }
   }
 
-  {
-    if (!map_ptr_) {
-      return missing("map");
-    }
+  if (status != DataReadyStatus::SUCCESS) {
+    diagnostics_message_timeout_->update_level_and_message(
+      diagnostic_msgs::msg::DiagnosticStatus::ERROR, "message timeout detected");
   }
 
-  if (!planner_data_->dynamic_object) {
-    return missing("dynamic_object");
-  }
-
-  if (!planner_data_->self_odometry) {
-    return missing("self_odometry");
-  }
-
-  if (!planner_data_->self_acceleration) {
-    return missing("self_acceleration");
-  }
-
-  if (!planner_data_->operation_mode) {
-    return missing("operation_mode");
-  }
-
-  if (!planner_data_->occupancy_grid) {
-    return missing("occupancy_grid");
-  }
-
-  return true;
+  return status;
 }
 
 void BehaviorPathPlannerNode::run()
@@ -304,7 +337,17 @@ void BehaviorPathPlannerNode::run()
 
   takeData();
 
-  if (!isDataReady()) {
+  const auto data_ready_status = isDataReady(stamp);
+  // `DataReadyStatus::TIMEOUT` is not handled intentionally as the reason in "NOTE" below
+  if (data_ready_status == DataReadyStatus::NOT_RECEIVED) {
+    /*
+     * NOTE:
+     * To preserve the existing logic of the run() callback,
+     * the run() callback will return early when mandatory data not received.
+     * There is controversy about the behavior when data is timed out. It will be discussed in the
+     * future.
+     */
+    diagnostics_message_timeout_->publish(stamp);
     return;
   }
 
@@ -436,6 +479,9 @@ void BehaviorPathPlannerNode::run()
   planner_manager_->publishMarker();
   planner_manager_->publishVirtualWall();
   lk_manager.unlock();  // release planner_manager_
+
+  // publish diagnostics for timeout checking.
+  diagnostics_message_timeout_->publish(stamp);
 
   RCLCPP_DEBUG(get_logger(), "----- behavior path planner end -----\n\n");
 }

--- a/simulator/autoware_dummy_perception_publisher/CMakeLists.txt
+++ b/simulator/autoware_dummy_perception_publisher/CMakeLists.txt
@@ -57,6 +57,10 @@ ament_auto_add_executable(empty_objects_publisher
   src/empty_objects_publisher.cpp
 )
 
+ament_auto_add_executable(empty_traffic_light_group_array_publisher
+  src/empty_traffic_light_group_array_publisher.cpp
+)
+
 if(BUILD_TESTING)
   ament_add_ros_isolated_gtest(signed_distance_function-test
     test/src/test_signed_distance_function.cpp

--- a/simulator/autoware_dummy_perception_publisher/README.md
+++ b/simulator/autoware_dummy_perception_publisher/README.md
@@ -46,4 +46,32 @@ None.
 
 ## Assumptions / Known limits
 
-TBD.
+| Name                               | Type   | Default Value | Explanation                                                             |
+| ---------------------------------- | ------ | ------------- | ----------------------------------------------------------------------- |
+| `min_predicted_path_keep_duration` | double | 3.0           | minimum time (seconds) to keep using same prediction                    |
+| `switch_time_threshold`            | double | 2.0           | time threshold (seconds) to switch from straight-line to predicted path |
+
+#### Common Remapping Parameters
+
+The plugin uses `CommonParameters` for both vehicle and pedestrian object types. Each parameter is prefixed with either `vehicle.` or `pedestrian.`:
+
+| Parameter Name               | Type   | Explanation                                               |
+| ---------------------------- | ------ | --------------------------------------------------------- |
+| `max_remapping_distance`     | double | maximum distance (meters) for remapping validation        |
+| `max_speed_difference_ratio` | double | maximum speed difference ratio tolerance                  |
+| `min_speed_ratio`            | double | minimum speed ratio relative to dummy object speed        |
+| `max_speed_ratio`            | double | maximum speed ratio relative to dummy object speed        |
+| `speed_check_threshold`      | double | speed threshold (m/s) above which speed checks apply      |
+| `path_selection_strategy`    | string | path selection strategy: "highest_confidence" or "random" |
+
+## Auxiliary Nodes
+
+### empty_objects_publisher
+
+A simple node that publishes empty `PredictedObjects` messages at 10 Hz on `~/output/objects`. This is used as a fallback when no object recognition is running, ensuring downstream nodes still receive the expected topic.
+
+### empty_traffic_light_group_array_publisher
+
+A simple node that publishes empty `TrafficLightGroupArray` messages at 10 Hz on `~/output/traffic_light_group_array`. This is used as a fallback when no traffic light recognition is running, ensuring downstream nodes still receive the expected topic.
+
+In the launch file, this node is enabled by the `use_empty_traffic_light_recognition` argument (default: `true`) and remaps its output to `/perception/traffic_light_recognition/traffic_signals`.

--- a/simulator/autoware_dummy_perception_publisher/launch/dummy_perception_publisher.launch.xml
+++ b/simulator/autoware_dummy_perception_publisher/launch/dummy_perception_publisher.launch.xml
@@ -4,6 +4,7 @@
   <arg name="visible_range" default="300.0"/>
   <arg name="real" default="true"/>
   <arg name="use_object_recognition" default="true"/>
+  <arg name="use_empty_traffic_light_recognition" default="true"/>
   <arg name="use_base_link_z" default="true"/>
 
   <group>
@@ -41,6 +42,12 @@
         <param name="enable_ray_tracing" value="false"/>
         <param name="use_object_recognition" value="$(var use_object_recognition)"/>
         <param name="use_base_link_z" value="$(var use_base_link_z)"/>
+      </node>
+    </group>
+
+    <group if="$(var use_empty_traffic_light_recognition)">
+      <node pkg="autoware_dummy_perception_publisher" exec="empty_traffic_light_group_array_publisher" name="empty_traffic_light_group_array_publisher" output="screen">
+        <remap from="~/output/traffic_light_group_array" to="/perception/traffic_light_recognition/traffic_signals"/>
       </node>
     </group>
 

--- a/simulator/autoware_dummy_perception_publisher/src/empty_traffic_light_group_array_publisher.cpp
+++ b/simulator/autoware_dummy_perception_publisher/src/empty_traffic_light_group_array_publisher.cpp
@@ -55,8 +55,7 @@ int main(int argc, char ** argv)
 {
   rclcpp::init(argc, argv);
   rclcpp::spin(
-    std::make_shared<
-      autoware::dummy_perception_publisher::EmptyTrafficLightGroupArrayPublisher>());
+    std::make_shared<autoware::dummy_perception_publisher::EmptyTrafficLightGroupArrayPublisher>());
   rclcpp::shutdown();
   return 0;
 }

--- a/simulator/autoware_dummy_perception_publisher/src/empty_traffic_light_group_array_publisher.cpp
+++ b/simulator/autoware_dummy_perception_publisher/src/empty_traffic_light_group_array_publisher.cpp
@@ -1,0 +1,62 @@
+// Copyright 2020 Tier IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <rclcpp/rclcpp.hpp>
+
+#include <autoware_perception_msgs/msg/traffic_light_group_array.hpp>
+
+#include <memory>
+
+namespace autoware::dummy_perception_publisher
+{
+
+class EmptyTrafficLightGroupArrayPublisher : public rclcpp::Node
+{
+public:
+  EmptyTrafficLightGroupArrayPublisher() : Node("empty_traffic_light_group_array_publisher")
+  {
+    empty_traffic_light_group_array_pub_ =
+      this->create_publisher<autoware_perception_msgs::msg::TrafficLightGroupArray>(
+        "~/output/traffic_light_group_array", 1);
+
+    using std::chrono_literals::operator""ms;
+    timer_ = rclcpp::create_timer(
+      this, get_clock(), 100ms,
+      std::bind(&EmptyTrafficLightGroupArrayPublisher::timerCallback, this));
+  }
+
+private:
+  rclcpp::Publisher<autoware_perception_msgs::msg::TrafficLightGroupArray>::SharedPtr
+    empty_traffic_light_group_array_pub_;
+  rclcpp::TimerBase::SharedPtr timer_;
+
+  void timerCallback()
+  {
+    autoware_perception_msgs::msg::TrafficLightGroupArray empty_traffic_light_group_array;
+    empty_traffic_light_group_array.stamp = this->now();
+    empty_traffic_light_group_array_pub_->publish(empty_traffic_light_group_array);
+  }
+};
+
+}  // namespace autoware::dummy_perception_publisher
+
+int main(int argc, char ** argv)
+{
+  rclcpp::init(argc, argv);
+  rclcpp::spin(
+    std::make_shared<
+      autoware::dummy_perception_publisher::EmptyTrafficLightGroupArrayPublisher>());
+  rclcpp::shutdown();
+  return 0;
+}

--- a/simulator/autoware_dummy_perception_publisher/src/empty_traffic_light_group_array_publisher.cpp
+++ b/simulator/autoware_dummy_perception_publisher/src/empty_traffic_light_group_array_publisher.cpp
@@ -43,6 +43,11 @@ private:
 
   void timerCallback()
   {
+    const auto topic_name = empty_traffic_light_group_array_pub_->get_topic_name();
+    if (this->count_publishers(topic_name) > 1) {
+      return;
+    }
+
     autoware_perception_msgs::msg::TrafficLightGroupArray empty_traffic_light_group_array;
     empty_traffic_light_group_array.stamp = this->now();
     empty_traffic_light_group_array_pub_->publish(empty_traffic_light_group_array);

--- a/simulator/autoware_dummy_perception_publisher/src/empty_traffic_light_group_array_publisher.cpp
+++ b/simulator/autoware_dummy_perception_publisher/src/empty_traffic_light_group_array_publisher.cpp
@@ -1,4 +1,4 @@
-// Copyright 2020 Tier IV, Inc.
+// Copyright 2026 TIER IV, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.


### PR DESCRIPTION
## Description

以下の変更を Cherry Pick して実験するための PR です。

* https://github.com/autowarefoundation/autoware_universe/pull/12075
* https://github.com/autowarefoundation/autoware_universe/pull/12214
* https://github.com/autowarefoundation/autoware_universe/pull/12082

## How was this PR tested?

* https://github.com/tier4/pilot-auto.x2/pull/3686
* https://github.com/tier4/autoware_launch.x2/pull/2106

上記の PR と組み合わせて、 Evaluator での動作確認は行っています。
ベースラインとなるマージ前の結果と同じ Pass/Fail をしており、本チケット固有の Fail がないことを確認しています。

* マージ前
https://evaluation.tier4.jp/evaluation/reports/8c0fd26a-4957-5dbe-8159-13d0e7acf4b0?project_id=x2_dev

* マージ後
https://evaluation.tier4.jp/evaluation/reports/90a341e1-456f-5c5d-8c70-7e236a98c5c5?project_id=x2_dev

## Notes for reviewers

None.

## Effects on system behavior

None.
