### PR TITLE
feat(trajectory_validator): add emergency stop behavior emulation

### DIFF
--- a/planning/autoware_trajectory_validator/CMakeLists.txt
+++ b/planning/autoware_trajectory_validator/CMakeLists.txt
@@ -15,6 +15,7 @@ include_directories(
 
 ament_auto_add_library(${PROJECT_NAME} SHARED
   src/trajectory_validator_node.cpp
+  src/pseudo_emergency_stop_handler.cpp
 )
 
 target_link_libraries(${PROJECT_NAME}

--- a/planning/autoware_trajectory_validator/config/trajectory_validator.param.yaml
+++ b/planning/autoware_trajectory_validator/config/trajectory_validator.param.yaml
@@ -52,3 +52,11 @@
       checked_trajectory_length:  # maximum length of the planned trajectory that is scanned for traffic light stop lines.
         deceleration_limit: 2.0  # [m/s^2] deceleration limit to calculate the stop distance used as trajectory length limit
         jerk_limit: 2.0  # [m/s^3] jerk limit to calculate the stop distance used as trajectory length limit
+
+    # NOTE: pseudo_emergency_stop emulates the MRM stop behaviors. This is for evaluation only.
+    pseudo_emergency_stop:
+      enable: false  # when true, the emergency-stop fallback is active; when false, all emergency-stop handling is skipped
+      deceleration_mps2: -6.0  # [m/s^2] target longitudinal deceleration (reference to InLaneEmergencyStop deceleration)
+      jerk_mps3: -20.0  # [m/s^3] longitudinal jerk to ramp the deceleration (reference to InLaneEmergencyStop jerk)
+      recovery_policy: "until_stopped"  # "until_stopped": keep decelerating until ego is stopped, "immediate": release as soon as the trigger disappears
+      recovery_velocity_threshold_mps: 0.1  # [m/s] ego velocity threshold under which the latched emergency-stop state is released when recovery_policy is "until_stopped"

--- a/planning/autoware_trajectory_validator/include/autoware/trajectory_validator/pseudo_emergency_stop_handler.hpp
+++ b/planning/autoware_trajectory_validator/include/autoware/trajectory_validator/pseudo_emergency_stop_handler.hpp
@@ -1,0 +1,75 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// NOTE: This file implements an ad-hoc pseudo emergency stop fallback used for evaluation only.
+// It is intended to be removed once the proper MRM is implemented.
+
+#ifndef AUTOWARE__TRAJECTORY_VALIDATOR__PSEUDO_EMERGENCY_STOP_HANDLER_HPP_
+#define AUTOWARE__TRAJECTORY_VALIDATOR__PSEUDO_EMERGENCY_STOP_HANDLER_HPP_
+
+#include "autoware/trajectory_validator/filter_context.hpp"
+#include "autoware/trajectory_validator/trajectory_validator_node.hpp"
+
+#include <autoware/planning_factor_interface/planning_factor_interface.hpp>
+#include <autoware_trajectory_validator/autoware_trajectory_validator_param.hpp>
+#include <rclcpp/rclcpp.hpp>
+
+#include <autoware_internal_planning_msgs/msg/candidate_trajectories.hpp>
+#include <autoware_internal_planning_msgs/msg/candidate_trajectory.hpp>
+
+#include <memory>
+#include <optional>
+#include <vector>
+
+namespace autoware::trajectory_validator
+{
+
+class PseudoEmergencyStopHandler
+{
+public:
+  using EvaluationTable = TrajectoryValidator::EvaluationTable;
+  using PluginEvaluation = TrajectoryValidator::PluginEvaluation;
+
+  explicit PseudoEmergencyStopHandler(rclcpp::Node & node);
+
+  void handle(
+    const CandidateTrajectories & input_trajectories, CandidateTrajectories & filtered_trajectories,
+    const std::vector<EvaluationTable> & evaluation_tables, const FilterContext & context,
+    const validator::Params & params);
+
+private:
+  bool has_infeasible_evaluation(const EvaluationTable & table) const;
+  bool is_pseudo_emergency_stop_triggered(
+    const std::vector<EvaluationTable> & evaluation_tables) const;
+  void update_pseudo_emergency_stop_state(
+    bool triggered, double ego_velocity_mps, const validator::Params & params);
+  void cache_fallback_trajectory(
+    const CandidateTrajectories & input_trajectories,
+    const std::vector<EvaluationTable> & evaluation_tables);
+  void apply_pseudo_emergency_stop_fallback(
+    CandidateTrajectories & filtered_trajectories, const FilterContext & context,
+    const validator::Params & params);
+
+  rclcpp::Logger logger_;
+  rclcpp::Clock::SharedPtr clock_;
+
+  bool pseudo_emergency_stop_active_{false};
+  std::optional<CandidateTrajectory> cached_fallback_trajectory_{std::nullopt};
+  std::unique_ptr<autoware::planning_factor_interface::PlanningFactorInterface>
+    planning_factor_interface_;
+};
+
+}  // namespace autoware::trajectory_validator
+
+#endif  // AUTOWARE__TRAJECTORY_VALIDATOR__PSEUDO_EMERGENCY_STOP_HANDLER_HPP_

--- a/planning/autoware_trajectory_validator/include/autoware/trajectory_validator/trajectory_validator_node.hpp
+++ b/planning/autoware_trajectory_validator/include/autoware/trajectory_validator/trajectory_validator_node.hpp
@@ -15,8 +15,10 @@
 #ifndef AUTOWARE__TRAJECTORY_VALIDATOR__TRAJECTORY_VALIDATOR_NODE_HPP_
 #define AUTOWARE__TRAJECTORY_VALIDATOR__TRAJECTORY_VALIDATOR_NODE_HPP_
 
+#include "autoware/trajectory_validator/filter_context.hpp"
 #include "autoware/trajectory_validator/validator_interface.hpp"
 
+#include <autoware/planning_factor_interface/planning_factor_interface.hpp>
 #include <autoware_lanelet2_extension/utility/message_conversion.hpp>
 #include <autoware_trajectory_validator/autoware_trajectory_validator_param.hpp>
 #include <autoware_utils_debug/debug_publisher.hpp>
@@ -39,6 +41,7 @@
 #include <nav_msgs/msg/odometry.hpp>
 
 #include <memory>
+#include <optional>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -130,6 +133,24 @@ private:
   // Tools
   mutable std::shared_ptr<autoware_utils_debug::TimeKeeper> time_keeper_{nullptr};
   DiagnosticsInterface diagnostics_interface_{this, "trajectory_validator"};
+
+  // Emergency-stop fallback (evaluation use only).
+  void handle_pseudo_emergency_stop(
+    const CandidateTrajectories & input_trajectories, CandidateTrajectories & filtered_trajectories,
+    const FilterContext & context);
+  bool has_infeasible_evaluation(const EvaluationTable & table) const;
+  bool is_pseudo_emergency_stop_triggered(
+    const std::vector<EvaluationTable> & evaluation_tables) const;
+  void update_pseudo_emergency_stop_state(bool triggered, double ego_velocity_mps);
+  void cache_fallback_trajectory(
+    const CandidateTrajectories & input_trajectories,
+    const std::vector<EvaluationTable> & evaluation_tables);
+  void apply_pseudo_emergency_stop_fallback(
+    CandidateTrajectories & filtered_trajectories, const FilterContext & context);
+  bool pseudo_emergency_stop_active_{false};
+  std::optional<CandidateTrajectory> cached_fallback_trajectory_{std::nullopt};
+  std::unique_ptr<autoware::planning_factor_interface::PlanningFactorInterface>
+    pseudo_emergency_stop_planning_factor_interface_;
 };
 
 }  // namespace autoware::trajectory_validator

