### PR TITLE
refactor(trajectory_validator): return report even if input is insufficient

### DIFF
--- a/planning/autoware_trajectory_validator/include/autoware/trajectory_validator/validator_interface.hpp
+++ b/planning/autoware_trajectory_validator/include/autoware/trajectory_validator/validator_interface.hpp
@@ -52,7 +52,7 @@ struct ValidationResult
 class ValidatorInterface
 {
 public:
-  using result_t = tl::expected<ValidationResult, std::string>;
+  using result_t = ValidationResult;
 
   explicit ValidatorInterface(std::string name) : name_(std::move(name)) {}
 

--- a/planning/autoware_trajectory_validator/src/filters/safety/out_of_lane_filter.cpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/out_of_lane_filter.cpp
@@ -78,7 +78,13 @@ OutOfLaneFilter::result_t OutOfLaneFilter::is_feasible(
   if (
     !context.lanelet_map || !context.odometry || traj_points.empty() ||
     !boundary_departure_checker_) {
-    return tl::make_unexpected("Insufficient context data");
+    std::vector<MetricReport> metrics{autoware_trajectory_validator::build<MetricReport>()
+                                        .validator_name(get_name())
+                                        .validator_category(category())
+                                        .metric_name("insufficient_input")
+                                        .metric_value(0.0)
+                                        .level(MetricReport::ERROR)};
+    return ValidationResult{false, std::move(metrics)};
   }
 
   const auto path = convert_to_path_with_lane_id(traj_points, params_.max_check_time);

--- a/planning/autoware_trajectory_validator/src/filters/safety/uncrossable_boundary_departure_filter.cpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/uncrossable_boundary_departure_filter.cpp
@@ -25,13 +25,25 @@ UncrossableBoundaryDepartureFilter::result_t UncrossableBoundaryDepartureFilter:
   const TrajectoryPoints & traj_points, const FilterContext & context)
 {
   if (const auto has_invalid_input = is_invalid_input(context)) {
-    return tl::make_unexpected(*has_invalid_input);
+    std::vector<MetricReport> metrics{autoware_trajectory_validator::build<MetricReport>()
+                                        .validator_name(get_name())
+                                        .validator_category(category())
+                                        .metric_name("insufficient_input")
+                                        .metric_value(0.0)
+                                        .level(MetricReport::ERROR)};
+    return ValidationResult{false, std::move(metrics)};
   }
 
   if (!is_initialized_) {
     uncrossable_boundary_checker_.set_lanelet_map(context.lanelet_map);
     if (const auto init = uncrossable_boundary_checker_.initialize(); !init) {
-      return tl::make_unexpected(init.error());
+      std::vector<MetricReport> metrics{autoware_trajectory_validator::build<MetricReport>()
+                                          .validator_name(get_name())
+                                          .validator_category(category())
+                                          .metric_name("boundary_initialization_failure")
+                                          .metric_value(0.0)
+                                          .level(MetricReport::ERROR)};
+      return ValidationResult{false, std::move(metrics)};
     }
     is_initialized_ = true;
   }
@@ -46,7 +58,13 @@ UncrossableBoundaryDepartureFilter::result_t UncrossableBoundaryDepartureFilter:
     uncrossable_boundary_checker_.check_departure(traj_points, *vehicle_info_ptr_, ego_state);
 
   if (!departure_data) {
-    return tl::make_unexpected(departure_data.error());
+    std::vector<MetricReport> metrics{autoware_trajectory_validator::build<MetricReport>()
+                                        .validator_name(get_name())
+                                        .validator_category(category())
+                                        .metric_name("no_departure_data")
+                                        .metric_value(0.0)
+                                        .level(MetricReport::ERROR)};
+    return ValidationResult{false, std::move(metrics)};
   }
 
   const bool is_feasible =

--- a/planning/autoware_trajectory_validator/src/filters/safety/vehicle_constraint_filter.cpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/vehicle_constraint_filter.cpp
@@ -119,7 +119,13 @@ VehicleConstraintFilter::result_t VehicleConstraintFilter::is_feasible(
   const TrajectoryPoints & traj_points, const FilterContext &)
 {
   if (!vehicle_info_ptr_) {
-    return tl::make_unexpected("Vehicle info not set");
+    std::vector<MetricReport> metrics{autoware_trajectory_validator::build<MetricReport>()
+                                        .validator_name(get_name())
+                                        .validator_category(category())
+                                        .metric_name("insufficient_input")
+                                        .metric_value(0.0)
+                                        .level(MetricReport::ERROR)};
+    return ValidationResult{false, std::move(metrics)};
   }
 
   // NOTE: Feasibility decision logic might be more complex in the future, but for now we just

--- a/planning/autoware_trajectory_validator/src/filters/traffic_rule/traffic_light_filter.cpp
+++ b/planning/autoware_trajectory_validator/src/filters/traffic_rule/traffic_light_filter.cpp
@@ -142,7 +142,13 @@ TrafficLightFilter::result_t TrafficLightFilter::is_feasible(
   const TrajectoryPoints & traj_points, const FilterContext & context)
 {
   if (const auto has_invalid_input = is_invalid_input(context, vehicle_info_ptr_)) {
-    return tl::make_unexpected(*has_invalid_input);
+    std::vector<MetricReport> metrics{autoware_trajectory_validator::build<MetricReport>()
+                                        .validator_name(get_name())
+                                        .validator_category(category())
+                                        .metric_name("insufficient_input")
+                                        .metric_value(0.0)
+                                        .level(MetricReport::ERROR)};
+    return ValidationResult{false, std::move(metrics)};
   }
   TrajectoryPoints trajectory;
   lanelet::BasicLineString2d trajectory_ls;

--- a/planning/autoware_trajectory_validator/src/trajectory_validator_node.cpp
+++ b/planning/autoware_trajectory_validator/src/trajectory_validator_node.cpp
@@ -204,20 +204,12 @@ void TrajectoryValidator::process(const CandidateTrajectories::ConstSharedPtr ms
       stop_watch.tic(evaluation.plugin_name);
 
       const auto res = plugin->is_feasible(trajectory.points, context);
-      if (!res) {
-        evaluation.is_feasible = false;
-        evaluation.reason = res.error();
-      } else {
-        const auto & val = res.value();
-        evaluation.is_feasible = evaluation.is_feasible && val.is_feasible;
-        if (!val.is_feasible) {
-          evaluation.reason = "Found failed metrics";
-        }
-        metrics.insert(metrics.end(), val.metrics.begin(), val.metrics.end());
-        add_planning_factors(val.planning_factors);
-      }
+      evaluation.is_feasible = res.is_feasible;
+      metrics.insert(metrics.end(), res.metrics.begin(), res.metrics.end());
+      add_planning_factors(res.planning_factors);
 
       if (!evaluation.is_feasible) {
+        evaluation.reason = "Found failed metrics";
         RCLCPP_WARN_THROTTLE(
           get_logger(), *get_clock(), 1000, "[%s] %s", plugin->get_name().c_str(),
           evaluation.reason.c_str());

--- a/planning/autoware_trajectory_validator/test/collision_check_filter/test_collision_check_filter.cpp
+++ b/planning/autoware_trajectory_validator/test/collision_check_filter/test_collision_check_filter.cpp
@@ -147,8 +147,7 @@ TEST_F(CollisionCheckFilterTest, EmptyObjects)
 
   const auto result = filter_->is_feasible(ego_path, context);
 
-  ASSERT_TRUE(result.has_value());
-  EXPECT_TRUE(result.value().is_feasible);
+  EXPECT_TRUE(result.is_feasible);
 }
 
 TEST_F(CollisionCheckFilterTest, NeuralNetworkPredictedObjectsAreAlsoChecked)
@@ -182,11 +181,10 @@ TEST_F(CollisionCheckFilterTest, NeuralNetworkPredictedObjectsAreAlsoChecked)
 
   const auto result = filter_->is_feasible(ego_path, context);
 
-  ASSERT_TRUE(result.has_value());
-  EXPECT_FALSE(result.value().is_feasible);
+  EXPECT_FALSE(result.is_feasible);
 
   bool found_diffusion_metric = false;
-  for (const auto & metric : result.value().metrics) {
+  for (const auto & metric : result.metrics) {
     if (metric.metric_name.find("diffusion_based_trajectory") != std::string::npos) {
       found_diffusion_metric = true;
       break;
@@ -215,8 +213,7 @@ TEST_F(CollisionCheckFilterTest, StoppedObjectInPath)
 
   const auto result = filter_->is_feasible(ego_path, context);
 
-  ASSERT_TRUE(result.has_value());
-  EXPECT_FALSE(result.value().is_feasible);
+  EXPECT_FALSE(result.is_feasible);
 }
 
 TEST_F(CollisionCheckFilterTest, ObjectWillDepartFromPath)
@@ -239,8 +236,7 @@ TEST_F(CollisionCheckFilterTest, ObjectWillDepartFromPath)
 
   const auto result = filter_->is_feasible(ego_path, context);
 
-  ASSERT_TRUE(result.has_value());
-  EXPECT_TRUE(result.value().is_feasible);
+  EXPECT_TRUE(result.is_feasible);
 }
 
 TEST_F(CollisionCheckFilterTest, ObjectWillEnterPath)
@@ -263,8 +259,7 @@ TEST_F(CollisionCheckFilterTest, ObjectWillEnterPath)
 
   const auto result = filter_->is_feasible(ego_path, context);
 
-  ASSERT_TRUE(result.has_value());
-  EXPECT_FALSE(result.value().is_feasible);
+  EXPECT_FALSE(result.is_feasible);
 }
 
 }  // namespace autoware::trajectory_validator::plugin::safety

--- a/planning/autoware_trajectory_validator/test/dummy_plugin/dummy_validator_plugin.cpp
+++ b/planning/autoware_trajectory_validator/test/dummy_plugin/dummy_validator_plugin.cpp
@@ -35,15 +35,26 @@ public:
     const TrajectoryPoints & traj_points, const FilterContext & /*context*/) final
   {
     if (traj_points.empty()) {
-      return tl::make_unexpected("Empty trajectory");
+      std::vector<MetricReport> metrics{autoware_trajectory_validator::build<MetricReport>()
+                                          .validator_name(get_name())
+                                          .validator_category(category())
+                                          .metric_name("empty_trajectory")
+                                          .metric_value(0.0)
+                                          .level(MetricReport::ERROR)};
+      return ValidationResult{false, std::move(metrics)};
     }
 
     // Magic trigger: If we set velocity to -999.0 in our test, simulate a plugin rejection
-    if (traj_points.front().longitudinal_velocity_mps == -999.0) {
-      return tl::make_unexpected("Dummy filter explicitly rejected this trajectory");
-    }
+    const auto is_feasible = traj_points.front().longitudinal_velocity_mps != -999.0;
 
-    return {};  // All other trajectories are feasible
+    std::vector<MetricReport> metrics{
+      autoware_trajectory_validator::build<MetricReport>()
+        .validator_name(get_name())
+        .validator_category(category())
+        .metric_name("explicit_rejection")
+        .metric_value(0.0)
+        .level(is_feasible ? MetricReport::OK : MetricReport::ERROR)};
+    return ValidationResult{is_feasible, std::move(metrics)};
   }
 
   void update_parameters([[maybe_unused]] const validator::Params & params) final {}

--- a/planning/autoware_trajectory_validator/test/plugins/test_traffic_light_filter.cpp
+++ b/planning/autoware_trajectory_validator/test/plugins/test_traffic_light_filter.cpp
@@ -172,7 +172,7 @@ TEST_F(TrafficLightFilterTest, IsInfeasibleWithoutMapAndSignals)
   const auto points = create_trajectory(0.0, 1.0);
   context_.lanelet_map = nullptr;
   context_.traffic_light_signals = nullptr;
-  EXPECT_FALSE(filter_->is_feasible(points, context_).has_value())
+  EXPECT_FALSE(filter_->is_feasible(points, context_).is_feasible)
     << "Should not be feasible without a map or traffic light signals";
 }
 TEST_F(TrafficLightFilterTest, IsInfeasibleWithoutMap)
@@ -182,7 +182,7 @@ TEST_F(TrafficLightFilterTest, IsInfeasibleWithoutMap)
   context_.lanelet_map = nullptr;
   // dummy map and light signal
   set_traffic_light_signal(0, TrafficLightElement::RED);
-  EXPECT_FALSE(filter_->is_feasible(points, context_).has_value())
+  EXPECT_FALSE(filter_->is_feasible(points, context_).is_feasible)
     << "Should not be feasible without a map (cannot verify whether a trajectory crosses a traffic "
        "light)";
 }
@@ -191,7 +191,7 @@ TEST_F(TrafficLightFilterTest, IsInfeasibleWithoutSignals)
   auto points = create_trajectory(0.0, 1.0);
   create_and_set_map(0, 0);
   context_.traffic_light_signals = nullptr;
-  EXPECT_FALSE(filter_->is_feasible(points, context_).has_value())
+  EXPECT_FALSE(filter_->is_feasible(points, context_).is_feasible)
     << "Should not be feasible without traffic light signals (cannot verify whether a trajectory "
        "crosses a traffic "
        "light)";
@@ -210,9 +210,7 @@ TEST_F(TrafficLightFilterTest, IsInfeasibleWithRedLightIntersection)
 
   const auto result = filter_->is_feasible(points, context_);
 
-  ASSERT_TRUE(result.has_value());
-  EXPECT_FALSE(result.value().is_feasible)
-    << "Should return false when crossing red light stop line";
+  EXPECT_FALSE(result.is_feasible) << "Should return false when crossing red light stop line";
 }
 
 TEST_F(TrafficLightFilterTest, IsFeasibleWithGreenLight)
