### PR TITLE
feat(trajectory_validator): select object trajectory types

### DIFF
--- a/planning/autoware_trajectory_validator/config/trajectory_validator.param.yaml
+++ b/planning/autoware_trajectory_validator/config/trajectory_validator.param.yaml
@@ -29,6 +29,9 @@
         time_resolution: 0.1
       drac:
         enable_assessment: false
+      predicted_path_trajectory: true
+      constant_curvature_trajectory: true
+      diffusion_based_trajectory: true
       pet_collision:
         enable_assessment: true
         ego_braking_delay: 0.4

--- a/planning/autoware_trajectory_validator/config/trajectory_validator.param.yaml
+++ b/planning/autoware_trajectory_validator/config/trajectory_validator.param.yaml
@@ -29,11 +29,14 @@
         time_resolution: 0.1
       drac:
         enable_assessment: false
-      predicted_path_trajectory: true
-      constant_curvature_trajectory: true
-      diffusion_based_trajectory: true
+        predicted_path_trajectory: true
+        constant_curvature_trajectory: true
+        diffusion_based_trajectory: true
       pet_collision:
         enable_assessment: true
+        predicted_path_trajectory: true
+        constant_curvature_trajectory: true
+        diffusion_based_trajectory: true
         ego_braking_delay: 0.4
         ego_assumed_acceleration: -5.0
         collision_time_threshold: 0.0

--- a/planning/autoware_trajectory_validator/include/autoware/trajectory_validator/filters/safety/collision_check_filter.hpp
+++ b/planning/autoware_trajectory_validator/include/autoware/trajectory_validator/filters/safety/collision_check_filter.hpp
@@ -291,9 +291,6 @@ private:
   validator::Params::CollisionCheck::Drac drac_params_;
   validator::Params::CollisionCheck::PetCollision pet_collision_params_;
   validator::Params::CollisionCheck::Rss rss_params_;
-  bool use_predicted_path_trajectory_{true};
-  bool use_constant_curvature_trajectory_{true};
-  bool use_diffusion_based_trajectory_{true};
   ContinuousDetectionTimes pet_continuous_times_;
   ContinuousDetectionTimes rss_continuous_times_;
   ContinuousDetectionTimes drac_continuous_times_;

--- a/planning/autoware_trajectory_validator/include/autoware/trajectory_validator/filters/safety/collision_check_filter.hpp
+++ b/planning/autoware_trajectory_validator/include/autoware/trajectory_validator/filters/safety/collision_check_filter.hpp
@@ -291,6 +291,9 @@ private:
   validator::Params::CollisionCheck::Drac drac_params_;
   validator::Params::CollisionCheck::PetCollision pet_collision_params_;
   validator::Params::CollisionCheck::Rss rss_params_;
+  bool use_predicted_path_trajectory_{true};
+  bool use_constant_curvature_trajectory_{true};
+  bool use_diffusion_based_trajectory_{true};
   ContinuousDetectionTimes pet_continuous_times_;
   ContinuousDetectionTimes rss_continuous_times_;
   ContinuousDetectionTimes drac_continuous_times_;

--- a/planning/autoware_trajectory_validator/param/parameter_struct.yaml
+++ b/planning/autoware_trajectory_validator/param/parameter_struct.yaml
@@ -69,26 +69,41 @@ validator:
         default_value: true
         description: When true, DRAC assessment is performed
         read_only: false
-    predicted_path_trajectory:
-      type: bool
-      default_value: true
-      description: Use predicted path trajectories for collision timing assessment
-      read_only: false
-    constant_curvature_trajectory:
-      type: bool
-      default_value: true
-      description: Use constant curvature trajectories for collision timing assessment
-      read_only: false
-    diffusion_based_trajectory:
-      type: bool
-      default_value: true
-      description: Use diffusion based trajectories for collision timing assessment
-      read_only: false
+      predicted_path_trajectory:
+        type: bool
+        default_value: true
+        description: Use predicted path trajectories for DRAC assessment
+        read_only: false
+      constant_curvature_trajectory:
+        type: bool
+        default_value: true
+        description: Use constant curvature trajectories for DRAC assessment
+        read_only: false
+      diffusion_based_trajectory:
+        type: bool
+        default_value: true
+        description: Use diffusion based trajectories for DRAC assessment
+        read_only: false
     pet_collision:
       enable_assessment:
         type: bool
         default_value: true
         description: When true, planned speed assessment is performed