--- a/planning/autoware_trajectory_validator/include/autoware/trajectory_validator/trajectory_validator_node.hpp
+++ b/planning/autoware_trajectory_validator/include/autoware/trajectory_validator/trajectory_validator_node.hpp
@@ -15,10 +15,8 @@
 #ifndef AUTOWARE__TRAJECTORY_VALIDATOR__TRAJECTORY_VALIDATOR_NODE_HPP_
 #define AUTOWARE__TRAJECTORY_VALIDATOR__TRAJECTORY_VALIDATOR_NODE_HPP_
 
-#include "autoware/trajectory_validator/filter_context.hpp"
 #include "autoware/trajectory_validator/validator_interface.hpp"
 
-#include <autoware/planning_factor_interface/planning_factor_interface.hpp>
 #include <autoware_lanelet2_extension/utility/message_conversion.hpp>
 #include <autoware_trajectory_validator/autoware_trajectory_validator_param.hpp>
 #include <autoware_utils_debug/debug_publisher.hpp>
@@ -41,7 +39,6 @@
 #include <nav_msgs/msg/odometry.hpp>
 
 #include <memory>
-#include <optional>
 #include <string>
 #include <unordered_map>
 #include <vector>
@@ -56,6 +53,8 @@ using autoware_planning_msgs::msg::TrajectoryPoint;
 using autoware_utils_diagnostics::DiagnosticsInterface;
 using geometry_msgs::msg::AccelWithCovarianceStamped;
 using nav_msgs::msg::Odometry;
+
+class PseudoEmergencyStopHandler;
 
 class TrajectoryValidator : public rclcpp::Node
 {
@@ -75,6 +74,7 @@ public:
   };
 
   explicit TrajectoryValidator(const rclcpp::NodeOptions & node_options);
+  ~TrajectoryValidator();
 
 private:
   // Methods
@@ -135,22 +135,7 @@ private:
   DiagnosticsInterface diagnostics_interface_{this, "trajectory_validator"};
 
   // Emergency-stop fallback (evaluation use only).
-  void handle_pseudo_emergency_stop(
-    const CandidateTrajectories & input_trajectories, CandidateTrajectories & filtered_trajectories,
-    const FilterContext & context);
-  bool has_infeasible_evaluation(const EvaluationTable & table) const;
-  bool is_pseudo_emergency_stop_triggered(
-    const std::vector<EvaluationTable> & evaluation_tables) const;
-  void update_pseudo_emergency_stop_state(bool triggered, double ego_velocity_mps);
-  void cache_fallback_trajectory(
-    const CandidateTrajectories & input_trajectories,
-    const std::vector<EvaluationTable> & evaluation_tables);
-  void apply_pseudo_emergency_stop_fallback(
-    CandidateTrajectories & filtered_trajectories, const FilterContext & context);
-  bool pseudo_emergency_stop_active_{false};
-  std::optional<CandidateTrajectory> cached_fallback_trajectory_{std::nullopt};
-  std::unique_ptr<autoware::planning_factor_interface::PlanningFactorInterface>
-    pseudo_emergency_stop_planning_factor_interface_;
+  std::unique_ptr<PseudoEmergencyStopHandler> pseudo_emergency_stop_handler_;
 };
 
 }  // namespace autoware::trajectory_validator

--- a/planning/autoware_trajectory_validator/launch/trajectory_validator.launch.xml
+++ b/planning/autoware_trajectory_validator/launch/trajectory_validator.launch.xml
@@ -9,11 +9,11 @@
   <arg name="input_acceleration" default="~/input/acceleration"/>
   <arg name="input_traffic_signals" default="~/input/traffic_signals"/>
 
-  <arg name="launch_pseudo_emergency_stop" default="false"/>
+  <arg name="enable_pseudo_emergency_stop" default="false"/>
 
   <node pkg="autoware_trajectory_validator" exec="autoware_trajectory_validator_node" name="trajectory_validator_node" output="screen">
     <param from="$(var trajectory_validator_param_path)" allow_substs="true"/>
