### PR TITLE
feat(trajectory_validator): add collision check system params

### DIFF
--- a/control/autoware_pid_longitudinal_controller/include/autoware/pid_longitudinal_controller/longitudinal_controller_utils.hpp
+++ b/control/autoware_pid_longitudinal_controller/include/autoware/pid_longitudinal_controller/longitudinal_controller_utils.hpp
@@ -19,8 +19,8 @@
 #include "autoware/interpolation/spherical_linear_interpolation.hpp"
 #include "autoware/motion_utils/trajectory/conversion.hpp"
 #include "autoware/motion_utils/trajectory/trajectory.hpp"
-#include "tf2/utils.h"
 #include "rclcpp/duration.hpp"
+#include "tf2/utils.h"
 
 #include <Eigen/Core>
 #include <Eigen/Geometry>

--- a/control/autoware_pid_longitudinal_controller/src/longitudinal_controller_utils.cpp
+++ b/control/autoware_pid_longitudinal_controller/src/longitudinal_controller_utils.cpp
@@ -15,9 +15,9 @@
 #include "autoware/pid_longitudinal_controller/longitudinal_controller_utils.hpp"
 
 #include "autoware_utils/geometry/geometry.hpp"
+#include "autoware_utils/math/normalization.hpp"
 #include "tf2/LinearMath/Matrix3x3.h"
 #include "tf2/LinearMath/Quaternion.h"
-#include "autoware_utils/math/normalization.hpp"
 
 #include <experimental/optional>  // NOLINT
 

--- a/planning/autoware_trajectory_validator/config/trajectory_validator.param.yaml
+++ b/planning/autoware_trajectory_validator/config/trajectory_validator.param.yaml
@@ -25,16 +25,21 @@
       min_value: 2.0
 
     collision_check:
+      global_setting:
+        time_resolution: 0.1
+      drac:
+        enable_assessment: false
       pet_collision:
+        enable_assessment: true
         ego_braking_delay: 0.4
         ego_assumed_acceleration: -5.0
         collision_time_threshold: 0.0
       rss:
+        enable_assessment: true
         ego_deceleration_threshold: 4.0
         stop_margin: 2.0
         ego_reaction_time: 0.4
         object_acceleration: -1.0
-
 
     vehicle_constraint:
       max_speed: 16.7 # m/s
@@ -44,20 +49,20 @@
       max_steering_rate: 0.3 # rad/s
 
     traffic_light:
-      deceleration_limit: 2.8  # [m/s^2] trajectories crossing an amber light are rejected if ego can stop at the stop line without breaking this limit
-      jerk_limit: 5.0  # [m/s^3] trajectories crossing an amber light are rejected if ego can stop at the stop line without breaking this limit
+      deceleration_limit: 2.8 # [m/s^2] trajectories crossing an amber light are rejected if ego can stop at the stop line without breaking this limit
+      jerk_limit: 5.0 # [m/s^3] trajectories crossing an amber light are rejected if ego can stop at the stop line without breaking this limit
       delay_response_time: 0.5 # [s] delay response time used to estimate the minimum ego stopping distance
       crossing_time_limit: 2.75 # [s] trajectories crossing an amber light are rejected if they cannot cross before this time
       treat_amber_light_as_red_light: true # [-] when true, amber lights are handled like red lights
       stop_overshoot_margin: 0.5 # [m] maximum distance between the stop line and the trajectory stop point to consider the trajectory feasible
-      checked_trajectory_length:  # maximum length of the planned trajectory that is scanned for traffic light stop lines.
-        deceleration_limit: 2.0  # [m/s^2] deceleration limit to calculate the stop distance used as trajectory length limit
-        jerk_limit: 2.0  # [m/s^3] jerk limit to calculate the stop distance used as trajectory length limit
+      checked_trajectory_length: # maximum length of the planned trajectory that is scanned for traffic light stop lines.
+        deceleration_limit: 2.0 # [m/s^2] deceleration limit to calculate the stop distance used as trajectory length limit
+        jerk_limit: 2.0 # [m/s^3] jerk limit to calculate the stop distance used as trajectory length limit
 
     # NOTE: pseudo_emergency_stop emulates the MRM stop behaviors. This is for evaluation only.
     pseudo_emergency_stop:
-      enable: false  # when true, the emergency-stop fallback is active; when false, all emergency-stop handling is skipped
-      deceleration_mps2: -6.0  # [m/s^2] target longitudinal deceleration (reference to InLaneEmergencyStop deceleration)
-      jerk_mps3: -20.0  # [m/s^3] longitudinal jerk to ramp the deceleration (reference to InLaneEmergencyStop jerk)
-      recovery_policy: "until_stopped"  # "until_stopped": keep decelerating until ego is stopped, "immediate": release as soon as the trigger disappears
-      recovery_velocity_threshold_mps: 0.1  # [m/s] ego velocity threshold under which the latched emergency-stop state is released when recovery_policy is "until_stopped"
+      enable: false # when true, the emergency-stop fallback is active; when false, all emergency-stop handling is skipped
+      deceleration_mps2: -6.0 # [m/s^2] target longitudinal deceleration (reference to InLaneEmergencyStop deceleration)
+      jerk_mps3: -20.0 # [m/s^3] longitudinal jerk to ramp the deceleration (reference to InLaneEmergencyStop jerk)
+      recovery_policy: "until_stopped" # "until_stopped": keep decelerating until ego is stopped, "immediate": release as soon as the trigger disappears
+      recovery_velocity_threshold_mps: 0.1 # [m/s] ego velocity threshold under which the latched emergency-stop state is released when recovery_policy is "until_stopped"

--- a/planning/autoware_trajectory_validator/config/trajectory_validator.param.yaml
+++ b/planning/autoware_trajectory_validator/config/trajectory_validator.param.yaml
@@ -49,20 +49,20 @@
       max_steering_rate: 0.3 # rad/s
 
     traffic_light:
-      deceleration_limit: 2.8 # [m/s^2] trajectories crossing an amber light are rejected if ego can stop at the stop line without breaking this limit
-      jerk_limit: 5.0 # [m/s^3] trajectories crossing an amber light are rejected if ego can stop at the stop line without breaking this limit
+      deceleration_limit: 2.8  # [m/s^2] trajectories crossing an amber light are rejected if ego can stop at the stop line without breaking this limit
+      jerk_limit: 5.0  # [m/s^3] trajectories crossing an amber light are rejected if ego can stop at the stop line without breaking this limit
       delay_response_time: 0.5 # [s] delay response time used to estimate the minimum ego stopping distance
       crossing_time_limit: 2.75 # [s] trajectories crossing an amber light are rejected if they cannot cross before this time
       treat_amber_light_as_red_light: true # [-] when true, amber lights are handled like red lights
       stop_overshoot_margin: 0.5 # [m] maximum distance between the stop line and the trajectory stop point to consider the trajectory feasible