@@ -228,8 +226,7 @@ TEST_F(TrafficLightFilterTest, IsFeasibleWithGreenLight)
 
   const auto result = filter_->is_feasible(points, context_);
 
-  ASSERT_TRUE(result.has_value());
-  EXPECT_TRUE(result.value().is_feasible) << "Should return true for green light";
+  EXPECT_TRUE(result.is_feasible) << "Should return true for green light";
 }
 
 TEST_F(TrafficLightFilterTest, IsFeasibleWithRedLightNoIntersection)
@@ -245,8 +242,7 @@ TEST_F(TrafficLightFilterTest, IsFeasibleWithRedLightNoIntersection)
 
   const auto result = filter_->is_feasible(points, context_);
 
-  ASSERT_TRUE(result.has_value());
-  EXPECT_TRUE(result.value().is_feasible) << "Should return true if red light is not crossed";
+  EXPECT_TRUE(result.is_feasible) << "Should return true if red light is not crossed";
 }
 
 TEST_F(TrafficLightFilterTest, IsInfeasibleWithFrontOverhang)
@@ -266,9 +262,7 @@ TEST_F(TrafficLightFilterTest, IsInfeasibleWithFrontOverhang)
 
   const auto result = filter_->is_feasible(points, context_);
 
-  ASSERT_TRUE(result.has_value());
-  EXPECT_FALSE(result.value().is_feasible)
-    << "Should return false when crossing red light stop line";
+  EXPECT_FALSE(result.is_feasible) << "Should return false when crossing red light stop line";
 }
 
 TEST_F(TrafficLightFilterTest, IsInfeasibleWithAmberLightCanStop)
