### PR TITLE
fix(trajecotry_validator): fix buid and test error

### DIFF
--- a/planning/autoware_trajectory_validator/include/autoware/trajectory_validator/filters/safety/collision_check_filter.hpp
+++ b/planning/autoware_trajectory_validator/include/autoware/trajectory_validator/filters/safety/collision_check_filter.hpp
@@ -212,9 +212,8 @@ private:
   ContinuousDetectionTimes drac_continuous_times_;
 
   void add_debug_markers(
-    const rclcpp::Time & stamp, const std::string & ns,
-    const Polygon2d & ego_hull, const Polygon2d & object_hull, const std::string & trajectory_id
-    );
+    const rclcpp::Time & stamp, const std::string & ns, const Polygon2d & ego_hull,
+    const Polygon2d & object_hull);
 };
 
 }  // namespace autoware::trajectory_validator::plugin::safety

--- a/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter.cpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter.cpp
@@ -753,7 +753,7 @@ void CollisionCheckFilter::update_parameters(const validator::Params & params)
 
 void CollisionCheckFilter::add_debug_markers(
   const rclcpp::Time & stamp, const std::string & ns, const Polygon2d & ego_hull,
-  const Polygon2d & object_hull, const std::string & trajectory_id)
+  const Polygon2d & object_hull)
 {
   int id = debug_markers_.markers.empty() ? 0 : debug_markers_.markers.back().id + 1;
 
@@ -833,7 +833,7 @@ tl::expected<void, std::string> CollisionCheckFilter::is_feasible(
       context.predicted_objects->header.stamp.nanosec);
     add_debug_markers(
       context.odometry->header.stamp, "planned_speed_collision", finding.ego_hull,
-      finding.object_hull, finding.trajectory_id);
+      finding.object_hull);
   }
 
   drac_continuous_times_.update(
@@ -852,8 +852,7 @@ tl::expected<void, std::string> CollisionCheckFilter::is_feasible(
         context.predicted_objects->header.stamp.sec,
         context.predicted_objects->header.stamp.nanosec);
       add_debug_markers(
-        context.odometry->header.stamp, "drac_collision", finding.ego_hull, finding.object_hull,
-        finding.trajectory_id);
+        context.odometry->header.stamp, "drac_collision", finding.ego_hull, finding.object_hull);
     }
   }
 