-      checked_trajectory_length: # maximum length of the planned trajectory that is scanned for traffic light stop lines.
-        deceleration_limit: 2.0 # [m/s^2] deceleration limit to calculate the stop distance used as trajectory length limit
-        jerk_limit: 2.0 # [m/s^3] jerk limit to calculate the stop distance used as trajectory length limit
+      checked_trajectory_length:  # maximum length of the planned trajectory that is scanned for traffic light stop lines.
+        deceleration_limit: 2.0  # [m/s^2] deceleration limit to calculate the stop distance used as trajectory length limit
+        jerk_limit: 2.0  # [m/s^3] jerk limit to calculate the stop distance used as trajectory length limit
 
     # NOTE: pseudo_emergency_stop emulates the MRM stop behaviors. This is for evaluation only.
     pseudo_emergency_stop:
-      enable: false # when true, the emergency-stop fallback is active; when false, all emergency-stop handling is skipped
-      deceleration_mps2: -6.0 # [m/s^2] target longitudinal deceleration (reference to InLaneEmergencyStop deceleration)
-      jerk_mps3: -20.0 # [m/s^3] longitudinal jerk to ramp the deceleration (reference to InLaneEmergencyStop jerk)
-      recovery_policy: "until_stopped" # "until_stopped": keep decelerating until ego is stopped, "immediate": release as soon as the trigger disappears
-      recovery_velocity_threshold_mps: 0.1 # [m/s] ego velocity threshold under which the latched emergency-stop state is released when recovery_policy is "until_stopped"
+      enable: false  # when true, the emergency-stop fallback is active; when false, all emergency-stop handling is skipped
+      deceleration_mps2: -6.0  # [m/s^2] target longitudinal deceleration (reference to InLaneEmergencyStop deceleration)
+      jerk_mps3: -20.0  # [m/s^3] longitudinal jerk to ramp the deceleration (reference to InLaneEmergencyStop jerk)
+      recovery_policy: "until_stopped"  # "until_stopped": keep decelerating until ego is stopped, "immediate": release as soon as the trigger disappears
+      recovery_velocity_threshold_mps: 0.1  # [m/s] ego velocity threshold under which the latched emergency-stop state is released when recovery_policy is "until_stopped"

--- a/planning/autoware_trajectory_validator/include/autoware/trajectory_validator/filters/safety/collision_check_filter.hpp
+++ b/planning/autoware_trajectory_validator/include/autoware/trajectory_validator/filters/safety/collision_check_filter.hpp
@@ -92,7 +92,7 @@ private:
   mutable std::map<IndexRange, Box2d> envelope_cache_;
   mutable std::map<IndexRange, Polygon2d> convex_cache_;
 