-    <param name="pseudo_emergency_stop.enable" value="$(var launch_pseudo_emergency_stop)"/>
+    <param name="pseudo_emergency_stop.enable" value="$(var enable_pseudo_emergency_stop)"/>
     <remap from="~/input/trajectories" to="$(var input_trajectories)"/>
     <remap from="~/output/trajectories" to="$(var output_trajectories)"/>
     <remap from="~/input/lanelet2_map" to="$(var input_vector_map)"/>

--- a/planning/autoware_trajectory_validator/launch/trajectory_validator.launch.xml
+++ b/planning/autoware_trajectory_validator/launch/trajectory_validator.launch.xml
@@ -9,8 +9,11 @@
   <arg name="input_acceleration" default="~/input/acceleration"/>
   <arg name="input_traffic_signals" default="~/input/traffic_signals"/>
 
+  <arg name="launch_pseudo_emergency_stop" default="false"/>
+
   <node pkg="autoware_trajectory_validator" exec="autoware_trajectory_validator_node" name="trajectory_validator_node" output="screen">
     <param from="$(var trajectory_validator_param_path)" allow_substs="true"/>
+    <param name="pseudo_emergency_stop.enable" value="$(var launch_pseudo_emergency_stop)"/>
     <remap from="~/input/trajectories" to="$(var input_trajectories)"/>
     <remap from="~/output/trajectories" to="$(var output_trajectories)"/>
     <remap from="~/input/lanelet2_map" to="$(var input_vector_map)"/>

--- a/planning/autoware_trajectory_validator/package.xml
+++ b/planning/autoware_trajectory_validator/package.xml
@@ -23,6 +23,7 @@
   <depend>autoware_map_msgs</depend>
   <depend>autoware_motion_utils</depend>
   <depend>autoware_perception_msgs</depend>
+  <depend>autoware_planning_factor_interface</depend>
   <depend>autoware_planning_msgs</depend>
   <depend>autoware_traffic_light_utils</depend>
   <depend>autoware_universe_utils</depend>

--- a/planning/autoware_trajectory_validator/param/parameter_struct.yaml
+++ b/planning/autoware_trajectory_validator/param/parameter_struct.yaml
@@ -164,3 +164,29 @@ validator:
       default_value: 2.0
       description: N/A
       read_only: false
+  pseudo_emergency_stop:
+    enable:
+      type: bool
+      default_value: false
+      description: When true, the emergency-stop fallback is active. When false, all emergency-stop handling is skipped. Evaluation use only.
+      read_only: false
+    deceleration_mps2:
+      type: double
+      default_value: -6.0
+      description: Target longitudinal deceleration (m/s^2, negative) used to build the emergency-stop velocity profile. Evaluation use only.
+      read_only: false
+    jerk_mps3:
+      type: double
+      default_value: -20.0
+      description: Longitudinal jerk (m/s^3, negative) used to ramp the deceleration when building the emergency-stop velocity profile. Evaluation use only.
+      read_only: false
+    recovery_policy:
+      type: string
+      default_value: until_stopped
+      description: Recovery policy after the emergency-stop is triggered. until_stopped keeps decelerating until the ego velocity falls below recovery_velocity_threshold_mps. immediate releases the deceleration as soon as the trigger condition disappears. Evaluation use only.
+      read_only: false
+    recovery_velocity_threshold_mps:
+      type: double
+      default_value: 0.1
+      description: Ego velocity threshold (m/s) under which the latched emergency-stop state is released when recovery_policy is until_stopped. Evaluation use only.
+      read_only: false