@@ -289,8 +283,7 @@ TEST_F(TrafficLightFilterTest, IsInfeasibleWithAmberLightCanStop)
 
   const auto result = filter_->is_feasible(points, context_);
 
-  ASSERT_TRUE(result.has_value());
-  EXPECT_FALSE(result.value().is_feasible) << "Should return false if amber light can be stopped";
+  EXPECT_FALSE(result.is_feasible) << "Should return false if amber light can be stopped";
 }
 
 TEST_F(TrafficLightFilterTest, IsFeasibleWithAmberLightCannotStop)
@@ -314,8 +307,7 @@ TEST_F(TrafficLightFilterTest, IsFeasibleWithAmberLightCannotStop)
 
   const auto result = filter_->is_feasible(points, context_);
 
-  ASSERT_TRUE(result.has_value());
-  EXPECT_TRUE(result.value().is_feasible)
+  EXPECT_TRUE(result.is_feasible)
     << "Should return true if amber light cannot be stopped but is reachable";
 }
 
@@ -345,8 +337,7 @@ TEST_F(TrafficLightFilterTest, IsInfeasibleWithAmberLightCanStopAndCannotPass)
 
   const auto result = filter_->is_feasible(points, context_);
 
-  ASSERT_TRUE(result.has_value());
-  EXPECT_FALSE(result.value().is_feasible) << "Should return false if ego can stop but cannot pass";
+  EXPECT_FALSE(result.is_feasible) << "Should return false if ego can stop but cannot pass";
 }
 
 TEST_F(TrafficLightFilterTest, IsInfeasibleWithAmberLightAsRedLight)
