### PR TITLE
feat(trajectory_validator): add rss stop margin

### DIFF
--- a/planning/autoware_trajectory_validator/config/trajectory_validator.param.yaml
+++ b/planning/autoware_trajectory_validator/config/trajectory_validator.param.yaml
@@ -31,6 +31,7 @@
         collision_time_threshold: 0.0
       rss:
         ego_deceleration_threshold: 4.0
+        stop_margin: 2.0
         ego_reaction_time: 0.4
         object_acceleration: -1.0
 

--- a/planning/autoware_trajectory_validator/param/parameter_struct.yaml
+++ b/planning/autoware_trajectory_validator/param/parameter_struct.yaml
@@ -79,6 +79,11 @@ validator:
         default_value: 4.0
         description: threshold to determine RSS collision
         read_only: false
+      stop_margin:
+        type: double
+        default_value: 2.0
+        description: required remaining distance to the object when ego stops
+        read_only: false
       ego_reaction_time:
         type: double
         default_value: 0.4

--- a/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter.cpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter.cpp
@@ -452,7 +452,7 @@ Assessment assess_required_deceleration(
   // compute safe distance
   const double obj_long_vel = std::clamp(
     rss_deceleration::compute_longitudinal_velocity(ego_trajectory.getPoses(), object), 0.0, 30.0);
-  const double safe_distance = distance_to_collision.value() +
+  const double safe_distance = distance_to_collision.value() - rss_params.stop_margin +
                                obj_long_vel * obj_long_vel * 0.5 / -rss_params.object_acceleration -
                                ego_long_vel * rss_params.ego_reaction_time;
 


### PR DESCRIPTION
  ## Summary

  This PR adds a configurable RSS stop margin to `autoware_trajectory_validator`.

  The RSS deceleration check now evaluates whether the ego vehicle can stop while keeping a specified remaining distance to the target object, instead of assuming stopping exactly at the collision boundary. This makes the RSS feasibility check stricter and more configurable.

  ## Changes

  - Added `collision_check.rss.stop_margin` parameter
  - Applied the stop margin in RSS required deceleration calculation
  - Set the default stop margin to `2.0 m`

  ## Behavior

  Before this change, the RSS check considered a trajectory acceptable if ego could stop right at the collision boundary.

  After this change, the RSS check requires ego to stop with `stop_margin` meters of clearance remaining. If the required deceleration to do that exceeds `ego_deceleration_threshold`, the trajectory is rejected.

  ## Default Parameter

  - `collision_check.rss.stop_margin: 2.0`

  ## Impact

  This change improves safety conservativeness in RSS-based trajectory validation by introducing an explicit stopping buffer to the object.