--- a/planning/autoware_trajectory_validator/src/pseudo_emergency_stop_handler.cpp
+++ b/planning/autoware_trajectory_validator/src/pseudo_emergency_stop_handler.cpp
@@ -1,0 +1,210 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// NOTE: This file implements an ad-hoc pseudo emergency stop fallback used for evaluation only.
+// It is intended to be removed once the proper MRM is implemented.
+
+#include "autoware/trajectory_validator/pseudo_emergency_stop_handler.hpp"
+
+#include <autoware/motion_utils/distance/distance.hpp>
+#include <autoware/motion_utils/trajectory/trajectory.hpp>
+#include <autoware_utils_geometry/geometry.hpp>
+#include <autoware_utils_uuid/uuid_helper.hpp>
+
+#include <autoware_internal_planning_msgs/msg/planning_factor.hpp>
+#include <autoware_internal_planning_msgs/msg/safety_factor_array.hpp>
+
+#include <algorithm>
+#include <cmath>
+#include <memory>
+#include <vector>
+
+namespace autoware::trajectory_validator
+{
+
+PseudoEmergencyStopHandler::PseudoEmergencyStopHandler(rclcpp::Node & node)
+: logger_(node.get_logger()),
+  clock_(node.get_clock()),
+  planning_factor_interface_(
+    std::make_unique<autoware::planning_factor_interface::PlanningFactorInterface>(
+      &node, "pseudo_emergency_stop"))
+{
+}
+
+void PseudoEmergencyStopHandler::handle(
+  const CandidateTrajectories & input_trajectories, CandidateTrajectories & filtered_trajectories,
+  const std::vector<EvaluationTable> & evaluation_tables, const FilterContext & context,
+  const validator::Params & params)
+{
+  const bool pseudo_emergency_stop_triggered =
+    is_pseudo_emergency_stop_triggered(evaluation_tables);
+  update_pseudo_emergency_stop_state(
+    pseudo_emergency_stop_triggered, context.odometry->twist.twist.linear.x, params);
+  // Refresh the cached fallback shape from the latest clean MinimumRuleBasedPlanner trajectory.
+  cache_fallback_trajectory(input_trajectories, evaluation_tables);
+  if (pseudo_emergency_stop_active_) {
+    apply_pseudo_emergency_stop_fallback(filtered_trajectories, context, params);
+  }
+  planning_factor_interface_->publish();
+}
+
+bool PseudoEmergencyStopHandler::has_infeasible_evaluation(const EvaluationTable & table) const
+{
+  return std::any_of(
+    table.evaluations.cbegin(), table.evaluations.cend(), [&](const auto & category_entry) {
+      return std::any_of(
+        category_entry.second.cbegin(), category_entry.second.cend(),
+        [&](const PluginEvaluation & plugin_eval) { return !plugin_eval.is_feasible; });
+    });
+}
+
+bool PseudoEmergencyStopHandler::is_pseudo_emergency_stop_triggered(
+  const std::vector<EvaluationTable> & evaluation_tables) const
+{
+  return std::any_of(
+    evaluation_tables.cbegin(), evaluation_tables.cend(),
+    [&](const EvaluationTable & table) { return has_infeasible_evaluation(table); });
+}
+
+void PseudoEmergencyStopHandler::update_pseudo_emergency_stop_state(
+  const bool triggered, const double ego_velocity_mps, const validator::Params & params)
+{
+  if (triggered) {
+    pseudo_emergency_stop_active_ = true;
+    return;
+  }
+  if (params.pseudo_emergency_stop.recovery_policy == "immediate") {
+    // Release the emergency stop immediately when the trigger condition disappears.
+    pseudo_emergency_stop_active_ = false;
+    return;
+  }
+  if (
+    pseudo_emergency_stop_active_ &&
+    params.pseudo_emergency_stop.recovery_policy == "until_stopped" &&
+    std::abs(ego_velocity_mps) < params.pseudo_emergency_stop.recovery_velocity_threshold_mps) {
+    // Ego has come to a stop, release the latched emergency-stop state.
+    pseudo_emergency_stop_active_ = false;
+  }
+}
+
+void PseudoEmergencyStopHandler::cache_fallback_trajectory(
+  const CandidateTrajectories & input_trajectories,
+  const std::vector<EvaluationTable> & evaluation_tables)
+{
+  constexpr const char * fallback_generator_name = "MinimumRuleBasedPlanner";
+
+  // Find the generator_id whose name matches the fallback generator name.
+  const auto generator_info_it = std::find_if(
+    input_trajectories.generator_info.cbegin(), input_trajectories.generator_info.cend(),
+    [&](const auto & info) { return info.generator_name.data == fallback_generator_name; });
+  if (generator_info_it == input_trajectories.generator_info.cend()) {
+    return;
+  }
+  const auto & fallback_generator_id = generator_info_it->generator_id;
+  const auto fallback_it = std::find_if(
+    input_trajectories.candidate_trajectories.cbegin(),
+    input_trajectories.candidate_trajectories.cend(),
+    [&](const autoware_internal_planning_msgs::msg::CandidateTrajectory & trajectory) {
+      return trajectory.generator_id.uuid == fallback_generator_id.uuid;
+    });
+  if (fallback_it == input_trajectories.candidate_trajectories.cend()) {
+    return;
+  }
+
+  // Only cache when no trigger filter has flagged this fallback trajectory as infeasible.
+  const auto generator_id_str = autoware_utils_uuid::to_hex_string(fallback_it->generator_id);
+  const auto table_it = std::find_if(
+    evaluation_tables.cbegin(), evaluation_tables.cend(),
+    [&](const EvaluationTable & table) { return table.generator_id == generator_id_str; });
+  if (table_it != evaluation_tables.cend() && has_infeasible_evaluation(*table_it)) {
+    return;
+  }
+
+  cached_fallback_trajectory_ = *fallback_it;
+}
+
+void PseudoEmergencyStopHandler::apply_pseudo_emergency_stop_fallback(
+  CandidateTrajectories & filtered_trajectories, const FilterContext & context,
+  const validator::Params & params)
+{
+  if (!cached_fallback_trajectory_) {
+    RCLCPP_WARN_THROTTLE(
+      logger_, *clock_, 1000,
+      "Emergency stop active but no cached fallback trajectory is available yet.");
+    return;
+  }
+
+  auto stopping_trajectory = *cached_fallback_trajectory_;
+  auto & points = stopping_trajectory.points;
+  if (points.size() < 2) {
+    return;
+  }
+
+  const double min_decel = params.pseudo_emergency_stop.deceleration_mps2;
+  const double min_jerk = params.pseudo_emergency_stop.jerk_mps3;
+
+  // Drop points behind ego so that the resulting trajectory starts at the nearest point to the
+  // current ego position.
+  const size_t ego_nearest_idx =
+    autoware::motion_utils::findNearestIndex(points, context.odometry->pose.pose.position);
+  points.erase(points.begin(), points.begin() + ego_nearest_idx);
+  if (points.size() < 2) {
+    return;
+  }
+
+  // Overwrite the velocity/acceleration profile in place with a jerk/decel-limited stopping
+  // profile starting from the current ego state.
+  double v = std::max(0.0, context.odometry->twist.twist.linear.x);
+  double a = std::min(0.0, context.acceleration->accel.accel.linear.x);
+  points.front().longitudinal_velocity_mps = v;
+  points.front().acceleration_mps2 = a;
+  for (size_t i = 1; i < points.size(); ++i) {
+    const double ds = autoware_utils_geometry::calc_distance2d(points[i - 1].pose, points[i].pose);
+    if (v <= 1e-3) {
+      v = 0.0;
+      a = 0.0;
+    } else {
+      const double dt = ds / v;
+      a = std::max(min_decel, a + min_jerk * dt);
+      v = std::max(0.0, v + a * dt);
+    }
+    points[i].longitudinal_velocity_mps = v;
+    points[i].acceleration_mps2 = a;
+  }
+
+  autoware::motion_utils::calculate_time_from_start(
+    stopping_trajectory.points, context.odometry->pose.pose.position);
+  filtered_trajectories.candidate_trajectories.clear();
+  filtered_trajectories.candidate_trajectories.push_back(stopping_trajectory);
+
+  const auto stop_distance = autoware::motion_utils::calculate_stop_distance(
+    context.odometry->twist.twist.linear.x, context.acceleration->accel.accel.linear.x, min_decel,
+    min_jerk);
+  const auto stop_pose_opt = stop_distance ? autoware::motion_utils::calcLongitudinalOffsetPose(
+                                               stopping_trajectory.points, 0, *stop_distance)
+                                           : std::nullopt;
+  const auto & stop_pose = stop_pose_opt ? *stop_pose_opt : stopping_trajectory.points.back().pose;
+  planning_factor_interface_->add(
+    stopping_trajectory.points, context.odometry->pose.pose, stop_pose,
+    autoware_internal_planning_msgs::msg::PlanningFactor::STOP,
+    autoware_internal_planning_msgs::msg::SafetyFactorArray{}, true /*is_driving_forward*/,
+    0.0 /*velocity*/, 0.0 /*shift_length*/);
+
+  RCLCPP_WARN_THROTTLE(
+    logger_, *clock_, 1000,
+    "Emergency-stop trigger filter fired; falling back to cached MinimumRuleBasedPlanner "
+    "trajectory with emergency stop.");
+}
+
+}  // namespace autoware::trajectory_validator