@@ -370,8 +361,7 @@ TEST_F(TrafficLightFilterTest, IsInfeasibleWithAmberLightAsRedLight)
 
   const auto result = filter_->is_feasible(points, context_);
 
-  ASSERT_TRUE(result.has_value());
-  EXPECT_FALSE(result.value().is_feasible)
+  EXPECT_FALSE(result.is_feasible)
     << "Should return false for amber light when treat_amber_light_as_red_light is true";
 }
 
@@ -410,8 +400,7 @@ TEST_F(TrafficLightFilterTest, IsFeasibleWithStopDistanceMargin)
 
     const auto result = filter_->is_feasible(points, context_);
 
-    ASSERT_TRUE(result.has_value());
-    EXPECT_TRUE(result.value().is_feasible)
+    EXPECT_TRUE(result.is_feasible)
       << "Should return true if stopped within margin beyond stop line";
   }
 
@@ -436,8 +425,7 @@ TEST_F(TrafficLightFilterTest, IsFeasibleWithStopDistanceMargin)
 
     const auto result = filter_->is_feasible(points, context_);
 
-    ASSERT_TRUE(result.has_value());
-    EXPECT_FALSE(result.value().is_feasible) << "Should return false if stopped beyond margin";
+    EXPECT_FALSE(result.is_feasible) << "Should return false if stopped beyond margin";
   }
 
   {
@@ -446,8 +434,7 @@ TEST_F(TrafficLightFilterTest, IsFeasibleWithStopDistanceMargin)
 
     const auto result = filter_->is_feasible(points, context_);
 
-    ASSERT_TRUE(result.has_value());
-    EXPECT_FALSE(result.value().is_feasible) << "Should return false if crossing without stopping";
+    EXPECT_FALSE(result.is_feasible) << "Should return false if crossing without stopping";
   }
 }
 

