### PR TITLE
feat(trajectory_modifier): improve obstacle stop rss collision check

### DIFF
--- a/planning/autoware_trajectory_modifier/config/trajectory_modifier.param.yaml
+++ b/planning/autoware_trajectory_modifier/config/trajectory_modifier.param.yaml
@@ -34,12 +34,12 @@
         off_time_buffer: 1.0
         object_distance_th: 1.0 # [m]
         object_yaw_th: 0.1745 # [rad] (10 degrees)
-        pcd_distance_th: 0.5 # [m]
+        pcd_distance_th: 1.0 # [m]
         grace_period: 0.2 # [s]
 
       objects:
         object_types: ["car", "truck", "bus", "trailer", "motorcycle", "bicycle", "pedestrian"] # object types to consider for obstacle stop
-        max_velocity_th: 1.0      # maximum velocity threshold for target object [m/s]
+        max_velocity_th: 5.0      # maximum velocity threshold for target object [m/s]
         stopped_velocity_th: 0.25 # [m/s]
 
       pointcloud:
@@ -70,4 +70,4 @@
         ego_decel: 4.0 # [m/s^2]
         reaction_time: 0.2 # [s]
         safety_margin: 2.0 # [m]
-        lookahead_horizon: 5.0 # [s]
+        lookahead_horizon: 1.5 # [s]