--- a/planning/autoware_trajectory_validator/src/trajectory_validator_node.cpp
+++ b/planning/autoware_trajectory_validator/src/trajectory_validator_node.cpp
@@ -15,11 +15,9 @@
 #include "autoware/trajectory_validator/trajectory_validator_node.hpp"
 
 #include "autoware/trajectory_validator/filter_context.hpp"
+#include "autoware/trajectory_validator/pseudo_emergency_stop_handler.hpp"
 #include "autoware/trajectory_validator/validator_interface.hpp"
 
-#include <autoware/motion_utils/distance/distance.hpp>
-#include <autoware/motion_utils/trajectory/trajectory.hpp>
-#include <autoware_utils_geometry/geometry.hpp>
 #include <autoware_utils_system/stop_watch.hpp>
 #include <autoware_utils_uuid/uuid_helper.hpp>
 #include <autoware_utils_visualization/marker_helper.hpp>
@@ -146,10 +144,10 @@ TrajectoryValidator::TrajectoryValidator(const rclcpp::NodeOptions & options)
   pub_processing_time_ = std::make_shared<autoware_utils_debug::DebugPublisher>(this, "~/debug");
   pub_debug_markers_ = std::make_shared<autoware_utils_debug::DebugPublisher>(this, "~/debug");
 
-  pseudo_emergency_stop_planning_factor_interface_ =
-    std::make_unique<autoware::planning_factor_interface::PlanningFactorInterface>(
-      this, "pseudo_emergency_stop");
+  pseudo_emergency_stop_handler_ = std::make_unique<PseudoEmergencyStopHandler>(*this);
 }
