### PR TITLE
feat(trajectory_validator): check diffusion trajectories for collisions

### DIFF
--- a/planning/autoware_trajectory_validator/include/autoware/trajectory_validator/filter_context.hpp
+++ b/planning/autoware_trajectory_validator/include/autoware/trajectory_validator/filter_context.hpp
@@ -36,6 +36,7 @@ struct FilterContext
   geometry_msgs::msg::AccelWithCovarianceStamped::ConstSharedPtr acceleration;
   std::shared_ptr<lanelet::LaneletMap> lanelet_map;
   autoware_perception_msgs::msg::PredictedObjects::ConstSharedPtr predicted_objects;
+  autoware_perception_msgs::msg::PredictedObjects::ConstSharedPtr neural_network_predicted_objects;
   autoware_perception_msgs::msg::TrafficLightGroupArray::ConstSharedPtr traffic_light_signals;
 };
 }  // namespace autoware::trajectory_validator

--- a/planning/autoware_trajectory_validator/include/autoware/trajectory_validator/filters/safety/collision_check_filter.hpp
+++ b/planning/autoware_trajectory_validator/include/autoware/trajectory_validator/filters/safety/collision_check_filter.hpp
@@ -21,6 +21,7 @@
 #include <autoware/motion_utils/trajectory/trajectory.hpp>
 #include <autoware/universe_utils/geometry/geometry.hpp>
 #include <autoware_utils_geometry/geometry.hpp>
+#include <builtin_interfaces/msg/time.hpp>
 #include <rclcpp/duration.hpp>
 #include <rclcpp/time.hpp>
 
@@ -58,6 +59,7 @@ struct ObjectIdentification
 {
   std::string classification;
   std::string id;
+  builtin_interfaces::msg::Time stamp{};
 };
 
 class TrajectoryData

--- a/planning/autoware_trajectory_validator/include/autoware/trajectory_validator/trajectory_validator_node.hpp
+++ b/planning/autoware_trajectory_validator/include/autoware/trajectory_validator/trajectory_validator_node.hpp
@@ -148,6 +148,8 @@ private:
     this, "~/input/odometry"};
   autoware_utils_rclcpp::InterProcessPollingSubscriber<PredictedObjects> sub_objects_{
     this, "~/input/objects"};
+  autoware_utils_rclcpp::InterProcessPollingSubscriber<PredictedObjects>
+    sub_neural_network_objects_{this, "~/input/diffusion/objects"};
   autoware_utils_rclcpp::InterProcessPollingSubscriber<AccelWithCovarianceStamped>
     sub_acceleration_{this, "~/input/acceleration"};
   autoware_utils_rclcpp::InterProcessPollingSubscriber<

--- a/planning/autoware_trajectory_validator/launch/trajectory_validator.launch.xml
+++ b/planning/autoware_trajectory_validator/launch/trajectory_validator.launch.xml
@@ -6,6 +6,7 @@
   <arg name="input_vector_map" default="~/input/lanelet2_map"/>
   <arg name="input_odometry" default="~/input/odometry"/>
   <arg name="input_objects" default="~/input/objects"/>
+  <arg name="input_diffusion_objects" default="/planning/trajectory_generator/neural_network_based_planner/diffusion_planner_node/output/predicted_objects"/>
   <arg name="input_acceleration" default="~/input/acceleration"/>
   <arg name="input_traffic_signals" default="~/input/traffic_signals"/>
 
@@ -19,6 +20,7 @@
     <remap from="~/input/lanelet2_map" to="$(var input_vector_map)"/>
     <remap from="~/input/odometry" to="$(var input_odometry)"/>
     <remap from="~/input/objects" to="$(var input_objects)"/>
+    <remap from="~/input/diffusion/objects" to="$(var input_diffusion_objects)"/>
     <remap from="~/input/acceleration" to="$(var input_acceleration)"/>
     <remap from="~/input/traffic_signals" to="$(var input_traffic_signals)"/>
   </node>

--- a/planning/autoware_trajectory_validator/package.xml
+++ b/planning/autoware_trajectory_validator/package.xml
@@ -35,6 +35,7 @@
   <depend>autoware_utils_geometry</depend>
   <depend>autoware_utils_rclcpp</depend>
   <depend>autoware_vehicle_info_utils</depend>
+  <depend>builtin_interfaces</depend>
   <depend>generate_parameter_library</depend>
   <depend>geometry_msgs</depend>
   <depend>nav_msgs</depend>
@@ -42,7 +43,6 @@
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
   <depend>tl_expected</depend>
-  <depend>builtin_interfaces</depend>
   <depend>unique_identifier_msgs</depend>
 
   <test_depend>ament_cmake_ros</test_depend>

--- a/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter.cpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter.cpp
@@ -426,7 +426,8 @@ TimeTrajectory compute_sample_times(double start_time, double end_time)
 }
 
 geometry_msgs::msg::Pose interpolate_predicted_path_pose(
-  const autoware_perception_msgs::msg::PredictedPath & predicted_path, double query_time)
+  const autoware_perception_msgs::msg::PredictedPath & predicted_path, double query_time,
+  double path_start_time)
 {
   if (predicted_path.path.empty()) {
     throw std::invalid_argument("predicted path must not be empty");
@@ -438,24 +439,15 @@ geometry_msgs::msg::Pose interpolate_predicted_path_pose(
   }
 
   const double clamped_query_time = std::clamp(
-    query_time, 0.0, path_time_step * static_cast<double>(predicted_path.path.size() - 1));
-  const size_t index = static_cast<size_t>(std::floor(clamped_query_time / path_time_step));
+    query_time, path_start_time,
+    path_start_time + path_time_step * static_cast<double>(predicted_path.path.size() - 1));
+  const double shifted_query_time = clamped_query_time - path_start_time;
+  const size_t index = static_cast<size_t>(std::floor(shifted_query_time / path_time_step));
   const size_t next_index = std::min(index + 1, predicted_path.path.size() - 1);
   const double ratio =
-    (clamped_query_time - static_cast<double>(index) * path_time_step) / path_time_step;
+    (shifted_query_time - static_cast<double>(index) * path_time_step) / path_time_step;
   return autoware::universe_utils::calcInterpolatedPose(
     predicted_path.path.at(index), predicted_path.path.at(next_index), ratio, false);
-}
-
-PoseTrajectory compute_diffusion_based_pose_trajectory(
-  const autoware_perception_msgs::msg::PredictedPath & predicted_path, const TimeTrajectory & times)
-{
-  PoseTrajectory poses;
-  poses.reserve(times.size());
-  for (const auto & time : times) {
-    poses.push_back(interpolate_predicted_path_pose(predicted_path, time));
-  }
-  return poses;
 }
 }  // namespace detail
 