--- a/planning/autoware_trajectory_modifier/config/trajectory_modifier.param.yaml
+++ b/planning/autoware_trajectory_modifier/config/trajectory_modifier.param.yaml
@@ -1,5 +1,8 @@
 /**:
   ros__parameters:
+    plugin_names:
+      - "autoware::trajectory_modifier::plugin::ObstacleStop"
+      - "autoware::trajectory_modifier::plugin::StopPointFixer"
     use_stop_point_fixer: true
     use_obstacle_stop: true
     trajectory_time_step: 0.1 # [s]
@@ -37,6 +40,7 @@
       objects:
         object_types: ["car", "truck", "bus", "trailer", "motorcycle", "bicycle", "pedestrian"] # object types to consider for obstacle stop
         max_velocity_th: 1.0      # maximum velocity threshold for target object [m/s]
+        stopped_velocity_th: 0.25 # [m/s]
 
       pointcloud:
         height_buffer: 0.5  # height buffer to add above ego height [m]
@@ -63,6 +67,7 @@
           motorcycle: 3.0
           bicycle: 5.0
           pedestrian: 5.0
-        response_time: 0.2 # [s]
+        ego_decel: 4.0 # [m/s^2]
+        reaction_time: 0.2 # [s]
         safety_margin: 2.0 # [m]
-        min_vel_th: 0.5 # [m/s] minimum object velocity to consider for rss check
+        lookahead_horizon: 5.0 # [s]

--- a/planning/autoware_trajectory_modifier/include/autoware/trajectory_modifier/trajectory_modifier_plugins/obstacle_stop.hpp
+++ b/planning/autoware_trajectory_modifier/include/autoware/trajectory_modifier/trajectory_modifier_plugins/obstacle_stop.hpp
@@ -22,6 +22,7 @@
 #include <autoware_utils_rclcpp/polling_subscriber.hpp>
 #include <rclcpp/rclcpp.hpp>
 
+#include <autoware_internal_debug_msgs/msg/string_stamped.hpp>
 #include <visualization_msgs/msg/marker_array.hpp>
 
 #include <memory>
@@ -31,6 +32,7 @@
 
 namespace autoware::trajectory_modifier::plugin
 {
+using autoware_internal_debug_msgs::msg::StringStamped;
 using autoware_internal_planning_msgs::msg::SafetyFactor;
 using autoware_internal_planning_msgs::msg::SafetyFactorArray;
 using autoware_utils_geometry::MultiPolygon2d;
@@ -78,7 +80,9 @@ private:
 
   MarkerArray marker_array_;
   rclcpp::Publisher<visualization_msgs::msg::MarkerArray>::SharedPtr debug_viz_pub_;
+  rclcpp::Publisher<PointCloud2>::SharedPtr pub_filtered_pointcloud_;
   rclcpp::Publisher<PointCloud2>::SharedPtr pub_clustered_pointcloud_;
+  rclcpp::Publisher<StringStamped>::SharedPtr pub_debug_text_;
 
   void check_obstacles(const TrajectoryPoints & traj_points);
   std::optional<CollisionPoint> check_predicted_objects(const TrajectoryPoints & traj_points);
@@ -88,6 +92,8 @@ private:
 
   bool apply_stopping(
     TrajectoryPoints & traj_points, const double target_stop_point_arc_length) const;
+
+  void publish_debug_string(bool is_safe) const;
 };
 
 }  // namespace autoware::trajectory_modifier::plugin

--- a/planning/autoware_trajectory_modifier/include/autoware/trajectory_modifier/trajectory_modifier_utils/obstacle_stop_utils.hpp
+++ b/planning/autoware_trajectory_modifier/include/autoware/trajectory_modifier/trajectory_modifier_utils/obstacle_stop_utils.hpp
@@ -159,10 +159,9 @@ using ObjectDecelMap = std::unordered_map<ObjectType, double>;
 std::optional<CollisionPoint> get_nearest_object_collision(
   const TrajectoryPoints & trajectory_points, const TrajectoryShape & trajectory_shape,
   const autoware::vehicle_info_utils::VehicleInfo & vehicle_info, const PredictedObjects & objects,
-  const ObjectDecelMap & object_decel_map, const double ego_vel, const double ego_decel,
-  const double reaction_time, const double safety_margin, const double stopped_vel_th,
-  const double lookahead_horizon, MultiPolygon2d & target_polygons,
-  PredictedObject & colliding_object);
+  const ObjectDecelMap & object_decel_map, const double ego_decel, const double reaction_time,
+  const double safety_margin, const double stopped_vel_th, const double lookahead_horizon,
+  MultiPolygon2d & target_polygons, PredictedObject & colliding_object);
 
 struct ObjectFilter
 {

--- a/planning/autoware_trajectory_modifier/include/autoware/trajectory_modifier/trajectory_modifier_utils/obstacle_stop_utils.hpp
+++ b/planning/autoware_trajectory_modifier/include/autoware/trajectory_modifier/trajectory_modifier_utils/obstacle_stop_utils.hpp
@@ -160,7 +160,7 @@ std::optional<CollisionPoint> get_nearest_object_collision(
   const TrajectoryPoints & trajectory_points, const TrajectoryShape & trajectory_shape,
   const autoware::vehicle_info_utils::VehicleInfo & vehicle_info, const PredictedObjects & objects,
   const ObjectDecelMap & object_decel_map, const double ego_vel, const double ego_decel,
-  const double reaction_time, const double safety_margin, const double min_vel_th,
+const double reaction_time, const double safety_margin, const double stopped_vel_th, const double lookahead_horizon,
   MultiPolygon2d & target_polygons, PredictedObject & colliding_object);
 
 struct ObjectFilter

--- a/planning/autoware_trajectory_modifier/include/autoware/trajectory_modifier/trajectory_modifier_utils/obstacle_stop_utils.hpp
+++ b/planning/autoware_trajectory_modifier/include/autoware/trajectory_modifier/trajectory_modifier_utils/obstacle_stop_utils.hpp
@@ -160,8 +160,9 @@ std::optional<CollisionPoint> get_nearest_object_collision(
   const TrajectoryPoints & trajectory_points, const TrajectoryShape & trajectory_shape,
   const autoware::vehicle_info_utils::VehicleInfo & vehicle_info, const PredictedObjects & objects,
   const ObjectDecelMap & object_decel_map, const double ego_vel, const double ego_decel,
-const double reaction_time, const double safety_margin, const double stopped_vel_th, const double lookahead_horizon,
-  MultiPolygon2d & target_polygons, PredictedObject & colliding_object);
+  const double reaction_time, const double safety_margin, const double stopped_vel_th,
+  const double lookahead_horizon, MultiPolygon2d & target_polygons,
+  PredictedObject & colliding_object);
 
 struct ObjectFilter
 {

--- a/planning/autoware_trajectory_modifier/include/autoware/trajectory_modifier/trajectory_modifier_utils/obstacle_stop_utils.hpp
+++ b/planning/autoware_trajectory_modifier/include/autoware/trajectory_modifier/trajectory_modifier_utils/obstacle_stop_utils.hpp
@@ -106,6 +106,13 @@ struct CollisionPoint
   }
 };
 
+struct ObjectState
+{
+  double arc_length;
+  double lon_vel;
+  geometry_msgs::msg::Point nearest_point;
+};
+
 struct TrajectoryShape
 {
   MultiPolygon2d polygon;
@@ -117,7 +124,8 @@ struct TrajectoryShape
 struct DebugData
 {
   PointCloud2::SharedPtr cluster_points;
-  PointCloud2::SharedPtr voxel_points;
+  PointCloud2::SharedPtr filtered_points;
+  PredictedObjects filtered_objects;
   MultiPolygon2d target_polygons;
   TrajectoryShape trajectory_shape;
   std::vector<geometry_msgs::msg::Point> target_pcd_points;

--- a/planning/autoware_trajectory_modifier/launch/trajectory_modifier.launch.xml
+++ b/planning/autoware_trajectory_modifier/launch/trajectory_modifier.launch.xml
@@ -6,25 +6,9 @@
   <arg name="input_objects_topic_name" default="/perception/object_recognition/objects"/>
   <arg name="input_pointcloud_topic_name" default="/perception/obstacle_segmentation/pointcloud"/>
   <arg name="output_candidate_trajectories" default="~/output/candidate_trajectories"/>
-  <arg name="launch_stop_point_fixer" default="true"/>
-  <arg name="launch_obstacle_stop" default="true"/>
-  <arg name="launch_modules_list_end" default="&quot;&quot;]"/>
-  <arg name="trajectory_modifier_launch_modules" default="["/>
-  <let
-    name="trajectory_modifier_launch_modules"
-    value="$(eval &quot;'$(var trajectory_modifier_launch_modules)' + 'autoware::trajectory_modifier::plugin::ObstacleStop, '&quot;)"
-    if="$(var launch_obstacle_stop)"
-  />
-  <let
-    name="trajectory_modifier_launch_modules"
-    value="$(eval &quot;'$(var trajectory_modifier_launch_modules)' + 'autoware::trajectory_modifier::plugin::StopPointFixer, '&quot;)"
-    if="$(var launch_stop_point_fixer)"
-  />
-  <let name="trajectory_modifier_launch_modules" value="$(eval &quot;'$(var trajectory_modifier_launch_modules)' + '$(var launch_modules_list_end)'&quot;)"/>
 
-  <node pkg="autoware_trajectory_modifier" exec="autoware_trajectory_modifier_node" name="trajectory_modifier" output="screen">
+  <node pkg="autoware_trajectory_modifier" exec="autoware_trajectory_modifier_node" name="trajectory_modifier" output="screen" launch-prefix="konsole -e gdb -ex run --args">
     <param from="$(var trajectory_modifier_param_path)"/>
-    <param name="launch_modules" value="$(var trajectory_modifier_launch_modules)"/>
     <remap from="~/input/objects" to="$(var input_objects_topic_name)"/>
     <remap from="~/input/pointcloud" to="$(var input_pointcloud_topic_name)"/>
     <remap from="~/input/candidate_trajectories" to="$(var input_candidate_trajectories)"/>

--- a/planning/autoware_trajectory_modifier/param/trajectory_modifier_parameter_struct.yaml
+++ b/planning/autoware_trajectory_modifier/param/trajectory_modifier_parameter_struct.yaml
@@ -161,7 +161,7 @@ trajectory_modifier_params:
         read_only: false
       pcd_distance_th:
         type: double
-        default_value: 0.5
+        default_value: 1.0
         description: Distance threshold for pointcloud tracking [m]
         validation:
           bounds<>: [0.0, 10.0]
@@ -182,7 +182,7 @@ trajectory_modifier_params:
         read_only: false
       max_velocity_th:
         type: double
-        default_value: 1.0
+        default_value: 5.0
         description: Maximum velocity threshold for target object to be considered for obstacle stop [m/s]
         validation:
           bounds<>: [0.0, 100.0]
@@ -348,7 +348,7 @@ trajectory_modifier_params:
         read_only: false
       lookahead_horizon:
         type: double
-        default_value: 5.0
+        default_value: 1.5
         description: lookahead horizon for RSS calculation [s]
         validation:
           bounds<>: [0.0, 10.0]

--- a/planning/autoware_trajectory_modifier/param/trajectory_modifier_parameter_struct.yaml
+++ b/planning/autoware_trajectory_modifier/param/trajectory_modifier_parameter_struct.yaml
@@ -1,4 +1,13 @@
 trajectory_modifier_params:
+  plugin_names:
+    type: string_array
+    default_value:
+      [
+        "autoware::trajectory_modifier::plugin::ObstacleStop",
+        "autoware::trajectory_modifier::plugin::StopPointFixer",
+      ]
+    description: List of plugin names to load
+    read_only: false
   use_stop_point_fixer:
     type: bool
     default_value: false
@@ -15,7 +24,7 @@ trajectory_modifier_params:
     description: Time step for trajectory modification [s]
     read_only: false
     validation:
-      gt_eq<>: [0.0]
+      bounds<>: [0.05, 1.0]
 
   stop_point_fixer:
     force_stop_long_stopped_trajectories:
@@ -34,21 +43,21 @@ trajectory_modifier_params:
       description: Velocity threshold below which ego vehicle is considered stationary [m/s]
       read_only: false
       validation:
-        gt_eq<>: [0.0]
+        bounds<>: [0.0, 100.0]
     min_distance_threshold:
       type: double
       default_value: 1.0
       description: Minimum distance threshold to trigger trajectory replacement [m]
       read_only: false
       validation:
-        gt_eq<>: [0.0]
+        bounds<>: [0.0, 100.0]
     min_stop_duration:
       type: double
       default_value: 0.5
       description: Minimum duration of stop to trigger trajectory replacement [s]
       read_only: false
       validation:
-        gt_eq<>: [0.0]
+        bounds<>: [0.0, 10.0]
 
   obstacle_stop:
     use_objects:
@@ -76,49 +85,49 @@ trajectory_modifier_params:
       default_value: 6.0
       description: Distance to maintain from an obstacle when stopped [m]
       validation:
-        gt_eq<>: [0.0]
+        bounds<>: [0.0, 100.0]
       read_only: false
     nominal_stopping_decel:
       type: double
       default_value: 1.0
       description: Nominal deceleration during stopping [m/s^2]
       validation:
-        gt_eq<>: [0.0]
+        bounds<>: [0.0, 10.0]
       read_only: false
     maximum_stopping_decel:
       type: double
       default_value: 4.0
       description: Maximum deceleration during stopping [m/s^2]
       validation:
-        gt_eq<>: [0.0]
+        bounds<>: [0.0, 10.0]
       read_only: false
     stopping_jerk:
       type: double
       default_value: 3.0
       description: Jerk during stopping [m/s^3]
       validation:
-        gt_eq<>: [0.0]
+        bounds<>: [0.0, 10.0]
       read_only: false
     lateral_margin:
       type: double
       default_value: 0.5
       description: Lateral margin on top of ego width from trajectory to consider for obstacle stop [m]
       validation:
-        gt_eq<>: [0.0]
+        bounds<>: [0.0, 10.0]
       read_only: false
     duplicate_check_threshold:
       type: double
       default_value: 1.0
       description: Threshold to check if the stop point is already in the trajectory [m]
       validation:
-        gt_eq<>: [0.0]
+        bounds<>: [0.0, 10.0]
       read_only: false
     arrived_distance_threshold:
       type: double
       default_value: 0.5
       description: Threshold to check if the ego vehicle has arrived at the stop point [m]
       validation:
-        gt_eq<>: [0.0]
+        bounds<>: [0.0, 10.0]
       read_only: false
 
     obstacle_tracking:
@@ -127,42 +136,42 @@ trajectory_modifier_params:
         default_value: 0.5
         description: Continuous detection duration to consider object/pointcloud to be persistent [s]
         validation:
-          gt_eq<>: [0.0]
+          bounds<>: [0.0, 5.0]
         read_only: false
       off_time_buffer:
         type: double
         default_value: 1.0
         description: Continuous non-detection duration to consider object/pointcloud as not persistent [s]
         validation:
-          gt_eq<>: [0.0]
+          bounds<>: [0.0, 5.0]
         read_only: false
       object_distance_th:
         type: double
         default_value: 1.0
         description: Distance threshold for object tracking [m]
         validation:
-          gt_eq<>: [0.0]
+          bounds<>: [0.0, 10.0]
         read_only: false
       object_yaw_th:
         type: double
         default_value: 0.1745
         description: Yaw threshold for object tracking [rad]
         validation:
-          gt_eq<>: [0.0]
+          bounds<>: [0.0, 3.14]
         read_only: false
       pcd_distance_th:
         type: double
         default_value: 0.5
         description: Distance threshold for pointcloud tracking [m]
         validation:
-          gt_eq<>: [0.0]
+          bounds<>: [0.0, 10.0]
         read_only: false
       grace_period:
         type: double
         default_value: 0.2
         description: Grace period for object tracking [s]
         validation:
-          gt_eq<>: [0.0]
+          bounds<>: [0.0, 1.0]
         read_only: false
 
     objects:
@@ -176,7 +185,14 @@ trajectory_modifier_params:
         default_value: 1.0
         description: Maximum velocity threshold for target object to be considered for obstacle stop [m/s]
         validation:
-          gt_eq<>: [0.0]
+          bounds<>: [0.0, 100.0]
+        read_only: false
+      stopped_velocity_th:
+        type: double
+        default_value: 0.25
+        description: Velocity threshold for target object to be considered as stopped [m/s]
+        validation:
+          bounds<>: [0.0, 10.0]
         read_only: false
 
     pointcloud:
@@ -185,42 +201,46 @@ trajectory_modifier_params:
         default_value: 0.5
         description: Height buffer to add above ego height [m]
         validation:
-          gt_eq<>: [0.0]
+          bounds<>: [0.0, 10.0]
         read_only: false
       min_height:
         type: double
         default_value: 0.2
         description: Minimum height of pointcloud [m]
         validation:
-          gt_eq<>: [0.0]
+          bounds<>: [0.0, 10.0]
         read_only: false
       detection_range:
         type: double
         default_value: 50.0
         description: Detection range [m]
         validation:
-          gt_eq<>: [0.0]
+          bounds<>: [0.0, 200.0]
         read_only: false
       voxel_grid_filter:
         x:
           type: double
+          default_value: 0.2
           validation:
-            gt<>: [0.0]
+            bounds<>: [0.0, 1.0]
           read_only: false
         y:
           type: double
+          default_value: 0.2
           validation:
-            gt<>: [0.0]
+            bounds<>: [0.0, 1.0]
           read_only: false
         z:
           type: double
+          default_value: 0.2
           validation:
-            gt<>: [0.0]
+            bounds<>: [0.0, 1.0]
           read_only: false
         min_size:
           type: int
+          default_value: 3
           validation:
-            bounds<>: [1, 2147483647]
+            bounds<>: [1, 100]
           read_only: false
       clustering:
         tolerance:
@@ -228,22 +248,25 @@ trajectory_modifier_params:
           default_value: 0.2
           description: Distance threshold for clustering points [m]
           validation:
-            gt<>: [0.0]
+            bounds<>: [0.0, 1.0]
           read_only: false
         min_height:
           type: double
+          default_value: 0.5
           validation:
-            gt_eq<>: [0.0]
+            bounds<>: [0.0, 1.0]
           read_only: false
         min_size:
           type: int
+          default_value: 10
           validation:
-            bounds<>: [1, 2147483647]
+            bounds<>: [1, 10000]
           read_only: false
         max_size:
           type: int
+          default_value: 10000
           validation:
-            bounds<>: [1, 2147483647]
+            bounds<>: [1, 10000]
           read_only: false
 
     rss_params:
@@ -258,68 +281,75 @@ trajectory_modifier_params:
           default_value: 1.5
           description: Deceleration for car type objects [m/s^2]
           validation:
-            gt_eq<>: [0.0]
+            bounds<>: [0.0, 10.0]
           read_only: false
         truck:
           type: double
           default_value: 1.5
           description: Deceleration for truck type objects [m/s^2]
           validation:
-            gt_eq<>: [0.0]
+            bounds<>: [0.0, 10.0]
           read_only: false
         bus:
           type: double
           default_value: 1.5
           description: Deceleration for bus type objects [m/s^2]
           validation:
-            gt_eq<>: [0.0]
+            bounds<>: [0.0, 10.0]
           read_only: false
         trailer:
           type: double
           default_value: 1.5
           description: Deceleration for trailer type objects [m/s^2]
           validation:
-            gt_eq<>: [0.0]
+            bounds<>: [0.0, 10.0]
           read_only: false
         motorcycle:
           type: double
           default_value: 3.0
           description: Deceleration for motorcycle type objects [m/s^2]
           validation:
-            gt_eq<>: [0.0]
+            bounds<>: [0.0, 10.0]
           read_only: false
         bicycle:
           type: double
           default_value: 5.0
           description: Deceleration for bicycle type objects [m/s^2]
           validation:
-            gt_eq<>: [0.0]
+            bounds<>: [0.0, 10.0]
           read_only: false
         pedestrian:
           type: double
           default_value: 5.0
           description: Deceleration for pedestrian type objects [m/s^2]
           validation:
-            gt_eq<>: [0.0]
+            bounds<>: [0.0, 10.0]
           read_only: false
+      ego_decel:
+        type: double
+        default_value: 4.0
+        description: Deceleration for ego vehicle [m/s^2]
+        validation:
+          bounds<>: [0.0, 10.0]
+        read_only: false
       reaction_time:
         type: double
         default_value: 0.2
         description: Reaction time to consider for RSS calculation [s]
         validation:
-          gt_eq<>: [0.0]
+          bounds<>: [0.0, 10.0]
         read_only: false
       safety_margin:
         type: double
         default_value: 2.0
         description: Safety margin to consider for RSS calculation [m]
         validation:
-          gt_eq<>: [0.0]
+          bounds<>: [0.0, 10.0]
         read_only: false
-      min_vel_th:
+      lookahead_horizon:
         type: double
-        default_value: 0.5
-        description: Minimum velocity threshold for object to be considered for RSS calculation [m/s]
+        default_value: 5.0
+        description: lookahead horizon for RSS calculation [s]
         validation:
-          gt_eq<>: [0.0]
+          bounds<>: [0.0, 10.0]
         read_only: false

--- a/planning/autoware_trajectory_modifier/schema/trajectory_modifier.schema.json
+++ b/planning/autoware_trajectory_modifier/schema/trajectory_modifier.schema.json
@@ -149,7 +149,7 @@
                 "pcd_distance_th": {
                   "type": "number",
                   "description": "Distance threshold for pointcloud tracking [m]",
-                  "default": 0.5,
+                  "default": 1.0,
                   "minimum": 0.0
                 },
                 "grace_period": {
@@ -185,7 +185,7 @@
                 "max_velocity_th": {
                   "type": "number",
                   "description": "Maximum velocity threshold for target object [m/s]",
-                  "default": 1.0,
+                  "default": 5.0,
                   "minimum": 0.0
                 },
                 "stopped_velocity_th": {
@@ -363,7 +363,7 @@
                 "lookahead_horizon": {
                   "type": "number",
                   "description": "Lookahead horizon for RSS calculation [s]",
-                  "default": 5.0,
+                  "default": 1.5,
                   "minimum": 0.0
                 }
               },

--- a/planning/autoware_trajectory_modifier/schema/trajectory_modifier.schema.json
+++ b/planning/autoware_trajectory_modifier/schema/trajectory_modifier.schema.json
@@ -187,6 +187,12 @@
                   "description": "Maximum velocity threshold for target object [m/s]",
                   "default": 1.0,
                   "minimum": 0.0
+                },
+                "stopped_velocity_th": {
+                  "type": "number",
+                  "description": "Velocity threshold for target object to be considered as stopped [m/s]",
+                  "default": 0.25,
+                  "minimum": 0.0
                 }
               },
               "required": [],
@@ -274,6 +280,91 @@
                   },
                   "required": [],
                   "additionalProperties": false
+                }
+              },
+              "required": [],
+              "additionalProperties": false
+            },
+            "rss_params": {
+              "type": "object",
+              "properties": {
+                "enable": {
+                  "type": "boolean",
+                  "description": "Enable RSS safety check",
+                  "default": true
+                },
+                "object_decel": {
+                  "type": "object",
+                  "properties": {
+                    "car": {
+                      "type": "number",
+                      "description": "Deceleration for car type objects [m/s^2]",
+                      "default": 1.5,
+                      "minimum": 0.0
+                    },
+                    "truck": {
+                      "type": "number",
+                      "description": "Deceleration for truck type objects [m/s^2]",
+                      "default": 1.5,
+                      "minimum": 0.0
+                    },
+                    "bus": {
+                      "type": "number",
+                      "description": "Deceleration for bus type objects [m/s^2]",
+                      "default": 1.5,
+                      "minimum": 0.0
+                    },
+                    "trailer": {
+                      "type": "number",
+                      "description": "Deceleration for trailer type objects [m/s^2]",
+                      "default": 1.5,
+                      "minimum": 0.0
+                    },
+                    "motorcycle": {
+                      "type": "number",
+                      "description": "Deceleration for motorcycle type objects [m/s^2]",
+                      "default": 3.0,
+                      "minimum": 0.0
+                    },
+                    "bicycle": {
+                      "type": "number",
+                      "description": "Deceleration for bicycle type objects [m/s^2]",
+                      "default": 5.0,
+                      "minimum": 0.0
+                    },
+                    "pedestrian": {
+                      "type": "number",
+                      "description": "Deceleration for pedestrian type objects [m/s^2]",
+                      "default": 5.0,
+                      "minimum": 0.0
+                    }
+                  },
+                  "required": [],
+                  "additionalProperties": false
+                },
+                "ego_decel": {
+                  "type": "number",
+                  "description": "Deceleration for ego vehicle [m/s^2]",
+                  "default": 4.0,
+                  "minimum": 0.0
+                },
+                "reaction_time": {
+                  "type": "number",
+                  "description": "Reaction time to consider for RSS calculation [s]",
+                  "default": 0.2,
+                  "minimum": 0.0
+                },
+                "safety_margin": {
+                  "type": "number",
+                  "description": "Safety margin to consider for RSS calculation [m]",
+                  "default": 2.0,
+                  "minimum": 0.0
+                },
+                "lookahead_horizon": {
+                  "type": "number",
+                  "description": "Lookahead horizon for RSS calculation [s]",
+                  "default": 5.0,
+                  "minimum": 0.0
                 }
               },
               "required": [],

--- a/planning/autoware_trajectory_modifier/src/trajectory_modifier.cpp
+++ b/planning/autoware_trajectory_modifier/src/trajectory_modifier.cpp
@@ -50,7 +50,7 @@ TrajectoryModifier::TrajectoryModifier(const rclcpp::NodeOptions & options)
   params_ = param_listener_->get_params();
 
   // initialize plugins
-  for (const auto & name : this->declare_parameter<std::vector<std::string>>("launch_modules")) {
+  for (const auto & name : params_.plugin_names) {
     if (name.empty()) continue;
     load_plugin(name);
   }

--- a/planning/autoware_trajectory_modifier/src/trajectory_modifier_plugins/obstacle_stop.cpp
+++ b/planning/autoware_trajectory_modifier/src/trajectory_modifier_plugins/obstacle_stop.cpp
@@ -465,8 +465,7 @@ std::optional<CollisionPoint> ObstacleStop::check_predicted_objects(
     }
     return get_nearest_object_collision(
       traj_points, debug_data_.trajectory_shape, data_->vehicle_info, active_objects,
-      object_decel_map_, data_->current_odometry->twist.twist.linear.x,
-      params_.rss_params.ego_decel, params_.rss_params.reaction_time,
+      object_decel_map_, params_.rss_params.ego_decel, params_.rss_params.reaction_time,
       params_.rss_params.safety_margin, params_.objects.stopped_velocity_th,
       params_.rss_params.lookahead_horizon, debug_data_.target_polygons, colliding_object);
   });

--- a/planning/autoware_trajectory_modifier/src/trajectory_modifier_plugins/obstacle_stop.cpp
+++ b/planning/autoware_trajectory_modifier/src/trajectory_modifier_plugins/obstacle_stop.cpp
@@ -94,6 +94,8 @@ void ObstacleStop::on_initialize(const TrajectoryModifierParams & params)
       {utils::obstacle_stop::ObjectType::CAR, p.object_decel.car},
       {utils::obstacle_stop::ObjectType::TRUCK, p.object_decel.truck},
       {utils::obstacle_stop::ObjectType::BUS, p.object_decel.bus},
+      {utils::obstacle_stop::ObjectType::TRAILER, p.object_decel.trailer},
+      {utils::obstacle_stop::ObjectType::MOTORCYCLE, p.object_decel.motorcycle},
       {utils::obstacle_stop::ObjectType::BICYCLE, p.object_decel.bicycle},
       {utils::obstacle_stop::ObjectType::PEDESTRIAN, p.object_decel.pedestrian}};
   }
@@ -247,52 +249,29 @@ size_t update_velocities(TrajectoryPoints & trajectory, const double jerk, const
   if (trajectory.size() < 2) return 0;
 
   auto get_vel_accel = [&](
-                         const auto & point, const auto & ref_point,
-                         const bool backward) -> std::pair<double, double> {
+                         const auto & point, const auto & ref_point) -> std::pair<double, double> {
     const auto v_ref = ref_point.longitudinal_velocity_mps;
-    const auto a_ref =
-      backward ? std::abs(ref_point.acceleration_mps2) : ref_point.acceleration_mps2;
+    const auto a_ref = std::abs(ref_point.acceleration_mps2);
 
     const auto ds = autoware_utils::calc_distance2d(point.pose.position, ref_point.pose.position);
     const auto da = jerk * (ds / std::max<double>(v_ref, 0.1));
-    const auto a_curr = backward ? std::min(a_ref + da, decel) : a_ref - da;
+    const auto a_curr = std::min(a_ref + da, decel);
     const auto a_avg = (a_ref + a_curr) / 2.0;
     const auto v_curr = std::sqrt(std::max(0.0, v_ref * v_ref + 2.0 * a_avg * ds));
-    return {v_curr, a_curr};
+    return {v_curr, -1.0 * a_curr};
   };
 
   const auto stop_index = trajectory.size() - 1;
   auto vel_update_start_index = stop_index;
   for (int i = static_cast<int>(stop_index) - 1; i > 0; --i) {
     auto & curr = trajectory.at(i);
-    const auto & next = trajectory.at(i + 1);
-    const auto [v_curr, a_curr] = get_vel_accel(curr, next, true);
+    auto & next = trajectory.at(i + 1);
+    const auto [v_curr, a_curr] = get_vel_accel(curr, next);
 
     if (v_curr >= curr.longitudinal_velocity_mps) break;
     curr.longitudinal_velocity_mps = static_cast<float>(v_curr);
-    curr.acceleration_mps2 = static_cast<float>(a_curr) * -1.0f;
+    curr.acceleration_mps2 = static_cast<float>(a_curr);
     vel_update_start_index = i;
-  }
-
-  const auto start_idx = std::max<int>(static_cast<int>(vel_update_start_index), 1);
-  for (int i = start_idx; i <= static_cast<int>(stop_index); ++i) {
-    auto & curr = trajectory.at(i);
-    const auto & prev = trajectory.at(i - 1);
-    const auto [v_curr, a_curr] = get_vel_accel(curr, prev, false);
-
-    if (v_curr <= curr.longitudinal_velocity_mps) {
-      auto j = std::max(i - 3, 1);
-      auto stop = std::min(i + 3, static_cast<int>(stop_index));
-      for (; j < stop; ++j) {
-        auto v_sum = trajectory.at(j - 1).longitudinal_velocity_mps +
-                     trajectory.at(j).longitudinal_velocity_mps +
-                     trajectory.at(j + 1).longitudinal_velocity_mps;
-        trajectory.at(j).longitudinal_velocity_mps = v_sum / 3.0f;
-      }
-      break;
-    }
-    curr.longitudinal_velocity_mps = v_curr;
-    curr.acceleration_mps2 = a_curr;
   }
   return vel_update_start_index;
 }
@@ -348,7 +327,7 @@ bool ObstacleStop::apply_stopping(
     std::abs(params_.maximum_stopping_decel));
 
   const auto vel_update_start_index = update_velocities(trajectory, jerk, decel);
-  auto interpolate_start_index = vel_update_start_index > 0 ? vel_update_start_index - 1 : 0;
+  const auto interpolate_start_index = vel_update_start_index > 0 ? vel_update_start_index - 1 : 0;
 
   auto trajectory_interpolation_util =
     InterpolationTrajectory::Builder{}
@@ -492,15 +471,17 @@ std::optional<CollisionPoint> ObstacleStop::check_pointcloud(const TrajectoryPoi
   {
     autoware_utils_debug::ScopedTimeTrack st("ObstacleStop::filter_pointcloud", *get_time_keeper());
     const auto & bounding_box = debug_data_.trajectory_shape.bounding_box;
-    const auto rel_min_point = autoware_utils::inverse_transform_point(
+    const auto rel_min_corner = autoware_utils::inverse_transform_point(
       bounding_box.min_corner().to_3d(), data_->current_odometry->pose.pose);
-    const auto rel_max_point = autoware_utils::inverse_transform_point(
+    const auto rel_max_corner = autoware_utils::inverse_transform_point(
       bounding_box.max_corner().to_3d(), data_->current_odometry->pose.pose);
+    constexpr double buffer = 1.0;
+    const auto [min_x, max_x] = std::minmax(rel_min_corner.x(), rel_max_corner.x());
+    const auto [min_y, max_y] = std::minmax(rel_min_corner.y(), rel_max_corner.y());
     const auto min_z = params_.pointcloud.min_height;
     const auto max_z = data_->vehicle_info.vehicle_height_m + params_.pointcloud.height_buffer;
     pointcloud_filter_->filter_pointcloud(
-      filtered_pointcloud, rel_min_point.x(), rel_max_point.x(), rel_min_point.y(),
-      rel_max_point.y(), min_z, max_z);
+      filtered_pointcloud, min_x - buffer, max_x + buffer, min_y - buffer, max_y + buffer, min_z, max_z);
   }
 
   PointCloud::Ptr clustered_points(new PointCloud);
@@ -561,6 +542,7 @@ void ObstacleStop::publish_debug_data(const std::string & ns) const
   const auto ego_z = data_->current_odometry->pose.pose.position.z;
   const auto white = autoware_utils::create_marker_color(1.0, 1.0, 1.0, 1.0);
   const auto yellow = autoware_utils::create_marker_color(1.0, 1.0, 0.0, 1.0);
+  const auto magenta = autoware_utils::create_marker_color(1.0, 0.0, 1.0, 1.0);
 
   auto add_point_marker = [&](
                             const geometry_msgs::msg::Point & point, const std::string & ns,
@@ -594,7 +576,7 @@ void ObstacleStop::publish_debug_data(const std::string & ns) const
 
   int id = 0;
   for (const auto & traj_polygon : debug_data_.trajectory_shape.polygon) {
-    add_polygon_marker(traj_polygon, ns + "/traj_polygon", id, white);
+    add_polygon_marker(traj_polygon, ns + "/traj_polygon", id, yellow);
     id++;
   }
 
@@ -610,12 +592,12 @@ void ObstacleStop::publish_debug_data(const std::string & ns) const
   }
 
   for (const auto & target_polygon : debug_data_.target_polygons) {
-    add_polygon_marker(target_polygon, ns + "/target_objects", id, yellow);
+    add_polygon_marker(target_polygon, ns + "/target_objects", id, magenta);
     id++;
   }
 
   for (const auto & target_pcd_point : debug_data_.target_pcd_points) {
-    add_point_marker(target_pcd_point, ns + "/target_pcd", id, yellow, 0.25);
+    add_point_marker(target_pcd_point, ns + "/target_pcd", id, magenta, 0.25);
     id++;
   }
 

--- a/planning/autoware_trajectory_modifier/src/trajectory_modifier_plugins/obstacle_stop.cpp
+++ b/planning/autoware_trajectory_modifier/src/trajectory_modifier_plugins/obstacle_stop.cpp
@@ -466,8 +466,8 @@ std::optional<CollisionPoint> ObstacleStop::check_predicted_objects(
     return get_nearest_object_collision(
       traj_points, debug_data_.trajectory_shape, data_->vehicle_info, active_objects,
       object_decel_map_, data_->current_odometry->twist.twist.linear.x,
-      params_.rss_params.ego_decel, params_.rss_params.reaction_time,
-      params_.rss_params.safety_margin, params_.objects.stopped_velocity_th,
+      params_.rss_params.ego_decel, params_.rss_params.reaction_time, params_.rss_params.safety_margin,
+      params_.objects.stopped_velocity_th, params_.rss_params.lookahead_horizon,
       debug_data_.target_polygons, colliding_object);
   });
 

--- a/planning/autoware_trajectory_modifier/src/trajectory_modifier_plugins/obstacle_stop.cpp
+++ b/planning/autoware_trajectory_modifier/src/trajectory_modifier_plugins/obstacle_stop.cpp
@@ -466,9 +466,9 @@ std::optional<CollisionPoint> ObstacleStop::check_predicted_objects(
     return get_nearest_object_collision(
       traj_points, debug_data_.trajectory_shape, data_->vehicle_info, active_objects,
       object_decel_map_, data_->current_odometry->twist.twist.linear.x,
-      params_.rss_params.ego_decel, params_.rss_params.reaction_time, params_.rss_params.safety_margin,
-      params_.objects.stopped_velocity_th, params_.rss_params.lookahead_horizon,
-      debug_data_.target_polygons, colliding_object);
+      params_.rss_params.ego_decel, params_.rss_params.reaction_time,
+      params_.rss_params.safety_margin, params_.objects.stopped_velocity_th,
+      params_.rss_params.lookahead_horizon, debug_data_.target_polygons, colliding_object);
   });
 
   if (collision_point) debug_data_.colliding_object = colliding_object;

--- a/planning/autoware_trajectory_modifier/src/trajectory_modifier_plugins/obstacle_stop.cpp
+++ b/planning/autoware_trajectory_modifier/src/trajectory_modifier_plugins/obstacle_stop.cpp
@@ -60,12 +60,21 @@ void ObstacleStop::on_initialize(const TrajectoryModifierParams & params)
 
   pub_clustered_pointcloud_ =
     node_ptr->create_publisher<PointCloud2>("~/obstacle_stop/debug/cluster_points", 1);
+  pub_filtered_pointcloud_ =
+    node_ptr->create_publisher<PointCloud2>("~/obstacle_stop/debug/filtered_points", 1);
   debug_viz_pub_ = node_ptr->create_publisher<visualization_msgs::msg::MarkerArray>(
     "~/obstacle_stop/debug/marker", 1);
+  pub_debug_text_ = node_ptr->create_publisher<StringStamped>("~/obstacle_stop/debug/text", 1);
 
   params_ = params.obstacle_stop;
   enabled_ = params.use_obstacle_stop;
   trajectory_time_step_ = params.trajectory_time_step;
+
+  {
+    auto & p = params_.rss_params;
+    p.ego_decel =
+      std::clamp(p.ego_decel, params_.nominal_stopping_decel, params_.maximum_stopping_decel);
+  }
 
   {
     const auto & p = params_.pointcloud;
@@ -106,6 +115,12 @@ void ObstacleStop::update_params(const TrajectoryModifierParams & params)
   params_ = params.obstacle_stop;
   enabled_ = params.use_obstacle_stop;
   trajectory_time_step_ = params.trajectory_time_step;
+
+  {
+    auto & p = params_.rss_params;
+    p.ego_decel =
+      std::clamp(p.ego_decel, params_.nominal_stopping_decel, params_.maximum_stopping_decel);
+  }
 
   {
     const auto & p = params_.pointcloud;
@@ -158,14 +173,18 @@ bool ObstacleStop::is_trajectory_modification_required(const TrajectoryPoints & 
   debug_data_.active_collision_point =
     nearest_collision_point_ ? nearest_collision_point_->point : geometry_msgs::msg::Point();
 
-  return nearest_collision_point_ != std::nullopt;
+  const bool is_safe = nearest_collision_point_ == std::nullopt;
+
+  publish_debug_string(is_safe);
+
+  return !is_safe;
 }
 
 bool ObstacleStop::modify_trajectory(TrajectoryPoints & traj_points)
 {
   autoware_utils_debug::ScopedTimeTrack st("ObstacleStop::modify_trajectory", *get_time_keeper());
 
-  if (!enabled_) return false;
+  if (!enabled_ || traj_points.size() < 2) return false;
 
   auto trajectory = traj_points;
   utils::obstacle_stop::trim_trajectory_and_remove_duplicates(trajectory);
@@ -429,12 +448,13 @@ std::optional<CollisionPoint> ObstacleStop::check_predicted_objects(
   if (
     !params_.use_objects || !data_->predicted_objects || data_->predicted_objects->objects.empty())
     return std::nullopt;
-  auto predicted_objects = *data_->predicted_objects;
+  debug_data_.filtered_objects = *data_->predicted_objects;
 
-  object_filter_->filter_objects(predicted_objects);
+  object_filter_->filter_objects(debug_data_.filtered_objects);
 
   PredictedObjects active_objects;
-  obstacle_tracker_->update_objects(predicted_objects, active_objects, get_clock()->now());
+  obstacle_tracker_->update_objects(
+    debug_data_.filtered_objects, active_objects, get_clock()->now());
 
   autoware_perception_msgs::msg::PredictedObject colliding_object;
   auto collision_point = std::invoke([&]() -> std::optional<CollisionPoint> {
@@ -446,9 +466,9 @@ std::optional<CollisionPoint> ObstacleStop::check_predicted_objects(
     return get_nearest_object_collision(
       traj_points, debug_data_.trajectory_shape, data_->vehicle_info, active_objects,
       object_decel_map_, data_->current_odometry->twist.twist.linear.x,
-      params_.nominal_stopping_decel, params_.rss_params.reaction_time,
-      params_.rss_params.safety_margin, params_.rss_params.min_vel_th, debug_data_.target_polygons,
-      colliding_object);
+      params_.rss_params.ego_decel, params_.rss_params.reaction_time,
+      params_.rss_params.safety_margin, params_.objects.stopped_velocity_th,
+      debug_data_.target_polygons, colliding_object);
   });
 
   if (collision_point) debug_data_.colliding_object = colliding_object;
@@ -481,7 +501,8 @@ std::optional<CollisionPoint> ObstacleStop::check_pointcloud(const TrajectoryPoi
     const auto min_z = params_.pointcloud.min_height;
     const auto max_z = data_->vehicle_info.vehicle_height_m + params_.pointcloud.height_buffer;
     pointcloud_filter_->filter_pointcloud(
-      filtered_pointcloud, min_x - buffer, max_x + buffer, min_y - buffer, max_y + buffer, min_z, max_z);
+      filtered_pointcloud, min_x - buffer, max_x + buffer, min_y - buffer, max_y + buffer, min_z,
+      max_z);
   }
 
   PointCloud::Ptr clustered_points(new PointCloud);
@@ -507,11 +528,16 @@ std::optional<CollisionPoint> ObstacleStop::check_pointcloud(const TrajectoryPoi
   }
 
   {
-    const auto cluster_pointcloud = std::make_shared<sensor_msgs::msg::PointCloud2>();
-    pcl::toROSMsg(*clustered_points, *cluster_pointcloud);
-    cluster_pointcloud->header.stamp = data_->obstacle_pointcloud->header.stamp;
-    cluster_pointcloud->header.frame_id = "map";
-    debug_data_.cluster_points = cluster_pointcloud;
+    const auto cluster_pointcloud_msg = std::make_shared<sensor_msgs::msg::PointCloud2>();
+    const auto filtered_pointcloud_msg = std::make_shared<sensor_msgs::msg::PointCloud2>();
+    pcl::toROSMsg(*clustered_points, *cluster_pointcloud_msg);
+    pcl::toROSMsg(*filtered_pointcloud, *filtered_pointcloud_msg);
+    cluster_pointcloud_msg->header.stamp = data_->obstacle_pointcloud->header.stamp;
+    cluster_pointcloud_msg->header.frame_id = "map";
+    filtered_pointcloud_msg->header.stamp = data_->obstacle_pointcloud->header.stamp;
+    filtered_pointcloud_msg->header.frame_id = "map";
+    debug_data_.cluster_points = cluster_pointcloud_msg;
+    debug_data_.filtered_points = filtered_pointcloud_msg;
   }
 
   if (data_->predicted_objects && !data_->predicted_objects->objects.empty()) {
@@ -534,8 +560,34 @@ std::optional<CollisionPoint> ObstacleStop::check_pointcloud(const TrajectoryPoi
   return collision_point;
 }
 
+void ObstacleStop::publish_debug_string(bool is_safe) const
+{
+  const auto filtered_pcd_size =
+    debug_data_.filtered_points ? debug_data_.filtered_points->data.size() : 0;
+  const auto cluster_pcd_size =
+    debug_data_.cluster_points ? debug_data_.cluster_points->data.size() : 0;
+  std::ostringstream ss;
+  ss << std::fixed << std::setprecision(2) << std::boolalpha;
+  ss << "OBSTACLE STOP MODIFIER: " << "\n";
+  ss << "\t\t" << "SAFE: " << is_safe << "\n";
+  ss << "\t\t" << "OBJECTS: " << debug_data_.filtered_objects.objects.size() << " --> "
+     << debug_data_.target_polygons.size() << "\n";
+  ss << "\t\t" << "POINTCLOUD: " << filtered_pcd_size << " --> " << cluster_pcd_size << " --> "
+     << debug_data_.target_pcd_points.size() << "\n";
+  if (nearest_collision_point_) {
+    ss << "\t\t" << "DISTANCE TO COLLISION: " << nearest_collision_point_->arc_length << " m"
+       << "\n";
+  }
+
+  StringStamped string_stamp;
+  string_stamp.stamp = get_clock()->now();
+  string_stamp.data = ss.str();
+  pub_debug_text_->publish(string_stamp);
+}
+
 void ObstacleStop::publish_debug_data(const std::string & ns) const
 {
+  if (debug_data_.filtered_points) pub_filtered_pointcloud_->publish(*debug_data_.filtered_points);
   if (debug_data_.cluster_points) pub_clustered_pointcloud_->publish(*debug_data_.cluster_points);
 
   MarkerArray marker_array;

--- a/planning/autoware_trajectory_modifier/src/trajectory_modifier_utils/obstacle_stop_utils.cpp
+++ b/planning/autoware_trajectory_modifier/src/trajectory_modifier_utils/obstacle_stop_utils.cpp
@@ -324,8 +324,9 @@ std::optional<CollisionPoint> get_nearest_object_collision(
   const TrajectoryPoints & trajectory_points, const TrajectoryShape & trajectory_shape,
   const autoware::vehicle_info_utils::VehicleInfo & vehicle_info, const PredictedObjects & objects,
   const ObjectDecelMap & object_decel_map, const double ego_vel, const double ego_decel,
-  const double reaction_time, const double safety_margin, const double stopped_vel_th, const double lookahead_horizon,
-  MultiPolygon2d & target_polygons, PredictedObject & colliding_object)
+  const double reaction_time, const double safety_margin, const double stopped_vel_th,
+  const double lookahead_horizon, MultiPolygon2d & target_polygons,
+  PredictedObject & colliding_object)
 {
   if (objects.objects.empty()) return std::nullopt;
 

--- a/planning/autoware_trajectory_modifier/src/trajectory_modifier_utils/obstacle_stop_utils.cpp
+++ b/planning/autoware_trajectory_modifier/src/trajectory_modifier_utils/obstacle_stop_utils.cpp
@@ -51,22 +51,57 @@ double get_detection_length(
 {
   // add a buffer length to account for the reaction time of the vehicle
   constexpr double buffer_length = 1.0;
+  constexpr double time_delay = 0.3;
   const auto margin = stop_margin + buffer_length;
   auto nominal_stopping_distance =
-    autoware::motion_utils::calculate_stop_distance(current_vel, current_accel, decel, jerk, 0.0);
+    autoware::motion_utils::calculate_stop_distance(current_vel, current_accel, decel, jerk, time_delay);
   if (nominal_stopping_distance) {
     return nominal_stopping_distance.value() + margin;
   }
   return forward_traj_length + margin;
 }
 
-TrajectoryPoints extend_trajectory(const TrajectoryPoints & trajectory_points, const double length)
+TrajectoryPoints extend_trajectory(const TrajectoryPoints & trajectory_points, const double length, const double wheelbase_length)
 {
-  if (length < 1e-3) return trajectory_points;
-  auto extended_trajectory = trajectory_points;
-  auto p = trajectory_points.back();
-  p.pose = autoware_utils::calc_offset_pose(p.pose, length, 0, 0);
-  extended_trajectory.push_back(p);
+  if (length < 1e-3 || trajectory_points.empty()) return trajectory_points;
+
+  const auto & last_p = trajectory_points.back();
+  const auto yaw_last = tf2::getYaw(last_p.pose.orientation);
+  constexpr double lookback_distance = 1.0;  // [m]
+  const auto lookback_pose = motion_utils::calcLongitudinalOffsetPose(trajectory_points, trajectory_points.size() - 1, -1.0 * lookback_distance);
+  
+  auto steering_angle = 0.0;
+  if (lookback_pose) {
+    const auto lookback_yaw = tf2::getYaw(lookback_pose.value().orientation);
+    const auto delta_yaw = autoware_utils_geometry::normalize_radian(yaw_last - lookback_yaw);
+    const auto k = delta_yaw / lookback_distance;
+    steering_angle = std::atan(k * wheelbase_length);
+  }
+
+  if (std::abs(steering_angle) < 1e-3) {
+    auto extended_trajectory = trajectory_points;
+    auto p = trajectory_points.back();
+    p.pose = autoware_utils::calc_offset_pose(p.pose, length, 0, 0);
+    extended_trajectory.push_back(p);
+    return extended_trajectory;
+  }
+
+  const auto turn_radius = wheelbase_length / std::tan(steering_angle);
+  const auto yaw = tf2::getYaw(last_p.pose.orientation);
+
+  constexpr double step = 0.5;
+  TrajectoryPoints extended_trajectory;
+  for (auto d = length; d > 0; d -= step) {
+    auto p = last_p;
+    const auto beta = d / turn_radius;
+    p.pose.position.x += turn_radius * (std::sin(yaw + beta) - std::sin(yaw));
+    p.pose.position.y += turn_radius * (std::cos(yaw) - std::cos(yaw + beta));
+    p.pose.orientation = autoware_utils::create_quaternion_from_yaw(yaw + beta);
+    extended_trajectory.push_back(p);
+  }
+  std::reverse(extended_trajectory.begin(), extended_trajectory.end());
+
+  extended_trajectory.insert(extended_trajectory.begin(), trajectory_points.begin(), trajectory_points.end());
   return extended_trajectory;
 }
 
@@ -93,7 +128,7 @@ TrajectoryShape get_trajectory_shape(
       return motion_utils::cropForwardPoints(
         trajectory_points, ego_pose.position, start_idx, detection_length);
     }
-    return extend_trajectory(trajectory_points, stop_margin);
+    return extend_trajectory(trajectory_points, stop_margin, vehicle_info.wheel_base_m);
   });
 
   autoware_utils_geometry::LineString2d ls_front_right;
@@ -181,9 +216,7 @@ std::optional<CollisionPoint> get_nearest_pcd_collision(
   auto min_arc_length = std::numeric_limits<double>::max();
   geometry_msgs::msg::Point nearest_collision_point;
   for (const auto & point : *pointcloud_in_polygon) {
-    geometry_msgs::msg::Point p;
-    p.x = point.x;
-    p.y = point.y;
+    geometry_msgs::msg::Point p = geometry_msgs::msg::Point().set__x(point.x).set__y(point.y).set__z(point.z);
     auto arc_length = motion_utils::calcSignedArcLength(trajectory_points, 0, p);
     if (arc_length < min_arc_length) {
       min_arc_length = arc_length;

--- a/planning/autoware_trajectory_modifier/src/trajectory_modifier_utils/obstacle_stop_utils.cpp
+++ b/planning/autoware_trajectory_modifier/src/trajectory_modifier_utils/obstacle_stop_utils.cpp
@@ -323,10 +323,9 @@ double get_safe_distance(
 std::optional<CollisionPoint> get_nearest_object_collision(
   const TrajectoryPoints & trajectory_points, const TrajectoryShape & trajectory_shape,
   const autoware::vehicle_info_utils::VehicleInfo & vehicle_info, const PredictedObjects & objects,
-  const ObjectDecelMap & object_decel_map, const double ego_vel, const double ego_decel,
-  const double reaction_time, const double safety_margin, const double stopped_vel_th,
-  const double lookahead_horizon, MultiPolygon2d & target_polygons,
-  PredictedObject & colliding_object)
+  const ObjectDecelMap & object_decel_map, const double ego_decel, const double reaction_time,
+  const double safety_margin, const double stopped_vel_th, const double lookahead_horizon,
+  MultiPolygon2d & target_polygons, PredictedObject & colliding_object)
 {
   if (objects.objects.empty()) return std::nullopt;
 
@@ -334,7 +333,7 @@ std::optional<CollisionPoint> get_nearest_object_collision(
 
   auto is_safe = [&](
                    const auto & object, const double obj_arc_length, const double obj_lon_vel,
-                   const double ego_arc_length) -> bool {
+                   const double ego_arc_length, const double ego_vel) -> bool {
     if (object.classification.empty()) return false;
     const auto obj_type = classification_to_object_type.at(object.classification.front().label);
     if (!object_decel_map.count(obj_type)) return false;
@@ -368,9 +367,11 @@ std::optional<CollisionPoint> get_nearest_object_collision(
     const auto t = rclcpp::Duration(traj_p.time_from_start).seconds();
     if (t > lookahead_horizon) break;
     curr_arc_length += autoware_utils::calc_distance2d(last_p, traj_p.pose.position);
+    const auto target_ego_vel = traj_p.longitudinal_velocity_mps;
     for (const auto & object : target_objects.objects) {
       const auto obj_state = get_object_state_at_time(trajectory_points, object, t);
-      if (is_safe(object, obj_state.arc_length, obj_state.lon_vel, curr_arc_length)) continue;
+      if (is_safe(object, obj_state.arc_length, obj_state.lon_vel, curr_arc_length, target_ego_vel))
+        continue;
       found_collision = true;
       if (obj_state.arc_length < min_obj_arc_length) {
         min_obj_arc_length = obj_state.arc_length;

--- a/planning/autoware_trajectory_modifier/src/trajectory_modifier_utils/obstacle_stop_utils.cpp
+++ b/planning/autoware_trajectory_modifier/src/trajectory_modifier_utils/obstacle_stop_utils.cpp
@@ -324,7 +324,7 @@ std::optional<CollisionPoint> get_nearest_object_collision(
   const TrajectoryPoints & trajectory_points, const TrajectoryShape & trajectory_shape,
   const autoware::vehicle_info_utils::VehicleInfo & vehicle_info, const PredictedObjects & objects,
   const ObjectDecelMap & object_decel_map, const double ego_vel, const double ego_decel,
-  const double reaction_time, const double safety_margin, const double min_vel_th,
+  const double reaction_time, const double safety_margin, const double stopped_vel_th, const double lookahead_horizon,
   MultiPolygon2d & target_polygons, PredictedObject & colliding_object)
 {
   if (objects.objects.empty()) return std::nullopt;
@@ -338,15 +338,13 @@ std::optional<CollisionPoint> get_nearest_object_collision(
     const auto obj_type = classification_to_object_type.at(object.classification.front().label);
     if (!object_decel_map.count(obj_type)) return false;
     const auto obj_decel = object_decel_map.at(obj_type);
-    if (obj_lon_vel < min_vel_th) return false;
+    if (obj_lon_vel < stopped_vel_th) return false;
     const auto safe_dist =
       get_safe_distance(ego_vel, obj_lon_vel, ego_decel, obj_decel, reaction_time, safety_margin);
     const auto ego_front_arc_length = ego_arc_length + ego_front_offset;
     const auto relative_arc_length = std::max(0.0, obj_arc_length - ego_front_arc_length);
     return relative_arc_length - safe_dist > 1e-3;
   };
-
-  constexpr double detection_horizon = 5.0;  // [s]
 
   PredictedObjects target_objects;
   for (const auto & object : objects.objects) {
@@ -367,7 +365,7 @@ std::optional<CollisionPoint> get_nearest_object_collision(
   auto last_p = trajectory_points.front().pose.position;
   for (const auto & traj_p : trajectory_points) {
     const auto t = rclcpp::Duration(traj_p.time_from_start).seconds();
-    if (t > detection_horizon) break;
+    if (t > lookahead_horizon) break;
     curr_arc_length += autoware_utils::calc_distance2d(last_p, traj_p.pose.position);
     for (const auto & object : target_objects.objects) {
       const auto obj_state = get_object_state_at_time(trajectory_points, object, t);
@@ -379,6 +377,7 @@ std::optional<CollisionPoint> get_nearest_object_collision(
         nearest_collision_point = obj_state.nearest_point;
       }
     }
+    last_p = traj_p.pose.position;
   }
 
   if (!found_collision) return std::nullopt;

--- a/planning/autoware_trajectory_modifier/src/trajectory_modifier_utils/obstacle_stop_utils.cpp
+++ b/planning/autoware_trajectory_modifier/src/trajectory_modifier_utils/obstacle_stop_utils.cpp
@@ -53,23 +53,25 @@ double get_detection_length(
   constexpr double buffer_length = 1.0;
   constexpr double time_delay = 0.3;
   const auto margin = stop_margin + buffer_length;
-  auto nominal_stopping_distance =
-    autoware::motion_utils::calculate_stop_distance(current_vel, current_accel, decel, jerk, time_delay);
+  auto nominal_stopping_distance = autoware::motion_utils::calculate_stop_distance(
+    current_vel, current_accel, decel, jerk, time_delay);
   if (nominal_stopping_distance) {
     return nominal_stopping_distance.value() + margin;
   }
   return forward_traj_length + margin;
 }
 
-TrajectoryPoints extend_trajectory(const TrajectoryPoints & trajectory_points, const double length, const double wheelbase_length)
+TrajectoryPoints extend_trajectory(
+  const TrajectoryPoints & trajectory_points, const double length, const double wheelbase_length)
 {
   if (length < 1e-3 || trajectory_points.empty()) return trajectory_points;
 
   const auto & last_p = trajectory_points.back();
   const auto yaw_last = tf2::getYaw(last_p.pose.orientation);
   constexpr double lookback_distance = 1.0;  // [m]
-  const auto lookback_pose = motion_utils::calcLongitudinalOffsetPose(trajectory_points, trajectory_points.size() - 1, -1.0 * lookback_distance);
-  
+  const auto lookback_pose = motion_utils::calcLongitudinalOffsetPose(
+    trajectory_points, trajectory_points.size() - 1, -1.0 * lookback_distance);
+
   auto steering_angle = 0.0;
   if (lookback_pose) {
     const auto lookback_yaw = tf2::getYaw(lookback_pose.value().orientation);
@@ -101,7 +103,8 @@ TrajectoryPoints extend_trajectory(const TrajectoryPoints & trajectory_points, c
   }
   std::reverse(extended_trajectory.begin(), extended_trajectory.end());
 
-  extended_trajectory.insert(extended_trajectory.begin(), trajectory_points.begin(), trajectory_points.end());
+  extended_trajectory.insert(
+    extended_trajectory.begin(), trajectory_points.begin(), trajectory_points.end());
   return extended_trajectory;
 }
 
@@ -216,7 +219,8 @@ std::optional<CollisionPoint> get_nearest_pcd_collision(
   auto min_arc_length = std::numeric_limits<double>::max();
   geometry_msgs::msg::Point nearest_collision_point;
   for (const auto & point : *pointcloud_in_polygon) {
-    geometry_msgs::msg::Point p = geometry_msgs::msg::Point().set__x(point.x).set__y(point.y).set__z(point.z);
+    geometry_msgs::msg::Point p =
+      geometry_msgs::msg::Point().set__x(point.x).set__y(point.y).set__z(point.z);
     auto arc_length = motion_utils::calcSignedArcLength(trajectory_points, 0, p);
     if (arc_length < min_arc_length) {
       min_arc_length = arc_length;
@@ -261,6 +265,46 @@ std::optional<CollisionPoint> get_nearest_object_collision(
   return CollisionPoint(nearest_collision_point, min_arc_length);
 }
 
+ObjectState get_object_state_at_time(
+  const TrajectoryPoints & trajectory_points, const PredictedObject & object, const double t)
+{
+  const auto predicted_obj_pose = std::invoke([&]() -> geometry_msgs::msg::Pose {
+    if (object.kinematics.predicted_paths.empty())
+      return object.kinematics.initial_pose_with_covariance.pose;
+    const auto & pred_path = object.kinematics.predicted_paths.front();
+    size_t pred_pose_index = t / rclcpp::Duration(pred_path.time_step).seconds();
+    pred_pose_index = std::min(pred_pose_index, pred_path.path.size() - 1);
+    return pred_path.path.at(pred_pose_index);
+  });
+
+  const auto nearest_seg =
+    motion_utils::findNearestSegmentIndex(trajectory_points, predicted_obj_pose.position);
+  const auto p1 = trajectory_points.at(nearest_seg).pose.position;
+  const auto p2 = trajectory_points.at(nearest_seg + 1).pose.position;
+  auto lon_vel = std::invoke([&]() -> double {
+    const auto traj_dir = Eigen::Vector2d(p2.x - p1.x, p2.y - p1.y).normalized();
+    const auto obj_yaw = tf2::getYaw(predicted_obj_pose.orientation);
+    const auto obj_dir = Eigen::Vector2d(std::cos(obj_yaw), std::sin(obj_yaw));
+    const auto obj_lon_vel = object.kinematics.initial_twist_with_covariance.twist.linear.x;
+    return std::max(0.0, obj_lon_vel * obj_dir.dot(traj_dir));
+  });
+
+  const auto obj_polygon = autoware_utils::to_polygon2d(predicted_obj_pose, object.shape);
+  auto min_arc_length = std::numeric_limits<double>::max();
+  geometry_msgs::msg::Point nearest_point;
+  for (const auto & point : obj_polygon.outer()) {
+    const geometry_msgs::msg::Point p =
+      geometry_msgs::msg::Point().set__x(point.x()).set__y(point.y());
+    const auto l = motion_utils::calcSignedArcLength(trajectory_points, 0, p);
+    if (l < min_arc_length) {
+      min_arc_length = l;
+      nearest_point = p;
+    }
+  }
+
+  return ObjectState{std::max(0.0, min_arc_length), lon_vel, nearest_point};
+}
+
 double get_safe_distance(
   const double ego_vel, const double object_vel, const double ego_decel, const double object_decel,
   const double reaction_time, const double safety_margin)
@@ -285,76 +329,60 @@ std::optional<CollisionPoint> get_nearest_object_collision(
 {
   if (objects.objects.empty()) return std::nullopt;
 
-  auto lon_vel = [&](const auto & object) -> std::optional<double> {
-    const auto nearest_seg = motion_utils::findNearestSegmentIndex(
-      trajectory_points, object.kinematics.initial_pose_with_covariance.pose.position);
-    if (!nearest_seg) return std::nullopt;
-    const auto traj_yaw = tf2::getYaw(trajectory_points.at(nearest_seg).pose.orientation);
-    const auto traj_direction = Eigen::Vector2d(std::cos(traj_yaw), std::sin(traj_yaw));
-    const auto obj_vel = object.kinematics.initial_twist_with_covariance.twist.linear;
-    const auto obj_vel_vector = Eigen::Vector2d(obj_vel.x, obj_vel.y);
-    return std::max(0.0, obj_vel_vector.dot(traj_direction));
-  };
+  const auto ego_front_offset = vehicle_info.max_longitudinal_offset_m;
 
-  auto safe_distance = [&](const auto & object) -> std::optional<double> {
-    if (object.classification.empty()) return std::nullopt;
+  auto is_safe = [&](
+                   const auto & object, const double obj_arc_length, const double obj_lon_vel,
+                   const double ego_arc_length) -> bool {
+    if (object.classification.empty()) return false;
     const auto obj_type = classification_to_object_type.at(object.classification.front().label);
-    if (!object_decel_map.count(obj_type)) return std::nullopt;
+    if (!object_decel_map.count(obj_type)) return false;
     const auto obj_decel = object_decel_map.at(obj_type);
-    const auto obj_vel = lon_vel(object);
-    if (!obj_vel || obj_vel.value() < min_vel_th) return std::nullopt;
-    return get_safe_distance(
-      ego_vel, obj_vel.value(), ego_decel, obj_decel, reaction_time, safety_margin);
+    if (obj_lon_vel < min_vel_th) return false;
+    const auto safe_dist =
+      get_safe_distance(ego_vel, obj_lon_vel, ego_decel, obj_decel, reaction_time, safety_margin);
+    const auto ego_front_arc_length = ego_arc_length + ego_front_offset;
+    const auto relative_arc_length = std::max(0.0, obj_arc_length - ego_front_arc_length);
+    return relative_arc_length - safe_dist > 1e-3;
   };
 
-  const auto ego_front_arc_length =
-    std::max(0.0, trajectory_shape.trajectory_length - trajectory_shape.forward_traj_length) +
-    vehicle_info.max_longitudinal_offset_m;
+  constexpr double detection_horizon = 5.0;  // [s]
 
-  auto min_arc_length = std::numeric_limits<double>::max();
-  geometry_msgs::msg::Point nearest_collision_point;
-  bool found_collision = false;
+  PredictedObjects target_objects;
   for (const auto & object : objects.objects) {
     const auto object_pose = object.kinematics.initial_pose_with_covariance.pose;
     const auto object_polygon = autoware_utils::to_polygon2d(object_pose, object.shape);
     if (boost::geometry::disjoint(object_polygon, trajectory_shape.polygon)) {
+      RCLCPP_INFO(rclcpp::get_logger("ObstacleStop"), "Object is out of trajectory shape");
       continue;
     }
-
+    target_objects.objects.push_back(object);
     target_polygons.emplace_back(object_polygon);
+  }
 
-    const auto [obj_arc_length, obj_nearest_p] =
-      std::invoke([&]() -> std::pair<double, geometry_msgs::msg::Point> {
-        double arc_length = std::numeric_limits<double>::max();
-        geometry_msgs::msg::Point nearest_p;
-        for (const auto & point : object_polygon.outer()) {
-          const geometry_msgs::msg::Point p =
-            geometry_msgs::msg::Point().set__x(point.x()).set__y(point.y());
-          const auto l = motion_utils::calcSignedArcLength(trajectory_points, 0, p);
-          if (l < arc_length) {
-            arc_length = l;
-            nearest_p = p;
-          }
-        }
-        return {arc_length, nearest_p};
-      });
-
-    const auto safe_dist = safe_distance(object);
-    const auto relative_arc_length = std::max(0.0, obj_arc_length - ego_front_arc_length);
-    if (safe_dist && relative_arc_length - safe_dist.value() > 1e-3) {
-      continue;
-    }
-
-    found_collision = true;
-    if (obj_arc_length < min_arc_length) {
-      min_arc_length = obj_arc_length;
-      nearest_collision_point = obj_nearest_p;
-      colliding_object = object;
+  auto min_obj_arc_length = std::numeric_limits<double>::max();
+  geometry_msgs::msg::Point nearest_collision_point;
+  bool found_collision = false;
+  auto curr_arc_length = 0.0;
+  auto last_p = trajectory_points.front().pose.position;
+  for (const auto & traj_p : trajectory_points) {
+    const auto t = rclcpp::Duration(traj_p.time_from_start).seconds();
+    if (t > detection_horizon) break;
+    curr_arc_length += autoware_utils::calc_distance2d(last_p, traj_p.pose.position);
+    for (const auto & object : target_objects.objects) {
+      const auto obj_state = get_object_state_at_time(trajectory_points, object, t);
+      if (is_safe(object, obj_state.arc_length, obj_state.lon_vel, curr_arc_length)) continue;
+      found_collision = true;
+      if (obj_state.arc_length < min_obj_arc_length) {
+        min_obj_arc_length = obj_state.arc_length;
+        colliding_object = object;
+        nearest_collision_point = obj_state.nearest_point;
+      }
     }
   }
 
   if (!found_collision) return std::nullopt;
-  return CollisionPoint(nearest_collision_point, min_arc_length);
+  return CollisionPoint(nearest_collision_point, min_obj_arc_length);
 }
 
 void PointCloudFilter::filter_pointcloud(


### PR DESCRIPTION
fix existing logic:
- fix extend_trajectory() function to account for turning at end
- fix update_velocities() function to ensure ego can stop at target
- fix pcd filter bounds calculation

improve rss check to:
- consider future ego states (within parameterized time horizon)
- consider future object states (within parameterized time horizon)

tune params

requires https://github.com/tier4/autoware_launch.x2/pull/2153