+
+TrajectoryValidator::~TrajectoryValidator() = default;
 
 void TrajectoryValidator::process(const CandidateTrajectories::ConstSharedPtr msg)
 {
@@ -233,7 +231,8 @@ void TrajectoryValidator::process(const CandidateTrajectories::ConstSharedPtr ms
   if (params_.pseudo_emergency_stop.enable) {
     // NOTE(odashima): this fallback is ad-hoc and for evaluation only.
     stop_watch.tic("handle_pseudo_emergency_stop");
-    handle_pseudo_emergency_stop(*msg, *filtered_msg, context);
+    pseudo_emergency_stop_handler_->handle(
+      *msg, *filtered_msg, evaluation_tables_, context, params_);
     processing_time_ms["handle_pseudo_emergency_stop"] =
       stop_watch.toc("handle_pseudo_emergency_stop");
   }
@@ -260,171 +259,6 @@ void TrajectoryValidator::process(const CandidateTrajectories::ConstSharedPtr ms
   publish_internal_state(processing_time_ms, evaluation_tables_, context.odometry->pose.pose);
   update_diagnostic(*msg, *filtered_msg);
   pub_trajectories_->publish(*filtered_msg);
-  if (params_.pseudo_emergency_stop.enable) {
-    pseudo_emergency_stop_planning_factor_interface_->publish();
-  }
-}
-
-void TrajectoryValidator::handle_pseudo_emergency_stop(
-  const CandidateTrajectories & input_trajectories, CandidateTrajectories & filtered_trajectories,
-  const FilterContext & context)
-{
-  const bool pseudo_emergency_stop_triggered =
-    is_pseudo_emergency_stop_triggered(evaluation_tables_);
-  update_pseudo_emergency_stop_state(
-    pseudo_emergency_stop_triggered, context.odometry->twist.twist.linear.x);
-  // Refresh the cached fallback shape from the latest clean MinimumRuleBasedPlanner trajectory.
-  cache_fallback_trajectory(input_trajectories, evaluation_tables_);
-  if (pseudo_emergency_stop_active_) {
-    apply_pseudo_emergency_stop_fallback(filtered_trajectories, context);
-  }
-}
-
-bool TrajectoryValidator::has_infeasible_evaluation(const EvaluationTable & table) const
-{
-  return std::any_of(
-    table.evaluations.cbegin(), table.evaluations.cend(), [&](const auto & category_entry) {
-      return std::any_of(
-        category_entry.second.cbegin(), category_entry.second.cend(),
-        [&](const PluginEvaluation & plugin_eval) { return !plugin_eval.is_feasible; });
-    });
-}
-
-bool TrajectoryValidator::is_pseudo_emergency_stop_triggered(
-  const std::vector<EvaluationTable> & evaluation_tables) const
-{
-  return std::any_of(
-    evaluation_tables.cbegin(), evaluation_tables.cend(),
-    [&](const EvaluationTable & table) { return has_infeasible_evaluation(table); });
-}
-
-void TrajectoryValidator::update_pseudo_emergency_stop_state(
-  const bool triggered, const double ego_velocity_mps)
-{
-  if (triggered) {
-    pseudo_emergency_stop_active_ = true;
-    return;
-  }
-  if (params_.pseudo_emergency_stop.recovery_policy == "immediate") {
-    // Release the emergency stop immediately when the trigger condition disappears.
-    pseudo_emergency_stop_active_ = false;
-    return;
-  }
-  if (
-    pseudo_emergency_stop_active_ &&
-    params_.pseudo_emergency_stop.recovery_policy == "until_stopped" &&
-    std::abs(ego_velocity_mps) < params_.pseudo_emergency_stop.recovery_velocity_threshold_mps) {
-    // Ego has come to a stop, release the latched emergency-stop state.
-    pseudo_emergency_stop_active_ = false;
-  }
-}
-
-void TrajectoryValidator::cache_fallback_trajectory(
-  const CandidateTrajectories & input_trajectories,
-  const std::vector<EvaluationTable> & evaluation_tables)
-{
-  constexpr const char * fallback_generator_name = "MinimumRuleBasedPlanner";
-
-  // Find the generator_id whose name matches the fallback generator name.
-  const auto generator_info_it = std::find_if(
-    input_trajectories.generator_info.cbegin(), input_trajectories.generator_info.cend(),
-    [&](const auto & info) { return info.generator_name.data == fallback_generator_name; });
-  if (generator_info_it == input_trajectories.generator_info.cend()) {
-    return;
-  }
-  const auto & fallback_generator_id = generator_info_it->generator_id;
-  const auto fallback_it = std::find_if(
-    input_trajectories.candidate_trajectories.cbegin(),
-    input_trajectories.candidate_trajectories.cend(),
-    [&](const autoware_internal_planning_msgs::msg::CandidateTrajectory & trajectory) {
-      return trajectory.generator_id.uuid == fallback_generator_id.uuid;
-    });
-  if (fallback_it == input_trajectories.candidate_trajectories.cend()) {
-    return;
-  }
-
-  // Only cache when no trigger filter has flagged this fallback trajectory as infeasible.
-  const auto generator_id_str = autoware_utils_uuid::to_hex_string(fallback_it->generator_id);
-  const auto table_it = std::find_if(
-    evaluation_tables.cbegin(), evaluation_tables.cend(),
-    [&](const EvaluationTable & table) { return table.generator_id == generator_id_str; });
-  if (table_it != evaluation_tables.cend() && has_infeasible_evaluation(*table_it)) {
-    return;
-  }
-
-  cached_fallback_trajectory_ = *fallback_it;
-}
-
-void TrajectoryValidator::apply_pseudo_emergency_stop_fallback(
-  CandidateTrajectories & filtered_trajectories, const FilterContext & context)
-{
-  if (!cached_fallback_trajectory_) {
-    RCLCPP_WARN_THROTTLE(
-      get_logger(), *get_clock(), 1000,
-      "Emergency stop active but no cached fallback trajectory is available yet.");
-    return;
-  }
-
-  auto stopping_trajectory = *cached_fallback_trajectory_;
-  auto & points = stopping_trajectory.points;
-  if (points.size() < 2) {
-    return;
-  }
-
-  const double min_decel = params_.pseudo_emergency_stop.deceleration_mps2;
-  const double min_jerk = params_.pseudo_emergency_stop.jerk_mps3;
-
-  // Drop points behind ego so that the resulting trajectory starts at the nearest point to the
-  // current ego position.
-  const size_t ego_nearest_idx =
-    autoware::motion_utils::findNearestIndex(points, context.odometry->pose.pose.position);
-  points.erase(points.begin(), points.begin() + ego_nearest_idx);
-  if (points.size() < 2) {
-    return;
-  }
-
-  // Overwrite the velocity/acceleration profile in place with a jerk/decel-limited stopping
-  // profile starting from the current ego state.
-  double v = std::max(0.0, context.odometry->twist.twist.linear.x);
-  double a = std::min(0.0, context.acceleration->accel.accel.linear.x);
-  points.front().longitudinal_velocity_mps = v;
-  points.front().acceleration_mps2 = a;
-  for (size_t i = 1; i < points.size(); ++i) {
-    const double ds = autoware_utils_geometry::calc_distance2d(points[i - 1].pose, points[i].pose);
-    if (v <= 1e-3) {
-      v = 0.0;
-      a = 0.0;
-    } else {
-      const double dt = ds / v;
-      a = std::max(min_decel, a + min_jerk * dt);
-      v = std::max(0.0, v + a * dt);
-    }
-    points[i].longitudinal_velocity_mps = v;
-    points[i].acceleration_mps2 = a;
-  }
-
-  autoware::motion_utils::calculate_time_from_start(
-    stopping_trajectory.points, context.odometry->pose.pose.position);
-  filtered_trajectories.candidate_trajectories.clear();
-  filtered_trajectories.candidate_trajectories.push_back(stopping_trajectory);
-
-  const auto stop_distance = autoware::motion_utils::calculate_stop_distance(
-    context.odometry->twist.twist.linear.x, context.acceleration->accel.accel.linear.x, min_decel,
-    min_jerk);
-  const auto stop_pose_opt = stop_distance ? autoware::motion_utils::calcLongitudinalOffsetPose(
-                                               stopping_trajectory.points, 0, *stop_distance)
-                                           : std::nullopt;
-  const auto & stop_pose = stop_pose_opt ? *stop_pose_opt : stopping_trajectory.points.back().pose;
-  pseudo_emergency_stop_planning_factor_interface_->add(
-    stopping_trajectory.points, context.odometry->pose.pose, stop_pose,
-    autoware_internal_planning_msgs::msg::PlanningFactor::STOP,
-    autoware_internal_planning_msgs::msg::SafetyFactorArray{}, true /*is_driving_forward*/,
-    0.0 /*velocity*/, 0.0 /*shift_length*/);
-
-  RCLCPP_WARN_THROTTLE(
-    get_logger(), *get_clock(), 1000,
-    "Emergency-stop trigger filter fired; falling back to cached MinimumRuleBasedPlanner "
-    "trajectory with emergency stop.");
 }
 
 void TrajectoryValidator::map_callback(const LaneletMapBin::ConstSharedPtr msg)

--- a/planning/autoware_trajectory_validator/src/trajectory_validator_node.cpp
+++ b/planning/autoware_trajectory_validator/src/trajectory_validator_node.cpp
@@ -17,6 +17,9 @@
 #include "autoware/trajectory_validator/filter_context.hpp"
 #include "autoware/trajectory_validator/validator_interface.hpp"
 
+#include <autoware/motion_utils/distance/distance.hpp>
+#include <autoware/motion_utils/trajectory/trajectory.hpp>
+#include <autoware_utils_geometry/geometry.hpp>
 #include <autoware_utils_system/stop_watch.hpp>
 #include <autoware_utils_uuid/uuid_helper.hpp>
 #include <autoware_utils_visualization/marker_helper.hpp>
@@ -142,6 +145,10 @@ TrajectoryValidator::TrajectoryValidator(const rclcpp::NodeOptions & options)
 
   pub_processing_time_ = std::make_shared<autoware_utils_debug::DebugPublisher>(this, "~/debug");
   pub_debug_markers_ = std::make_shared<autoware_utils_debug::DebugPublisher>(this, "~/debug");
+
+  pseudo_emergency_stop_planning_factor_interface_ =
+    std::make_unique<autoware::planning_factor_interface::PlanningFactorInterface>(
+      this, "pseudo_emergency_stop");
 }
 
 void TrajectoryValidator::process(const CandidateTrajectories::ConstSharedPtr msg)
@@ -223,6 +230,14 @@ void TrajectoryValidator::process(const CandidateTrajectories::ConstSharedPtr ms
     if (table.is_overall_feasible) filtered_msg->candidate_trajectories.push_back(trajectory);
   }
 
+  if (params_.pseudo_emergency_stop.enable) {
+    // NOTE(odashima): this fallback is ad-hoc and for evaluation only.
+    stop_watch.tic("handle_pseudo_emergency_stop");
+    handle_pseudo_emergency_stop(*msg, *filtered_msg, context);
+    processing_time_ms["handle_pseudo_emergency_stop"] =
+      stop_watch.toc("handle_pseudo_emergency_stop");
+  }
+
   // Also filter generator_info to match kept trajectories
   for (const auto & traj : filtered_msg->candidate_trajectories) {
     auto it = std::find_if(
@@ -245,6 +260,171 @@ void TrajectoryValidator::process(const CandidateTrajectories::ConstSharedPtr ms
   publish_internal_state(processing_time_ms, evaluation_tables_, context.odometry->pose.pose);
   update_diagnostic(*msg, *filtered_msg);
   pub_trajectories_->publish(*filtered_msg);
+  if (params_.pseudo_emergency_stop.enable) {
+    pseudo_emergency_stop_planning_factor_interface_->publish();
+  }
+}
+
+void TrajectoryValidator::handle_pseudo_emergency_stop(
+  const CandidateTrajectories & input_trajectories, CandidateTrajectories & filtered_trajectories,
+  const FilterContext & context)
+{
+  const bool pseudo_emergency_stop_triggered =
+    is_pseudo_emergency_stop_triggered(evaluation_tables_);
+  update_pseudo_emergency_stop_state(
+    pseudo_emergency_stop_triggered, context.odometry->twist.twist.linear.x);
+  // Refresh the cached fallback shape from the latest clean MinimumRuleBasedPlanner trajectory.
+  cache_fallback_trajectory(input_trajectories, evaluation_tables_);
+  if (pseudo_emergency_stop_active_) {
+    apply_pseudo_emergency_stop_fallback(filtered_trajectories, context);
+  }
+}
+
+bool TrajectoryValidator::has_infeasible_evaluation(const EvaluationTable & table) const
+{
+  return std::any_of(
+    table.evaluations.cbegin(), table.evaluations.cend(), [&](const auto & category_entry) {
+      return std::any_of(
+        category_entry.second.cbegin(), category_entry.second.cend(),
+        [&](const PluginEvaluation & plugin_eval) { return !plugin_eval.is_feasible; });
+    });
+}
+
+bool TrajectoryValidator::is_pseudo_emergency_stop_triggered(
+  const std::vector<EvaluationTable> & evaluation_tables) const
+{
+  return std::any_of(
+    evaluation_tables.cbegin(), evaluation_tables.cend(),
+    [&](const EvaluationTable & table) { return has_infeasible_evaluation(table); });
+}
+
+void TrajectoryValidator::update_pseudo_emergency_stop_state(
+  const bool triggered, const double ego_velocity_mps)
+{
+  if (triggered) {
+    pseudo_emergency_stop_active_ = true;
+    return;
+  }
+  if (params_.pseudo_emergency_stop.recovery_policy == "immediate") {
+    // Release the emergency stop immediately when the trigger condition disappears.
+    pseudo_emergency_stop_active_ = false;
+    return;
+  }
+  if (
+    pseudo_emergency_stop_active_ &&
+    params_.pseudo_emergency_stop.recovery_policy == "until_stopped" &&
+    std::abs(ego_velocity_mps) < params_.pseudo_emergency_stop.recovery_velocity_threshold_mps) {
+    // Ego has come to a stop, release the latched emergency-stop state.
+    pseudo_emergency_stop_active_ = false;
+  }
+}
+
+void TrajectoryValidator::cache_fallback_trajectory(
+  const CandidateTrajectories & input_trajectories,
+  const std::vector<EvaluationTable> & evaluation_tables)
+{
+  constexpr const char * fallback_generator_name = "MinimumRuleBasedPlanner";
+
+  // Find the generator_id whose name matches the fallback generator name.
+  const auto generator_info_it = std::find_if(
+    input_trajectories.generator_info.cbegin(), input_trajectories.generator_info.cend(),
+    [&](const auto & info) { return info.generator_name.data == fallback_generator_name; });
+  if (generator_info_it == input_trajectories.generator_info.cend()) {
+    return;
+  }
+  const auto & fallback_generator_id = generator_info_it->generator_id;
+  const auto fallback_it = std::find_if(
+    input_trajectories.candidate_trajectories.cbegin(),
+    input_trajectories.candidate_trajectories.cend(),
+    [&](const autoware_internal_planning_msgs::msg::CandidateTrajectory & trajectory) {
+      return trajectory.generator_id.uuid == fallback_generator_id.uuid;
+    });
+  if (fallback_it == input_trajectories.candidate_trajectories.cend()) {
+    return;
+  }
+
+  // Only cache when no trigger filter has flagged this fallback trajectory as infeasible.
+  const auto generator_id_str = autoware_utils_uuid::to_hex_string(fallback_it->generator_id);
+  const auto table_it = std::find_if(
+    evaluation_tables.cbegin(), evaluation_tables.cend(),
+    [&](const EvaluationTable & table) { return table.generator_id == generator_id_str; });
+  if (table_it != evaluation_tables.cend() && has_infeasible_evaluation(*table_it)) {
+    return;
+  }
+
+  cached_fallback_trajectory_ = *fallback_it;
+}
+
+void TrajectoryValidator::apply_pseudo_emergency_stop_fallback(
+  CandidateTrajectories & filtered_trajectories, const FilterContext & context)
+{
+  if (!cached_fallback_trajectory_) {
+    RCLCPP_WARN_THROTTLE(
+      get_logger(), *get_clock(), 1000,
+      "Emergency stop active but no cached fallback trajectory is available yet.");
+    return;
+  }
+
+  auto stopping_trajectory = *cached_fallback_trajectory_;
+  auto & points = stopping_trajectory.points;
+  if (points.size() < 2) {
+    return;
+  }
+
+  const double min_decel = params_.pseudo_emergency_stop.deceleration_mps2;
+  const double min_jerk = params_.pseudo_emergency_stop.jerk_mps3;
+
+  // Drop points behind ego so that the resulting trajectory starts at the nearest point to the
+  // current ego position.
+  const size_t ego_nearest_idx =
+    autoware::motion_utils::findNearestIndex(points, context.odometry->pose.pose.position);
+  points.erase(points.begin(), points.begin() + ego_nearest_idx);
+  if (points.size() < 2) {
+    return;
+  }
+
+  // Overwrite the velocity/acceleration profile in place with a jerk/decel-limited stopping
+  // profile starting from the current ego state.
+  double v = std::max(0.0, context.odometry->twist.twist.linear.x);
+  double a = std::min(0.0, context.acceleration->accel.accel.linear.x);
+  points.front().longitudinal_velocity_mps = v;
+  points.front().acceleration_mps2 = a;
+  for (size_t i = 1; i < points.size(); ++i) {
+    const double ds = autoware_utils_geometry::calc_distance2d(points[i - 1].pose, points[i].pose);
+    if (v <= 1e-3) {
+      v = 0.0;
+      a = 0.0;
+    } else {
+      const double dt = ds / v;
+      a = std::max(min_decel, a + min_jerk * dt);
+      v = std::max(0.0, v + a * dt);
+    }
+    points[i].longitudinal_velocity_mps = v;
+    points[i].acceleration_mps2 = a;
+  }
+
+  autoware::motion_utils::calculate_time_from_start(
+    stopping_trajectory.points, context.odometry->pose.pose.position);
+  filtered_trajectories.candidate_trajectories.clear();
+  filtered_trajectories.candidate_trajectories.push_back(stopping_trajectory);
+
+  const auto stop_distance = autoware::motion_utils::calculate_stop_distance(
+    context.odometry->twist.twist.linear.x, context.acceleration->accel.accel.linear.x, min_decel,
+    min_jerk);
+  const auto stop_pose_opt = stop_distance ? autoware::motion_utils::calcLongitudinalOffsetPose(
+                                               stopping_trajectory.points, 0, *stop_distance)
+                                           : std::nullopt;
+  const auto & stop_pose = stop_pose_opt ? *stop_pose_opt : stopping_trajectory.points.back().pose;
+  pseudo_emergency_stop_planning_factor_interface_->add(
+    stopping_trajectory.points, context.odometry->pose.pose, stop_pose,
+    autoware_internal_planning_msgs::msg::PlanningFactor::STOP,
+    autoware_internal_planning_msgs::msg::SafetyFactorArray{}, true /*is_driving_forward*/,
+    0.0 /*velocity*/, 0.0 /*shift_length*/);
+
+  RCLCPP_WARN_THROTTLE(
+    get_logger(), *get_clock(), 1000,
+    "Emergency-stop trigger filter fired; falling back to cached MinimumRuleBasedPlanner "
+    "trajectory with emergency stop.");
 }
 
 void TrajectoryValidator::map_callback(const LaneletMapBin::ConstSharedPtr msg)


### PR DESCRIPTION
This PR introduces an temporary emergency stop behavior for evaluation.
when any filter is triggered, the validator node outputs a stop trajectory. 

To use this feature, the `pseudo_emergency_stop.enable` parameter must be set to `true`.
Since PlanningFactor is published for the emegency stop behavior, the stop wall can be visualized using the rviz plugin. 

**This feature will be removed once the proper MRM is implemented.**

https://github.com/user-attachments/assets/65e0fe51-7be3-4309-bca1-0d608689cb08


requires: https://github.com/tier4/autoware_launch.x2/pull/2112