--- a/planning/autoware_trajectory_validator/test/plugins/test_vehicle_constraint_filter.cpp
+++ b/planning/autoware_trajectory_validator/test/plugins/test_vehicle_constraint_filter.cpp
@@ -63,8 +63,7 @@ TEST(VehicleConstraintFilterTest, FeasibleWhenAllConstraintsSatisfied)
   FilterContext context;  // Empty context for now
   auto result = filter.is_feasible(traj_points, context);
 
-  ASSERT_TRUE(result.has_value());
-  EXPECT_TRUE(result.value().is_feasible);
+  EXPECT_TRUE(result.is_feasible);
 }
 
 TEST(VehicleConstraintFilterTest, InfeasibleWhenSpeedExceedsMax)
@@ -88,8 +87,7 @@ TEST(VehicleConstraintFilterTest, InfeasibleWhenSpeedExceedsMax)
   FilterContext context;  // Empty context for now
   auto result = filter.is_feasible(traj_points, context);
 
-  ASSERT_TRUE(result.has_value());
-  EXPECT_FALSE(result.value().is_feasible);
+  EXPECT_FALSE(result.is_feasible);
 }
 
 TEST(VehicleConstraintFilterTest, InfeasibleWhenAccelerationExceedsMax)
@@ -113,8 +111,7 @@ TEST(VehicleConstraintFilterTest, InfeasibleWhenAccelerationExceedsMax)
   FilterContext context;  // Empty context for now
   auto result = filter.is_feasible(traj_points, context);
 
