### PR TITLE
fix(roi_cluster_fusion): separate agnocast subscription callback group

### DIFF
--- a/perception/autoware_image_projection_based_fusion/include/autoware/image_projection_based_fusion/fusion_collector.hpp
+++ b/perception/autoware_image_projection_based_fusion/include/autoware/image_projection_based_fusion/fusion_collector.hpp
@@ -107,7 +107,7 @@ private:
   std::unordered_map<std::size_t, typename Msg2D::ConstSharedPtr> id_to_rois_map_;
   bool is_first_msg3d_{false};
   bool debug_mode_;
-  std::mutex fusion_mutex_;
+  mutable std::mutex fusion_mutex_;
   std::shared_ptr<FusionCollectorInfoBase> fusion_collector_info_;
   CollectorStatus status_;
 };

--- a/perception/autoware_image_projection_based_fusion/src/fusion_collector.cpp
+++ b/perception/autoware_image_projection_based_fusion/src/fusion_collector.cpp
@@ -55,12 +55,14 @@ template <class Msg3D, class Msg2D, class ExportObj>
 void FusionCollector<Msg3D, Msg2D, ExportObj>::set_info(
   std::shared_ptr<FusionCollectorInfoBase> fusion_collector_info)
 {
+  std::lock_guard<std::mutex> lock(fusion_mutex_);
   fusion_collector_info_ = std::move(fusion_collector_info);
 }
 
 template <class Msg3D, class Msg2D, class ExportObj>
 std::shared_ptr<FusionCollectorInfoBase> FusionCollector<Msg3D, Msg2D, ExportObj>::get_info() const
 {
+  std::lock_guard<std::mutex> lock(fusion_mutex_);
   return fusion_collector_info_;
 }
 

--- a/perception/autoware_image_projection_based_fusion/src/roi_cluster_fusion/node.cpp
+++ b/perception/autoware_image_projection_based_fusion/src/roi_cluster_fusion/node.cpp
@@ -68,7 +68,15 @@ RoiClusterFusionNode::RoiClusterFusionNode(const rclcpp::NodeOptions & options)
       auto ros2_msg = std::make_shared<const ClusterMsgType>(*msg);
       this->sub_callback(ros2_msg);
     },
-    AUTOWARE_SUBSCRIPTION_OPTIONS{});
+    [this]() {
+      AUTOWARE_SUBSCRIPTION_OPTIONS opts;
+      // Use a dedicated callback group because this subscription may run as an agnocast
+      // subscription, which should be separated from other callbacks. This would not cause
+      // any issue after migrating to agnocast::Node, but is planned to be removed then.
+      opts.callback_group =
+        this->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive);
+      return opts;
+    }());
 
   // publisher
   // TODO(Koichi98): replace pub_ptr_ in FusionNode with agnocast_wrapper


### PR DESCRIPTION
Cherry-pick
https://github.com/autowarefoundation/autoware_universe/pull/12439.


Perception pipelineでtotal latencyが閾値を超えてしまう問題に対処するため。
https://star4.slack.com/archives/CRUE57C30/p1775641547228509