-  //todo: use for loop search with hint, instead of binary search.
+  // todo: use for loop search with hint, instead of binary search.
   size_t get_same_or_earlier_time_index(const double t) const
   {
     const auto it = std::upper_bound(times_.begin(), times_.end(), t + TIME_INDEX_EPSILON);
@@ -288,6 +288,8 @@ public:
   void update_parameters(const validator::Params & params) final;
 
 private:
+  validator::Params::CollisionCheck::GlobalSetting global_setting_;
+  validator::Params::CollisionCheck::Drac drac_params_;
   validator::Params::CollisionCheck::PetCollision pet_collision_params_;
   validator::Params::CollisionCheck::Rss rss_params_;
   ContinuousDetectionTimes pet_continuous_times_;

--- a/planning/autoware_trajectory_validator/include/autoware/trajectory_validator/filters/safety/collision_check_filter.hpp
+++ b/planning/autoware_trajectory_validator/include/autoware/trajectory_validator/filters/safety/collision_check_filter.hpp
@@ -63,7 +63,6 @@ using StepPolygonTrajectory = std::vector<Polygon2d>;
 using IndexRange = std::pair<size_t, size_t>;
 using TimeRange = std::pair<double, double>;
 
-static constexpr double TIME_RESOLUTION = 0.1;
 static constexpr double TIME_INDEX_EPSILON = 1e-3;
 
 struct ObjectIdentification

--- a/planning/autoware_trajectory_validator/param/parameter_struct.yaml
+++ b/planning/autoware_trajectory_validator/param/parameter_struct.yaml
@@ -62,8 +62,6 @@ validator:
         type: double
         default_value: 0.1
         description: sampling interval used in collision check trajectory generation
-        validation:
-          gt<>: [0.0]
         read_only: false
     drac:
       enable_assessment:

--- a/planning/autoware_trajectory_validator/param/parameter_struct.yaml
+++ b/planning/autoware_trajectory_validator/param/parameter_struct.yaml
@@ -57,6 +57,14 @@ validator:
       read_only: false
 
   collision_check:
+    global_setting:
+      time_resolution:
+        type: double
+        default_value: 0.1
+        description: sampling interval used in collision check trajectory generation
+        validation:
+          gt<>: [0.0]
+        read_only: false
     drac:
       enable_assessment:
         type: bool

--- a/planning/autoware_trajectory_validator/param/parameter_struct.yaml
+++ b/planning/autoware_trajectory_validator/param/parameter_struct.yaml
@@ -57,7 +57,18 @@ validator:
       read_only: false
 
   collision_check:
+    drac:
+      enable_assessment:
+        type: bool
+        default_value: true
+        description: When true, DRAC assessment is performed
+        read_only: false
     pet_collision:
+      enable_assessment:
+        type: bool
+        default_value: true
+        description: When true, planned speed assessment is performed
+        read_only: false
       ego_braking_delay:
         type: double
         default_value: 0.4
@@ -74,6 +85,11 @@ validator:
         description: time threshold for PET collision check
         read_only: false
     rss:
+      enable_assessment:
+        type: bool
+        default_value: true
+        description: When true, RSS assessment is performed
+        read_only: false
       ego_deceleration_threshold:
         type: double
         default_value: 4.0

--- a/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter.cpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter.cpp
@@ -1112,7 +1112,7 @@ DracAssessment assess_drac(
 Result assess(
   const TrajectoryPoints & traj_points, const FilterContext & context,
   const validator::Params::CollisionCheck::PetCollision & pet_collision_params,
-  VehicleInfo & vehicle_info)
+  const validator::Params::CollisionCheck::Drac & drac_params, VehicleInfo & vehicle_info)
 {
   const double ego_time_horizon_for_pet = std::abs(context.odometry->twist.twist.linear.x) * 0.5 /
                                             -pet_collision_params.ego_assumed_acceleration +
@@ -1127,15 +1127,23 @@ Result assess(
     generate_object_trajectories(context, required_object_time_horizon, -1.0);
 
   Result result{};
-  result.planned_speed_findings = assess_planned_speed_collision_timing(
-    traj_points, context, pet_collision_params, vehicle_info, constant_speed_object_trajectories);
-  // const auto drac_assessment = assess_drac(
-  //   traj_points, context, pet_collision_params, vehicle_info,
-  //   constant_speed_object_trajectories);
-  DracAssessment drac_assessment{0.0, {}};  // dummy
-  result.drac_findings = drac_assessment.findings;
-  result.drac = drac_assessment.drac;
+  if (!pet_collision_params.enable_assessment) {
+    result.planned_speed_findings = {};
+  } else {
+    result.planned_speed_findings = assess_planned_speed_collision_timing(
+      traj_points, context, pet_collision_params, vehicle_info, constant_speed_object_trajectories);
+  }
 
+  if (!drac_params.enable_assessment) {
+    DracAssessment drac_assessment{0.0, {}};  // dummy
+    result.drac_findings = drac_assessment.findings;
+    result.drac = drac_assessment.drac;
+  } else {
+    const auto drac_assessment = assess_drac(
+      traj_points, context, pet_collision_params, vehicle_info, constant_speed_object_trajectories);
+    result.drac_findings = drac_assessment.findings;
+    result.drac = drac_assessment.drac;
+  }
   return result;
 }
 
@@ -1143,6 +1151,8 @@ Result assess(
 
 void CollisionCheckFilter::update_parameters(const validator::Params & params)
 {
+  global_setting_ = params.collision_check.global_setting;
+  drac_params_ = params.collision_check.drac;
   pet_collision_params_ = params.collision_check.pet_collision;
   rss_params_ = params.collision_check.rss;
 }
@@ -1289,6 +1299,8 @@ void CollisionCheckFilter::add_error_text_marker(
   debug_markers_.markers.push_back(std::move(m));
 }
 
+// todo: refactor to each metric, including debug marker generation
+
 CollisionCheckFilter::result_t CollisionCheckFilter::is_feasible(
   const TrajectoryPoints & traj_points, const FilterContext & context)
 {
@@ -1339,7 +1351,7 @@ CollisionCheckFilter::result_t CollisionCheckFilter::is_feasible(
   };
 
   const auto collision_timing_result = collision_timing_assessment::assess(
-    traj_points, context, pet_collision_params_, *vehicle_info_ptr_);
+    traj_points, context, pet_collision_params_, drac_params_, *vehicle_info_ptr_);
 
   pet_continuous_times_.update(
     current_time, collision_timing_result.planned_speed_findings,
@@ -1410,30 +1422,34 @@ CollisionCheckFilter::result_t CollisionCheckFilter::is_feasible(
     }
   }
 
-  const auto rss_result =
-    rss_deceleration::assess(traj_points, context, rss_params_, *vehicle_info_ptr_);
-  rss_continuous_times_.update(current_time, rss_result.violations, [](const auto & violation) {
-    return to_object_id_string(violation.object);
-  });
-  for (const auto & violation : rss_result.violations) {
-    const auto object_id = to_object_id_string(violation.object);
-    // Mark as infeasible if any RSS violation exists
-    is_feasible = false;
+  if (rss_params_.enable_assessment) {
+    const auto rss_result =
+      rss_deceleration::assess(traj_points, context, rss_params_, *vehicle_info_ptr_);
+    rss_continuous_times_.update(current_time, rss_result.violations, [](const auto & violation) {
+      return to_object_id_string(violation.object);
+    });
+    for (const auto & violation : rss_result.violations) {
+      const auto object_id = to_object_id_string(violation.object);
+      // Mark as infeasible if any RSS violation exists
+      is_feasible = false;
 
-    // Record metrics for each RSS violation
-    metrics.push_back(
-      autoware_trajectory_validator::build<MetricReport>()
-        .validator_name(get_name())
-        .validator_category(category())
-        .metric_name(fmt::format("check_RSS_{}_{}", violation.object.classification, object_id))
-        .metric_value(violation.required_deceleration)
-        .level(MetricReport::ERROR));
-    const double detection_duration = rss_continuous_times_.get_time(object_id);
-    error_msg += fmt::format(
-      "RSS collision, classification: {}, ID: {}, duration: {}, required deceleration: {}, stamp: "
-      "{}.{}; \n",
-      violation.object.classification, object_id, detection_duration,
-      violation.required_deceleration, violation.object.stamp.sec, violation.object.stamp.nanosec);
+      // Record metrics for each RSS violation
+      metrics.push_back(
+        autoware_trajectory_validator::build<MetricReport>()
+          .validator_name(get_name())
+          .validator_category(category())
+          .metric_name(fmt::format("check_RSS_{}_{}", violation.object.classification, object_id))
+          .metric_value(violation.required_deceleration)
+          .level(MetricReport::ERROR));
+      const double detection_duration = rss_continuous_times_.get_time(object_id);
+      error_msg += fmt::format(
+        "RSS collision, classification: {}, ID: {}, duration: {}, required deceleration: {}, "
+        "stamp: "
+        "{}.{}; \n",
+        violation.object.classification, object_id, detection_duration,
+        violation.required_deceleration, violation.object.stamp.sec,
+        violation.object.stamp.nanosec);
+    }
   }
 
   if (!error_msg.empty()) {

--- a/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter.cpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter.cpp
@@ -82,7 +82,7 @@ namespace trajectory::time_distance
 {
 std::pair<TimeTrajectory, TravelDistanceTrajectory> compute_motion_profile_1d(
   const geometry_msgs::msg::Twist & initial_twist, double braking_lag, double assumed_acceleration,
-  double start_time, double end_time)
+  double start_time, double end_time, double time_resolution)
 {
   const double initial_velocity = std::hypot(initial_twist.linear.x, initial_twist.linear.y);
   if (initial_velocity <= 0.0 || start_time >= end_time) {
@@ -105,7 +105,7 @@ std::pair<TimeTrajectory, TravelDistanceTrajectory> compute_motion_profile_1d(
 
   TimeTrajectory times;
   TravelDistanceTrajectory distances;
-  times.reserve(static_cast<size_t>((end_time - start_time) / TIME_RESOLUTION) + 4U);
+  times.reserve(static_cast<size_t>((end_time - start_time) / time_resolution) + 4U);
   distances.reserve(times.capacity());
 
   auto distance = [&](double t) {
@@ -128,8 +128,8 @@ std::pair<TimeTrajectory, TravelDistanceTrajectory> compute_motion_profile_1d(
   };
 
   append_sample(start_time);
-  for (int64_t tick = static_cast<int64_t>(std::floor(start_time / TIME_RESOLUTION)) + 1;; ++tick) {
-    const double tick_time = static_cast<double>(tick) * TIME_RESOLUTION;
+  for (int64_t tick = static_cast<int64_t>(std::floor(start_time / time_resolution)) + 1;; ++tick) {
+    const double tick_time = static_cast<double>(tick) * time_resolution;
     if (
       stop_profile.has_value() && times.back() < stop_profile.value().stop_time &&
       tick_time > stop_profile.value().stop_time) {
@@ -414,10 +414,10 @@ TravelDistanceTrajectory compute_cumulative_distances(const PoseTrajectory & pos
   return distances;
 }
 
-TimeTrajectory compute_sample_times(double start_time, double end_time)
+TimeTrajectory compute_sample_times(double start_time, double end_time, double time_resolution)
 {
   TimeTrajectory times;
-  times.reserve(static_cast<size_t>((end_time - start_time) / TIME_RESOLUTION) + 2U);
+  times.reserve(static_cast<size_t>((end_time - start_time) / time_resolution) + 2U);
 
   constexpr double epsilon = 1e-3;
   auto append_sample = [&](const double t) {
@@ -427,8 +427,8 @@ TimeTrajectory compute_sample_times(double start_time, double end_time)
   };
 
   append_sample(start_time);
-  for (int64_t tick = static_cast<int64_t>(std::floor(start_time / TIME_RESOLUTION)) + 1;; ++tick) {
-    const double tick_time = static_cast<double>(tick) * TIME_RESOLUTION;
+  for (int64_t tick = static_cast<int64_t>(std::floor(start_time / time_resolution)) + 1;; ++tick) {
+    const double tick_time = static_cast<double>(tick) * time_resolution;
     if (tick_time >= end_time) {
       break;
     }
@@ -467,10 +467,11 @@ geometry_msgs::msg::Pose interpolate_predicted_path_pose(
 
 TrajectoryData generate_ego_trajectory(
   const geometry_msgs::msg::Twist & initial_twist, double braking_lag, double assumed_acceleration,
-  double max_time, const TrajectoryPoints & traj_points, VehicleInfo & vehicle_info)
+  double max_time, double time_resolution, const TrajectoryPoints & traj_points,
+  VehicleInfo & vehicle_info)
 {
   auto [times, distances] = time_distance::compute_motion_profile_1d(
-    initial_twist, braking_lag, assumed_acceleration, 0.0, max_time);
+    initial_twist, braking_lag, assumed_acceleration, 0.0, max_time, time_resolution);
 
   // todo(takagi): use initial pose from context instead of traj_points.front()
   // check https://star4.slack.com/archives/C03QW0GU6P7/p1773898469086129
@@ -490,7 +491,7 @@ TrajectoryData generate_ego_trajectory(
 
 TrajectoryData generate_ego_trajectory(
   const TrajectoryPoints & traj_points, const FilterContext & context, double max_time,
-  VehicleInfo & vehicle_info)
+  double time_resolution, VehicleInfo & vehicle_info)
 {
   if (traj_points.empty()) {
     throw std::invalid_argument("points must not be empty");
@@ -503,9 +504,9 @@ TrajectoryData generate_ego_trajectory(
 
   TimeTrajectory relative_times{0.0};
   TimeTrajectory absolute_times{start_time};
-  for (double sample_time = TIME_RESOLUTION; start_time + sample_time < end_time;
+  for (double sample_time = time_resolution; start_time + sample_time < end_time;
        sample_time =
-         std::floor((sample_time + TIME_RESOLUTION + 1e-6) / TIME_RESOLUTION) * TIME_RESOLUTION) {
+         std::floor((sample_time + time_resolution + 1e-6) / time_resolution) * time_resolution) {
     relative_times.push_back(sample_time);
     absolute_times.push_back(start_time + sample_time);
   }
@@ -522,7 +523,7 @@ TrajectoryData generate_ego_trajectory(
 TrajectoryData generate_predicted_path_trajectory(
   const autoware_perception_msgs::msg::PredictedObject & predicted_object, double braking_lag,
   double assumed_acceleration, rclcpp::Duration start_time, double max_time,
-  const builtin_interfaces::msg::Time & stamp)
+  const builtin_interfaces::msg::Time & stamp, double time_resolution)
 {
   // todo(takagi): use all or appropriate predicted paths
   const auto most_confident_path_it = std::max_element(
@@ -534,7 +535,8 @@ TrajectoryData generate_predicted_path_trajectory(
     assumed_acceleration, start_time.seconds(),
     std::min(
       max_time, most_confident_path_it->path.size() *
-                  rclcpp::Duration(most_confident_path_it->time_step).seconds()));
+                  rclcpp::Duration(most_confident_path_it->time_step).seconds()),
+    time_resolution);
 
   auto poses = pose::compute_pose_trajectory(most_confident_path_it->path, distances);
   auto footprints = footprint::compute_footprint_trajectory(poses, predicted_object.shape);
@@ -546,7 +548,8 @@ TrajectoryData generate_predicted_path_trajectory(
 
 TrajectoryData generate_diffusion_based_trajectory(
   const autoware_perception_msgs::msg::PredictedObject & predicted_object,
-  rclcpp::Duration start_time, double max_time, const builtin_interfaces::msg::Time & stamp)
+  rclcpp::Duration start_time, double max_time, const builtin_interfaces::msg::Time & stamp,
+  double time_resolution)
 {
   const auto most_confident_path_it = std::max_element(
     predicted_object.kinematics.predicted_paths.begin(),
@@ -556,8 +559,8 @@ TrajectoryData generate_diffusion_based_trajectory(
   const double prediction_horizon =
     start_time.seconds() + static_cast<double>(predicted_path.path.size() - 1) *
                              rclcpp::Duration(predicted_path.time_step).seconds();
-  auto times =
-    detail::compute_sample_times(start_time.seconds(), std::min(max_time, prediction_horizon));
+  auto times = detail::compute_sample_times(
+    start_time.seconds(), std::min(max_time, prediction_horizon), time_resolution);
   PoseTrajectory poses;
   poses.reserve(times.size());
   for (const auto & time : times) {
@@ -583,11 +586,11 @@ TrajectoryData generate_diffusion_based_trajectory(
 TrajectoryData generate_constant_curvature_trajectory(
   const autoware_perception_msgs::msg::PredictedObject & predicted_object, double braking_lag,
   double assumed_acceleration, rclcpp::Duration start_time, double max_time,
-  const builtin_interfaces::msg::Time & stamp)
+  const builtin_interfaces::msg::Time & stamp, double time_resolution)
 {
   auto [times, distances] = time_distance::compute_motion_profile_1d(
     predicted_object.kinematics.initial_twist_with_covariance.twist, braking_lag,
-    assumed_acceleration, start_time.seconds(), max_time);
+    assumed_acceleration, start_time.seconds(), max_time, time_resolution);
 
   auto poses = pose::constant_curvature_predictor::compute(
     predicted_object.kinematics.initial_pose_with_covariance.pose,
@@ -798,13 +801,14 @@ std::optional<double> compute_distance_to_collision(
 }
 
 TrajectoryData generate_rss_ego_trajectory(
-  const TrajectoryPoints & traj_points, const FilterContext & context, VehicleInfo & vehicle_info)
+  const TrajectoryPoints & traj_points, const FilterContext & context, double time_resolution,
+  VehicleInfo & vehicle_info)
 {
   const double ego_time_horizon_for_rss =
     rclcpp::Duration(traj_points.back().time_from_start).seconds();
 
   return trajectory::generate_ego_trajectory(
-    traj_points, context, ego_time_horizon_for_rss, vehicle_info);
+    traj_points, context, ego_time_horizon_for_rss, time_resolution, vehicle_info);
 }
 
 Assessment assess_required_deceleration(
@@ -842,13 +846,15 @@ Assessment assess_required_deceleration(
 
 Result assess(
   const TrajectoryPoints & traj_points, const FilterContext & context,
-  const validator::Params::CollisionCheck::Rss & rss_params, VehicleInfo & vehicle_info)
+  const validator::Params::CollisionCheck::Rss & rss_params, double time_resolution,
+  VehicleInfo & vehicle_info)
 {
   if (!context.predicted_objects || context.predicted_objects->objects.empty()) {
     return {};
   }
 
-  const auto ego_trajectory = generate_rss_ego_trajectory(traj_points, context, vehicle_info);
+  const auto ego_trajectory =
+    generate_rss_ego_trajectory(traj_points, context, time_resolution, vehicle_info);
 
   Result result{};
   result.violations.reserve(context.predicted_objects->objects.size());
@@ -905,7 +911,8 @@ struct DracAssessment
 };
 
 std::vector<TrajectoryData> generate_object_trajectories(
-  const FilterContext & context, double required_time_horizon, double object_assumed_acceleration)
+  const FilterContext & context, double required_time_horizon, double object_assumed_acceleration,
+  double time_resolution)
 {
   std::vector<TrajectoryData> object_trajectories{};
 
@@ -918,12 +925,12 @@ std::vector<TrajectoryData> generate_object_trajectories(
       if (!object.kinematics.predicted_paths.empty()) {
         object_trajectories.push_back(trajectory::generate_predicted_path_trajectory(
           object, 0.0, object_assumed_acceleration, objects_reference_time, required_time_horizon,
-          context.predicted_objects->header.stamp));
+          context.predicted_objects->header.stamp, time_resolution));
       }
 
       object_trajectories.push_back(trajectory::generate_constant_curvature_trajectory(
         object, 0.0, object_assumed_acceleration, objects_reference_time, required_time_horizon,
-        context.predicted_objects->header.stamp));
+        context.predicted_objects->header.stamp, time_resolution));
     }
   }
 
@@ -937,7 +944,7 @@ std::vector<TrajectoryData> generate_object_trajectories(
       }
       object_trajectories.push_back(trajectory::generate_diffusion_based_trajectory(
         object, neural_network_objects_reference_time, required_time_horizon,
-        context.neural_network_predicted_objects->header.stamp));
+        context.neural_network_predicted_objects->header.stamp, time_resolution));
     }
   }
   return object_trajectories;
@@ -945,7 +952,7 @@ std::vector<TrajectoryData> generate_object_trajectories(
 
 std::optional<Finding> find_collision_timing(
   const TrajectoryData & ref_trajectory, const TrajectoryData & test_trajectory,
-  double pet_threshold)
+  double pet_threshold, double time_resolution)
 {
   if (!boost::geometry::intersects(
         ref_trajectory.get_or_compute_overall_envelope(),
@@ -1007,7 +1014,7 @@ std::optional<Finding> find_collision_timing(
         ref_convex, test_trajectory.get_or_compute_convex(time_range));
     };
 
-    for (double pet_range = 0.0; pet_range < current_pet_limit; pet_range += TIME_RESOLUTION) {
+    for (double pet_range = 0.0; pet_range < current_pet_limit; pet_range += time_resolution) {
       const TimeRange test_time_range_before{ref_start_time - pet_range, ref_end_time - pet_range};
       const bool has_intersects_before = has_intersects(test_time_range_before);
 
@@ -1039,14 +1046,16 @@ std::optional<Finding> find_collision_timing(
 
 std::vector<Finding> assess_collision_timing(
   const TrajectoryData & ego_trajectory, const std::vector<TrajectoryData> & object_trajectories,
-  const validator::Params::CollisionCheck::PetCollision & pet_collision_params)
+  const validator::Params::CollisionCheck::PetCollision & pet_collision_params,
+  double time_resolution)
 {
   std::vector<Finding> findings{};
   findings.reserve(object_trajectories.size());
 
   for (const auto & object_trajectory : object_trajectories) {
     auto finding = find_collision_timing(
-      ego_trajectory, object_trajectory, pet_collision_params.collision_time_threshold);
+      ego_trajectory, object_trajectory, pet_collision_params.collision_time_threshold,
+      time_resolution);
     if (finding.has_value()) {
       findings.push_back(std::move(finding.value()));
     }
@@ -1058,22 +1067,25 @@ std::vector<Finding> assess_collision_timing(
 std::vector<Finding> assess_planned_speed_collision_timing(
   const TrajectoryPoints & traj_points, const FilterContext & context,
   const validator::Params::CollisionCheck::PetCollision & pet_collision_params,
-  VehicleInfo & vehicle_info, const std::vector<TrajectoryData> & object_trajectories)
+  double time_resolution, VehicleInfo & vehicle_info,
+  const std::vector<TrajectoryData> & object_trajectories)
 {
   const double ego_time_horizon_for_pet = std::abs(context.odometry->twist.twist.linear.x) * 0.5 /
                                             -pet_collision_params.ego_assumed_acceleration +
                                           pet_collision_params.ego_braking_delay;
 
   auto ego_trajectory = trajectory::generate_ego_trajectory(
-    traj_points, context, ego_time_horizon_for_pet, vehicle_info);
+    traj_points, context, ego_time_horizon_for_pet, time_resolution, vehicle_info);
 
-  return assess_collision_timing(ego_trajectory, object_trajectories, pet_collision_params);
+  return assess_collision_timing(
+    ego_trajectory, object_trajectories, pet_collision_params, time_resolution);
 }
 
 DracAssessment assess_drac(
   const TrajectoryPoints & traj_points, const FilterContext & context,
   const validator::Params::CollisionCheck::PetCollision & pet_collision_params,
-  VehicleInfo & vehicle_info, const std::vector<TrajectoryData> & object_trajectories)
+  double time_resolution, VehicleInfo & vehicle_info,
+  const std::vector<TrajectoryData> & object_trajectories)
 {
   const double ego_time_horizon = rclcpp::Duration(traj_points.back().time_from_start).seconds();
 
@@ -1086,19 +1098,19 @@ DracAssessment assess_drac(
     const auto ego_deceleration_trajectory = [&]() {
       if (ego_dec == 0.0) {
         return trajectory::generate_ego_trajectory(
-          traj_points, context, ego_time_horizon, vehicle_info);
+          traj_points, context, ego_time_horizon, time_resolution, vehicle_info);
       } else if (ego_dec > DEFAULT_MAX_EGO_DECELERATION - 1e-3) {
         return trajectory::generate_ego_trajectory(
-          context.odometry->twist.twist, 0.0, -ego_dec, ego_time_horizon, traj_points,
-          vehicle_info);
+          context.odometry->twist.twist, 0.0, -ego_dec, ego_time_horizon, time_resolution,
+          traj_points, vehicle_info);
       }
       return trajectory::generate_ego_trajectory(
         context.odometry->twist.twist, pet_collision_params.ego_braking_delay, -ego_dec,
-        ego_time_horizon, traj_points, vehicle_info);
+        ego_time_horizon, time_resolution, traj_points, vehicle_info);
     }();
 
     auto findings = assess_collision_timing(
-      ego_deceleration_trajectory, object_trajectories, pet_collision_params);
+      ego_deceleration_trajectory, object_trajectories, pet_collision_params, time_resolution);
     if (findings.empty()) {
       return DracAssessment{ego_dec, std::move(last_findings)};
     }
@@ -1112,7 +1124,9 @@ DracAssessment assess_drac(
 Result assess(
   const TrajectoryPoints & traj_points, const FilterContext & context,
   const validator::Params::CollisionCheck::PetCollision & pet_collision_params,
-  const validator::Params::CollisionCheck::Drac & drac_params, VehicleInfo & vehicle_info)
+  const validator::Params::CollisionCheck::Drac & drac_params,
+  const validator::Params::CollisionCheck::GlobalSetting & global_setting,
+  VehicleInfo & vehicle_info)
 {
   const double ego_time_horizon_for_pet = std::abs(context.odometry->twist.twist.linear.x) * 0.5 /
                                             -pet_collision_params.ego_assumed_acceleration +
@@ -1123,15 +1137,16 @@ Result assess(
     std::max(ego_time_horizon_for_pet, ego_time_horizon_for_drac) +
     pet_collision_params.collision_time_threshold;
 
-  auto constant_speed_object_trajectories =
-    generate_object_trajectories(context, required_object_time_horizon, -1.0);
+  auto constant_speed_object_trajectories = generate_object_trajectories(
+    context, required_object_time_horizon, -1.0, global_setting.time_resolution);
 
   Result result{};
   if (!pet_collision_params.enable_assessment) {
     result.planned_speed_findings = {};
   } else {
     result.planned_speed_findings = assess_planned_speed_collision_timing(
-      traj_points, context, pet_collision_params, vehicle_info, constant_speed_object_trajectories);
+      traj_points, context, pet_collision_params, global_setting.time_resolution, vehicle_info,
+      constant_speed_object_trajectories);
   }
 
   if (!drac_params.enable_assessment) {
@@ -1140,7 +1155,8 @@ Result assess(
     result.drac = drac_assessment.drac;
   } else {
     const auto drac_assessment = assess_drac(
-      traj_points, context, pet_collision_params, vehicle_info, constant_speed_object_trajectories);
+      traj_points, context, pet_collision_params, global_setting.time_resolution, vehicle_info,
+      constant_speed_object_trajectories);
     result.drac_findings = drac_assessment.findings;
     result.drac = drac_assessment.drac;
   }
@@ -1159,7 +1175,7 @@ void CollisionCheckFilter::update_parameters(const validator::Params & params)
 
 autoware_internal_planning_msgs::msg::SafetyFactorArray make_safety_factor_array(
   const builtin_interfaces::msg::Time & stamp, const collision_timing_assessment::Finding & finding,
-  const std::string & collision_type)
+  const std::string & collision_type, double time_resolution)
 {
   using autoware_internal_planning_msgs::msg::SafetyFactor;
   using autoware_internal_planning_msgs::msg::SafetyFactorArray;
@@ -1168,7 +1184,7 @@ autoware_internal_planning_msgs::msg::SafetyFactorArray make_safety_factor_array
   safety_factor.type = SafetyFactor::OBJECT;
   safety_factor.object_id = finding.object.uuid;
   safety_factor.ttc_begin = static_cast<float>(finding.ttc);
-  safety_factor.ttc_end = static_cast<float>(finding.ttc + TIME_RESOLUTION);
+  safety_factor.ttc_end = static_cast<float>(finding.ttc + time_resolution);
   safety_factor.is_safe = false;
   if (!finding.object_trajectory.empty()) {
     safety_factor.points.push_back(finding.object_trajectory.front().position);
@@ -1331,8 +1347,8 @@ CollisionCheckFilter::result_t CollisionCheckFilter::is_feasible(
   const auto add_collision_planning_factor = [&](
                                                const collision_timing_assessment::Finding & finding,
                                                const std::string & collision_type) {
-    const auto safety_factors =
-      make_safety_factor_array(context.odometry->header.stamp, finding, collision_type);
+    const auto safety_factors = make_safety_factor_array(
+      context.odometry->header.stamp, finding, collision_type, global_setting_.time_resolution);
     const auto control_point =
       autoware_internal_planning_msgs::build<autoware_internal_planning_msgs::msg::ControlPoint>()
         .pose(context.odometry->pose.pose)
@@ -1351,7 +1367,7 @@ CollisionCheckFilter::result_t CollisionCheckFilter::is_feasible(
   };
 
   const auto collision_timing_result = collision_timing_assessment::assess(
-    traj_points, context, pet_collision_params_, drac_params_, *vehicle_info_ptr_);
+    traj_points, context, pet_collision_params_, drac_params_, global_setting_, *vehicle_info_ptr_);
 
   pet_continuous_times_.update(
     current_time, collision_timing_result.planned_speed_findings,
@@ -1423,8 +1439,8 @@ CollisionCheckFilter::result_t CollisionCheckFilter::is_feasible(
   }
 
   if (rss_params_.enable_assessment) {
-    const auto rss_result =
-      rss_deceleration::assess(traj_points, context, rss_params_, *vehicle_info_ptr_);
+    const auto rss_result = rss_deceleration::assess(
+      traj_points, context, rss_params_, global_setting_.time_resolution, *vehicle_info_ptr_);
     rss_continuous_times_.update(current_time, rss_result.violations, [](const auto & violation) {
       return to_object_id_string(violation.object);
     });

--- a/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter.cpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter.cpp
@@ -954,7 +954,30 @@ std::optional<Finding> find_collision_timing(
     return std::nullopt;
   }
 
-  std::optional<Finding> candidate_finding{};
+  struct CandidateFinding
+  {
+    double ttc;
+    double pet;
+    IndexRange ref_index_range;
+    TimeRange test_time_range;
+  };
+
+  // todo: return only trajectory identification and index/time ranges from here,
+  // and move add_debug_markers() generation to assessment to avoid carrying debug-only copies.
+  const auto make_finding = [&](const CandidateFinding & candidate) -> Finding {
+    const auto & object_identification = test_trajectory.getObjectIdentification();
+    return Finding{
+      to_trajectory_id_string(object_identification),
+      object_identification,
+      candidate.pet,
+      candidate.ttc,
+      ref_trajectory.getPoses(),
+      test_trajectory.getPoses(),
+      ref_trajectory.get_or_compute_convex(candidate.ref_index_range),
+      test_trajectory.get_or_compute_convex(candidate.test_time_range)};
+  };
+
+  std::optional<CandidateFinding> candidate_finding{};
   for (size_t i = 0; i < ref_trajectory.size(); ++i) {
     size_t prev_i = (i == 0) ? 0 : i - 1;
     const double ref_start_time = ref_trajectory.getTimes().at(prev_i);
@@ -995,29 +1018,23 @@ std::optional<Finding> find_collision_timing(
         continue;
       }
 
-      // todo: restrict the copy until return.
-      const auto & object_identification = test_trajectory.getObjectIdentification();
       const double pet = has_intersects_before ? -pet_range : pet_range;
-      const auto & object_poly = test_trajectory.get_or_compute_convex(
-        has_intersects_before ? test_time_range_before : test_time_range_after);
+      const TimeRange test_time_range =
+        has_intersects_before ? test_time_range_before : test_time_range_after;
 
-      candidate_finding = Finding{
-        to_trajectory_id_string(object_identification),
-        object_identification,
-        pet,
-        ref_start_time,
-        ref_trajectory.getPoses(),
-        test_trajectory.getPoses(),
-        ref_convex,
-        object_poly};
+      candidate_finding = CandidateFinding{ref_start_time, pet, ref_index_range, test_time_range};
       break;
     }
     if (candidate_finding.has_value() && candidate_finding->pet == 0.0) {
-      return candidate_finding;
+      return make_finding(candidate_finding.value());
     }
   }
 
-  return candidate_finding;
+  if (!candidate_finding.has_value()) {
+    return std::nullopt;
+  }
+
+  return make_finding(candidate_finding.value());
 }
 
 std::vector<Finding> assess_collision_timing(

--- a/planning/autoware_trajectory_validator/test/collision_check_filter/test_collision_check_filter.cpp
+++ b/planning/autoware_trajectory_validator/test/collision_check_filter/test_collision_check_filter.cpp
@@ -22,6 +22,11 @@
 
 namespace autoware::trajectory_validator::plugin::safety
 {
+namespace
+{
+constexpr double kDefaultTimeResolution =
+  validator::Params::CollisionCheck::GlobalSetting{}.time_resolution;
+}  // namespace
 
 class CollisionCheckFilterTest : public ::testing::Test
 {
@@ -79,14 +84,14 @@ protected:
     const double max_time = 10.0;
 
     auto [times, distances] = trajectory::time_distance::compute_motion_profile_1d(
-      twist, assumed_lag, assumed_acceleration, 0.0, max_time);
+      twist, assumed_lag, assumed_acceleration, 0.0, max_time, kDefaultTimeResolution);
     auto pose_trajectory =
       trajectory::pose::constant_curvature_predictor::compute(initial_pose, twist, distances);
 
     autoware_perception_msgs::msg::PredictedPath predicted_path;
     predicted_path.confidence = 1.0;
 
-    predicted_path.time_step = rclcpp::Duration::from_seconds(TIME_RESOLUTION);
+    predicted_path.time_step = rclcpp::Duration::from_seconds(kDefaultTimeResolution);
 
     for (const auto & pose : pose_trajectory) {
       predicted_path.path.push_back(pose);

--- a/planning/autoware_trajectory_validator/test/collision_check_filter/test_time_distance.cpp
+++ b/planning/autoware_trajectory_validator/test/collision_check_filter/test_time_distance.cpp
@@ -21,6 +21,12 @@
 
 namespace autoware::trajectory_validator::plugin::safety::trajectory::time_distance
 {
+namespace
+{
+constexpr double kDefaultTimeResolution =
+  validator::Params::CollisionCheck::GlobalSetting{}.time_resolution;
+}  // namespace
+
 class TimeDistanceTest : public ::testing::Test
 {
 protected:
@@ -36,7 +42,8 @@ protected:
 TEST_F(TimeDistanceTest, ZeroInitialVelocity)
 {
   auto twist = create_twist(0.0, 0.0);
-  auto [times, distances] = compute_motion_profile_1d(twist, 1.0, 1.0, 0.0, 5.0);
+  auto [times, distances] =
+    compute_motion_profile_1d(twist, 1.0, 1.0, 0.0, 5.0, kDefaultTimeResolution);
 
   ASSERT_EQ(times.size(), 1u);
   ASSERT_EQ(distances.size(), 1u);
@@ -51,13 +58,14 @@ TEST_F(TimeDistanceTest, ConstantVelocity)
   double accel = 0.0;
   double end_time = 3.05;
 
-  auto [times, distances] = compute_motion_profile_1d(twist, lag, accel, 0.0, end_time);
+  auto [times, distances] =
+    compute_motion_profile_1d(twist, lag, accel, 0.0, end_time, kDefaultTimeResolution);
 
   EXPECT_EQ(times.front(), 0.0);
   EXPECT_NEAR(times.back(), end_time, 1e-6);
   for (size_t i = 1; i < times.size() - 1; ++i) {
     double t = times[i];
-    EXPECT_NEAR(t, i * TIME_RESOLUTION, 1e-6);
+    EXPECT_NEAR(t, i * kDefaultTimeResolution, 1e-6);
     EXPECT_NEAR(distances[i], 10.0 * t, 1e-6);
   }
 }
@@ -69,7 +77,8 @@ TEST_F(TimeDistanceTest, Acceleration)
   double accel = 2.0;
   double end_time = 2.05;
 
-  auto [times, distances] = compute_motion_profile_1d(twist, lag, accel, 0.0, end_time);
+  auto [times, distances] =
+    compute_motion_profile_1d(twist, lag, accel, 0.0, end_time, kDefaultTimeResolution);
 
   ASSERT_FALSE(times.empty());
 
@@ -93,7 +102,8 @@ TEST_F(TimeDistanceTest, DecelerationAndStop)
   double accel = -5.0;
   double end_time = 5.0;
 
-  auto [times, distances] = compute_motion_profile_1d(twist, lag, accel, 0.0, end_time);
+  auto [times, distances] =
+    compute_motion_profile_1d(twist, lag, accel, 0.0, end_time, kDefaultTimeResolution);
 
   double expected_stop_time = 3.0;
 
@@ -116,7 +126,8 @@ TEST_F(TimeDistanceTest, LagLongerThanMaxTime)
   double accel = -10.0;
   double end_time = 2.05;
 
-  auto [times, distances] = compute_motion_profile_1d(twist, lag, accel, 0.0, end_time);
+  auto [times, distances] =
+    compute_motion_profile_1d(twist, lag, accel, 0.0, end_time, kDefaultTimeResolution);
 
   for (size_t i = 0; i < times.size(); ++i) {
     double t = times[i];
@@ -132,7 +143,8 @@ TEST_F(TimeDistanceTest, SamplesStayWithinRangeAndMonotonicWhenStopTimeExceedsEn
   const double end_time = 2.95;
   const double expected_stop_time = 2.97;
 
-  auto [times, distances] = compute_motion_profile_1d(twist, lag, accel, 0.0, end_time);
+  auto [times, distances] =
+    compute_motion_profile_1d(twist, lag, accel, 0.0, end_time, kDefaultTimeResolution);
 
   ASSERT_FALSE(times.empty());
   ASSERT_EQ(times.size(), distances.size());

--- a/planning/autoware_trajectory_validator/test/collision_check_filter/test_trajectory_utilities.cpp
+++ b/planning/autoware_trajectory_validator/test/collision_check_filter/test_trajectory_utilities.cpp
@@ -27,6 +27,8 @@ namespace autoware::trajectory_validator::plugin::safety
 {
 namespace
 {
+constexpr double kDefaultTimeResolution =
+  validator::Params::CollisionCheck::GlobalSetting{}.time_resolution;
 
 geometry_msgs::msg::Pose create_pose(const double x, const double y, const double yaw = 0.0)
 {
@@ -112,7 +114,7 @@ autoware_perception_msgs::msg::PredictedPath create_straight_predicted_path(
 {
   autoware_perception_msgs::msg::PredictedPath predicted_path;
   predicted_path.confidence = confidence;
-  predicted_path.time_step = rclcpp::Duration::from_seconds(TIME_RESOLUTION);
+  predicted_path.time_step = rclcpp::Duration::from_seconds(kDefaultTimeResolution);
   predicted_path.path.reserve(xs.size());
   for (const auto x : xs) {
     predicted_path.path.push_back(create_pose(x, y, 0.0));
@@ -264,8 +266,8 @@ TEST(TrajectoryUtilitiesTest, GenerateEgoTrajectoryBuildsConsistentTrajectoryDat
   const auto traj_points = create_straight_trajectory_points({0.0, 10.0, 20.0});
   const auto initial_twist = create_twist(2.0);
 
-  const auto trajectory_data =
-    trajectory::generate_ego_trajectory(initial_twist, 0.0, 0.0, 1.05, traj_points, vehicle_info);
+  const auto trajectory_data = trajectory::generate_ego_trajectory(
+    initial_twist, 0.0, 0.0, 1.05, kDefaultTimeResolution, traj_points, vehicle_info);
 
   ASSERT_EQ(trajectory_data.getObjectIdentification().classification, "EGO");
   ASSERT_TRUE(trajectory_data.getObjectIdentification().trajectory_suffix.empty());
@@ -288,8 +290,8 @@ TEST(TrajectoryUtilitiesTest, GenerateTimedEgoTrajectoryProjectsCurrentPoseOntoT
   const auto odometry = create_odometry(create_pose(5.0, 1.0, 0.0));
   const auto context = create_filter_context(odometry);
 
-  const auto trajectory_data =
-    trajectory::generate_ego_trajectory(traj_points, context, 0.25, vehicle_info);
+  const auto trajectory_data = trajectory::generate_ego_trajectory(
+    traj_points, context, 0.25, kDefaultTimeResolution, vehicle_info);
 
   ASSERT_EQ(trajectory_data.getObjectIdentification().classification, "EGO");
   ASSERT_EQ(trajectory_data.size(), 3u);
@@ -315,8 +317,8 @@ TEST(TrajectoryUtilitiesTest, GenerateTimedEgoTrajectoryAllowsExtrapolationBefor
 
   const double projected_time =
     trajectory::detail::project_current_pose_on_trajectory(traj_points, odometry->pose.pose);
-  const auto trajectory_data =
-    trajectory::generate_ego_trajectory(traj_points, context, 0.25, vehicle_info);
+  const auto trajectory_data = trajectory::generate_ego_trajectory(
+    traj_points, context, 0.25, kDefaultTimeResolution, vehicle_info);
 
   EXPECT_NEAR(projected_time, -0.5, 1e-6);
   ASSERT_EQ(trajectory_data.size(), 3u);
@@ -337,8 +339,8 @@ TEST(TrajectoryUtilitiesTest, GenerateTimedEgoTrajectoryWithSinglePointReturnsSi
 
   const double projected_time =
     trajectory::detail::project_current_pose_on_trajectory(traj_points, odometry->pose.pose);
-  const auto trajectory_data =
-    trajectory::generate_ego_trajectory(traj_points, context, 1.0, vehicle_info);
+  const auto trajectory_data = trajectory::generate_ego_trajectory(
+    traj_points, context, 1.0, kDefaultTimeResolution, vehicle_info);
 
   EXPECT_NEAR(projected_time, 1.0, 1e-6);
   ASSERT_EQ(trajectory_data.size(), 1u);
@@ -358,8 +360,8 @@ TEST(TrajectoryUtilitiesTest, GenerateTimedEgoTrajectoryHandlesNonUniformTimeAnd
 
   const double projected_time =
     trajectory::detail::project_current_pose_on_trajectory(traj_points, odometry->pose.pose);
-  const auto trajectory_data =
-    trajectory::generate_ego_trajectory(traj_points, context, 0.25, vehicle_info);
+  const auto trajectory_data = trajectory::generate_ego_trajectory(
+    traj_points, context, 0.25, kDefaultTimeResolution, vehicle_info);
 
   EXPECT_NEAR(projected_time, 0.9, 1e-6);
 
@@ -377,7 +379,7 @@ TEST(TrajectoryUtilitiesTest, GenerateTimedEgoTrajectoryHandlesNonUniformTimeAnd
 
 TEST(TrajectoryUtilitiesTest, ComputeSampleTimesStartsAtStartTimeAndIncludesEndTime)
 {
-  const auto times = trajectory::detail::compute_sample_times(-0.1, 0.4);
+  const auto times = trajectory::detail::compute_sample_times(-0.1, 0.4, kDefaultTimeResolution);
 
   ASSERT_EQ(times.size(), 6u);
   EXPECT_NEAR(times.at(0), -0.1, 1e-6);
@@ -399,7 +401,8 @@ TEST(TrajectoryUtilitiesTest, GeneratePredictedPathTrajectoryUsesHighestConfiden
   const auto object = create_predicted_object(initial_pose, initial_twist, shape, predicted_paths);
 
   const auto trajectory_data = trajectory::generate_predicted_path_trajectory(
-    object, 0.0, 0.0, rclcpp::Duration::from_seconds(0.1), 0.35, builtin_interfaces::msg::Time{});
+    object, 0.0, 0.0, rclcpp::Duration::from_seconds(0.1), 0.35, builtin_interfaces::msg::Time{},
+    kDefaultTimeResolution);
 
   EXPECT_EQ(trajectory_data.getObjectIdentification().trajectory_suffix, "_predicted_path");
   EXPECT_NEAR(trajectory_data.getTimes().front(), 0.1, 1e-6);
@@ -454,9 +457,11 @@ TEST(TrajectoryUtilitiesTest, GenerateConstantCurvaturePathTrajectoryMatchesPred
   const auto object = create_predicted_object(initial_pose, initial_twist, shape, {});
 
   const auto trajectory_data = trajectory::generate_constant_curvature_trajectory(
-    object, 0.0, 0.0, rclcpp::Duration::from_seconds(0.0), 0.25, builtin_interfaces::msg::Time{});
+    object, 0.0, 0.0, rclcpp::Duration::from_seconds(0.0), 0.25, builtin_interfaces::msg::Time{},
+    kDefaultTimeResolution);
   const auto [expected_times, expected_distances] =
-    trajectory::time_distance::compute_motion_profile_1d(initial_twist, 0.0, 0.0, 0.0, 0.25);
+    trajectory::time_distance::compute_motion_profile_1d(
+      initial_twist, 0.0, 0.0, 0.0, 0.25, kDefaultTimeResolution);
   const auto expected_poses = trajectory::pose::constant_curvature_predictor::compute(
     initial_pose, initial_twist, expected_distances);
 
@@ -484,7 +489,8 @@ TEST(TrajectoryUtilitiesTest, GenerateTimeInterpolatedPredictedPathTrajectoryUse
   object.kinematics.predicted_paths.front().time_step = rclcpp::Duration::from_seconds(0.2);
 
   const auto trajectory_data = trajectory::generate_diffusion_based_trajectory(
-    object, rclcpp::Duration::from_seconds(-0.15), 0.4, builtin_interfaces::msg::Time{});
+    object, rclcpp::Duration::from_seconds(-0.15), 0.4, builtin_interfaces::msg::Time{},
+    kDefaultTimeResolution);
 
   ASSERT_EQ(trajectory_data.size(), 6u);
   EXPECT_EQ(


### PR DESCRIPTION
以下の変更です。

- 各アセスメントの実行有無切り替えパラメータの追加
- 時間分解能をマクロ設定ではなくROSパラメータ設定に変更
- 二重forループ内でのvectorコピーの除去

psimでエンゲージできること、パラメータ変更が挙動に反映されるところまでをか確認しています。

https://github.com/tier4/autoware_launch.x2/pull/2154