@@ -547,8 +539,17 @@ TrajectoryData generate_diffusion_based_trajectory(
     predicted_object.kinematics.predicted_paths.end(),
     [](const auto & a, const auto & b) { return a.confidence < b.confidence; });
   const auto & predicted_path = *most_confident_path_it;
-  auto times = detail::compute_sample_times(start_time.seconds(), max_time);
-  auto poses = detail::compute_diffusion_based_pose_trajectory(predicted_path, times);
+  const double prediction_horizon =
+    start_time.seconds() + static_cast<double>(predicted_path.path.size() - 1) *
+                             rclcpp::Duration(predicted_path.time_step).seconds();
+  auto times =
+    detail::compute_sample_times(start_time.seconds(), std::min(max_time, prediction_horizon));
+  PoseTrajectory poses;
+  poses.reserve(times.size());
+  for (const auto & time : times) {
+    poses.push_back(
+      detail::interpolate_predicted_path_pose(predicted_path, time, start_time.seconds()));
+  }
 
   TravelDistanceTrajectory distances;
   distances.reserve(poses.size());

--- a/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter.cpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter.cpp
@@ -454,8 +454,7 @@ PoseTrajectory compute_diffusion_based_pose_trajectory(
   PoseTrajectory poses;
   poses.reserve(times.size());
   for (const auto & time : times) {
-    poses.push_back(
-      interpolate_predicted_path_pose(predicted_path, time - objects_reference_time));
+    poses.push_back(interpolate_predicted_path_pose(predicted_path, time - objects_reference_time));
   }
   return poses;
 }
