### PR TITLE
feat: enhance metric info

### DIFF
--- a/planning/autoware_trajectory_validator/include/autoware/trajectory_validator/filters/safety/collision_check_filter.hpp
+++ b/planning/autoware_trajectory_validator/include/autoware/trajectory_validator/filters/safety/collision_check_filter.hpp
@@ -33,6 +33,7 @@
 
 #include <any>
 #include <memory>
+#include <optional>
 #include <string>
 #include <unordered_map>
 #include <unordered_set>
@@ -130,6 +131,55 @@ private:
   }
 };
 
+class ContinuousDetectionTimes
+{
+public:
+  void clear()
+  {
+    current_time_.reset();
+    detection_start_times_.clear();
+  }
+
+  template <typename Detections, typename KeyFunc>
+  void update(const rclcpp::Time & current_time, const Detections & detections, KeyFunc key_func)
+  {
+    current_time_ = current_time;
+
+    std::unordered_set<std::string> active_keys{};
+    for (const auto & detection : detections) {
+      const auto key = key_func(detection);
+      active_keys.insert(key);
+      detection_start_times_.try_emplace(key, current_time);
+    }
+
+    for (auto it = detection_start_times_.begin(); it != detection_start_times_.end();) {
+      if (!active_keys.count(it->first)) {
+        it = detection_start_times_.erase(it);
+      } else {
+        ++it;
+      }
+    }
+  }
+
+  double get_time(const std::string & key) const
+  {
+    if (!current_time_) {
+      return 0.0;
+    }
+
+    const auto it = detection_start_times_.find(key);
+    if (it == detection_start_times_.end()) {
+      return 0.0;
+    }
+
+    return (*current_time_ - it->second).seconds();
+  }
+
+private:
+  std::optional<rclcpp::Time> current_time_;
+  std::unordered_map<std::string, rclcpp::Time> detection_start_times_;
+};
+
 class CollisionCheckFilter : public plugin::ValidatorInterface
 {
 public:
@@ -143,8 +193,8 @@ public:
 private:
   validator::Params::CollisionCheck::PetCollision pet_collision_params_;
   validator::Params::CollisionCheck::Rss rss_params_;
-  std::unordered_map<std::string, rclcpp::Time> pet_collision_start_times_;
-  std::unordered_map<std::string, rclcpp::Time> rss_collision_start_times_;
+  ContinuousDetectionTimes pet_continuous_times_;
+  ContinuousDetectionTimes rss_continuous_times_;
 
   void add_debug_markers(
     const Polygon2d & ego_hull, const Polygon2d & object_hull, const std::string & trajectory_id,

--- a/planning/autoware_trajectory_validator/include/autoware/trajectory_validator/filters/safety/collision_check_filter.hpp
+++ b/planning/autoware_trajectory_validator/include/autoware/trajectory_validator/filters/safety/collision_check_filter.hpp
@@ -22,6 +22,7 @@
 #include <autoware/universe_utils/geometry/geometry.hpp>
 #include <autoware_utils_geometry/geometry.hpp>
 #include <rclcpp/duration.hpp>
+#include <rclcpp/time.hpp>
 
 #include <autoware_perception_msgs/msg/predicted_object.hpp>
 #include <geometry_msgs/msg/point.hpp>
@@ -34,6 +35,7 @@
 #include <memory>
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 #include <vector>
 
 namespace autoware::trajectory_validator::plugin::safety
@@ -141,6 +143,8 @@ public:
 private:
   validator::Params::CollisionCheck::PetCollision pet_collision_params_;
   validator::Params::CollisionCheck::Rss rss_params_;
+  std::unordered_map<std::string, rclcpp::Time> pet_collision_start_times_;
+  std::unordered_map<std::string, rclcpp::Time> rss_collision_start_times_;
 
   void add_debug_markers(
     const Polygon2d & ego_hull, const Polygon2d & object_hull, const std::string & trajectory_id,

--- a/planning/autoware_trajectory_validator/include/autoware/trajectory_validator/filters/safety/collision_check_filter.hpp
+++ b/planning/autoware_trajectory_validator/include/autoware/trajectory_validator/filters/safety/collision_check_filter.hpp
@@ -54,10 +54,16 @@ using StepPolygonTrajectory = std::vector<Polygon2d>;
 
 static constexpr double TIME_RESOLUTION = 0.1;  // 100ms intervals
 
+struct ObjectIdentification
+{
+  std::string classification;
+  std::string id;
+};
+
 class TrajectoryData
 {
 private:
-  std::string id_;
+  ObjectIdentification object_identification_;
   TimeTrajectory times_;
   TravelDistanceTrajectory distances_;
   PoseTrajectory poses_;
@@ -65,31 +71,39 @@ private:
 
 public:
   TrajectoryData(
-    std::string id, TimeTrajectory times, TravelDistanceTrajectory distances, PoseTrajectory poses,
-    FootprintTrajectory footprints)
-  : id_(std::move(id)),
+    ObjectIdentification object_identification, TimeTrajectory times,
+    TravelDistanceTrajectory distances, PoseTrajectory poses, FootprintTrajectory footprints)
+  : object_identification_(std::move(object_identification)),
     times_(std::move(times)),
     distances_(std::move(distances)),
     poses_(std::move(poses)),
     footprints_(std::move(footprints))
   {
     if (times_.empty()) {
-      throw std::invalid_argument("Trajectory must not be empty " + id_);
+      throw std::invalid_argument(
+        "Trajectory must not be empty classification: " + object_identification_.classification +
+        ", ID: " + object_identification_.id);
     }
     if (times_.size() != distances_.size()) {
-      throw std::invalid_argument("Trajectory sizes mismatch (times vs distances) " + id_);
+      throw std::invalid_argument(
+        "Trajectory sizes mismatch (times vs distances) classification: " +
+        object_identification_.classification + ", ID: " + object_identification_.id);
     }
     if (times_.size() != poses_.size()) {
-      throw std::invalid_argument("Trajectory sizes mismatch (times vs poses) " + id_);
+      throw std::invalid_argument(
+        "Trajectory sizes mismatch (times vs poses) classification: " +
+        object_identification_.classification + ", ID: " + object_identification_.id);
     }
     if (times_.size() != footprints_.size()) {
-      throw std::invalid_argument("Trajectory sizes mismatch (times vs footprints) " + id_);
+      throw std::invalid_argument(
+        "Trajectory sizes mismatch (times vs footprints) classification: " +
+        object_identification_.classification + ", ID: " + object_identification_.id);
     }
   }
 
   TrajectoryData() = delete;
 
-  const std::string & getId() const { return id_; }
+  const ObjectIdentification & getObjectIdentification() const { return object_identification_; }
   const TimeTrajectory & getTimes() const { return times_; }
   const TravelDistanceTrajectory & getDistances() const { return distances_; }
   const PoseTrajectory & getPoses() const { return poses_; }

--- a/planning/autoware_trajectory_validator/package.xml
+++ b/planning/autoware_trajectory_validator/package.xml
@@ -22,6 +22,7 @@
   <depend>autoware_lanelet2_extension</depend>
   <depend>autoware_map_msgs</depend>
   <depend>autoware_motion_utils</depend>
+  <depend>autoware_object_recognition_utils</depend>
   <depend>autoware_perception_msgs</depend>
   <depend>autoware_planning_msgs</depend>
   <depend>autoware_traffic_light_utils</depend>

--- a/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter.cpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter.cpp
@@ -15,6 +15,8 @@
 #include "autoware/trajectory_validator/filters/safety/collision_check_filter.hpp"
 
 #include <autoware/universe_utils/geometry/pose_deviation.hpp>
+#include <autoware/object_recognition_utils/object_classification.hpp>
+#include <autoware/object_recognition_utils/object_recognition_utils.hpp>
 #include <autoware_utils/system/stop_watch.hpp>
 #include <autoware_utils_geometry/boost_polygon_utils.hpp>
 #include <autoware_utils_uuid/uuid_helper.hpp>
@@ -38,6 +40,8 @@
 
 namespace autoware::trajectory_validator::plugin::safety
 {
+using autoware::object_recognition_utils::convertLabelToString;
+using autoware::object_recognition_utils::getHighestProbLabel;
 
 // Trajectory generation helpers.
 namespace trajectory::time_distance
@@ -358,6 +362,7 @@ namespace rss_deceleration
 struct Assessment
 {
   std::string object_id;
+  std::string classification;
   double required_deceleration;
 };
 
@@ -439,14 +444,18 @@ Assessment assess_required_deceleration(
 {
   const auto ego_long_vel = ego_twist.linear.x;
   if (ego_long_vel <= 0.0) {
-    return Assessment{autoware_utils_uuid::to_hex_string(object.object_id), 0.0};
+    return Assessment{
+      autoware_utils_uuid::to_hex_string(object.object_id),
+      convertLabelToString(getHighestProbLabel(object.classification)), 0.0};
   }
 
   // compute current distance
   const auto distance_to_collision =
     rss_deceleration::compute_distance_to_collision(ego_trajectory, object);
   if (!distance_to_collision.has_value()) {
-    return Assessment{autoware_utils_uuid::to_hex_string(object.object_id), 0.0};
+    return Assessment{
+      autoware_utils_uuid::to_hex_string(object.object_id),
+      convertLabelToString(getHighestProbLabel(object.classification)), 0.0};
   }
 
   // compute safe distance
@@ -461,7 +470,9 @@ Assessment assess_required_deceleration(
                                          ? std::numeric_limits<double>::infinity()
                                          : ego_long_vel * ego_long_vel * 0.5 / safe_distance;
 
-  return Assessment{autoware_utils_uuid::to_hex_string(object.object_id), required_deceleration};
+  return Assessment{
+    autoware_utils_uuid::to_hex_string(object.object_id),
+    convertLabelToString(getHighestProbLabel(object.classification)), required_deceleration};
 }
 
 Result assess(
@@ -709,8 +720,8 @@ tl::expected<void, std::string> CollisionCheckFilter::is_feasible(
     rss_deceleration::assess(traj_points, context, rss_params_, *vehicle_info_ptr_);
   for (const auto & violation : rss_result.violations) {
     error_msg += fmt::format(
-      "RSS collision, ID: {}, required deceleration: {}; ", violation.object_id,
-      violation.required_deceleration);
+      "RSS collision, ID: {}, classification: {}, required deceleration: {}; ",
+      violation.object_id, violation.classification, violation.required_deceleration);
   }
 
   if (!error_msg.empty()) {

--- a/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter.cpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter.cpp
@@ -35,6 +35,7 @@
 #include <stdexcept>
 #include <string>
 #include <unordered_map>
+#include <unordered_set>
 #include <utility>
 #include <vector>
 
@@ -42,6 +43,32 @@ namespace autoware::trajectory_validator::plugin::safety
 {
 using autoware::object_recognition_utils::convertLabelToString;
 using autoware::object_recognition_utils::getHighestProbLabel;
+namespace
+{
+double update_detection_duration(
+  const std::string & key, const rclcpp::Time & current_time,
+  std::unordered_map<std::string, rclcpp::Time> & collision_start_times)
+{
+  auto [it, inserted] = collision_start_times.try_emplace(key, current_time);
+  if (inserted) {
+    return 0.0;
+  }
+  return (current_time - it->second).seconds();
+}
+
+void reset_inactive_detections(
+  const std::unordered_set<std::string> & active_keys,
+  std::unordered_map<std::string, rclcpp::Time> & collision_start_times)
+{
+  for (auto it = collision_start_times.begin(); it != collision_start_times.end();) {
+    if (!active_keys.count(it->first)) {
+      it = collision_start_times.erase(it);
+    } else {
+      ++it;
+    }
+  }
+}
+}  // namespace
 
 // Trajectory generation helpers.
 namespace trajectory::time_distance
@@ -696,33 +723,50 @@ tl::expected<void, std::string> CollisionCheckFilter::is_feasible(
   // stopwatch.tic();
 
   if (!context.predicted_objects || context.predicted_objects->objects.empty()) {
+    pet_collision_start_times_.clear();
+    rss_collision_start_times_.clear();
     return {};  // No objects to check collision with
   }
 
   if (traj_points.empty()) {
+    pet_collision_start_times_.clear();
+    rss_collision_start_times_.clear();
     return {};  // No trajectory to check
   }
 
   std::string error_msg{};
+  const rclcpp::Time current_time = context.odometry->header.stamp;
+  std::unordered_set<std::string> active_pet_collision_keys{};
+  std::unordered_set<std::string> active_rss_collision_keys{};
 
   const auto planned_speed_timing_findings = planned_speed_collision_timing::assess(
     traj_points, context, pet_collision_params_, *vehicle_info_ptr_);
   for (const auto & finding : planned_speed_timing_findings) {
+    active_pet_collision_keys.insert(finding.trajectory_id);
+    const double detection_duration =
+      update_detection_duration(finding.trajectory_id, current_time, pet_collision_start_times_);
     error_msg += fmt::format(
-      "PET collision, ID: {}, PET: {}, TTC: {}, stamp: {}.{}; ", finding.trajectory_id, finding.pet,
+      "PET collision, ID: {}, PET: {}, TTC: {}, duration: {}, stamp: {}.{}; ",
+      finding.trajectory_id, finding.pet,
       finding.ttc.has_value() ? std::to_string(finding.ttc.value()) : "N/A",
+      detection_duration,
       context.predicted_objects->header.stamp.sec, context.predicted_objects->header.stamp.nanosec);
     add_debug_markers(
       finding.ego_hull, finding.object_hull, finding.trajectory_id, context.odometry->header.stamp);
   }
+  reset_inactive_detections(active_pet_collision_keys, pet_collision_start_times_);
 
   const auto rss_result =
     rss_deceleration::assess(traj_points, context, rss_params_, *vehicle_info_ptr_);
   for (const auto & violation : rss_result.violations) {
+    active_rss_collision_keys.insert(violation.object_id);
+    const double detection_duration =
+      update_detection_duration(violation.object_id, current_time, rss_collision_start_times_);
     error_msg += fmt::format(
-      "RSS collision, ID: {}, classification: {}, required deceleration: {}; ",
-      violation.object_id, violation.classification, violation.required_deceleration);
+      "RSS collision, ID: {}, classification: {}, duration: {}, required deceleration: {}; ",
+      violation.object_id, violation.classification, detection_duration, violation.required_deceleration);
   }
+  reset_inactive_detections(active_rss_collision_keys, rss_collision_start_times_);
 
   if (!error_msg.empty()) {
     RCLCPP_WARN(rclcpp::get_logger("CollisionCheckFilter"), "Not feasible: %s", error_msg.c_str());

--- a/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter.cpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter.cpp
@@ -44,6 +44,22 @@ namespace autoware::trajectory_validator::plugin::safety
 using autoware::object_recognition_utils::convertLabelToString;
 using autoware::object_recognition_utils::getHighestProbLabel;
 
+ObjectIdentification make_object_identification(
+  const autoware_perception_msgs::msg::PredictedObject & object)
+{
+  return {
+    convertLabelToString(getHighestProbLabel(object.classification)),
+    autoware_utils_uuid::to_hex_string(object.object_id)};
+}
+
+ObjectIdentification make_trajectory_identification(
+  const autoware_perception_msgs::msg::PredictedObject & object, const std::string & suffix)
+{
+  return {
+    convertLabelToString(getHighestProbLabel(object.classification)),
+    autoware_utils_uuid::to_hex_string(object.object_id) + suffix};
+}
+
 // Trajectory generation helpers.
 namespace trajectory::time_distance
 {
@@ -254,7 +270,7 @@ TrajectoryData generate_ego_trajectory(
   auto footprints = footprint::compute_footprint_trajectory(poses, vehicle_info);
 
   return TrajectoryData(
-    std::string("ego"), std::move(times), std::move(distances), std::move(poses),
+    ObjectIdentification{"EGO", ""}, std::move(times), std::move(distances), std::move(poses),
     std::move(footprints));
 }
 
@@ -278,8 +294,8 @@ TrajectoryData generate_predicted_path_trajectory(
   auto footprints = footprint::compute_footprint_trajectory(poses, predicted_object.shape);
 
   return TrajectoryData(
-    autoware_utils_uuid::to_hex_string(predicted_object.object_id) + "_predicted_path",
-    std::move(times), std::move(distances), std::move(poses), std::move(footprints));
+    make_trajectory_identification(predicted_object, "_predicted_path"), std::move(times),
+    std::move(distances), std::move(poses), std::move(footprints));
 }
 
 TrajectoryData generate_constant_curvature_trajectory(
@@ -296,8 +312,8 @@ TrajectoryData generate_constant_curvature_trajectory(
   auto footprints = footprint::compute_footprint_trajectory(poses, predicted_object.shape);
 
   return TrajectoryData(
-    autoware_utils_uuid::to_hex_string(predicted_object.object_id) + "_constant_curvature_path",
-    std::move(times), std::move(distances), std::move(poses), std::move(footprints));
+    make_trajectory_identification(predicted_object, "_constant_curvature_path"), std::move(times),
+    std::move(distances), std::move(poses), std::move(footprints));
 }
 }  // namespace trajectory
 
@@ -362,8 +378,7 @@ namespace rss_deceleration
 {
 struct Assessment
 {
-  std::string object_id;
-  std::string classification;
+  ObjectIdentification object;
   double required_deceleration;
 };
 
@@ -445,18 +460,14 @@ Assessment assess_required_deceleration(
 {
   const auto ego_long_vel = ego_twist.linear.x;
   if (ego_long_vel <= 0.0) {
-    return Assessment{
-      autoware_utils_uuid::to_hex_string(object.object_id),
-      convertLabelToString(getHighestProbLabel(object.classification)), 0.0};
+    return Assessment{make_object_identification(object), 0.0};
   }
 
   // compute current distance
   const auto distance_to_collision =
     rss_deceleration::compute_distance_to_collision(ego_trajectory, object);
   if (!distance_to_collision.has_value()) {
-    return Assessment{
-      autoware_utils_uuid::to_hex_string(object.object_id),
-      convertLabelToString(getHighestProbLabel(object.classification)), 0.0};
+    return Assessment{make_object_identification(object), 0.0};
   }
 
   // compute safe distance
@@ -471,9 +482,7 @@ Assessment assess_required_deceleration(
                                          ? std::numeric_limits<double>::infinity()
                                          : ego_long_vel * ego_long_vel * 0.5 / safe_distance;
 
-  return Assessment{
-    autoware_utils_uuid::to_hex_string(object.object_id),
-    convertLabelToString(getHighestProbLabel(object.classification)), required_deceleration};
+  return Assessment{make_object_identification(object), required_deceleration};
 }
 
 Result assess(
@@ -518,6 +527,7 @@ struct Trajectories
 struct Finding
 {
   std::string trajectory_id;
+  ObjectIdentification object;
   double pet;
   std::optional<double> ttc;
   Polygon2d ego_hull;
@@ -560,7 +570,7 @@ Trajectories generate_trajectories(
 // is returned as ttc.
 std::optional<Finding> find_collision_timing(
   const TrajectoryData & ref_trajectory, const TrajectoryData & test_trajectory,
-  double pet_threshold)
+  const ObjectIdentification & object, double pet_threshold)
 {
   if (!geometry::has_overall_convex_hull_overlap(
         ref_trajectory.getFootprints(), test_trajectory.getFootprintsInTimeRange(
@@ -596,7 +606,8 @@ std::optional<Finding> find_collision_timing(
         check_slice_collision(test_start_time_before, test_end_time_before) ||
         check_slice_collision(test_start_time_after, test_end_time_after)) {
         Finding finding;
-        finding.trajectory_id = test_trajectory.getId();
+        finding.trajectory_id = test_trajectory.getObjectIdentification().id;
+        finding.object = object;
         finding.pet = pet_range;
         finding.ttc = ref_start_time;
         finding.ego_hull = geometry::compute_overall_convex_hull(
@@ -629,7 +640,7 @@ std::vector<Finding> assess(
 
   for (const auto & object_trajectory : trajectories.object_trajectories) {
     auto finding = find_collision_timing(
-      trajectories.ego_trajectory, object_trajectory,
+      trajectories.ego_trajectory, object_trajectory, object_trajectory.getObjectIdentification(),
       pet_collision_params.collision_time_threshold);
     if (finding.has_value()) {
       findings.push_back(std::move(finding.value()));
@@ -719,8 +730,8 @@ tl::expected<void, std::string> CollisionCheckFilter::is_feasible(
   for (const auto & finding : planned_speed_timing_findings) {
     const double detection_duration = pet_continuous_times_.get_time(finding.trajectory_id);
     error_msg += fmt::format(
-      "PET collision, ID: {}, PET: {}, TTC: {}, duration: {}, stamp: {}.{}; ",
-      finding.trajectory_id, finding.pet,
+      "PET collision, classification: {}, ID: {}, PET: {}, TTC: {}, duration: {}, stamp: {}.{}; ",
+      finding.object.classification, finding.trajectory_id, finding.pet,
       finding.ttc.has_value() ? std::to_string(finding.ttc.value()) : "N/A", detection_duration,
       context.predicted_objects->header.stamp.sec, context.predicted_objects->header.stamp.nanosec);
     add_debug_markers(
@@ -730,13 +741,13 @@ tl::expected<void, std::string> CollisionCheckFilter::is_feasible(
   const auto rss_result =
     rss_deceleration::assess(traj_points, context, rss_params_, *vehicle_info_ptr_);
   rss_continuous_times_.update(current_time, rss_result.violations, [](const auto & violation) {
-    return violation.object_id;
+    return violation.object.id;
   });
   for (const auto & violation : rss_result.violations) {
-    const double detection_duration = rss_continuous_times_.get_time(violation.object_id);
+    const double detection_duration = rss_continuous_times_.get_time(violation.object.id);
     error_msg += fmt::format(
-      "RSS collision, ID: {}, classification: {}, duration: {}, required deceleration: {}; ",
-      violation.object_id, violation.classification, detection_duration,
+      "RSS collision, classification: {}, ID: {}, duration: {}, required deceleration: {}; ",
+      violation.object.classification, violation.object.id, detection_duration,
       violation.required_deceleration);
   }
 

--- a/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter.cpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter.cpp
@@ -14,9 +14,9 @@
 
 #include "autoware/trajectory_validator/filters/safety/collision_check_filter.hpp"
 
-#include <autoware/universe_utils/geometry/pose_deviation.hpp>
 #include <autoware/object_recognition_utils/object_classification.hpp>
 #include <autoware/object_recognition_utils/object_recognition_utils.hpp>
+#include <autoware/universe_utils/geometry/pose_deviation.hpp>
 #include <autoware_utils/system/stop_watch.hpp>
 #include <autoware_utils_geometry/boost_polygon_utils.hpp>
 #include <autoware_utils_uuid/uuid_helper.hpp>
@@ -43,32 +43,6 @@ namespace autoware::trajectory_validator::plugin::safety
 {
 using autoware::object_recognition_utils::convertLabelToString;
 using autoware::object_recognition_utils::getHighestProbLabel;
-namespace
-{
-double update_detection_duration(
-  const std::string & key, const rclcpp::Time & current_time,
-  std::unordered_map<std::string, rclcpp::Time> & collision_start_times)
-{
-  auto [it, inserted] = collision_start_times.try_emplace(key, current_time);
-  if (inserted) {
-    return 0.0;
-  }
-  return (current_time - it->second).seconds();
-}
-
-void reset_inactive_detections(
-  const std::unordered_set<std::string> & active_keys,
-  std::unordered_map<std::string, rclcpp::Time> & collision_start_times)
-{
-  for (auto it = collision_start_times.begin(); it != collision_start_times.end();) {
-    if (!active_keys.count(it->first)) {
-      it = collision_start_times.erase(it);
-    } else {
-      ++it;
-    }
-  }
-}
-}  // namespace
 
 // Trajectory generation helpers.
 namespace trajectory::time_distance
@@ -723,50 +697,48 @@ tl::expected<void, std::string> CollisionCheckFilter::is_feasible(
   // stopwatch.tic();
 
   if (!context.predicted_objects || context.predicted_objects->objects.empty()) {
-    pet_collision_start_times_.clear();
-    rss_collision_start_times_.clear();
+    pet_continuous_times_.clear();
+    rss_continuous_times_.clear();
     return {};  // No objects to check collision with
   }
 
   if (traj_points.empty()) {
-    pet_collision_start_times_.clear();
-    rss_collision_start_times_.clear();
+    pet_continuous_times_.clear();
+    rss_continuous_times_.clear();
     return {};  // No trajectory to check
   }
 
   std::string error_msg{};
   const rclcpp::Time current_time = context.odometry->header.stamp;
-  std::unordered_set<std::string> active_pet_collision_keys{};
-  std::unordered_set<std::string> active_rss_collision_keys{};
 
   const auto planned_speed_timing_findings = planned_speed_collision_timing::assess(
     traj_points, context, pet_collision_params_, *vehicle_info_ptr_);
+  pet_continuous_times_.update(
+    current_time, planned_speed_timing_findings,
+    [](const auto & finding) { return finding.trajectory_id; });
   for (const auto & finding : planned_speed_timing_findings) {
-    active_pet_collision_keys.insert(finding.trajectory_id);
-    const double detection_duration =
-      update_detection_duration(finding.trajectory_id, current_time, pet_collision_start_times_);
+    const double detection_duration = pet_continuous_times_.get_time(finding.trajectory_id);
     error_msg += fmt::format(
       "PET collision, ID: {}, PET: {}, TTC: {}, duration: {}, stamp: {}.{}; ",
       finding.trajectory_id, finding.pet,
-      finding.ttc.has_value() ? std::to_string(finding.ttc.value()) : "N/A",
-      detection_duration,
+      finding.ttc.has_value() ? std::to_string(finding.ttc.value()) : "N/A", detection_duration,
       context.predicted_objects->header.stamp.sec, context.predicted_objects->header.stamp.nanosec);
     add_debug_markers(
       finding.ego_hull, finding.object_hull, finding.trajectory_id, context.odometry->header.stamp);
   }
-  reset_inactive_detections(active_pet_collision_keys, pet_collision_start_times_);
 
   const auto rss_result =
     rss_deceleration::assess(traj_points, context, rss_params_, *vehicle_info_ptr_);
+  rss_continuous_times_.update(current_time, rss_result.violations, [](const auto & violation) {
+    return violation.object_id;
+  });
   for (const auto & violation : rss_result.violations) {
-    active_rss_collision_keys.insert(violation.object_id);
-    const double detection_duration =
-      update_detection_duration(violation.object_id, current_time, rss_collision_start_times_);
+    const double detection_duration = rss_continuous_times_.get_time(violation.object_id);
     error_msg += fmt::format(
       "RSS collision, ID: {}, classification: {}, duration: {}, required deceleration: {}; ",
-      violation.object_id, violation.classification, detection_duration, violation.required_deceleration);
+      violation.object_id, violation.classification, detection_duration,
+      violation.required_deceleration);
   }
-  reset_inactive_detections(active_rss_collision_keys, rss_collision_start_times_);
 
   if (!error_msg.empty()) {
     RCLCPP_WARN(rclcpp::get_logger("CollisionCheckFilter"), "Not feasible: %s", error_msg.c_str());

--- a/planning/autoware_trajectory_validator/test/collision_check_filter/test_collision_check_filter.cpp
+++ b/planning/autoware_trajectory_validator/test/collision_check_filter/test_collision_check_filter.cpp
@@ -171,6 +171,8 @@ TEST_F(CollisionCheckFilterTest, StoppedObjectInPath)
 
   ASSERT_FALSE(result.has_value());
   const std::string & error_msg = result.error();
+  EXPECT_NE(error_msg.find("classification: CAR"), std::string::npos)
+    << "Error string did not contain 'classification: CAR'. Actual: " << error_msg;
   EXPECT_NE(error_msg.find("predicted_path"), std::string::npos)
     << "Error string did not contain 'predicted_path'. Actual: " << error_msg;
   EXPECT_NE(error_msg.find("constant_curvature_path"), std::string::npos)
@@ -222,6 +224,8 @@ TEST_F(CollisionCheckFilterTest, ObjectWillEnterPath)
 
   ASSERT_FALSE(result.has_value());
   const std::string & error_msg = result.error();
+  EXPECT_NE(error_msg.find("classification: CAR"), std::string::npos)
+    << "Error string did not contain 'classification: CAR'. Actual: " << error_msg;
   EXPECT_NE(error_msg.find("predicted_path"), std::string::npos)
     << "Error string did not contain 'predicted_path'. Actual: " << error_msg;
   EXPECT_NE(error_msg.find("constant_curvature_path"), std::string::npos)

--- a/planning/autoware_trajectory_validator/test/collision_check_filter/test_pose_constant_curvature_predictor.cpp
+++ b/planning/autoware_trajectory_validator/test/collision_check_filter/test_pose_constant_curvature_predictor.cpp
@@ -22,7 +22,8 @@
 
 #include <cmath>
 
-namespace autoware::trajectory_validator::plugin::safety::trajectory::pose::constant_curvature_predictor
+namespace autoware::trajectory_validator::plugin::safety::trajectory::pose::
+  constant_curvature_predictor
 {
 
 TEST(PoseConstantCurvaturePredictorTest, PoseToIsometry)
@@ -215,4 +216,5 @@ TEST(PoseConstantCurvaturePredictorTest, ComputeTrajectory)
   }
 }
 
-}  // namespace autoware::trajectory_validator::plugin::safety::trajectory::pose::constant_curvature_predictor
+}  // namespace
+   // autoware::trajectory_validator::plugin::safety::trajectory::pose::constant_curvature_predictor

--- a/planning/autoware_trajectory_validator/test/collision_check_filter/test_trajectory_utilities.cpp
+++ b/planning/autoware_trajectory_validator/test/collision_check_filter/test_trajectory_utilities.cpp
@@ -186,7 +186,8 @@ TEST(TrajectoryUtilitiesTest, GenerateEgoTrajectoryBuildsConsistentTrajectoryDat
   const auto trajectory_data =
     trajectory::generate_ego_trajectory(initial_twist, 0.0, 0.0, 1.05, traj_points, vehicle_info);
 
-  ASSERT_EQ(trajectory_data.getId(), "ego");
+  ASSERT_EQ(trajectory_data.getObjectIdentification().classification, "EGO");
+  ASSERT_TRUE(trajectory_data.getObjectIdentification().id.empty());
   ASSERT_EQ(trajectory_data.size(), 11u);
   EXPECT_DOUBLE_EQ(trajectory_data.getTimes().front(), 0.0);
   EXPECT_NEAR(trajectory_data.getTimes().back(), 1.0, 1e-6);
@@ -213,7 +214,9 @@ TEST(TrajectoryUtilitiesTest, GeneratePredictedPathTrajectoryUsesHighestConfiden
     object, 0.0, 0.0, rclcpp::Duration::from_seconds(0.1), 0.35);
 
   ASSERT_EQ(trajectory_data.size(), 3u);
-  EXPECT_EQ(trajectory_data.getId().find("_predicted_path"), trajectory_data.getId().size() - 15);
+  EXPECT_EQ(
+    trajectory_data.getObjectIdentification().id.find("_predicted_path"),
+    trajectory_data.getObjectIdentification().id.size() - 15);
   EXPECT_NEAR(trajectory_data.getTimes().front(), 0.1, 1e-6);
   EXPECT_NEAR(trajectory_data.getTimes().back(), 0.3, 1e-6);
   EXPECT_NEAR(trajectory_data.getPoses().at(0).position.x, 0.1, 1e-6);
@@ -274,7 +277,8 @@ TEST(TrajectoryUtilitiesTest, GenerateConstantCurvaturePathTrajectoryMatchesPred
 
   ASSERT_EQ(trajectory_data.size(), expected_times.size());
   EXPECT_EQ(
-    trajectory_data.getId().find("_constant_curvature_path"), trajectory_data.getId().size() - 24);
+    trajectory_data.getObjectIdentification().id.find("_constant_curvature_path"),
+    trajectory_data.getObjectIdentification().id.size() - 24);
   for (size_t i = 0; i < expected_times.size(); ++i) {
     EXPECT_NEAR(trajectory_data.getTimes().at(i), expected_times.at(i), 1e-6);
     EXPECT_NEAR(trajectory_data.getPoses().at(i).position.x, expected_poses.at(i).position.x, 1e-6);
@@ -296,7 +300,8 @@ TEST(TrajectoryUtilitiesTest, TrajectoryDataReturnsFootprintsInNearestTimeRange)
     autoware_utils_geometry::to_polygon2d(poses.at(0), shape),
     autoware_utils_geometry::to_polygon2d(poses.at(1), shape),
     autoware_utils_geometry::to_polygon2d(poses.at(2), shape)};
-  const TrajectoryData trajectory_data("sample", times, distances, poses, footprints);
+  const TrajectoryData trajectory_data(
+    ObjectIdentification{"", "sample"}, times, distances, poses, footprints);
 
   const auto range = trajectory_data.getFootprintsInTimeRange(0.05, 0.15);
   const auto empty_range = trajectory_data.getFootprintsInTimeRange(0.3, 0.2);


### PR DESCRIPTION
This PR updates `autoware_trajectory_validator` to make RSS-based collision validation more informative and enriching RSS collision error messages with the target object’s classification, and including collision detection duration in both PET and RSS error outputs using a simple stateful timer that tracks when each collision was first detected and resets when the collision is cleared; together, these changes make the safety judgment stricter, improve observability for debugging and hysteresis tuning.