### PR TITLE
feat(trajectory_validator): add timed ego trajectory generation

### DIFF
--- a/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter.cpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter.cpp
@@ -14,6 +14,7 @@
 
 #include "autoware/trajectory_validator/filters/safety/collision_check_filter.hpp"
 
+#include <autoware/interpolation/linear_interpolation.hpp>
 #include <autoware/object_recognition_utils/object_classification.hpp>
 #include <autoware/object_recognition_utils/object_recognition_utils.hpp>
 #include <autoware/universe_utils/geometry/pose_deviation.hpp>
@@ -134,6 +135,27 @@ std::pair<TimeTrajectory, TravelDistanceTrajectory> compute_motion_profile_1d(
 
 namespace trajectory::pose
 {
+geometry_msgs::msg::Pose interpolate_pose(
+  const geometry_msgs::msg::Pose & start_pose, const geometry_msgs::msg::Pose & end_pose,
+  const double ratio)
+{
+  geometry_msgs::msg::Pose interpolated_pose;
+  interpolated_pose.position.x =
+    interpolation::lerp(start_pose.position.x, end_pose.position.x, ratio);
+  interpolated_pose.position.y =
+    interpolation::lerp(start_pose.position.y, end_pose.position.y, ratio);
+  interpolated_pose.position.z =
+    interpolation::lerp(start_pose.position.z, end_pose.position.z, ratio);
+
+  tf2::Quaternion start_q;
+  tf2::Quaternion end_q;
+  tf2::fromMsg(start_pose.orientation, start_q);
+  tf2::fromMsg(end_pose.orientation, end_q);
+  interpolated_pose.orientation = tf2::toMsg(start_q.slerp(end_q, ratio));
+
+  return interpolated_pose;
+}
+
 namespace constant_curvature_predictor
 {
 struct TwistPerDistance
@@ -234,6 +256,52 @@ PoseTrajectory compute_pose_trajectory(
   return pose_trajectory;
 }
 
+PoseTrajectory compute_pose_trajectory_from_time(
+  const TrajectoryPoints & traj_points, const TimeTrajectory & time_trajectory)
+{
+  if (traj_points.empty()) {
+    throw std::invalid_argument("traj_points must not be empty");
+  }
+
+  std::vector<double> point_times;
+  point_times.reserve(traj_points.size());
+  for (const auto & point : traj_points) {
+    point_times.push_back(rclcpp::Duration(point.time_from_start).seconds());
+  }
+
+  PoseTrajectory pose_trajectory;
+  pose_trajectory.reserve(time_trajectory.size());
+
+  for (const auto target_time : time_trajectory) {
+    size_t lower_idx = 0;
+    size_t upper_idx = 0;
+    if (traj_points.size() == 1) {
+      pose_trajectory.push_back(traj_points.front().pose);
+      continue;
+    } else if (target_time <= point_times.front()) {
+      lower_idx = 0;
+      upper_idx = 1;
+    } else if (target_time >= point_times.back()) {
+      lower_idx = traj_points.size() - 2;
+      upper_idx = traj_points.size() - 1;
+    } else {
+      const auto upper_it = std::lower_bound(point_times.begin(), point_times.end(), target_time);
+      upper_idx = static_cast<size_t>(std::distance(point_times.begin(), upper_it));
+      lower_idx = upper_idx - 1;
+    }
+
+    const double lower_time = point_times.at(lower_idx);
+    const double upper_time = point_times.at(upper_idx);
+    const double denom = upper_time - lower_time;
+    const double ratio = denom > 1e-6 ? (target_time - lower_time) / denom : 0.0;
+
+    pose_trajectory.push_back(
+      interpolate_pose(traj_points.at(lower_idx).pose, traj_points.at(upper_idx).pose, ratio));
+  }
+
+  return pose_trajectory;
+}
+
 }  // namespace trajectory::pose
 
 namespace trajectory::footprint
@@ -268,6 +336,69 @@ FootprintTrajectory compute_footprint_trajectory(
 namespace trajectory
 {
 
+namespace detail
+{
+double to_seconds(const builtin_interfaces::msg::Duration & duration)
+{
+  return rclcpp::Duration(duration).seconds();
+}
+
+double project_current_pose_on_trajectory(
+  const TrajectoryPoints & traj_points, const geometry_msgs::msg::Pose & current_pose)
+{
+  if (traj_points.empty()) {
+    throw std::invalid_argument("traj_points must not be empty");
+  }
+
+  if (traj_points.size() == 1) {
+    return to_seconds(traj_points.front().time_from_start);
+  }
+
+  const auto project_on_segment = [&](const size_t start_idx, const size_t end_idx) {
+    const auto & start_pose = traj_points.at(start_idx).pose;
+    const auto & end_pose = traj_points.at(end_idx).pose;
+    const double current_x = current_pose.position.x;
+    const double current_y = current_pose.position.y;
+
+    const double dx = end_pose.position.x - start_pose.position.x;
+    const double dy = end_pose.position.y - start_pose.position.y;
+    const double segment_length_sq = dx * dx + dy * dy;
+
+    double ratio = 0.0;
+    if (segment_length_sq > 1e-6) {
+      ratio =
+        ((current_x - start_pose.position.x) * dx + (current_y - start_pose.position.y) * dy) /
+        segment_length_sq;
+    }
+
+    return interpolation::lerp(
+      to_seconds(traj_points.at(start_idx).time_from_start),
+      to_seconds(traj_points.at(end_idx).time_from_start), ratio);
+  };
+
+  const size_t nearest_segment_idx =
+    autoware::motion_utils::findNearestSegmentIndex(traj_points, current_pose.position);
+  return project_on_segment(nearest_segment_idx, nearest_segment_idx + 1);
+}
+
+TravelDistanceTrajectory compute_cumulative_distances(const PoseTrajectory & pose_trajectory)
+{
+  TravelDistanceTrajectory distances;
+  distances.reserve(pose_trajectory.size());
+
+  double cumulative_distance = 0.0;
+  for (size_t i = 0; i < pose_trajectory.size(); ++i) {
+    if (i > 0) {
+      cumulative_distance += autoware_utils_geometry::calc_distance2d(
+        pose_trajectory.at(i - 1).position, pose_trajectory.at(i).position);
+    }
+    distances.push_back(cumulative_distance);
+  }
+
+  return distances;
+}
+}  // namespace detail
+
 TrajectoryData generate_ego_trajectory(
   const geometry_msgs::msg::Twist & initial_twist, double braking_lag, double assumed_acceleration,
   double max_time, const TrajectoryPoints & traj_points, VehicleInfo & vehicle_info)
@@ -289,6 +420,37 @@ TrajectoryData generate_ego_trajectory(
   return TrajectoryData(
     ObjectIdentification{"EGO", ""}, std::move(times), std::move(distances), std::move(poses),
     std::move(footprints));
+}
+
+TrajectoryData generate_ego_trajectory(
+  const TrajectoryPoints & traj_points, const FilterContext & context, double max_time,
+  VehicleInfo & vehicle_info)
+{
+  if (traj_points.empty()) {
+    throw std::invalid_argument("traj_points must not be empty");
+  }
+
+  const double start_time =
+    detail::project_current_pose_on_trajectory(traj_points, context.odometry->pose.pose);
+  const double end_time =
+    std::min(detail::to_seconds(traj_points.back().time_from_start), start_time + max_time);
+
+  TimeTrajectory relative_times{};
+  TimeTrajectory absolute_times{};
+  for (double sample_time = 0.0; start_time + sample_time < end_time;
+       sample_time =
+         std::floor((sample_time + TIME_RESOLUTION + 1e-6) / TIME_RESOLUTION) * TIME_RESOLUTION) {
+    relative_times.push_back(sample_time);
+    absolute_times.push_back(start_time + sample_time);
+  }
+
+  auto poses = pose::compute_pose_trajectory_from_time(traj_points, absolute_times);
+  auto distances = detail::compute_cumulative_distances(poses);
+  auto footprints = footprint::compute_footprint_trajectory(poses, vehicle_info);
+
+  return TrajectoryData(
+    ObjectIdentification{"EGO", ""}, std::move(relative_times), std::move(distances),
+    std::move(poses), std::move(footprints));
 }
 
 TrajectoryData generate_predicted_path_trajectory(
@@ -467,7 +629,7 @@ TrajectoryData generate_rss_ego_trajectory(
     rclcpp::Duration(traj_points.back().time_from_start).seconds();
 
   return trajectory::generate_ego_trajectory(
-    context.odometry->twist.twist, 0.0, 0.0, ego_time_horizon_for_rss, traj_points, vehicle_info);
+    traj_points, context, ego_time_horizon_for_rss, vehicle_info);
 }
 
 Assessment assess_required_deceleration(
@@ -565,7 +727,6 @@ std::vector<TrajectoryData> generate_object_trajectories(
   const rclcpp::Duration objects_reference_time =
     rclcpp::Time(context.predicted_objects->header.stamp) -
     rclcpp::Time(context.odometry->header.stamp);
-
   std::vector<TrajectoryData> object_trajectories{};
   object_trajectories.reserve(context.predicted_objects->objects.size() * 2);
   for (const auto & object : context.predicted_objects->objects) {

--- a/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter.cpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter.cpp
@@ -260,7 +260,7 @@ PoseTrajectory compute_pose_trajectory_from_time(
   const TrajectoryPoints & traj_points, const TimeTrajectory & time_trajectory)
 {
   if (traj_points.empty()) {
-    throw std::invalid_argument("traj_points must not be empty");
+    throw std::invalid_argument("points must not be empty");
   }
 
   std::vector<double> point_times;
@@ -347,7 +347,7 @@ double project_current_pose_on_trajectory(
   const TrajectoryPoints & traj_points, const geometry_msgs::msg::Pose & current_pose)
 {
   if (traj_points.empty()) {
-    throw std::invalid_argument("traj_points must not be empty");
+    throw std::invalid_argument("points must not be empty");
   }
 
   if (traj_points.size() == 1) {
@@ -427,7 +427,7 @@ TrajectoryData generate_ego_trajectory(
   VehicleInfo & vehicle_info)
 {
   if (traj_points.empty()) {
-    throw std::invalid_argument("traj_points must not be empty");
+    throw std::invalid_argument("points must not be empty");
   }
 
   const double start_time =
@@ -435,9 +435,9 @@ TrajectoryData generate_ego_trajectory(
   const double end_time =
     std::min(detail::to_seconds(traj_points.back().time_from_start), start_time + max_time);
 
-  TimeTrajectory relative_times{};
-  TimeTrajectory absolute_times{};
-  for (double sample_time = 0.0; start_time + sample_time < end_time;
+  TimeTrajectory relative_times{0.0};
+  TimeTrajectory absolute_times{start_time};
+  for (double sample_time = TIME_RESOLUTION; start_time + sample_time < end_time;
        sample_time =
          std::floor((sample_time + TIME_RESOLUTION + 1e-6) / TIME_RESOLUTION) * TIME_RESOLUTION) {
     relative_times.push_back(sample_time);

--- a/planning/autoware_trajectory_validator/test/collision_check_filter/test_trajectory_utilities.cpp
+++ b/planning/autoware_trajectory_validator/test/collision_check_filter/test_trajectory_utilities.cpp
@@ -313,12 +313,12 @@ TEST(TrajectoryUtilitiesTest, GenerateTimedEgoTrajectoryAllowsExtrapolationBefor
   const auto odometry = create_odometry(create_pose(-5.0, 0.0, 0.0));
   const auto context = create_filter_context(odometry);
 
-  const auto projected =
+  const double projected_time =
     trajectory::detail::project_current_pose_on_trajectory(traj_points, odometry->pose.pose);
   const auto trajectory_data =
     trajectory::generate_ego_trajectory(traj_points, context, 0.25, vehicle_info);
 
-  EXPECT_NEAR(projected.time, -0.5, 1e-6);
+  EXPECT_NEAR(projected_time, -0.5, 1e-6);
   ASSERT_EQ(trajectory_data.size(), 3u);
   EXPECT_DOUBLE_EQ(trajectory_data.getTimes().front(), 0.0);
   EXPECT_NEAR(trajectory_data.getPoses().front().position.x, -5.0, 1e-6);
@@ -335,14 +335,12 @@ TEST(TrajectoryUtilitiesTest, GenerateTimedEgoTrajectoryWithSinglePointReturnsSi
   const auto odometry = create_odometry(create_pose(8.0, 1.0, 0.0));
   const auto context = create_filter_context(odometry);
 
-  const auto projected =
+  const double projected_time =
     trajectory::detail::project_current_pose_on_trajectory(traj_points, odometry->pose.pose);
   const auto trajectory_data =
     trajectory::generate_ego_trajectory(traj_points, context, 1.0, vehicle_info);
 
-  EXPECT_NEAR(projected.time, 1.0, 1e-6);
-  EXPECT_DOUBLE_EQ(projected.pose.position.x, 3.0);
-  EXPECT_DOUBLE_EQ(projected.pose.position.y, 0.0);
+  EXPECT_NEAR(projected_time, 1.0, 1e-6);
   ASSERT_EQ(trajectory_data.size(), 1u);
   EXPECT_DOUBLE_EQ(trajectory_data.getTimes().front(), 0.0);
   EXPECT_DOUBLE_EQ(trajectory_data.getDistances().front(), 0.0);
@@ -358,14 +356,12 @@ TEST(TrajectoryUtilitiesTest, GenerateTimedEgoTrajectoryHandlesNonUniformTimeAnd
   const auto odometry = create_odometry(create_pose(6.0, 0.5, 0.0));
   const auto context = create_filter_context(odometry);
 
-  const auto projected =
+  const double projected_time =
     trajectory::detail::project_current_pose_on_trajectory(traj_points, odometry->pose.pose);
   const auto trajectory_data =
     trajectory::generate_ego_trajectory(traj_points, context, 0.25, vehicle_info);
 
-  EXPECT_NEAR(projected.time, 0.9, 1e-6);
-  EXPECT_NEAR(projected.pose.position.x, 6.0, 1e-6);
-  EXPECT_NEAR(projected.pose.position.y, 0.0, 1e-6);
+  EXPECT_NEAR(projected_time, 0.9, 1e-6);
 
   ASSERT_EQ(trajectory_data.size(), 3u);
   EXPECT_DOUBLE_EQ(trajectory_data.getTimes().front(), 0.0);

--- a/planning/autoware_trajectory_validator/test/collision_check_filter/test_trajectory_utilities.cpp
+++ b/planning/autoware_trajectory_validator/test/collision_check_filter/test_trajectory_utilities.cpp
@@ -19,6 +19,7 @@
 
 #include <cmath>
 #include <iterator>
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -57,6 +58,42 @@ TrajectoryPoints create_straight_trajectory_points(const std::vector<double> & x
     traj_points.push_back(point);
   }
   return traj_points;
+}
+
+TrajectoryPoints create_straight_timed_trajectory_points(
+  const std::vector<double> & xs, const std::vector<double> & times)
+{
+  if (xs.size() != times.size()) {
+    throw std::invalid_argument("xs and times must have the same size");
+  }
+
+  TrajectoryPoints traj_points;
+  traj_points.reserve(xs.size());
+  for (size_t i = 0; i < xs.size(); ++i) {
+    TrajectoryPoint point;
+    point.pose = create_pose(xs.at(i), 0.0, 0.0);
+    point.time_from_start = rclcpp::Duration::from_seconds(times.at(i));
+    traj_points.push_back(point);
+  }
+  return traj_points;
+}
+
+nav_msgs::msg::Odometry::ConstSharedPtr create_odometry(
+  const geometry_msgs::msg::Pose & pose,
+  const geometry_msgs::msg::Twist & twist = create_twist(0.0))
+{
+  auto odometry = std::make_shared<nav_msgs::msg::Odometry>();
+  odometry->pose.pose = pose;
+  odometry->twist.twist = twist;
+  odometry->header.stamp = rclcpp::Time(0, 0, RCL_ROS_TIME);
+  return odometry;
+}
+
+FilterContext create_filter_context(const nav_msgs::msg::Odometry::ConstSharedPtr & odometry)
+{
+  FilterContext context;
+  context.odometry = odometry;
+  return context;
 }
 
 autoware_perception_msgs::msg::Shape create_bounding_box_shape(
@@ -151,6 +188,36 @@ TEST(TrajectoryUtilitiesTest, ComputePoseTrajectoryInterpolatesOrientationSpheri
   EXPECT_NEAR(tf2::getYaw(poses.at(0).orientation), M_PI / 6.0, 1e-6);
 }
 
+TEST(TrajectoryUtilitiesTest, ComputePoseTrajectoryFromTimeInterpolatesAndExtrapolates)
+{
+  const auto traj_points =
+    create_straight_timed_trajectory_points({0.0, 10.0, 20.0}, {0.0, 1.0, 2.0});
+  const TimeTrajectory times = {-0.5, 0.5, 1.5, 3.0};
+
+  const auto poses = trajectory::pose::compute_pose_trajectory_from_time(traj_points, times);
+
+  ASSERT_EQ(poses.size(), times.size());
+  EXPECT_DOUBLE_EQ(poses.at(0).position.x, -5.0);
+  EXPECT_DOUBLE_EQ(poses.at(1).position.x, 5.0);
+  EXPECT_DOUBLE_EQ(poses.at(2).position.x, 15.0);
+  EXPECT_DOUBLE_EQ(poses.at(3).position.x, 30.0);
+}
+
+TEST(TrajectoryUtilitiesTest, ComputePoseTrajectoryFromTimeWithSinglePointReturnsSamePose)
+{
+  const auto traj_points = create_straight_timed_trajectory_points({3.0}, {1.0});
+  const TimeTrajectory times = {-1.0, 0.0, 1.0, 2.0};
+
+  const auto poses = trajectory::pose::compute_pose_trajectory_from_time(traj_points, times);
+
+  ASSERT_EQ(poses.size(), times.size());
+  for (const auto & pose : poses) {
+    EXPECT_DOUBLE_EQ(pose.position.x, 3.0);
+    EXPECT_DOUBLE_EQ(pose.position.y, 0.0);
+    EXPECT_DOUBLE_EQ(tf2::getYaw(pose.orientation), 0.0);
+  }
+}
+
 TEST(TrajectoryUtilitiesTest, ComputeFootprintTrajectoryForObjectShapeMatchesUtility)
 {
   const PoseTrajectory poses = {create_pose(1.0, 2.0, 0.0)};
@@ -197,6 +264,76 @@ TEST(TrajectoryUtilitiesTest, GenerateEgoTrajectoryBuildsConsistentTrajectoryDat
     autoware_utils_geometry::to_footprint(
       trajectory_data.getPoses().front(), vehicle_info.max_longitudinal_offset_m,
       -vehicle_info.min_longitudinal_offset_m, vehicle_info.vehicle_width_m));
+}
+
+TEST(TrajectoryUtilitiesTest, GenerateTimedEgoTrajectoryProjectsCurrentPoseOntoTrajectory)
+{
+  auto vehicle_info = create_vehicle_info();
+  const auto traj_points =
+    create_straight_timed_trajectory_points({0.0, 10.0, 20.0}, {0.0, 1.0, 2.0});
+  const auto odometry = create_odometry(create_pose(5.0, 1.0, 0.0));
+  const auto context = create_filter_context(odometry);
+
+  const auto trajectory_data =
+    trajectory::generate_ego_trajectory(traj_points, context, 0.25, vehicle_info);
+
+  ASSERT_EQ(trajectory_data.getObjectIdentification().classification, "EGO");
+  ASSERT_EQ(trajectory_data.size(), 3u);
+  EXPECT_DOUBLE_EQ(trajectory_data.getTimes().front(), 0.0);
+  EXPECT_NEAR(trajectory_data.getTimes().at(1), 0.1, 1e-6);
+  EXPECT_NEAR(trajectory_data.getTimes().at(2), 0.2, 1e-6);
+  EXPECT_NEAR(trajectory_data.getPoses().front().position.x, 5.0, 1e-6);
+  EXPECT_NEAR(trajectory_data.getPoses().front().position.y, 0.0, 1e-6);
+  EXPECT_NEAR(trajectory_data.getPoses().at(1).position.x, 6.0, 1e-6);
+  EXPECT_NEAR(trajectory_data.getPoses().at(2).position.x, 7.0, 1e-6);
+  EXPECT_NEAR(trajectory_data.getDistances().front(), 0.0, 1e-6);
+  EXPECT_NEAR(trajectory_data.getDistances().at(1), 1.0, 1e-6);
+  EXPECT_NEAR(trajectory_data.getDistances().at(2), 2.0, 1e-6);
+}
+
+TEST(TrajectoryUtilitiesTest, GenerateTimedEgoTrajectoryAllowsExtrapolationBeforeTrajectoryStart)
+{
+  auto vehicle_info = create_vehicle_info();
+  const auto traj_points =
+    create_straight_timed_trajectory_points({0.0, 10.0, 20.0}, {0.0, 1.0, 2.0});
+  const auto odometry = create_odometry(create_pose(-5.0, 0.0, 0.0));
+  const auto context = create_filter_context(odometry);
+
+  const auto projected =
+    trajectory::detail::project_current_pose_on_trajectory(traj_points, odometry->pose.pose);
+  const auto trajectory_data =
+    trajectory::generate_ego_trajectory(traj_points, context, 0.25, vehicle_info);
+
+  EXPECT_NEAR(projected.time, -0.5, 1e-6);
+  ASSERT_EQ(trajectory_data.size(), 3u);
+  EXPECT_DOUBLE_EQ(trajectory_data.getTimes().front(), 0.0);
+  EXPECT_NEAR(trajectory_data.getPoses().front().position.x, -5.0, 1e-6);
+  EXPECT_NEAR(trajectory_data.getPoses().at(1).position.x, -4.0, 1e-6);
+  EXPECT_NEAR(trajectory_data.getPoses().at(2).position.x, -3.0, 1e-6);
+  EXPECT_NEAR(trajectory_data.getDistances().at(1), 1.0, 1e-6);
+  EXPECT_NEAR(trajectory_data.getDistances().at(2), 2.0, 1e-6);
+}
+
+TEST(TrajectoryUtilitiesTest, GenerateTimedEgoTrajectoryWithSinglePointReturnsSingleSample)
+{
+  auto vehicle_info = create_vehicle_info();
+  const auto traj_points = create_straight_timed_trajectory_points({3.0}, {1.0});
+  const auto odometry = create_odometry(create_pose(8.0, 1.0, 0.0));
+  const auto context = create_filter_context(odometry);
+
+  const auto projected =
+    trajectory::detail::project_current_pose_on_trajectory(traj_points, odometry->pose.pose);
+  const auto trajectory_data =
+    trajectory::generate_ego_trajectory(traj_points, context, 1.0, vehicle_info);
+
+  EXPECT_NEAR(projected.time, 1.0, 1e-6);
+  EXPECT_DOUBLE_EQ(projected.pose.position.x, 3.0);
+  EXPECT_DOUBLE_EQ(projected.pose.position.y, 0.0);
+  ASSERT_EQ(trajectory_data.size(), 1u);
+  EXPECT_DOUBLE_EQ(trajectory_data.getTimes().front(), 0.0);
+  EXPECT_DOUBLE_EQ(trajectory_data.getDistances().front(), 0.0);
+  EXPECT_DOUBLE_EQ(trajectory_data.getPoses().front().position.x, 3.0);
+  EXPECT_DOUBLE_EQ(trajectory_data.getPoses().front().position.y, 0.0);
 }
 
 TEST(TrajectoryUtilitiesTest, GeneratePredictedPathTrajectoryUsesHighestConfidencePath)

--- a/planning/autoware_trajectory_validator/test/collision_check_filter/test_trajectory_utilities.cpp
+++ b/planning/autoware_trajectory_validator/test/collision_check_filter/test_trajectory_utilities.cpp
@@ -218,6 +218,20 @@ TEST(TrajectoryUtilitiesTest, ComputePoseTrajectoryFromTimeWithSinglePointReturn
   }
 }
 
+TEST(TrajectoryUtilitiesTest, ComputePoseTrajectoryFromTimeHandlesNonUniformTimeAndPositionSpacing)
+{
+  const auto traj_points =
+    create_straight_timed_trajectory_points({0.0, 3.0, 9.0}, {0.0, 0.3, 1.5});
+  const TimeTrajectory times = {0.15, 0.9, 1.8};
+
+  const auto poses = trajectory::pose::compute_pose_trajectory_from_time(traj_points, times);
+
+  ASSERT_EQ(poses.size(), times.size());
+  EXPECT_NEAR(poses.at(0).position.x, 1.5, 1e-6);
+  EXPECT_NEAR(poses.at(1).position.x, 6.0, 1e-6);
+  EXPECT_NEAR(poses.at(2).position.x, 10.5, 1e-6);
+}
+
 TEST(TrajectoryUtilitiesTest, ComputeFootprintTrajectoryForObjectShapeMatchesUtility)
 {
   const PoseTrajectory poses = {create_pose(1.0, 2.0, 0.0)};
@@ -334,6 +348,35 @@ TEST(TrajectoryUtilitiesTest, GenerateTimedEgoTrajectoryWithSinglePointReturnsSi
   EXPECT_DOUBLE_EQ(trajectory_data.getDistances().front(), 0.0);
   EXPECT_DOUBLE_EQ(trajectory_data.getPoses().front().position.x, 3.0);
   EXPECT_DOUBLE_EQ(trajectory_data.getPoses().front().position.y, 0.0);
+}
+
+TEST(TrajectoryUtilitiesTest, GenerateTimedEgoTrajectoryHandlesNonUniformTimeAndPositionSpacing)
+{
+  auto vehicle_info = create_vehicle_info();
+  const auto traj_points =
+    create_straight_timed_trajectory_points({0.0, 3.0, 9.0}, {0.0, 0.3, 1.5});
+  const auto odometry = create_odometry(create_pose(6.0, 0.5, 0.0));
+  const auto context = create_filter_context(odometry);
+
+  const auto projected =
+    trajectory::detail::project_current_pose_on_trajectory(traj_points, odometry->pose.pose);
+  const auto trajectory_data =
+    trajectory::generate_ego_trajectory(traj_points, context, 0.25, vehicle_info);
+
+  EXPECT_NEAR(projected.time, 0.9, 1e-6);
+  EXPECT_NEAR(projected.pose.position.x, 6.0, 1e-6);
+  EXPECT_NEAR(projected.pose.position.y, 0.0, 1e-6);
+
+  ASSERT_EQ(trajectory_data.size(), 3u);
+  EXPECT_DOUBLE_EQ(trajectory_data.getTimes().front(), 0.0);
+  EXPECT_NEAR(trajectory_data.getTimes().at(1), 0.1, 1e-6);
+  EXPECT_NEAR(trajectory_data.getTimes().at(2), 0.2, 1e-6);
+  EXPECT_NEAR(trajectory_data.getPoses().front().position.x, 6.0, 1e-6);
+  EXPECT_NEAR(trajectory_data.getPoses().at(1).position.x, 6.5, 1e-6);
+  EXPECT_NEAR(trajectory_data.getPoses().at(2).position.x, 7.0, 1e-6);
+  EXPECT_NEAR(trajectory_data.getDistances().front(), 0.0, 1e-6);
+  EXPECT_NEAR(trajectory_data.getDistances().at(1), 0.5, 1e-6);
+  EXPECT_NEAR(trajectory_data.getDistances().at(2), 1.0, 1e-6);
 }
 
 TEST(TrajectoryUtilitiesTest, GeneratePredictedPathTrajectoryUsesHighestConfidencePath)


### PR DESCRIPTION
  - Added timed ego trajectory generation to `collision_check_filter` in autoware_trajectory_validator, using TrajectoryPoint.time_from_start as the primary timeline.
  - The new logic projects the current ego pose onto the nearest trajectory segment, compensates for the time offset between odometry and the planned trajectory, and generates ego poses at a fixed 0.1 s
    interval.
  - It also supports extrapolation when the current ego pose lies before the start or beyond the end of the trajectory, so the projected ego time can fall outside the original trajectory range.
  - The timed ego trajectory is now used in both PET-based collision assessment and RSS-based collision assessment, so collision evaluation follows the planned trajectory’s time axis more closely.
  - Expanded unit tests to cover interpolation, extrapolation, single-point trajectories, and non-uniform time_from_start / position spacing for the new behavior.