-  ASSERT_TRUE(result.has_value());
-  EXPECT_FALSE(result.value().is_feasible);
+  EXPECT_FALSE(result.is_feasible);
 }
 
 TEST(VehicleConstraintFilterTest, InfeasibleWhenDecelerationExceedsMax)
@@ -139,8 +136,7 @@ TEST(VehicleConstraintFilterTest, InfeasibleWhenDecelerationExceedsMax)
   FilterContext context;  // Empty context for now
   auto result = filter.is_feasible(traj_points, context);
 
-  ASSERT_TRUE(result.has_value());
-  EXPECT_FALSE(result.value().is_feasible);
+  EXPECT_FALSE(result.is_feasible);
 }
 
 TEST(VehicleConstraintFilterTest, InfeasibleWhenSteeringAngleExceedsMax)
@@ -168,8 +164,7 @@ TEST(VehicleConstraintFilterTest, InfeasibleWhenSteeringAngleExceedsMax)
   FilterContext context;  // Empty context for now
   auto result = filter.is_feasible(traj_points, context);
 
-  ASSERT_TRUE(result.has_value());
-  EXPECT_FALSE(result.value().is_feasible);
+  EXPECT_FALSE(result.is_feasible);
 }
 
 TEST(VehicleConstraintFilterTest, InfeasibleWhenSteeringRateExceedsMax)
@@ -199,8 +194,7 @@ TEST(VehicleConstraintFilterTest, InfeasibleWhenSteeringRateExceedsMax)
   FilterContext context;  // Empty context for now
   auto result = filter.is_feasible(traj_points, context);
 
-  ASSERT_TRUE(result.has_value());
-  EXPECT_FALSE(result.value().is_feasible);
+  EXPECT_FALSE(result.is_feasible);
 }
 
 // --- is_speed_ok(...) tests ---


### PR DESCRIPTION
## What

This pull request refactors the validation result handling in the Autoware trajectory validator, unifying the interface for filter feasibility checks and improving error reporting. Instead of using `tl::expected` for error handling, all filters now consistently return a `ValidationResult` object with detailed metric reports, even in error cases. Related tests and plugin implementations have been updated to match the new interface.

**Core interface and error handling changes:**

* The `ValidatorInterface::result_t` type has been changed from `tl::expected<ValidationResult, std::string>` to simply `ValidationResult`, standardizing return types across all validators.
* All filter implementations (e.g., `OutOfLaneFilter`, `UncrossableBoundaryDepartureFilter`, `VehicleConstraintFilter`, `TrafficLightFilter`, and test plugins) now return a `ValidationResult` with appropriate error metrics instead of using `tl::make_unexpected`. This provides richer error information and a uniform interface. [[1]](diffhunk://#diff-59a66336469b28a6ea073cf4a40fe02a87ba68de45c3f71c5c5844193ed369b1L81-R87) [[2]](diffhunk://#diff-8c039171676b8943b2fee2d9a6761bba9039786a1a4aa02977bbe7235f7eac47L28-R46) [[3]](diffhunk://#diff-8c039171676b8943b2fee2d9a6761bba9039786a1a4aa02977bbe7235f7eac47L49-R67) [[4]](diffhunk://#diff-f20cabfeb70817285457312a5cc64c33001e803f068488e243d05553cb3ab29cL122-R128) [[5]](diffhunk://#diff-cf7b7f71ecb1c835fc173c7aa9aa7d56bbee81023a00ebbeb8c299cc3c99a743L145-R151) [[6]](diffhunk://#diff-3eaf3b35ba57fbc54f9e6b7c5435518d35f048070eb7d6c6d9db3031f3e7a975L38-R57)