### PR TITLE
fix(goal_planner): prevent crash when output path is empty (#12284)

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/goal_planner_module.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_goal_planner_module/src/goal_planner_module.cpp
@@ -1453,6 +1453,14 @@ void GoalPlannerModule::setModifiedGoal(
 void GoalPlannerModule::setTurnSignalInfo(
   const PullOverContextData & context_data, BehaviorModuleOutput & output)
 {
+  if (output.path.points.empty()) {
+    RCLCPP_WARN_THROTTLE(
+      getLogger(), *clock_, 5000,
+      "setTurnSignalInfo() received empty path. Keeping previous turn signal.");
+    output.turn_signal_info = getPreviousModuleOutput().turn_signal_info;
+    return;
+  }
+
   const auto original_signal = getPreviousModuleOutput().turn_signal_info;
   const auto new_signal = calcTurnSignalInfo(context_data);
   const auto current_seg_idx = planner_data_->findEgoSegmentIndex(output.path.points);
@@ -1466,6 +1474,14 @@ void GoalPlannerModule::setTurnSignalInfoForStopPath(
   const BehaviorModuleOutput & stop_path, const Pose & decel_start_pose,
   const std::optional<Pose> & stop_pose, BehaviorModuleOutput & output)
 {
+  if (stop_path.path.points.empty()) {
+    RCLCPP_WARN_THROTTLE(
+      getLogger(), *clock_, 5000,
+      "setTurnSignalInfoForStopPath() received empty stop path. Keeping previous turn signal.");
+    output.turn_signal_info = getPreviousModuleOutput().turn_signal_info;
+    return;
+  }
+
   const auto original_signal = getPreviousModuleOutput().turn_signal_info;
   const auto current_seg_idx = planner_data_->findEgoSegmentIndex(stop_path.path.points);
   auto preempt_turn_signal =


### PR DESCRIPTION
cherry-pick https://github.com/autowarefoundation/autoware_universe/pull/12284