@@ -542,8 +541,7 @@ TrajectoryData generate_predicted_path_trajectory(
 
 TrajectoryData generate_diffusion_based_trajectory(
   const autoware_perception_msgs::msg::PredictedObject & predicted_object,
-  rclcpp::Duration start_time, double max_time,
-  const builtin_interfaces::msg::Time & stamp)
+  rclcpp::Duration start_time, double max_time, const builtin_interfaces::msg::Time & stamp)
 {
   const auto most_confident_path_it = std::max_element(
     predicted_object.kinematics.predicted_paths.begin(),
@@ -551,8 +549,8 @@ TrajectoryData generate_diffusion_based_trajectory(
     [](const auto & a, const auto & b) { return a.confidence < b.confidence; });
   const auto & predicted_path = *most_confident_path_it;
   auto times = detail::compute_sample_times(0.0, max_time);
-  auto poses = detail::compute_diffusion_based_pose_trajectory(
-    predicted_path, times, start_time.seconds());
+  auto poses =
+    detail::compute_diffusion_based_pose_trajectory(predicted_path, times, start_time.seconds());
 
   TravelDistanceTrajectory distances;
   distances.reserve(poses.size());
@@ -823,22 +821,24 @@ struct DracAssessment
 std::vector<TrajectoryData> generate_object_trajectories(
   const FilterContext & context, double required_time_horizon, double object_assumed_acceleration)
 {
-  const rclcpp::Duration objects_reference_time =
-    rclcpp::Time(context.predicted_objects->header.stamp) -
-    rclcpp::Time(context.odometry->header.stamp);
-
   std::vector<TrajectoryData> object_trajectories{};
-  object_trajectories.reserve(context.predicted_objects->objects.size() * 3);
-  for (const auto & object : context.predicted_objects->objects) {
-    if (!object.kinematics.predicted_paths.empty()) {
-      object_trajectories.push_back(trajectory::generate_predicted_path_trajectory(
+
+  if (context.predicted_objects) {
+    object_trajectories.reserve(context.predicted_objects->objects.size() * 3);
+    const rclcpp::Duration objects_reference_time =
+      rclcpp::Time(context.predicted_objects->header.stamp) -
+      rclcpp::Time(context.odometry->header.stamp);
+    for (const auto & object : context.predicted_objects->objects) {
+      if (!object.kinematics.predicted_paths.empty()) {
+        object_trajectories.push_back(trajectory::generate_predicted_path_trajectory(
+          object, 0.0, object_assumed_acceleration, objects_reference_time, required_time_horizon,
+          context.predicted_objects->header.stamp));
+      }
+
+      object_trajectories.push_back(trajectory::generate_constant_curvature_trajectory(
         object, 0.0, object_assumed_acceleration, objects_reference_time, required_time_horizon,
         context.predicted_objects->header.stamp));
     }
-
-    object_trajectories.push_back(trajectory::generate_constant_curvature_trajectory(
-      object, 0.0, object_assumed_acceleration, objects_reference_time, required_time_horizon,
-      context.predicted_objects->header.stamp));
   }
 
   if (context.neural_network_predicted_objects) {

--- a/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter.cpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter.cpp
@@ -448,13 +448,12 @@ geometry_msgs::msg::Pose interpolate_predicted_path_pose(
 }
 
 PoseTrajectory compute_diffusion_based_pose_trajectory(
-  const autoware_perception_msgs::msg::PredictedPath & predicted_path, const TimeTrajectory & times,
-  double objects_reference_time)
+  const autoware_perception_msgs::msg::PredictedPath & predicted_path, const TimeTrajectory & times)
 {
   PoseTrajectory poses;
   poses.reserve(times.size());
   for (const auto & time : times) {
-    poses.push_back(interpolate_predicted_path_pose(predicted_path, time - objects_reference_time));
+    poses.push_back(interpolate_predicted_path_pose(predicted_path, time));
   }
   return poses;
 }
@@ -548,9 +547,8 @@ TrajectoryData generate_diffusion_based_trajectory(
     predicted_object.kinematics.predicted_paths.end(),
     [](const auto & a, const auto & b) { return a.confidence < b.confidence; });
   const auto & predicted_path = *most_confident_path_it;
-  auto times = detail::compute_sample_times(0.0, max_time);
-  auto poses =
-    detail::compute_diffusion_based_pose_trajectory(predicted_path, times, start_time.seconds());
+  auto times = detail::compute_sample_times(start_time.seconds(), max_time);
+  auto poses = detail::compute_diffusion_based_pose_trajectory(predicted_path, times);
 
   TravelDistanceTrajectory distances;
   distances.reserve(poses.size());

--- a/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter.cpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter.cpp
@@ -47,19 +47,21 @@ using autoware::object_recognition_utils::convertLabelToString;
 using autoware::object_recognition_utils::getHighestProbLabel;
 
 ObjectIdentification make_object_identification(
-  const autoware_perception_msgs::msg::PredictedObject & object)
+  const autoware_perception_msgs::msg::PredictedObject & object,
+  const builtin_interfaces::msg::Time & stamp)
 {
   return {
     convertLabelToString(getHighestProbLabel(object.classification)),
-    autoware_utils_uuid::to_hex_string(object.object_id)};
+    autoware_utils_uuid::to_hex_string(object.object_id), stamp};
 }
 
 ObjectIdentification make_trajectory_identification(
-  const autoware_perception_msgs::msg::PredictedObject & object, const std::string & suffix)
+  const autoware_perception_msgs::msg::PredictedObject & object, const std::string & suffix,
+  const builtin_interfaces::msg::Time & stamp)
 {
   return {
     convertLabelToString(getHighestProbLabel(object.classification)),
-    autoware_utils_uuid::to_hex_string(object.object_id) + suffix};
+    autoware_utils_uuid::to_hex_string(object.object_id) + suffix, stamp};
 }
 
 // Trajectory generation helpers.
@@ -455,7 +457,8 @@ TrajectoryData generate_ego_trajectory(
 
 TrajectoryData generate_predicted_path_trajectory(
   const autoware_perception_msgs::msg::PredictedObject & predicted_object, double braking_lag,
-  double assumed_acceleration, rclcpp::Duration start_time, double max_time)
+  double assumed_acceleration, rclcpp::Duration start_time, double max_time,
+  const builtin_interfaces::msg::Time & stamp)
 {
   // todo(takagi): use all or appropriate predicted paths
   const auto most_confident_path_it = std::max_element(
@@ -473,13 +476,13 @@ TrajectoryData generate_predicted_path_trajectory(
   auto footprints = footprint::compute_footprint_trajectory(poses, predicted_object.shape);
 
   return TrajectoryData(
-    make_trajectory_identification(predicted_object, "_predicted_path"), std::move(times),
+    make_trajectory_identification(predicted_object, "_predicted_path", stamp), std::move(times),
     std::move(distances), std::move(poses), std::move(footprints));
 }
-
 TrajectoryData generate_constant_curvature_trajectory(
   const autoware_perception_msgs::msg::PredictedObject & predicted_object, double braking_lag,
-  double assumed_acceleration, rclcpp::Duration start_time, double max_time)
+  double assumed_acceleration, rclcpp::Duration start_time, double max_time,
+  const builtin_interfaces::msg::Time & stamp)
 {
   auto [times, distances] = time_distance::compute_motion_profile_1d(
     predicted_object.kinematics.initial_twist_with_covariance.twist, braking_lag,
@@ -491,8 +494,8 @@ TrajectoryData generate_constant_curvature_trajectory(
   auto footprints = footprint::compute_footprint_trajectory(poses, predicted_object.shape);
 
   return TrajectoryData(
-    make_trajectory_identification(predicted_object, "_constant_curvature_path"), std::move(times),
-    std::move(distances), std::move(poses), std::move(footprints));
+    make_trajectory_identification(predicted_object, "_constant_curvature_path", stamp),
+    std::move(times), std::move(distances), std::move(poses), std::move(footprints));
 }
 }  // namespace trajectory
 
@@ -635,18 +638,19 @@ TrajectoryData generate_rss_ego_trajectory(
 Assessment assess_required_deceleration(
   const TrajectoryData & ego_trajectory, const geometry_msgs::msg::Twist & ego_twist,
   const autoware_perception_msgs::msg::PredictedObject & object,
-  const validator::Params::CollisionCheck::Rss & rss_params)
+  const validator::Params::CollisionCheck::Rss & rss_params,
+  const builtin_interfaces::msg::Time & stamp)
 {
   const auto ego_long_vel = ego_twist.linear.x;
   if (ego_long_vel <= 0.0) {
-    return Assessment{make_object_identification(object), 0.0};
+    return Assessment{make_object_identification(object, stamp), 0.0};
   }
 
   // compute current distance
   const auto distance_to_collision =
     rss_deceleration::compute_distance_to_collision(ego_trajectory, object);
   if (!distance_to_collision.has_value()) {
-    return Assessment{make_object_identification(object), 0.0};
+    return Assessment{make_object_identification(object, stamp), 0.0};
   }
 
   // compute safe distance
@@ -661,7 +665,7 @@ Assessment assess_required_deceleration(
                                          ? std::numeric_limits<double>::infinity()
                                          : ego_long_vel * ego_long_vel * 0.5 / safe_distance;
 
-  return Assessment{make_object_identification(object), required_deceleration};
+  return Assessment{make_object_identification(object, stamp), required_deceleration};
 }
 
 Result assess(
@@ -675,7 +679,8 @@ Result assess(
 
   for (const auto & object : context.predicted_objects->objects) {
     const auto assessment = assess_required_deceleration(
-      ego_trajectory, context.odometry->twist.twist, object, rss_params);
+      ego_trajectory, context.odometry->twist.twist, object, rss_params,
+      context.predicted_objects->header.stamp);
 
     if (
       !result.worst_assessment.has_value() ||
@@ -731,12 +736,13 @@ std::vector<TrajectoryData> generate_object_trajectories(
   object_trajectories.reserve(context.predicted_objects->objects.size() * 2);
   for (const auto & object : context.predicted_objects->objects) {
     object_trajectories.push_back(trajectory::generate_predicted_path_trajectory(
-      object, 0.0, object_assumed_acceleration, objects_reference_time, required_time_horizon));
+      object, 0.0, object_assumed_acceleration, objects_reference_time, required_time_horizon,
+      context.predicted_objects->header.stamp));
 
     object_trajectories.push_back(trajectory::generate_constant_curvature_trajectory(
-      object, 0.0, object_assumed_acceleration, objects_reference_time, required_time_horizon));
+      object, 0.0, object_assumed_acceleration, objects_reference_time, required_time_horizon,
+      context.predicted_objects->header.stamp));
   }
-
   return object_trajectories;
 }
 
@@ -961,6 +967,7 @@ CollisionCheckFilter::result_t CollisionCheckFilter::is_feasible(
 {
   // autoware_utils::StopWatch<std::chrono::microseconds> stopwatch;
   // stopwatch.tic();
+  std::string error_msg{};
 
   if (!context.predicted_objects || context.predicted_objects->objects.empty()) {
     pet_continuous_times_.clear();
@@ -1009,6 +1016,11 @@ CollisionCheckFilter::result_t CollisionCheckFilter::is_feasible(
                         .metric_value(finding.ttc)
                         .level(MetricReport::ERROR));
 
+    const double detection_duration = pet_continuous_times_.get_time(finding.trajectory_id);
+    error_msg += fmt::format(
+      "PET collision, classification: {}, ID: {}, PET: {}, TTC: {}, duration: {}, stamp: {}.{}; ",
+      finding.object.classification, finding.trajectory_id, finding.pet, finding.ttc,
+      detection_duration, finding.object.stamp.sec, finding.object.stamp.nanosec);
     add_debug_markers(
       context.odometry->header.stamp, "planned_speed_collision", finding.ego_hull,
       finding.object_hull);
@@ -1022,15 +1034,22 @@ CollisionCheckFilter::result_t CollisionCheckFilter::is_feasible(
     collision_timing_result.drac.value() >= -pet_collision_params_.ego_assumed_acceleration) {
     for (const auto & finding : collision_timing_result.drac_findings) {
       is_feasible = false;
-  
+
       metrics.push_back(autoware_trajectory_validator::build<MetricReport>()
                           .validator_name(get_name())
                           .validator_category(category())
                           .metric_name(fmt::format(
-                            "check_DRAC_{}_{}_{}", finding.trajectory_id, finding.object.classification,
-                            finding.object.id))
+                            "check_DRAC_{}_{}_{}", finding.trajectory_id,
+                            finding.object.classification, finding.object.id))
                           .metric_value(collision_timing_result.drac.value_or(0.0))
                           .level(MetricReport::ERROR));
+      error_msg += fmt::format(
+        "DRAC collision, ID: {}, PET: {}, TTC: {}, DRAC: {}, stamp: {}.{}; ", finding.trajectory_id,
+        finding.pet, finding.ttc,
+        collision_timing_result.drac.has_value()
+          ? std::to_string(collision_timing_result.drac.value())
+          : "Cant be avoided",
+        finding.object.stamp.sec, finding.object.stamp.nanosec);
       add_debug_markers(
         context.odometry->header.stamp, "drac_collision", finding.ego_hull, finding.object_hull);
     }
@@ -1053,6 +1072,16 @@ CollisionCheckFilter::result_t CollisionCheckFilter::is_feasible(
                           "check_RSS_{}_{}", violation.object.classification, violation.object.id))
                         .metric_value(violation.required_deceleration)
                         .level(MetricReport::ERROR));
+    const double detection_duration = rss_continuous_times_.get_time(violation.object.id);
+    error_msg += fmt::format(
+      "RSS collision, classification: {}, ID: {}, duration: {}, required deceleration: {}, stamp: "
+      "{}.{}; ",
+      violation.object.classification, violation.object.id, detection_duration,
+      violation.required_deceleration, violation.object.stamp.sec, violation.object.stamp.nanosec);
+  }
+
+  if (!error_msg.empty()) {
+    RCLCPP_WARN(rclcpp::get_logger("CollisionCheckFilter"), "Not feasible: %s", error_msg.c_str());
   }
 
   return ValidationResult{is_feasible, std::move(metrics)};

--- a/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter.cpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter.cpp
@@ -399,6 +399,66 @@ TravelDistanceTrajectory compute_cumulative_distances(const PoseTrajectory & pos
 
   return distances;
 }
+
+TimeTrajectory compute_sample_times(double start_time, double end_time)
+{
+  TimeTrajectory times;
+  times.reserve(static_cast<size_t>((end_time - start_time) / TIME_RESOLUTION) + 2U);
+
+  constexpr double epsilon = 1e-3;
+  auto append_sample = [&](const double t) {
+    if (t < start_time || t > end_time) return;
+    if (!times.empty() && t < times.back() + epsilon) return;
+    times.push_back(t);
+  };
+
+  append_sample(start_time);
+  for (int64_t tick = static_cast<int64_t>(std::floor(start_time / TIME_RESOLUTION)) + 1;; ++tick) {
+    const double tick_time = static_cast<double>(tick) * TIME_RESOLUTION;
+    if (tick_time >= end_time) {
+      break;
+    }
+    append_sample(tick_time);
+  }
+  append_sample(end_time);
+
+  return times;
+}
+
+geometry_msgs::msg::Pose interpolate_predicted_path_pose(
+  const autoware_perception_msgs::msg::PredictedPath & predicted_path, double query_time)
+{
+  if (predicted_path.path.empty()) {
+    throw std::invalid_argument("predicted path must not be empty");
+  }
+
+  const double path_time_step = rclcpp::Duration(predicted_path.time_step).seconds();
+  if (predicted_path.path.size() == 1 || path_time_step <= 0.0) {
+    return predicted_path.path.front();
+  }
+
+  const double clamped_query_time = std::clamp(
+    query_time, 0.0, path_time_step * static_cast<double>(predicted_path.path.size() - 1));
+  const size_t index = static_cast<size_t>(std::floor(clamped_query_time / path_time_step));
+  const size_t next_index = std::min(index + 1, predicted_path.path.size() - 1);
+  const double ratio =
+    (clamped_query_time - static_cast<double>(index) * path_time_step) / path_time_step;
+  return autoware::universe_utils::calcInterpolatedPose(
+    predicted_path.path.at(index), predicted_path.path.at(next_index), ratio, false);
+}
+
+PoseTrajectory compute_diffusion_based_pose_trajectory(
+  const autoware_perception_msgs::msg::PredictedPath & predicted_path, const TimeTrajectory & times,
+  double objects_reference_time)
+{
+  PoseTrajectory poses;
+  poses.reserve(times.size());
+  for (const auto & time : times) {
+    poses.push_back(
+      interpolate_predicted_path_pose(predicted_path, time - objects_reference_time));
+  }
+  return poses;
+}
 }  // namespace detail
 
 TrajectoryData generate_ego_trajectory(
@@ -478,6 +538,36 @@ TrajectoryData generate_predicted_path_trajectory(
   return TrajectoryData(
     make_trajectory_identification(predicted_object, "_predicted_path", stamp), std::move(times),
     std::move(distances), std::move(poses), std::move(footprints));
+}
+
+TrajectoryData generate_diffusion_based_trajectory(
+  const autoware_perception_msgs::msg::PredictedObject & predicted_object,
+  rclcpp::Duration start_time, double max_time,
+  const builtin_interfaces::msg::Time & stamp)
+{
+  const auto most_confident_path_it = std::max_element(
+    predicted_object.kinematics.predicted_paths.begin(),
+    predicted_object.kinematics.predicted_paths.end(),
+    [](const auto & a, const auto & b) { return a.confidence < b.confidence; });
+  const auto & predicted_path = *most_confident_path_it;
+  auto times = detail::compute_sample_times(0.0, max_time);
+  auto poses = detail::compute_diffusion_based_pose_trajectory(
+    predicted_path, times, start_time.seconds());
+
+  TravelDistanceTrajectory distances;
+  distances.reserve(poses.size());
+  distances.push_back(0.0);
+  for (size_t i = 1; i < poses.size(); ++i) {
+    distances.push_back(
+      distances.back() +
+      autoware_utils_geometry::calc_distance2d(poses.at(i - 1).position, poses.at(i).position));
+  }
+
+  auto footprints = footprint::compute_footprint_trajectory(poses, predicted_object.shape);
+
+  return TrajectoryData(
+    make_trajectory_identification(predicted_object, "_diffusion_based_trajectory", stamp),
+    std::move(times), std::move(distances), std::move(poses), std::move(footprints));
 }
 TrajectoryData generate_constant_curvature_trajectory(
   const autoware_perception_msgs::msg::PredictedObject & predicted_object, double braking_lag,
@@ -672,6 +762,10 @@ Result assess(
   const TrajectoryPoints & traj_points, const FilterContext & context,
   const validator::Params::CollisionCheck::Rss & rss_params, VehicleInfo & vehicle_info)
 {
+  if (!context.predicted_objects || context.predicted_objects->objects.empty()) {
+    return {};
+  }
+
   const auto ego_trajectory = generate_rss_ego_trajectory(traj_points, context, vehicle_info);
 
   Result result{};
@@ -732,16 +826,33 @@ std::vector<TrajectoryData> generate_object_trajectories(
   const rclcpp::Duration objects_reference_time =
     rclcpp::Time(context.predicted_objects->header.stamp) -
     rclcpp::Time(context.odometry->header.stamp);
+
   std::vector<TrajectoryData> object_trajectories{};
-  object_trajectories.reserve(context.predicted_objects->objects.size() * 2);
+  object_trajectories.reserve(context.predicted_objects->objects.size() * 3);
   for (const auto & object : context.predicted_objects->objects) {
-    object_trajectories.push_back(trajectory::generate_predicted_path_trajectory(
-      object, 0.0, object_assumed_acceleration, objects_reference_time, required_time_horizon,
-      context.predicted_objects->header.stamp));
+    if (!object.kinematics.predicted_paths.empty()) {
+      object_trajectories.push_back(trajectory::generate_predicted_path_trajectory(
+        object, 0.0, object_assumed_acceleration, objects_reference_time, required_time_horizon,
+        context.predicted_objects->header.stamp));
+    }
 
     object_trajectories.push_back(trajectory::generate_constant_curvature_trajectory(
       object, 0.0, object_assumed_acceleration, objects_reference_time, required_time_horizon,
       context.predicted_objects->header.stamp));
+  }
+
+  if (context.neural_network_predicted_objects) {
+    const rclcpp::Duration neural_network_objects_reference_time =
+      rclcpp::Time(context.neural_network_predicted_objects->header.stamp) -
+      rclcpp::Time(context.odometry->header.stamp);
+    for (const auto & object : context.neural_network_predicted_objects->objects) {
+      if (object.kinematics.predicted_paths.empty()) {
+        continue;
+      }
+      object_trajectories.push_back(trajectory::generate_diffusion_based_trajectory(
+        object, neural_network_objects_reference_time, required_time_horizon,
+        context.neural_network_predicted_objects->header.stamp));
+    }
   }
   return object_trajectories;
 }
@@ -969,7 +1080,10 @@ CollisionCheckFilter::result_t CollisionCheckFilter::is_feasible(
   // stopwatch.tic();
   std::string error_msg{};
 
-  if (!context.predicted_objects || context.predicted_objects->objects.empty()) {
+  if (
+    (!context.predicted_objects || context.predicted_objects->objects.empty()) &&
+    (!context.neural_network_predicted_objects ||
+     context.neural_network_predicted_objects->objects.empty())) {
     pet_continuous_times_.clear();
     rss_continuous_times_.clear();
     drac_continuous_times_.clear();

--- a/planning/autoware_trajectory_validator/src/trajectory_validator_node.cpp
+++ b/planning/autoware_trajectory_validator/src/trajectory_validator_node.cpp
@@ -151,6 +151,7 @@ void TrajectoryValidator::process(const CandidateTrajectories::ConstSharedPtr ms
   }
 
   context.predicted_objects = sub_objects_.take_data();
+  context.neural_network_predicted_objects = sub_neural_network_objects_.take_data();
   if (!context.predicted_objects) {
     return;
   }

--- a/planning/autoware_trajectory_validator/test/collision_check_filter/test_collision_check_filter.cpp
+++ b/planning/autoware_trajectory_validator/test/collision_check_filter/test_collision_check_filter.cpp
@@ -150,6 +150,46 @@ TEST_F(CollisionCheckFilterTest, EmptyObjects)
   EXPECT_TRUE(result.value().is_feasible);
 }
 
+TEST_F(CollisionCheckFilterTest, NeuralNetworkPredictedObjectsAreAlsoChecked)
+{
+  const auto ego_path = create_ego_path();
+
+  FilterContext context;
+
+  auto odom_msg = std::make_shared<nav_msgs::msg::Odometry>();
+  odom_msg->header.stamp = rclcpp::Time(1, 0, RCL_ROS_TIME);
+  odom_msg->pose.pose = create_pose(0.0, 0.0, 0.0);
+  odom_msg->twist.twist = create_twist(10.0, 0.0);
+  context.odometry = odom_msg;
+
+  auto predicted_objects_msg = std::make_shared<autoware_perception_msgs::msg::PredictedObjects>();
+  predicted_objects_msg->header.stamp = odom_msg->header.stamp;
+  predicted_objects_msg->objects.push_back(create_dummy_object(
+    create_pose(100.0, 100.0, 0.0), create_twist(0.0, 0.0),
+    create_predicted_path(create_pose(100.0, 100.0, 0.0), create_twist(0.0, 0.0)),
+    create_object_shape(5.0, 1.0)));
+  context.predicted_objects = predicted_objects_msg;
+
+  auto neural_network_objects_msg =
+    std::make_shared<autoware_perception_msgs::msg::PredictedObjects>();
+  neural_network_objects_msg->header.stamp = odom_msg->header.stamp;
+  auto pose = create_pose(20.0, -10.0, M_PI_2);
+  auto twist = create_twist(10.0, 0.0);
+  neural_network_objects_msg->objects.push_back(create_dummy_object(
+    pose, twist, create_predicted_path(pose, twist), create_object_shape(5.0, 1.0)));
+  context.neural_network_predicted_objects = neural_network_objects_msg;
+
+  const auto result = filter_->is_feasible(ego_path, context);
+  EXPECT_TRUE(!result.has_value());
+
+  ASSERT_FALSE(result.has_value());
+  const std::string & error_msg = result.error();
+  EXPECT_NE(error_msg.find("classification: CAR"), std::string::npos)
+    << "Error string did not contain 'classification: CAR'. Actual: " << error_msg;
+  EXPECT_NE(error_msg.find("diffusion_based_trajectory"), std::string::npos)
+    << "Error string did not contain 'diffusion_based_trajectory'. Actual: " << error_msg;
+}
+
 TEST_F(CollisionCheckFilterTest, StoppedObjectInPath)
 {
   const auto ego_path = create_ego_path();

--- a/planning/autoware_trajectory_validator/test/collision_check_filter/test_collision_check_filter.cpp
+++ b/planning/autoware_trajectory_validator/test/collision_check_filter/test_collision_check_filter.cpp
@@ -180,14 +180,18 @@ TEST_F(CollisionCheckFilterTest, NeuralNetworkPredictedObjectsAreAlsoChecked)
   context.neural_network_predicted_objects = neural_network_objects_msg;
 
   const auto result = filter_->is_feasible(ego_path, context);
-  EXPECT_TRUE(!result.has_value());
 
-  ASSERT_FALSE(result.has_value());
-  const std::string & error_msg = result.error();
-  EXPECT_NE(error_msg.find("classification: CAR"), std::string::npos)
-    << "Error string did not contain 'classification: CAR'. Actual: " << error_msg;
-  EXPECT_NE(error_msg.find("diffusion_based_trajectory"), std::string::npos)
-    << "Error string did not contain 'diffusion_based_trajectory'. Actual: " << error_msg;
+  ASSERT_TRUE(result.has_value());
+  EXPECT_FALSE(result.value().is_feasible);
+
+  bool found_diffusion_metric = false;
+  for (const auto & metric : result.value().metrics) {
+    if (metric.metric_name.find("diffusion_based_trajectory") != std::string::npos) {
+      found_diffusion_metric = true;
+      break;
+    }
+  }
+  EXPECT_TRUE(found_diffusion_metric);
 }
 
 TEST_F(CollisionCheckFilterTest, StoppedObjectInPath)

--- a/planning/autoware_trajectory_validator/test/collision_check_filter/test_trajectory_utilities.cpp
+++ b/planning/autoware_trajectory_validator/test/collision_check_filter/test_trajectory_utilities.cpp
@@ -375,6 +375,38 @@ TEST(TrajectoryUtilitiesTest, GenerateTimedEgoTrajectoryHandlesNonUniformTimeAnd
   EXPECT_NEAR(trajectory_data.getDistances().at(2), 1.0, 1e-6);
 }
 
+TEST(TrajectoryUtilitiesTest, ComputeSampleTimesStartsAtStartTimeAndIncludesEndTime)
+{
+  const auto times = trajectory::detail::compute_sample_times(-0.1, 0.4);
+
+  ASSERT_EQ(times.size(), 6u);
+  EXPECT_NEAR(times.at(0), -0.1, 1e-6);
+  EXPECT_NEAR(times.at(1), 0.0, 1e-6);
+  EXPECT_NEAR(times.at(2), 0.1, 1e-6);
+  EXPECT_NEAR(times.at(3), 0.2, 1e-6);
+  EXPECT_NEAR(times.at(4), 0.3, 1e-6);
+  EXPECT_NEAR(times.at(5), 0.4, 1e-6);
+}
+
+TEST(TrajectoryUtilitiesTest, ComputeDiffusionBasedPoseTrajectoryUsesArbitraryTimeStep)
+{
+  const std::vector<autoware_perception_msgs::msg::PredictedPath> predicted_paths = {
+    create_straight_predicted_path(0.0, 1.0, {0.0, 2.0, 4.0})};
+  auto predicted_path = predicted_paths.front();
+  predicted_path.time_step = rclcpp::Duration::from_seconds(0.2);
+  const auto times = trajectory::detail::compute_sample_times(0.0, 0.4);
+
+  const auto poses =
+    trajectory::detail::compute_diffusion_based_pose_trajectory(predicted_path, times, -0.1);
+
+  ASSERT_EQ(poses.size(), 5u);
+  EXPECT_NEAR(poses.at(0).position.x, 1.0, 1e-6);
+  EXPECT_NEAR(poses.at(1).position.x, 2.0, 1e-6);
+  EXPECT_NEAR(poses.at(2).position.x, 3.0, 1e-6);
+  EXPECT_NEAR(poses.at(3).position.x, 4.0, 1e-6);
+  EXPECT_NEAR(poses.at(4).position.x, 4.0, 1e-6);
+}
+
 TEST(TrajectoryUtilitiesTest, GeneratePredictedPathTrajectoryUsesHighestConfidencePath)
 {
   const auto shape = create_bounding_box_shape(4.0, 2.0);
@@ -461,6 +493,34 @@ TEST(TrajectoryUtilitiesTest, GenerateConstantCurvaturePathTrajectoryMatchesPred
       tf2::getYaw(trajectory_data.getPoses().at(i).orientation),
       tf2::getYaw(expected_poses.at(i).orientation), 1e-6);
   }
+}
+TEST(TrajectoryUtilitiesTest, GenerateTimeInterpolatedPredictedPathTrajectoryUsesTimeStep)
+{
+  const auto shape = create_bounding_box_shape(4.0, 2.0);
+  const auto initial_pose = create_pose(0.0, 0.0, 0.0);
+  const auto initial_twist = create_twist(0.0);
+  const std::vector<autoware_perception_msgs::msg::PredictedPath> predicted_paths = {
+    create_straight_predicted_path(0.0, 1.0, {0.0, 2.0, 4.0})};
+  auto object = create_predicted_object(initial_pose, initial_twist, shape, predicted_paths);
+
+  object.kinematics.predicted_paths.front().time_step = rclcpp::Duration::from_seconds(0.2);
+
+  const auto trajectory_data = trajectory::generate_diffusion_based_trajectory(
+    object, rclcpp::Duration::from_seconds(-0.1), 0.4, builtin_interfaces::msg::Time{});
+
+  ASSERT_EQ(trajectory_data.size(), 5u);
+  EXPECT_EQ(
+    trajectory_data.getObjectIdentification().id.find("_diffusion_based_trajectory"),
+    trajectory_data.getObjectIdentification().id.size() - 27);
+  EXPECT_NEAR(trajectory_data.getTimes().at(0), 0.0, 1e-6);
+  EXPECT_NEAR(trajectory_data.getTimes().at(1), 0.1, 1e-6);
+  EXPECT_NEAR(trajectory_data.getTimes().at(4), 0.4, 1e-6);
+  EXPECT_NEAR(trajectory_data.getDistances().at(0), 0.0, 1e-6);
+  EXPECT_NEAR(trajectory_data.getDistances().at(1), 1.0, 1e-6);
+  EXPECT_NEAR(trajectory_data.getDistances().at(2), 2.0, 1e-6);
+  EXPECT_NEAR(trajectory_data.getDistances().at(3), 3.0, 1e-6);
+  EXPECT_NEAR(trajectory_data.getDistances().at(4), 3.0, 1e-6);
+  EXPECT_NEAR(trajectory_data.getPoses().at(0).position.x, 1.0, 1e-6);
 }
 TEST(TrajectoryUtilitiesTest, TrajectoryDataReturnsFootprintsInNearestTimeRange)
 {

--- a/planning/autoware_trajectory_validator/test/collision_check_filter/test_trajectory_utilities.cpp
+++ b/planning/autoware_trajectory_validator/test/collision_check_filter/test_trajectory_utilities.cpp
@@ -394,10 +394,13 @@ TEST(TrajectoryUtilitiesTest, ComputeDiffusionBasedPoseTrajectoryUsesArbitraryTi
     create_straight_predicted_path(0.0, 1.0, {0.0, 2.0, 4.0})};
   auto predicted_path = predicted_paths.front();
   predicted_path.time_step = rclcpp::Duration::from_seconds(0.2);
-  const auto times = trajectory::detail::compute_sample_times(0.0, 0.4);
+  auto times = trajectory::detail::compute_sample_times(0.0, 0.4);
+  for (auto & time : times) {
+    time += 0.1;
+  }
 
   const auto poses =
-    trajectory::detail::compute_diffusion_based_pose_trajectory(predicted_path, times, -0.1);
+    trajectory::detail::compute_diffusion_based_pose_trajectory(predicted_path, times);
 
   ASSERT_EQ(poses.size(), 5u);
   EXPECT_NEAR(poses.at(0).position.x, 1.0, 1e-6);
@@ -508,19 +511,25 @@ TEST(TrajectoryUtilitiesTest, GenerateTimeInterpolatedPredictedPathTrajectoryUse
   const auto trajectory_data = trajectory::generate_diffusion_based_trajectory(
     object, rclcpp::Duration::from_seconds(-0.1), 0.4, builtin_interfaces::msg::Time{});
 
-  ASSERT_EQ(trajectory_data.size(), 5u);
+  ASSERT_EQ(trajectory_data.size(), 6u);
   EXPECT_EQ(
     trajectory_data.getObjectIdentification().id.find("_diffusion_based_trajectory"),
     trajectory_data.getObjectIdentification().id.size() - 27);
-  EXPECT_NEAR(trajectory_data.getTimes().at(0), 0.0, 1e-6);
-  EXPECT_NEAR(trajectory_data.getTimes().at(1), 0.1, 1e-6);
-  EXPECT_NEAR(trajectory_data.getTimes().at(4), 0.4, 1e-6);
+  EXPECT_NEAR(trajectory_data.getTimes().at(0), -0.1, 1e-6);
+  EXPECT_NEAR(trajectory_data.getTimes().at(1), 0.0, 1e-6);
+  EXPECT_NEAR(trajectory_data.getTimes().at(5), 0.4, 1e-6);
   EXPECT_NEAR(trajectory_data.getDistances().at(0), 0.0, 1e-6);
-  EXPECT_NEAR(trajectory_data.getDistances().at(1), 1.0, 1e-6);
-  EXPECT_NEAR(trajectory_data.getDistances().at(2), 2.0, 1e-6);
-  EXPECT_NEAR(trajectory_data.getDistances().at(3), 3.0, 1e-6);
+  EXPECT_NEAR(trajectory_data.getDistances().at(1), 0.0, 1e-6);
+  EXPECT_NEAR(trajectory_data.getDistances().at(2), 1.0, 1e-6);
+  EXPECT_NEAR(trajectory_data.getDistances().at(3), 2.0, 1e-6);
   EXPECT_NEAR(trajectory_data.getDistances().at(4), 3.0, 1e-6);
-  EXPECT_NEAR(trajectory_data.getPoses().at(0).position.x, 1.0, 1e-6);
+  EXPECT_NEAR(trajectory_data.getDistances().at(5), 4.0, 1e-6);
+  EXPECT_NEAR(trajectory_data.getPoses().at(0).position.x, 0.0, 1e-6);
+  EXPECT_NEAR(trajectory_data.getPoses().at(1).position.x, 0.0, 1e-6);
+  EXPECT_NEAR(trajectory_data.getPoses().at(2).position.x, 1.0, 1e-6);
+  EXPECT_NEAR(trajectory_data.getPoses().at(3).position.x, 2.0, 1e-6);
+  EXPECT_NEAR(trajectory_data.getPoses().at(4).position.x, 3.0, 1e-6);
+  EXPECT_NEAR(trajectory_data.getPoses().at(5).position.x, 4.0, 1e-6);
 }
 TEST(TrajectoryUtilitiesTest, TrajectoryDataReturnsFootprintsInNearestTimeRange)
 {

--- a/planning/autoware_trajectory_validator/test/collision_check_filter/test_trajectory_utilities.cpp
+++ b/planning/autoware_trajectory_validator/test/collision_check_filter/test_trajectory_utilities.cpp
@@ -388,28 +388,6 @@ TEST(TrajectoryUtilitiesTest, ComputeSampleTimesStartsAtStartTimeAndIncludesEndT
   EXPECT_NEAR(times.at(5), 0.4, 1e-6);
 }
 
-TEST(TrajectoryUtilitiesTest, ComputeDiffusionBasedPoseTrajectoryUsesArbitraryTimeStep)
-{
-  const std::vector<autoware_perception_msgs::msg::PredictedPath> predicted_paths = {
-    create_straight_predicted_path(0.0, 1.0, {0.0, 2.0, 4.0})};
-  auto predicted_path = predicted_paths.front();
-  predicted_path.time_step = rclcpp::Duration::from_seconds(0.2);
-  auto times = trajectory::detail::compute_sample_times(0.0, 0.4);
-  for (auto & time : times) {
-    time += 0.1;
-  }
-
-  const auto poses =
-    trajectory::detail::compute_diffusion_based_pose_trajectory(predicted_path, times);
-
-  ASSERT_EQ(poses.size(), 5u);
-  EXPECT_NEAR(poses.at(0).position.x, 1.0, 1e-6);
-  EXPECT_NEAR(poses.at(1).position.x, 2.0, 1e-6);
-  EXPECT_NEAR(poses.at(2).position.x, 3.0, 1e-6);
-  EXPECT_NEAR(poses.at(3).position.x, 4.0, 1e-6);
-  EXPECT_NEAR(poses.at(4).position.x, 4.0, 1e-6);
-}
-
 TEST(TrajectoryUtilitiesTest, GeneratePredictedPathTrajectoryUsesHighestConfidencePath)
 {
   const auto shape = create_bounding_box_shape(4.0, 2.0);
@@ -509,26 +487,27 @@ TEST(TrajectoryUtilitiesTest, GenerateTimeInterpolatedPredictedPathTrajectoryUse
   object.kinematics.predicted_paths.front().time_step = rclcpp::Duration::from_seconds(0.2);
 
   const auto trajectory_data = trajectory::generate_diffusion_based_trajectory(
-    object, rclcpp::Duration::from_seconds(-0.1), 0.4, builtin_interfaces::msg::Time{});
+    object, rclcpp::Duration::from_seconds(-0.15), 0.4, builtin_interfaces::msg::Time{});
 
   ASSERT_EQ(trajectory_data.size(), 6u);
   EXPECT_EQ(
     trajectory_data.getObjectIdentification().id.find("_diffusion_based_trajectory"),
     trajectory_data.getObjectIdentification().id.size() - 27);
-  EXPECT_NEAR(trajectory_data.getTimes().at(0), -0.1, 1e-6);
-  EXPECT_NEAR(trajectory_data.getTimes().at(1), 0.0, 1e-6);
-  EXPECT_NEAR(trajectory_data.getTimes().at(5), 0.4, 1e-6);
+  EXPECT_NEAR(trajectory_data.getTimes().at(0), -0.15, 1e-6);
+  EXPECT_NEAR(trajectory_data.getTimes().at(1), -0.1, 1e-6);
+  EXPECT_NEAR(trajectory_data.getTimes().at(2), 0.0, 1e-6);
+  EXPECT_NEAR(trajectory_data.getTimes().at(5), 0.25, 1e-6);
   EXPECT_NEAR(trajectory_data.getDistances().at(0), 0.0, 1e-6);
-  EXPECT_NEAR(trajectory_data.getDistances().at(1), 0.0, 1e-6);
-  EXPECT_NEAR(trajectory_data.getDistances().at(2), 1.0, 1e-6);
-  EXPECT_NEAR(trajectory_data.getDistances().at(3), 2.0, 1e-6);
-  EXPECT_NEAR(trajectory_data.getDistances().at(4), 3.0, 1e-6);
+  EXPECT_NEAR(trajectory_data.getDistances().at(1), 0.5, 1e-6);
+  EXPECT_NEAR(trajectory_data.getDistances().at(2), 1.5, 1e-6);
+  EXPECT_NEAR(trajectory_data.getDistances().at(3), 2.5, 1e-6);
+  EXPECT_NEAR(trajectory_data.getDistances().at(4), 3.5, 1e-6);
   EXPECT_NEAR(trajectory_data.getDistances().at(5), 4.0, 1e-6);
   EXPECT_NEAR(trajectory_data.getPoses().at(0).position.x, 0.0, 1e-6);
-  EXPECT_NEAR(trajectory_data.getPoses().at(1).position.x, 0.0, 1e-6);
-  EXPECT_NEAR(trajectory_data.getPoses().at(2).position.x, 1.0, 1e-6);
-  EXPECT_NEAR(trajectory_data.getPoses().at(3).position.x, 2.0, 1e-6);
-  EXPECT_NEAR(trajectory_data.getPoses().at(4).position.x, 3.0, 1e-6);
+  EXPECT_NEAR(trajectory_data.getPoses().at(1).position.x, 0.5, 1e-6);
+  EXPECT_NEAR(trajectory_data.getPoses().at(2).position.x, 1.5, 1e-6);
+  EXPECT_NEAR(trajectory_data.getPoses().at(3).position.x, 2.5, 1e-6);
+  EXPECT_NEAR(trajectory_data.getPoses().at(4).position.x, 3.5, 1e-6);
   EXPECT_NEAR(trajectory_data.getPoses().at(5).position.x, 4.0, 1e-6);
 }
 TEST(TrajectoryUtilitiesTest, TrajectoryDataReturnsFootprintsInNearestTimeRange)

--- a/planning/autoware_trajectory_validator/test/collision_check_filter/test_trajectory_utilities.cpp
+++ b/planning/autoware_trajectory_validator/test/collision_check_filter/test_trajectory_utilities.cpp
@@ -386,7 +386,7 @@ TEST(TrajectoryUtilitiesTest, GeneratePredictedPathTrajectoryUsesHighestConfiden
   const auto object = create_predicted_object(initial_pose, initial_twist, shape, predicted_paths);
 
   const auto trajectory_data = trajectory::generate_predicted_path_trajectory(
-    object, 0.0, 0.0, rclcpp::Duration::from_seconds(0.1), 0.35);
+    object, 0.0, 0.0, rclcpp::Duration::from_seconds(0.1), 0.35, builtin_interfaces::msg::Time{});
 
   EXPECT_EQ(
     trajectory_data.getObjectIdentification().id.find("_predicted_path"),
@@ -443,7 +443,7 @@ TEST(TrajectoryUtilitiesTest, GenerateConstantCurvaturePathTrajectoryMatchesPred
   const auto object = create_predicted_object(initial_pose, initial_twist, shape, {});
 
   const auto trajectory_data = trajectory::generate_constant_curvature_trajectory(
-    object, 0.0, 0.0, rclcpp::Duration::from_seconds(0.0), 0.25);
+    object, 0.0, 0.0, rclcpp::Duration::from_seconds(0.0), 0.25, builtin_interfaces::msg::Time{});
   const auto [expected_times, expected_distances] =
     trajectory::time_distance::compute_motion_profile_1d(initial_twist, 0.0, 0.0, 0.0, 0.25);
   const auto expected_poses = trajectory::pose::constant_curvature_predictor::compute(
@@ -462,7 +462,6 @@ TEST(TrajectoryUtilitiesTest, GenerateConstantCurvaturePathTrajectoryMatchesPred
       tf2::getYaw(expected_poses.at(i).orientation), 1e-6);
   }
 }
-
 TEST(TrajectoryUtilitiesTest, TrajectoryDataReturnsFootprintsInNearestTimeRange)
 {
   const TimeTrajectory times = {0.0, 0.1, 0.2};


### PR DESCRIPTION
  ## Summary

  This PR extends `autoware_trajectory_validator` to validate diffusion-planner object predictions in addition to the existing predicted object sources.

  ## What Changed

  - Added a dedicated subscription/remap path for diffusion-based predicted objects in `trajectory_validator`
  - Extended `FilterContext` and node processing to pass object timestamps through the collision check pipeline
  - Added diffusion-based trajectory generation for neural-network predicted objects
  - Updated collision checking to evaluate those diffusion trajectories alongside existing object trajectories
  - Refactored object trajectory generation to make different object sources easier to handle consistently
  - Improved collision diagnostics by carrying per-object timestamps and detection duration in logs
  - Updated and expanded unit tests for diffusion-based trajectory sampling and collision checking behavior

  ## Motivation

  The trajectory validator previously checked only the standard predicted object input. This change makes collision validation aware of diffusion-planner object predictions so that infeasible trajectories can
  be detected earlier and reported with better diagnostic context.
