### PR TITLE
feat(cherry-pick): remove redundant diagnostic updates from lateral and longitudinal controllers

### DIFF
--- a/control/autoware_mpc_lateral_controller/src/mpc_lateral_controller.cpp
+++ b/control/autoware_mpc_lateral_controller/src/mpc_lateral_controller.cpp
@@ -278,8 +278,6 @@ trajectory_follower::LateralOutput MpcLateralController::run(
   }
   m_mpc_solved_status = mpc_solved_status;  // for diagnostic updater
 
-  diag_updater_->force_update();
-
   // reset previous MPC result
   // Note: When a large deviation from the trajectory occurs, the optimization stops and
   // the vehicle will return to the path by re-planning the trajectory or external operation.

--- a/control/autoware_pid_longitudinal_controller/src/pid_longitudinal_controller.cpp
+++ b/control/autoware_pid_longitudinal_controller/src/pid_longitudinal_controller.cpp
@@ -438,9 +438,6 @@ trajectory_follower::LongitudinalOutput PidLongitudinalController::run(
   // publish debug data
   publishDebugData(ctrl_cmd, control_data);
 
-  // diagnostic
-  diag_updater_->force_update();
-
   return output;
 }
 

--- a/control/autoware_trajectory_follower_node/src/controller_node.cpp
+++ b/control/autoware_trajectory_follower_node/src/controller_node.cpp
@@ -248,6 +248,9 @@ void Controller::callbackTimerControl()
   // TODO(Horibe): Think specification. This comes from the old implementation.
   if (isTimeOut(lon_out, lat_out)) return;
 
+  // 4.5. update diagnostics
+  diag_updater_->force_update();
+
   // 5. publish control command
   out.lateral = lat_out.control_cmd;
   out.longitudinal = lon_out.control_cmd;

--- a/system/autoware_topic_state_monitor/src/topic_state_monitor_core.cpp
+++ b/system/autoware_topic_state_monitor/src/topic_state_monitor_core.cpp
@@ -99,11 +99,7 @@ TopicStateMonitorNode::TopicStateMonitorNode(const rclcpp::NodeOptions & node_op
   // Diagnostic Updater
   updater_.setHardwareID("topic_state_monitor");
   updater_.add(node_param_.diag_name, this, &TopicStateMonitorNode::checkTopicStatus);
-
-  // Timer
-  const auto period_ns = rclcpp::Rate(node_param_.update_rate).period();
-  timer_ = rclcpp::create_timer(
-    this, get_clock(), period_ns, std::bind(&TopicStateMonitorNode::onTimer, this));
+  updater_.setPeriod(1.0 / node_param_.update_rate);
 }
 
 rcl_interfaces::msg::SetParametersResult TopicStateMonitorNode::onParameter(
@@ -125,12 +121,6 @@ rcl_interfaces::msg::SetParametersResult TopicStateMonitorNode::onParameter(
   }
 
   return result;
-}
-
-void TopicStateMonitorNode::onTimer()
-{
-  // Publish diagnostics
-  updater_.force_update();
 }
 
 void TopicStateMonitorNode::checkTopicStatus(diagnostic_updater::DiagnosticStatusWrapper & stat)

--- a/system/autoware_topic_state_monitor/src/topic_state_monitor_core.hpp
+++ b/system/autoware_topic_state_monitor/src/topic_state_monitor_core.hpp
@@ -65,10 +65,6 @@ private:
   rclcpp::GenericSubscription::SharedPtr sub_topic_;
   rclcpp::Subscription<tf2_msgs::msg::TFMessage>::SharedPtr sub_transform_;
 
-  // Timer
-  void onTimer();
-  rclcpp::TimerBase::SharedPtr timer_;
-
   // Diagnostic Updater
   diagnostic_updater::Updater updater_;
 


### PR DESCRIPTION
## Description

cherry pick following PRs
https://github.com/autowarefoundation/autoware_universe/pull/11934
https://github.com/autowarefoundation/autoware_universe/pull/11951

## Notes

- To improve the `/diagnostics` transmission cycle, this change must be applied in conjunction with the following cherry-pick PR.
  - https://github.com/tier4/autoware_universe/pull/2840
  - https://github.com/tier4/autoware_launch.x2/pull/2107
  - https://github.com/tier4/aip_launcher/pull/682
  - https://github.com/tier4/autoware_core/pull/91

## How was this PR tested?

### 1. `/diagnostics` Transmission Frequency

| Metric | Before | After | Change |
|--------|--------|-------|--------|
| Mean Hz | 1,216 Hz | 855 Hz | −30% |
| Std Hz | 171 Hz | 115 Hz | −33% |
| Max Hz | 1,278 Hz | 884 Hz | −31% |

**Analysis:** The transmission frequency decreased by approximately 30%, and variance was reduced. This indicates a lighter input load on the diagnostics pipeline.

---

### 2. Total CPU Utilization

> Combined load of multiple `topic_state_monitor` instances + `aggregator_node`

| Metric | Before | After | Change |
|--------|--------|-------|--------|
| Mean | 47.7% | 33.0% | −14.7 pt (−31%) |
| P50 (Median) | 52.0% | 34.0% | −18.0 pt (−35%) |
| P95 | 62.0% | 44.0% | −18.0 pt (−29%) |
| Max | 70.0% | 50.0% | −20.0 pt (−29%) |
| Std | 13.8% | 8.4% | −39% (Improved Stability) |

**Analysis:** CPU usage was reduced by approximately 30% in both mean and median values. The standard deviation also decreased by about 40%, effectively suppressing load fluctuations.

---

## Overall Summary

The reduction in `/diagnostics` transmission frequency (~30%) is almost directly proportional to the reduction in CPU usage (~30%). This confirms that the high transmission frequency was the primary cause of the CPU load.