+        read_only: false
+      predicted_path_trajectory:
+        type: bool
+        default_value: true
+        description: Use predicted path trajectories for PET assessment
+        read_only: false
+      constant_curvature_trajectory:
+        type: bool
+        default_value: true
+        description: Use constant curvature trajectories for PET assessment
+        read_only: false
+      diffusion_based_trajectory:
+        type: bool
+        default_value: true
+        description: Use diffusion based trajectories for PET assessment
         read_only: false
       ego_braking_delay:
         type: double

--- a/planning/autoware_trajectory_validator/param/parameter_struct.yaml
+++ b/planning/autoware_trajectory_validator/param/parameter_struct.yaml
@@ -69,6 +69,21 @@ validator:
         default_value: true
         description: When true, DRAC assessment is performed
         read_only: false
+    predicted_path_trajectory:
+      type: bool
+      default_value: true
+      description: Use predicted path trajectories for collision timing assessment
+      read_only: false
+    constant_curvature_trajectory:
+      type: bool
+      default_value: true
+      description: Use constant curvature trajectories for collision timing assessment
+      read_only: false
+    diffusion_based_trajectory:
+      type: bool
+      default_value: true
+      description: Use diffusion based trajectories for collision timing assessment
+      read_only: false
     pet_collision:
       enable_assessment:
         type: bool
@@ -203,7 +218,7 @@ validator:
       read_only: false
     boundary_types:
       type: string_array
-      default_value: ["road_border"]
+      default_value: [road_border]
       description: metrics.
       read_only: true
 

--- a/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter.cpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter.cpp
@@ -1142,28 +1142,25 @@ Result assess(
   const validator::Params::CollisionCheck::PetCollision & pet_collision_params,
   const validator::Params::CollisionCheck::Drac & drac_params,
   const validator::Params::CollisionCheck::GlobalSetting & global_setting,
-  VehicleInfo & vehicle_info, const ObjectTrajectoryGenerationOptions & object_trajectory_options)
+  VehicleInfo & vehicle_info, const ObjectTrajectoryGenerationOptions & pet_trajectory_options,
+  const ObjectTrajectoryGenerationOptions & drac_trajectory_options)
 {
   const double ego_time_horizon_for_pet = std::abs(context.odometry->twist.twist.linear.x) * 0.5 /
                                             -pet_collision_params.ego_assumed_acceleration +
                                           pet_collision_params.ego_braking_delay;
   const double ego_time_horizon_for_drac =
     rclcpp::Duration(traj_points.back().time_from_start).seconds();
-  const double required_object_time_horizon =
-    std::max(ego_time_horizon_for_pet, ego_time_horizon_for_drac) +
-    pet_collision_params.collision_time_threshold;
-
-  auto constant_speed_object_trajectories = generate_object_trajectories(
-    context, required_object_time_horizon, -1.0, global_setting.time_resolution,
-    object_trajectory_options);
 
   Result result{};
   if (!pet_collision_params.enable_assessment) {
     result.planned_speed_findings = {};
   } else {
+    const auto pet_object_trajectories = generate_object_trajectories(
+      context, ego_time_horizon_for_pet + pet_collision_params.collision_time_threshold, -1.0,
+      global_setting.time_resolution, pet_trajectory_options);
     result.planned_speed_findings = assess_planned_speed_collision_timing(
       traj_points, context, pet_collision_params, global_setting.time_resolution, vehicle_info,
-      constant_speed_object_trajectories);
+      pet_object_trajectories);
   }
 
   if (!drac_params.enable_assessment) {
@@ -1171,9 +1168,12 @@ Result assess(
     result.drac_findings = drac_assessment.findings;
     result.drac = drac_assessment.drac;
   } else {
+    const auto drac_object_trajectories = generate_object_trajectories(
+      context, ego_time_horizon_for_drac + pet_collision_params.collision_time_threshold, -1.0,
+      global_setting.time_resolution, drac_trajectory_options);
     const auto drac_assessment = assess_drac(
       traj_points, context, pet_collision_params, global_setting.time_resolution, vehicle_info,
-      constant_speed_object_trajectories);
+      drac_object_trajectories);
     result.drac_findings = drac_assessment.findings;
     result.drac = drac_assessment.drac;
   }