--- a/planning/autoware_trajectory_validator/test/collision_check_filter/test_trajectory_utilities.cpp
+++ b/planning/autoware_trajectory_validator/test/collision_check_filter/test_trajectory_utilities.cpp
@@ -188,11 +188,10 @@ TEST(TrajectoryUtilitiesTest, GenerateEgoTrajectoryBuildsConsistentTrajectoryDat
 
   ASSERT_EQ(trajectory_data.getObjectIdentification().classification, "EGO");
   ASSERT_TRUE(trajectory_data.getObjectIdentification().id.empty());
-  ASSERT_EQ(trajectory_data.size(), 11u);
   EXPECT_DOUBLE_EQ(trajectory_data.getTimes().front(), 0.0);
-  EXPECT_NEAR(trajectory_data.getTimes().back(), 1.0, 1e-6);
-  EXPECT_NEAR(trajectory_data.getDistances().back(), 2.0, 1e-6);
-  EXPECT_NEAR(trajectory_data.getPoses().back().position.x, 2.0, 1e-6);
+  EXPECT_NEAR(trajectory_data.getTimes().back(), 1.05, 1e-6);
+  EXPECT_NEAR(trajectory_data.getDistances().back(), 2.1, 1e-6);
+  EXPECT_NEAR(trajectory_data.getPoses().back().position.x, 2.1, 1e-6);
   expect_same_polygon(
     trajectory_data.getFootprints().front(),
     autoware_utils_geometry::to_footprint(
@@ -213,12 +212,11 @@ TEST(TrajectoryUtilitiesTest, GeneratePredictedPathTrajectoryUsesHighestConfiden
   const auto trajectory_data = trajectory::generate_predicted_path_trajectory(
     object, 0.0, 0.0, rclcpp::Duration::from_seconds(0.1), 0.35);
 
-  ASSERT_EQ(trajectory_data.size(), 3u);
   EXPECT_EQ(
     trajectory_data.getObjectIdentification().id.find("_predicted_path"),
     trajectory_data.getObjectIdentification().id.size() - 15);
   EXPECT_NEAR(trajectory_data.getTimes().front(), 0.1, 1e-6);
-  EXPECT_NEAR(trajectory_data.getTimes().back(), 0.3, 1e-6);
+  EXPECT_NEAR(trajectory_data.getTimes().back(), 0.35, 1e-6);
   EXPECT_NEAR(trajectory_data.getPoses().at(0).position.x, 0.1, 1e-6);
   EXPECT_NEAR(trajectory_data.getPoses().at(1).position.x, 0.2, 1e-6);
   EXPECT_NEAR(trajectory_data.getPoses().at(2).position.x, 0.3, 1e-6);


### PR DESCRIPTION
https://github.com/tier4/autoware_universe/pull/2856 のミスにより、
unused errorとunit testのfailが発生していたので、修正しました。


unit test実行結果
```
92% tests passed, 1 tests failed out of 12

Label Time Summary:
copyright     =   0.73 sec*proc (1 test)
cppcheck      =   0.17 sec*proc (1 test)
gtest         =   1.47 sec*proc (8 tests)
lint_cmake    =   0.16 sec*proc (1 test)
linter        =   1.90 sec*proc (4 tests)
xmllint       =   0.84 sec*proc (1 test)

Total Test time (real) =   3.37 sec

The following tests FAILED:
	  8 - test_trajectory_validator_node (Failed)
Errors while running CTest
Output from these tests are in: /home/yukitakagi/pilot-auto.x2.43.e2e.dev/build/autoware_trajectory_validator/Testing/Temporary/LastTest.log
Use "--rerun-failed --output-on-failure" to re-run the failed cases verbosely.
---

```

unusedのerrorを有効にした状態でのビルド結果
```
/home/yukitakagi/pilot-auto.x2.43.e2e.dev/install/parameter_traits/include/parameter_traits/parameter_traits/parameter_traits.hpp:51:13: note: declared here
In file included from /home/yukitakagi/pilot-auto.x2.43.e2e.dev/build/autoware_trajectory_validator/include/autoware_trajectory_validator/autoware_trajectory_validator_param.hpp:24,
                 from /home/yukitakagi/pilot-auto.x2.43.e2e.dev/src/autoware/universe/planning/autoware_trajectory_validator/include/autoware/trajectory_validator/validator_interface.hpp:20,
                 from /home/yukitakagi/pilot-auto.x2.43.e2e.dev/src/autoware/universe/planning/autoware_trajectory_validator/include/autoware/trajectory_validator/filters/safety/vehicle_constraint_filter.hpp:18,
                 from /home/yukitakagi/pilot-auto.x2.43.e2e.dev/src/autoware/universe/planning/autoware_trajectory_validator/test/plugins/test_vehicle_constraint_filter.cpp:15:
/home/yukitakagi/pilot-auto.x2.43.e2e.dev/install/parameter_traits/include/parameter_traits/parameter_traits/parameter_traits.hpp: In function ‘void __static_initialization_and_destruction_0(int, int)’:
/home/yukitakagi/pilot-auto.x2.43.e2e.dev/install/parameter_traits/include/parameter_traits/parameter_traits/parameter_traits.hpp:51:13: warning: ‘parameter_traits::OK’ is deprecated: When returning tl::expected<void, std::string> default construct for OK with `{}`. [-Wdeprecated-declarations]
   51 | auto static OK
      |             ^~
/home/yukitakagi/pilot-auto.x2.43.e2e.dev/install/parameter_traits/include/parameter_traits/parameter_traits/parameter_traits.hpp:51:13: note: declared here
In file included from /home/yukitakagi/pilot-auto.x2.43.e2e.dev/build/autoware_trajectory_validator/include/autoware_trajectory_validator/autoware_trajectory_validator_param.hpp:24,
                 from /home/yukitakagi/pilot-auto.x2.43.e2e.dev/src/autoware/universe/planning/autoware_trajectory_validator/include/autoware/trajectory_validator/validator_interface.hpp:20,
                 from /home/yukitakagi/pilot-auto.x2.43.e2e.dev/src/autoware/universe/planning/autoware_trajectory_validator/include/autoware/trajectory_validator/filters/traffic_rule/traffic_light_filter.hpp:18,
                 from /home/yukitakagi/pilot-auto.x2.43.e2e.dev/src/autoware/universe/planning/autoware_trajectory_validator/test/plugins/test_traffic_light_filter.cpp:15:
/home/yukitakagi/pilot-auto.x2.43.e2e.dev/install/parameter_traits/include/parameter_traits/parameter_traits/parameter_traits.hpp: In function ‘void __static_initialization_and_destruction_0(int, int)’:
/home/yukitakagi/pilot-auto.x2.43.e2e.dev/install/parameter_traits/include/parameter_traits/parameter_traits/parameter_traits.hpp:51:13: warning: ‘parameter_traits::OK’ is deprecated: When returning tl::expected<void, std::string> default construct for OK with `{}`. [-Wdeprecated-declarations]
   51 | auto static OK
      |             ^~
/home/yukitakagi/pilot-auto.x2.43.e2e.dev/install/parameter_traits/include/parameter_traits/parameter_traits/parameter_traits.hpp:51:13: note: declared here
In file included from /home/yukitakagi/pilot-auto.x2.43.e2e.dev/build/autoware_trajectory_validator/include/autoware_trajectory_validator/autoware_trajectory_validator_param.hpp:24,
                 from /home/yukitakagi/pilot-auto.x2.43.e2e.dev/src/autoware/universe/planning/autoware_trajectory_validator/include/autoware/trajectory_validator/validator_interface.hpp:20,
                 from /home/yukitakagi/pilot-auto.x2.43.e2e.dev/src/autoware/universe/planning/autoware_trajectory_validator/include/autoware/trajectory_validator/trajectory_validator_node.hpp:18,
                 from /home/yukitakagi/pilot-auto.x2.43.e2e.dev/src/autoware/universe/planning/autoware_trajectory_validator/test/node/test_trajectory_validator_node.cpp:15:
/home/yukitakagi/pilot-auto.x2.43.e2e.dev/install/parameter_traits/include/parameter_traits/parameter_traits/parameter_traits.hpp: In function ‘void __static_initialization_and_destruction_0(int, int)’:
/home/yukitakagi/pilot-auto.x2.43.e2e.dev/install/parameter_traits/include/parameter_traits/parameter_traits/parameter_traits.hpp:51:13: warning: ‘parameter_traits::OK’ is deprecated: When returning tl::expected<void, std::string> default construct for OK with `{}`. [-Wdeprecated-declarations]
   51 | auto static OK
      |             ^~
/home/yukitakagi/pilot-auto.x2.43.e2e.dev/install/parameter_traits/include/parameter_traits/parameter_traits/parameter_traits.hpp:51:13: note: declared here
---
Finished <<< autoware_trajectory_validator [1min 36s]

Summary: 1 package finished [1min 37s]
  1 package had stderr output: autoware_trajectory_validator

```

