### PR TITLE
feat(trajectory_validator): update diagnostic level logic

### DIFF
--- a/planning/autoware_trajectory_validator/include/autoware/trajectory_validator/trajectory_validator_node.hpp
+++ b/planning/autoware_trajectory_validator/include/autoware/trajectory_validator/trajectory_validator_node.hpp
@@ -84,8 +84,7 @@ private:
    */
   void unload_metric(const std::string & name);
   void update_diagnostic(
-    const CandidateTrajectories & input_trajectories,
-    const CandidateTrajectories & filtered_trajectories);
+    const CandidateTrajectories & input_trajectories, const size_t num_feasible_trajectories);
   void publish_processing_time(const std::unordered_map<std::string, double> & processing_time);
   void publish_internal_state(
     const std::unordered_map<std::string, double> & processing_time,

--- a/planning/autoware_trajectory_validator/src/trajectory_validator_node.cpp
+++ b/planning/autoware_trajectory_validator/src/trajectory_validator_node.cpp
@@ -170,6 +170,8 @@ void TrajectoryValidator::process(const CandidateTrajectories::ConstSharedPtr ms
     table.generator_id = autoware_utils_uuid::to_hex_string(trajectory.generator_id);
     table.is_overall_feasible = true;
 
+    // NOTE: this is used to determine diagnostic status, and doesn't affect whether filtering is
+    // applied
     bool is_overall_feasible = true;
     for (const auto & plugin : plugins_) {
       PluginEvaluation evaluation;
@@ -196,6 +198,8 @@ void TrajectoryValidator::process(const CandidateTrajectories::ConstSharedPtr ms
 
     evaluation_tables_.push_back(table);
 
+    // NOTE: table.is_overall_feasible considers debug mode,
+    // so in debug mode, all trajectories are kept
     if (table.is_overall_feasible) filtered_msg->candidate_trajectories.push_back(trajectory);
     if (is_overall_feasible) ++num_feasible_trajectories;
   }

--- a/planning/autoware_trajectory_validator/src/trajectory_validator_node.cpp
+++ b/planning/autoware_trajectory_validator/src/trajectory_validator_node.cpp
@@ -36,33 +36,6 @@
 
 namespace
 {
-// for error diagnostic. Will be removed once node is combined.
-std::unordered_map<std::string, std::string> get_generator_uuid_to_name_map(
-  const autoware_internal_planning_msgs::msg::CandidateTrajectories & candidate_trajectories)
-{
-  std::unordered_map<std::string, std::string> uuid_to_name;
-  uuid_to_name.reserve(candidate_trajectories.generator_info.size());
-  for (const auto & info : candidate_trajectories.generator_info) {
-    uuid_to_name[autoware_utils_uuid::to_hex_string(info.generator_id)] = info.generator_name.data;
-  }
-  return uuid_to_name;
-}
-
-bool has_trajectory_from_generator(
-  const std::unordered_map<std::string, std::string> & uuid_to_generator_name_map,
-  const autoware_internal_planning_msgs::msg::CandidateTrajectories & trajectories,
-  const std::string & generator_name_prefix)
-{
-  return std::any_of(
-    trajectories.candidate_trajectories.cbegin(), trajectories.candidate_trajectories.cend(),
-    [&](const autoware_internal_planning_msgs::msg::CandidateTrajectory & trajectory) {
-      const auto generator_id_str = autoware_utils_uuid::to_hex_string(trajectory.generator_id);
-      const auto generator_name_it = uuid_to_generator_name_map.find(generator_id_str);
-      return generator_name_it != uuid_to_generator_name_map.end() &&
-             generator_name_it->second.rfind(generator_name_prefix, 0) == 0;
-    });
-}
-
 visualization_msgs::msg::MarkerArray create_internal_state_text(
   const std::unordered_map<std::string, std::vector<std::string>> & plugin_filtered_paths,
   const std::vector<std::string> & sorted_plugins, const geometry_msgs::msg::Pose & marker_pose,
@@ -191,11 +164,13 @@ void TrajectoryValidator::process(const CandidateTrajectories::ConstSharedPtr ms
 
   auto filtered_msg = std::make_unique<CandidateTrajectories>();
   diagnostics_interface_.clear();
+  size_t num_feasible_trajectories = 0;
   for (const auto & trajectory : msg->candidate_trajectories) {
     EvaluationTable table;
     table.generator_id = autoware_utils_uuid::to_hex_string(trajectory.generator_id);
     table.is_overall_feasible = true;
 
+    bool is_overall_feasible = true;
     for (const auto & plugin : plugins_) {
       PluginEvaluation evaluation;
       evaluation.plugin_name = plugin->get_name();
@@ -212,6 +187,7 @@ void TrajectoryValidator::process(const CandidateTrajectories::ConstSharedPtr ms
         if (!plugin->is_debug_mode()) {
           table.is_overall_feasible = false;
         }
+        is_overall_feasible = false;
       }
       processing_time_ms[evaluation.plugin_name] += stop_watch.toc(evaluation.plugin_name);
 
@@ -221,6 +197,7 @@ void TrajectoryValidator::process(const CandidateTrajectories::ConstSharedPtr ms
     evaluation_tables_.push_back(table);
 
     if (table.is_overall_feasible) filtered_msg->candidate_trajectories.push_back(trajectory);
+    if (is_overall_feasible) ++num_feasible_trajectories;
   }
 
   // Also filter generator_info to match kept trajectories
@@ -243,7 +220,7 @@ void TrajectoryValidator::process(const CandidateTrajectories::ConstSharedPtr ms
   }
   publish_processing_time(processing_time_ms);
   publish_internal_state(processing_time_ms, evaluation_tables_, context.odometry->pose.pose);
-  update_diagnostic(*msg, *filtered_msg);
+  update_diagnostic(*msg, num_feasible_trajectories);
   pub_trajectories_->publish(*filtered_msg);
 }
 
@@ -303,25 +280,19 @@ void TrajectoryValidator::unload_metric(const std::string & name)
 }
 
 void TrajectoryValidator::update_diagnostic(
-  const CandidateTrajectories & input_trajectories,
-  const CandidateTrajectories & filtered_trajectories)
+  const CandidateTrajectories & input_trajectories, const size_t num_feasible_trajectories)
 {
-  const auto uuid_to_name_map = get_generator_uuid_to_name_map(input_trajectories);
-  const auto input_has_diffusion_trajectories =
-    has_trajectory_from_generator(uuid_to_name_map, input_trajectories, "Diffusion");
-  const auto filtered_has_diffusion_trajectories =
-    has_trajectory_from_generator(uuid_to_name_map, filtered_trajectories, "Diffusion");
-  if (
-    !input_trajectories.candidate_trajectories.empty() &&
-    filtered_trajectories.candidate_trajectories.empty()) {
+  if (input_trajectories.candidate_trajectories.size() == num_feasible_trajectories) {
+    // All trajectories are feasible
+    diagnostics_interface_.update_level_and_message(diagnostic_msgs::msg::DiagnosticStatus::OK, "");
+  } else if (num_feasible_trajectories == 0) {
+    // No feasible trajectories found
     diagnostics_interface_.update_level_and_message(
       diagnostic_msgs::msg::DiagnosticStatus::ERROR, "No feasible trajectories found");
-  } else if (input_has_diffusion_trajectories && !filtered_has_diffusion_trajectories) {
-    diagnostics_interface_.update_level_and_message(
-      diagnostic_msgs::msg::DiagnosticStatus::WARN,
-      "All diffusion planner trajectories are infeasible");
   } else {
-    diagnostics_interface_.update_level_and_message(diagnostic_msgs::msg::DiagnosticStatus::OK, "");
+    // At least one trajectory is infeasible
+    diagnostics_interface_.update_level_and_message(
+      diagnostic_msgs::msg::DiagnosticStatus::WARN, "At least one trajectory is infeasible");
   }
 
   diagnostics_interface_.publish(this->get_clock()->now());


### PR DESCRIPTION
## What

This pull request simplifies and streamlines the diagnostic logic in the `TrajectoryValidator` node by removing generator-specific checks and instead basing diagnostics on the overall feasibility of trajectories. The most important changes include refactoring the diagnostic update mechanism, removing unused helper functions, and updating function signatures to reflect the new logic.

**Diagnostic logic simplification:**

* If **all trajectories are feasible**, diagnostic level will be **OK**
* If **all trajectories are infeasible**, diagnostic level will be **ERROR**
* Otherwise, **at least one trajectory is infeasible**, diagnostic level will be **WARN**

**Code cleanup and refactoring:**

* Removed the helper functions `get_generator_uuid_to_name_map` and `has_trajectory_from_generator`, as generator-specific diagnostics are no longer needed.
* Updated the signature of `update_diagnostic` in both the header and implementation to accept the count of feasible trajectories instead of the filtered trajectories themselves. [[1]](diffhunk://#diff-a45a833dfd699f6ab2fd8bdc4f36a0c2d4f78b1e627f24be40c281e7529856bcL87-R87) [[2]](diffhunk://#diff-c0ceecabd703e961332864184f3854e67774492789b8e5b0b26f8fc277502657L306-R295)
* Modified the `process` method to count the number of feasible trajectories and pass this count to `update_diagnostic`, reflecting the new diagnostic approach. [[1]](diffhunk://#diff-c0ceecabd703e961332864184f3854e67774492789b8e5b0b26f8fc277502657R167-R173) [[2]](diffhunk://#diff-c0ceecabd703e961332864184f3854e67774492789b8e5b0b26f8fc277502657R190) [[3]](diffhunk://#diff-c0ceecabd703e961332864184f3854e67774492789b8e5b0b26f8fc277502657R200) [[4]](diffhunk://#diff-c0ceecabd703e961332864184f3854e67774492789b8e5b0b26f8fc277502657L246-R223)