@@ -1188,9 +1188,6 @@ void CollisionCheckFilter::update_parameters(const validator::Params & params)
   drac_params_ = params.collision_check.drac;
   pet_collision_params_ = params.collision_check.pet_collision;
   rss_params_ = params.collision_check.rss;
-  use_predicted_path_trajectory_ = params.collision_check.predicted_path_trajectory;
-  use_constant_curvature_trajectory_ = params.collision_check.constant_curvature_trajectory;
-  use_diffusion_based_trajectory_ = params.collision_check.diffusion_based_trajectory;
 }
 
 autoware_internal_planning_msgs::msg::SafetyFactorArray make_safety_factor_array(
@@ -1386,13 +1383,18 @@ CollisionCheckFilter::result_t CollisionCheckFilter::is_feasible(
     planning_factors.factors.push_back(std::move(factor));
   };
 
-  const auto object_trajectory_options =
+  const auto pet_trajectory_options =
     collision_timing_assessment::ObjectTrajectoryGenerationOptions{
-      use_predicted_path_trajectory_, use_constant_curvature_trajectory_,
-      use_diffusion_based_trajectory_};
+      pet_collision_params_.predicted_path_trajectory,
+      pet_collision_params_.constant_curvature_trajectory,
+      pet_collision_params_.diffusion_based_trajectory};
+  const auto drac_trajectory_options =
+    collision_timing_assessment::ObjectTrajectoryGenerationOptions{
+      drac_params_.predicted_path_trajectory, drac_params_.constant_curvature_trajectory,
+      drac_params_.diffusion_based_trajectory};
   const auto collision_timing_result = collision_timing_assessment::assess(
     traj_points, context, pet_collision_params_, drac_params_, global_setting_, *vehicle_info_ptr_,
-    object_trajectory_options);
+    pet_trajectory_options, drac_trajectory_options);
 
   pet_continuous_times_.update(
     current_time, collision_timing_result.planned_speed_findings,

--- a/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter.cpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter.cpp
@@ -904,6 +904,13 @@ struct Result
   std::vector<Finding> drac_findings;  // Last evaluated PET findings during DRAC search.
 };
 
+struct ObjectTrajectoryGenerationOptions
+{
+  bool predicted_path_trajectory{true};
+  bool constant_curvature_trajectory{true};
+  bool diffusion_based_trajectory{true};
+};
+
 struct DracAssessment
 {
   std::optional<double> drac{0.0};
@@ -912,29 +919,38 @@ struct DracAssessment
 
 std::vector<TrajectoryData> generate_object_trajectories(
   const FilterContext & context, double required_time_horizon, double object_assumed_acceleration,
-  double time_resolution)
+  double time_resolution, const ObjectTrajectoryGenerationOptions & options)
 {
   std::vector<TrajectoryData> object_trajectories{};
 
   if (context.predicted_objects) {
-    object_trajectories.reserve(context.predicted_objects->objects.size() * 3);
+    const auto trajectory_num_per_object =
+      static_cast<size_t>(options.predicted_path_trajectory) +
+      static_cast<size_t>(options.constant_curvature_trajectory);
+    object_trajectories.reserve(
+      object_trajectories.size() +
+      context.predicted_objects->objects.size() * trajectory_num_per_object);
     const rclcpp::Duration objects_reference_time =
       rclcpp::Time(context.predicted_objects->header.stamp) -
       rclcpp::Time(context.odometry->header.stamp);
     for (const auto & object : context.predicted_objects->objects) {
-      if (!object.kinematics.predicted_paths.empty()) {
+      if (options.predicted_path_trajectory && !object.kinematics.predicted_paths.empty()) {
         object_trajectories.push_back(trajectory::generate_predicted_path_trajectory(
           object, 0.0, object_assumed_acceleration, objects_reference_time, required_time_horizon,
           context.predicted_objects->header.stamp, time_resolution));
       }
 
-      object_trajectories.push_back(trajectory::generate_constant_curvature_trajectory(
-        object, 0.0, object_assumed_acceleration, objects_reference_time, required_time_horizon,
-        context.predicted_objects->header.stamp, time_resolution));
+      if (options.constant_curvature_trajectory) {
+        object_trajectories.push_back(trajectory::generate_constant_curvature_trajectory(
+          object, 0.0, object_assumed_acceleration, objects_reference_time, required_time_horizon,
+          context.predicted_objects->header.stamp, time_resolution));
+      }
     }
   }
 
-  if (context.neural_network_predicted_objects) {
+  if (options.diffusion_based_trajectory && context.neural_network_predicted_objects) {
+    object_trajectories.reserve(
+      object_trajectories.size() + context.neural_network_predicted_objects->objects.size());
     const rclcpp::Duration neural_network_objects_reference_time =
       rclcpp::Time(context.neural_network_predicted_objects->header.stamp) -
       rclcpp::Time(context.odometry->header.stamp);
@@ -1126,7 +1142,7 @@ Result assess(
   const validator::Params::CollisionCheck::PetCollision & pet_collision_params,
   const validator::Params::CollisionCheck::Drac & drac_params,
   const validator::Params::CollisionCheck::GlobalSetting & global_setting,
-  VehicleInfo & vehicle_info)
+  VehicleInfo & vehicle_info, const ObjectTrajectoryGenerationOptions & object_trajectory_options)
 {
   const double ego_time_horizon_for_pet = std::abs(context.odometry->twist.twist.linear.x) * 0.5 /
                                             -pet_collision_params.ego_assumed_acceleration +
@@ -1138,7 +1154,8 @@ Result assess(
     pet_collision_params.collision_time_threshold;
 
   auto constant_speed_object_trajectories = generate_object_trajectories(
-    context, required_object_time_horizon, -1.0, global_setting.time_resolution);
+    context, required_object_time_horizon, -1.0, global_setting.time_resolution,
+    object_trajectory_options);
 
   Result result{};
   if (!pet_collision_params.enable_assessment) {
@@ -1171,6 +1188,9 @@ void CollisionCheckFilter::update_parameters(const validator::Params & params)
   drac_params_ = params.collision_check.drac;
   pet_collision_params_ = params.collision_check.pet_collision;
   rss_params_ = params.collision_check.rss;
+  use_predicted_path_trajectory_ = params.collision_check.predicted_path_trajectory;
+  use_constant_curvature_trajectory_ = params.collision_check.constant_curvature_trajectory;
+  use_diffusion_based_trajectory_ = params.collision_check.diffusion_based_trajectory;
 }
 
 autoware_internal_planning_msgs::msg::SafetyFactorArray make_safety_factor_array(
@@ -1366,8 +1386,13 @@ CollisionCheckFilter::result_t CollisionCheckFilter::is_feasible(
     planning_factors.factors.push_back(std::move(factor));
   };
 
+  const auto object_trajectory_options =
+    collision_timing_assessment::ObjectTrajectoryGenerationOptions{
+      use_predicted_path_trajectory_, use_constant_curvature_trajectory_,
+      use_diffusion_based_trajectory_};
   const auto collision_timing_result = collision_timing_assessment::assess(
-    traj_points, context, pet_collision_params_, drac_params_, global_setting_, *vehicle_info_ptr_);
+    traj_points, context, pet_collision_params_, drac_params_, global_setting_, *vehicle_info_ptr_,
+    object_trajectory_options);
 
   pet_continuous_times_.update(
     current_time, collision_timing_result.planned_speed_findings,

--- a/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter.cpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter.cpp
@@ -1142,9 +1142,15 @@ Result assess(
   const validator::Params::CollisionCheck::PetCollision & pet_collision_params,
   const validator::Params::CollisionCheck::Drac & drac_params,
   const validator::Params::CollisionCheck::GlobalSetting & global_setting,
-  VehicleInfo & vehicle_info, const ObjectTrajectoryGenerationOptions & pet_trajectory_options,
-  const ObjectTrajectoryGenerationOptions & drac_trajectory_options)
+  VehicleInfo & vehicle_info)
 {
+  const auto pet_trajectory_options = ObjectTrajectoryGenerationOptions{
+    pet_collision_params.predicted_path_trajectory,
+    pet_collision_params.constant_curvature_trajectory,
+    pet_collision_params.diffusion_based_trajectory};
+  const auto drac_trajectory_options = ObjectTrajectoryGenerationOptions{
+    drac_params.predicted_path_trajectory, drac_params.constant_curvature_trajectory,
+    drac_params.diffusion_based_trajectory};
   const double ego_time_horizon_for_pet = std::abs(context.odometry->twist.twist.linear.x) * 0.5 /
                                             -pet_collision_params.ego_assumed_acceleration +
                                           pet_collision_params.ego_braking_delay;
@@ -1383,18 +1389,8 @@ CollisionCheckFilter::result_t CollisionCheckFilter::is_feasible(
     planning_factors.factors.push_back(std::move(factor));
   };
 
-  const auto pet_trajectory_options =
-    collision_timing_assessment::ObjectTrajectoryGenerationOptions{
-      pet_collision_params_.predicted_path_trajectory,
-      pet_collision_params_.constant_curvature_trajectory,
-      pet_collision_params_.diffusion_based_trajectory};
-  const auto drac_trajectory_options =
-    collision_timing_assessment::ObjectTrajectoryGenerationOptions{
-      drac_params_.predicted_path_trajectory, drac_params_.constant_curvature_trajectory,
-      drac_params_.diffusion_based_trajectory};
   const auto collision_timing_result = collision_timing_assessment::assess(
-    traj_points, context, pet_collision_params_, drac_params_, global_setting_, *vehicle_info_ptr_,
-    pet_trajectory_options, drac_trajectory_options);
+    traj_points, context, pet_collision_params_, drac_params_, global_setting_, *vehicle_info_ptr_);
 
   pet_continuous_times_.update(
     current_time, collision_timing_result.planned_speed_findings,

--- a/planning/autoware_trajectory_validator/test/collision_check_filter/test_collision_check_filter.cpp
+++ b/planning/autoware_trajectory_validator/test/collision_check_filter/test_collision_check_filter.cpp
@@ -200,6 +200,52 @@ TEST_F(CollisionCheckFilterTest, NeuralNetworkPredictedObjectsAreAlsoChecked)
   EXPECT_TRUE(found_diffusion_metric);
 }
 
+TEST_F(CollisionCheckFilterTest, ObjectTrajectoryTypesCanBeConfiguredIndependentlyForPetAndDrac)
+{
+  const auto ego_path = create_ego_path();
+
+  FilterContext context;
+
+  auto odom_msg = std::make_shared<nav_msgs::msg::Odometry>();
+  odom_msg->header.stamp = rclcpp::Time(1, 0, RCL_ROS_TIME);
+  odom_msg->pose.pose = create_pose(0.0, 0.0, 0.0);
+  odom_msg->twist.twist = create_twist(10.0, 0.0);
+  context.odometry = odom_msg;
+
+  auto predicted_objects_msg = std::make_shared<autoware_perception_msgs::msg::PredictedObjects>();
+  predicted_objects_msg->header.stamp = odom_msg->header.stamp;
+  predicted_objects_msg->objects.push_back(create_dummy_object(
+    create_pose(100.0, 100.0, 0.0), create_twist(0.0, 0.0),
+    create_predicted_path(create_pose(100.0, 100.0, 0.0), create_twist(0.0, 0.0)),
+    create_object_shape(5.0, 1.0)));
+  context.predicted_objects = predicted_objects_msg;
+
+  auto neural_network_objects_msg =
+    std::make_shared<autoware_perception_msgs::msg::PredictedObjects>();
+  neural_network_objects_msg->header.stamp = odom_msg->header.stamp;
+  const auto pose = create_pose(20.0, -10.0, M_PI_2);
+  const auto twist = create_twist(10.0, 0.0);
+  neural_network_objects_msg->objects.push_back(create_dummy_object(
+    pose, twist, create_predicted_path(pose, twist), create_object_shape(5.0, 1.0)));
+  context.neural_network_predicted_objects = neural_network_objects_msg;
+
+  autoware::vehicle_info_utils::VehicleInfo vehicle_info;
+  vehicle_info.max_longitudinal_offset_m = 4.0;
+  vehicle_info.min_longitudinal_offset_m = -1.0;
+  vehicle_info.vehicle_width_m = 2.0;
+
+  const auto result = collision_timing_assessment::assess(
+    ego_path, context, validator::Params::CollisionCheck::PetCollision{},
+    validator::Params::CollisionCheck::Drac{}, validator::Params::CollisionCheck::GlobalSetting{},
+    vehicle_info,
+    collision_timing_assessment::ObjectTrajectoryGenerationOptions{false, false, false},
+    collision_timing_assessment::ObjectTrajectoryGenerationOptions{false, false, true});
+
+  EXPECT_TRUE(result.planned_speed_findings.empty());
+  ASSERT_FALSE(result.drac_findings.empty());
+  EXPECT_EQ(result.drac_findings.front().object.trajectory_suffix, "_diffusion_based_trajectory");
+}
+
 TEST_F(CollisionCheckFilterTest, StoppedObjectInPath)
 {
   const auto ego_path = create_ego_path();

--- a/planning/autoware_trajectory_validator/test/collision_check_filter/test_collision_check_filter.cpp
+++ b/planning/autoware_trajectory_validator/test/collision_check_filter/test_collision_check_filter.cpp
@@ -234,12 +234,18 @@ TEST_F(CollisionCheckFilterTest, ObjectTrajectoryTypesCanBeConfiguredIndependent
   vehicle_info.min_longitudinal_offset_m = -1.0;
   vehicle_info.vehicle_width_m = 2.0;
 
+  validator::Params::CollisionCheck::PetCollision pet_collision_params;
+  pet_collision_params.predicted_path_trajectory = false;
+  pet_collision_params.constant_curvature_trajectory = false;
+  pet_collision_params.diffusion_based_trajectory = false;
+  validator::Params::CollisionCheck::Drac drac_params;
+  drac_params.predicted_path_trajectory = false;
+  drac_params.constant_curvature_trajectory = false;
+  drac_params.diffusion_based_trajectory = true;
+
   const auto result = collision_timing_assessment::assess(
-    ego_path, context, validator::Params::CollisionCheck::PetCollision{},
-    validator::Params::CollisionCheck::Drac{}, validator::Params::CollisionCheck::GlobalSetting{},
-    vehicle_info,
-    collision_timing_assessment::ObjectTrajectoryGenerationOptions{false, false, false},
-    collision_timing_assessment::ObjectTrajectoryGenerationOptions{false, false, true});
+    ego_path, context, pet_collision_params, drac_params,
+    validator::Params::CollisionCheck::GlobalSetting{}, vehicle_info);
 
   EXPECT_TRUE(result.planned_speed_findings.empty());
   ASSERT_FALSE(result.drac_findings.empty());

--- a/planning/autoware_trajectory_validator/test/collision_check_filter/test_trajectory_utilities.cpp
+++ b/planning/autoware_trajectory_validator/test/collision_check_filter/test_trajectory_utilities.cpp
@@ -547,7 +547,7 @@ TEST(TrajectoryUtilitiesTest, GenerateObjectTrajectoriesRespectsEnabledTypes)
     };
 
   const auto all_enabled = collision_timing_assessment::generate_object_trajectories(
-    context, 0.2, 0.0,
+    context, 0.2, 0.0, 0.1,
     collision_timing_assessment::ObjectTrajectoryGenerationOptions{true, true, true});
   EXPECT_EQ(all_enabled.size(), 3u);
   EXPECT_EQ(count_suffix(all_enabled, "_predicted_path"), 1);
@@ -555,7 +555,7 @@ TEST(TrajectoryUtilitiesTest, GenerateObjectTrajectoriesRespectsEnabledTypes)
   EXPECT_EQ(count_suffix(all_enabled, "_diffusion_based_trajectory"), 1);
 
   const auto constant_curvature_only = collision_timing_assessment::generate_object_trajectories(
-    context, 0.2, 0.0,
+    context, 0.2, 0.0, 0.1,
     collision_timing_assessment::ObjectTrajectoryGenerationOptions{false, true, false});
   ASSERT_EQ(constant_curvature_only.size(), 1u);
   EXPECT_EQ(
@@ -564,7 +564,7 @@ TEST(TrajectoryUtilitiesTest, GenerateObjectTrajectoriesRespectsEnabledTypes)
 
   const auto predicted_path_and_diffusion =
     collision_timing_assessment::generate_object_trajectories(
-      context, 0.2, 0.0,
+      context, 0.2, 0.0, 0.1,
       collision_timing_assessment::ObjectTrajectoryGenerationOptions{true, false, true});
   EXPECT_EQ(predicted_path_and_diffusion.size(), 2u);
   EXPECT_EQ(count_suffix(predicted_path_and_diffusion, "_predicted_path"), 1);

--- a/planning/autoware_trajectory_validator/test/collision_check_filter/test_trajectory_utilities.cpp
+++ b/planning/autoware_trajectory_validator/test/collision_check_filter/test_trajectory_utilities.cpp
@@ -17,6 +17,7 @@
 #include <gtest/gtest.h>
 #include <tf2/utils.h>
 
+#include <algorithm>
 #include <cmath>
 #include <iterator>
 #include <memory>
@@ -511,6 +512,63 @@ TEST(TrajectoryUtilitiesTest, GenerateTimeInterpolatedPredictedPathTrajectoryUse
   EXPECT_NEAR(trajectory_data.getPoses().at(3).position.x, 2.5, 1e-6);
   EXPECT_NEAR(trajectory_data.getPoses().at(4).position.x, 3.5, 1e-6);
   EXPECT_NEAR(trajectory_data.getPoses().at(5).position.x, 4.0, 1e-6);
+}
+
+TEST(TrajectoryUtilitiesTest, GenerateObjectTrajectoriesRespectsEnabledTypes)
+{
+  const auto shape = create_bounding_box_shape(4.0, 2.0);
+  const auto object = create_predicted_object(
+    create_pose(0.0, 0.0, 0.0), create_twist(1.0), shape,
+    {create_straight_predicted_path(0.0, 1.0, {0.0, 1.0, 2.0})});
+
+  auto odometry = std::make_shared<nav_msgs::msg::Odometry>();
+  odometry->header.stamp = rclcpp::Time(1, 0, RCL_ROS_TIME);
+  odometry->pose.pose = create_pose(0.0, 0.0, 0.0);
+
+  auto predicted_objects = std::make_shared<autoware_perception_msgs::msg::PredictedObjects>();
+  predicted_objects->header.stamp = odometry->header.stamp;
+  predicted_objects->objects.push_back(object);
+
+  auto neural_network_predicted_objects =
+    std::make_shared<autoware_perception_msgs::msg::PredictedObjects>();
+  neural_network_predicted_objects->header.stamp = odometry->header.stamp;
+  neural_network_predicted_objects->objects.push_back(object);
+
+  FilterContext context;
+  context.odometry = odometry;
+  context.predicted_objects = predicted_objects;
+  context.neural_network_predicted_objects = neural_network_predicted_objects;
+
+  const auto count_suffix =
+    [](const std::vector<TrajectoryData> & trajectories, const std::string & suffix) {
+      return std::count_if(trajectories.begin(), trajectories.end(), [&](const auto & trajectory) {
+        return trajectory.getObjectIdentification().trajectory_suffix == suffix;
+      });
+    };
+
+  const auto all_enabled = collision_timing_assessment::generate_object_trajectories(
+    context, 0.2, 0.0,
+    collision_timing_assessment::ObjectTrajectoryGenerationOptions{true, true, true});
+  EXPECT_EQ(all_enabled.size(), 3u);
+  EXPECT_EQ(count_suffix(all_enabled, "_predicted_path"), 1);
+  EXPECT_EQ(count_suffix(all_enabled, "_constant_curvature_path"), 1);
+  EXPECT_EQ(count_suffix(all_enabled, "_diffusion_based_trajectory"), 1);
+
+  const auto constant_curvature_only = collision_timing_assessment::generate_object_trajectories(
+    context, 0.2, 0.0,
+    collision_timing_assessment::ObjectTrajectoryGenerationOptions{false, true, false});
+  ASSERT_EQ(constant_curvature_only.size(), 1u);
+  EXPECT_EQ(
+    constant_curvature_only.front().getObjectIdentification().trajectory_suffix,
+    "_constant_curvature_path");
+
+  const auto predicted_path_and_diffusion =
+    collision_timing_assessment::generate_object_trajectories(
+      context, 0.2, 0.0,
+      collision_timing_assessment::ObjectTrajectoryGenerationOptions{true, false, true});
+  EXPECT_EQ(predicted_path_and_diffusion.size(), 2u);
+  EXPECT_EQ(count_suffix(predicted_path_and_diffusion, "_predicted_path"), 1);
+  EXPECT_EQ(count_suffix(predicted_path_and_diffusion, "_diffusion_based_trajectory"), 1);
 }
 
 }  // namespace autoware::trajectory_validator::plugin::safety


### PR DESCRIPTION
  ## Description

  This PR adds per-assessment configuration for object trajectory types used by the trajectory validator collision check filter.

  The collision check filter can now independently enable or disable the following object trajectory sources for PET and DRAC assessment:

  - predicted path trajectory
  - constant curvature trajectory
  - diffusion-based trajectory

  The parameters were moved under each assessment namespace:

  - `collision_check.pet_collision.predicted_path_trajectory`
  - `collision_check.pet_collision.constant_curvature_trajectory`
  - `collision_check.pet_collision.diffusion_based_trajectory`
  - `collision_check.drac.predicted_path_trajectory`
  - `collision_check.drac.constant_curvature_trajectory`
  - `collision_check.drac.diffusion_based_trajectory`

  This allows PET and DRAC to use different object trajectory sources, instead of sharing one global set of object trajectory selection flags.

  The implementation now builds separate `ObjectTrajectoryGenerationOptions` for PET and DRAC, and generates object trajectories independently for each assessment. Tests were added to cover trajectory type
  filtering and to verify that PET and DRAC can be configured independently.

  ## How was this PR tested?

  - `colcon build --packages-select autoware_trajectory_validator --cmake-args -DCMAKE_BUILD_TYPE=Release`
  - `colcon test --packages-select autoware_trajectory_validator --event-handlers console_direct+`

  ## Notes for reviewers

Please review this simultaneously.
- https://github.com/tier4/autoware_launch.x2/pull/2148
