### PR TITLE
fix(trajectory_validator): split collision warnings and errors

### DIFF
--- a/planning/autoware_trajectory_validator/config/trajectory_validator.param.yaml
+++ b/planning/autoware_trajectory_validator/config/trajectory_validator.param.yaml
@@ -32,20 +32,21 @@
         predicted_path_trajectory: true
         constant_curvature_trajectory: true
         diffusion_based_trajectory: true
+        ego_deceleration_threshold: -5.0
       pet_collision:
         enable_assessment: true
         predicted_path_trajectory: true
         constant_curvature_trajectory: true
         diffusion_based_trajectory: true
-        ego_braking_delay: 0.4
-        ego_assumed_acceleration: -5.0
+        ego_reaction_time: 0.4
+        ego_assumed_deceleration: -5.0
         collision_time_threshold: 0.0
       rss:
         enable_assessment: true
-        ego_deceleration_threshold: 4.0
+        ego_deceleration_threshold: -4.0
         stop_margin: 2.0
         ego_reaction_time: 0.4
-        object_acceleration: -1.0
+        object_assumed_deceleration: -1.0
 
     vehicle_constraint:
       max_speed: 16.7 # m/s

--- a/planning/autoware_trajectory_validator/config/trajectory_validator.param.yaml
+++ b/planning/autoware_trajectory_validator/config/trajectory_validator.param.yaml
@@ -29,32 +29,36 @@
         time_resolution: 0.1
       drac:
         enable_assessment: false
-        predicted_path_trajectory: true
-        constant_curvature_trajectory: true
-        diffusion_based_trajectory: true
-        warn:
-          ego_deceleration_threshold: -3.0
-        error:
-          ego_deceleration_threshold: -5.0
+        assessment_trajectories:
+          map_based: true
+          constant_curvature: true
+          diffusion_based: true
+        ego_total_braking_delay: 0.4
+        warn_threshold:
+          ego_acceleration: -3.0
+        error_threshold:
+          ego_acceleration: -5.0
       pet_collision:
         enable_assessment: true
-        predicted_path_trajectory: true
-        constant_curvature_trajectory: true
-        diffusion_based_trajectory: true
-        ego_reaction_time: 0.4
-        ego_assumed_deceleration: -5.0
-        warn:
-          collision_time_threshold_positive: 1.0
-          collision_time_threshold_negative: -1.0
-        error:
-          collision_time_threshold_positive: 0.6
-          collision_time_threshold_negative: -0.3
+        assessment_trajectories:
+          map_based: true
+          constant_curvature: true
+          diffusion_based: true
+        ego_total_braking_delay: 0.4
+        ego_assumed_acceleration: -5.0
+        warn_threshold:
+          ego_first_passing_time_gap: 1.0
+          object_first_passing_time_gap: 1.0
+        error_threshold:
+          ego_first_passing_time_gap: 0.3
+          object_first_passing_time_gap: 0.6
       rss:
         enable_assessment: true
-        ego_deceleration_threshold: -4.0
-        stop_margin: 2.0
-        ego_reaction_time: 0.4
-        object_assumed_deceleration: -1.0
+        stop_distance_margin: 2.0
+        ego_total_braking_delay: 0.4
+        object_assumed_acceleration: -1.0
+        error_threshold:
+          ego_acceleration: -4.0
 
     vehicle_constraint:
       max_speed: 16.7 # m/s

--- a/planning/autoware_trajectory_validator/config/trajectory_validator.param.yaml
+++ b/planning/autoware_trajectory_validator/config/trajectory_validator.param.yaml
@@ -32,7 +32,10 @@
         predicted_path_trajectory: true
         constant_curvature_trajectory: true
         diffusion_based_trajectory: true
-        ego_deceleration_threshold: -5.0
+        warn:
+          ego_deceleration_threshold: -3.0
+        error:
+          ego_deceleration_threshold: -5.0
       pet_collision:
         enable_assessment: true
         predicted_path_trajectory: true
@@ -40,7 +43,12 @@
         diffusion_based_trajectory: true
         ego_reaction_time: 0.4
         ego_assumed_deceleration: -5.0
-        collision_time_threshold: 0.0
+        warn:
+          collision_time_threshold_positive: 1.0
+          collision_time_threshold_negative: -1.0
+        error:
+          collision_time_threshold_positive: 0.6
+          collision_time_threshold_negative: -0.3
       rss:
         enable_assessment: true
         ego_deceleration_threshold: -4.0

--- a/planning/autoware_trajectory_validator/config/trajectory_validator.param.yaml
+++ b/planning/autoware_trajectory_validator/config/trajectory_validator.param.yaml
@@ -50,8 +50,8 @@
           ego_first_passing_time_gap: 1.0
           object_first_passing_time_gap: 1.0
         error_threshold:
-          ego_first_passing_time_gap: 0.3
-          object_first_passing_time_gap: 0.6
+          ego_first_passing_time_gap: 0.6
+          object_first_passing_time_gap: 0.3
       rss:
         enable_assessment: true
         stop_distance_margin: 2.0

--- a/planning/autoware_trajectory_validator/include/autoware/trajectory_validator/filters/safety/collision_check_filter.hpp
+++ b/planning/autoware_trajectory_validator/include/autoware/trajectory_validator/filters/safety/collision_check_filter.hpp
@@ -324,6 +324,7 @@ private:
   ContinuousDetectionTimes rss_continuous_times_;
   ContinuousDetectionTimes drac_continuous_times_;
 
+  void clear_detection_times();
   void add_debug_markers(
     const rclcpp::Time & stamp, const std::string & ns, const std::string & trajectory_id,
     const PoseTrajectory & ego_trajectory, const PoseTrajectory & object_trajectory,

--- a/planning/autoware_trajectory_validator/param/parameter_struct.yaml
+++ b/planning/autoware_trajectory_validator/param/parameter_struct.yaml
@@ -84,11 +84,18 @@ validator:
         default_value: true
         description: Use diffusion based trajectories for DRAC assessment
         read_only: false
-      ego_deceleration_threshold:
-        type: double
-        default_value: -5.0
-        description: Ego deceleration threshold for DRAC assessment (m/s^2, negative)
-        read_only: false
+      warn:
+        ego_deceleration_threshold:
+          type: double
+          default_value: -3.0
+          description: Ego deceleration threshold for DRAC warning (m/s^2, negative)
+          read_only: false
+      error:
+        ego_deceleration_threshold:
+          type: double
+          default_value: -5.0
+          description: Ego deceleration threshold for DRAC error (m/s^2, negative)
+          read_only: false
     pet_collision:
       enable_assessment:
         type: bool
@@ -120,11 +127,28 @@ validator:
         default_value: -5.0
         description: Assumed ego deceleration for PET assessment (m/s^2, negative)
         read_only: false
-      collision_time_threshold:
-        type: double
-        default_value: 1.0
-        description: time threshold for PET collision check
-        read_only: false
+      warn:
+        collision_time_threshold_positive:
+          type: double
+          default_value: 1.0
+          description: Positive PET threshold for warning
+          read_only: false
+        collision_time_threshold_negative:
+          type: double
+          default_value: -1.0
+          description: Negative PET threshold for warning
+          read_only: false
+      error:
+        collision_time_threshold_positive:
+          type: double
+          default_value: 0.6
+          description: Positive PET threshold for error
+          read_only: false
+        collision_time_threshold_negative:
+          type: double
+          default_value: -0.3
+          description: Negative PET threshold for error
+          read_only: false
     rss:
       enable_assessment:
         type: bool

--- a/planning/autoware_trajectory_validator/param/parameter_struct.yaml
+++ b/planning/autoware_trajectory_validator/param/parameter_struct.yaml
@@ -84,6 +84,11 @@ validator:
         default_value: true
         description: Use diffusion based trajectories for DRAC assessment
         read_only: false
+      ego_deceleration_threshold:
+        type: double
+        default_value: -5.0
+        description: Ego deceleration threshold for DRAC assessment (m/s^2, negative)
+        read_only: false
     pet_collision:
       enable_assessment:
         type: bool
@@ -105,15 +110,15 @@ validator:
         default_value: true
         description: Use diffusion based trajectories for PET assessment
         read_only: false
-      ego_braking_delay:
+      ego_reaction_time:
         type: double
         default_value: 0.4
-        description: N/A
+        description: Ego reaction time for PET assessment
         read_only: false
-      ego_assumed_acceleration:
+      ego_assumed_deceleration:
         type: double
-        default_value: -4.0
-        description: Used for code test, not used in actual collision check
+        default_value: -5.0
+        description: Assumed ego deceleration for PET assessment (m/s^2, negative)
         read_only: false
       collision_time_threshold:
         type: double
@@ -128,8 +133,8 @@ validator:
         read_only: false
       ego_deceleration_threshold:
         type: double
-        default_value: 4.0
-        description: threshold to determine RSS collision
+        default_value: -4.0
+        description: Ego deceleration threshold to determine RSS collision (m/s^2, negative)
         read_only: false
       stop_margin:
         type: double
@@ -141,10 +146,10 @@ validator:
         default_value: 0.4
         description: reaction time of the ego vehicle
         read_only: false
-      object_acceleration:
+      object_assumed_deceleration:
         type: double
         default_value: -1.0
-        description: assumed acceleration of the object for RSS calculation
+        description: Assumed object deceleration for RSS calculation (m/s^2, negative)
         read_only: false
 
   traffic_light:

--- a/planning/autoware_trajectory_validator/param/parameter_struct.yaml
+++ b/planning/autoware_trajectory_validator/param/parameter_struct.yaml
@@ -69,32 +69,38 @@ validator:
         default_value: true
         description: When true, DRAC assessment is performed
         read_only: false
-      predicted_path_trajectory:
-        type: bool
-        default_value: true
-        description: Use predicted path trajectories for DRAC assessment
+      assessment_trajectories:
+        map_based:
+          type: bool
+          default_value: true
+          description: Use map based predicted path trajectories for DRAC assessment
+          read_only: false
+        constant_curvature:
+          type: bool
+          default_value: true
+          description: Use constant curvature trajectories for DRAC assessment
+          read_only: false
+        diffusion_based:
+          type: bool
+          default_value: true
+          description: Use diffusion based trajectories for DRAC assessment
+          read_only: false
+      ego_total_braking_delay:
+        type: double
+        default_value: 0.4
+        description: Total ego braking delay for DRAC assessment
         read_only: false
-      constant_curvature_trajectory:
-        type: bool
-        default_value: true
-        description: Use constant curvature trajectories for DRAC assessment
-        read_only: false
-      diffusion_based_trajectory:
-        type: bool
-        default_value: true
-        description: Use diffusion based trajectories for DRAC assessment
-        read_only: false
-      warn:
-        ego_deceleration_threshold:
+      warn_threshold:
+        ego_acceleration:
           type: double
           default_value: -3.0
-          description: Ego deceleration threshold for DRAC warning (m/s^2, negative)
+          description: Ego acceleration threshold for DRAC warning (m/s^2, negative)
           read_only: false
-      error:
-        ego_deceleration_threshold:
+      error_threshold:
+        ego_acceleration:
           type: double
           default_value: -5.0
-          description: Ego deceleration threshold for DRAC error (m/s^2, negative)
+          description: Ego acceleration threshold for DRAC error (m/s^2, negative)
           read_only: false
     pet_collision:
       enable_assessment:
@@ -102,52 +108,53 @@ validator:
         default_value: true
         description: When true, planned speed assessment is performed
         read_only: false
-      predicted_path_trajectory:
-        type: bool
-        default_value: true
-        description: Use predicted path trajectories for PET assessment
-        read_only: false
-      constant_curvature_trajectory:
-        type: bool
-        default_value: true
-        description: Use constant curvature trajectories for PET assessment
-        read_only: false
-      diffusion_based_trajectory:
-        type: bool
-        default_value: true
-        description: Use diffusion based trajectories for PET assessment
-        read_only: false
-      ego_reaction_time:
+      assessment_trajectories:
+        map_based:
+          type: bool
+          default_value: true
+          description: Use map based predicted path trajectories for PET assessment
+          read_only: false
+        constant_curvature:
+          type: bool
+          default_value: true
+          description: Use constant curvature trajectories for PET assessment
+          read_only: false
+        diffusion_based:
+          type: bool
+          default_value: true
+          description: Use diffusion based trajectories for PET assessment
+          read_only: false
+      ego_total_braking_delay:
         type: double
         default_value: 0.4
-        description: Ego reaction time for PET assessment
+        description: Total ego braking delay for PET assessment
         read_only: false
-      ego_assumed_deceleration:
+      ego_assumed_acceleration:
         type: double
         default_value: -5.0
-        description: Assumed ego deceleration for PET assessment (m/s^2, negative)
+        description: Assumed ego acceleration for PET assessment (m/s^2, negative)
         read_only: false
-      warn:
-        collision_time_threshold_positive:
+      warn_threshold:
+        ego_first_passing_time_gap:
           type: double
           default_value: 1.0
-          description: Positive PET threshold for warning
+          description: Allowed time gap when ego passes first for PET warning
           read_only: false
-        collision_time_threshold_negative:
+        object_first_passing_time_gap:
           type: double
-          default_value: -1.0
-          description: Negative PET threshold for warning
+          default_value: 1.0
+          description: Allowed time gap when object passes first for PET warning
           read_only: false
-      error:
-        collision_time_threshold_positive:
+      error_threshold:
+        ego_first_passing_time_gap:
+          type: double
+          default_value: 0.3
+          description: Allowed time gap when ego passes first for PET error
+          read_only: false
+        object_first_passing_time_gap:
           type: double
           default_value: 0.6
-          description: Positive PET threshold for error
-          read_only: false
-        collision_time_threshold_negative:
-          type: double
-          default_value: -0.3
-          description: Negative PET threshold for error
+          description: Allowed time gap when object passes first for PET error
           read_only: false
     rss:
       enable_assessment:
@@ -155,26 +162,27 @@ validator:
         default_value: true
         description: When true, RSS assessment is performed
         read_only: false
-      ego_deceleration_threshold:
-        type: double
-        default_value: -4.0
-        description: Ego deceleration threshold to determine RSS collision (m/s^2, negative)
-        read_only: false
-      stop_margin:
+      stop_distance_margin:
         type: double
         default_value: 2.0
         description: required remaining distance to the object when ego stops
         read_only: false
-      ego_reaction_time:
+      ego_total_braking_delay:
         type: double
         default_value: 0.4
-        description: reaction time of the ego vehicle
+        description: Total ego braking delay for RSS calculation
         read_only: false
-      object_assumed_deceleration:
+      object_assumed_acceleration:
         type: double
         default_value: -1.0
-        description: Assumed object deceleration for RSS calculation (m/s^2, negative)
+        description: Assumed object acceleration for RSS calculation (m/s^2, negative)
         read_only: false
+      error_threshold:
+        ego_acceleration:
+          type: double
+          default_value: -4.0
+          description: Ego acceleration threshold to determine RSS collision (m/s^2, negative)
+          read_only: false
 
   traffic_light:
     deceleration_limit:

--- a/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter.cpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter.cpp
@@ -31,6 +31,7 @@
 #include <algorithm>
 #include <any>
 #include <cmath>
+#include <cstdint>
 #include <iterator>
 #include <limits>
 #include <memory>
@@ -1033,12 +1034,17 @@ std::vector<TrajectoryData> generate_object_trajectories(
 
 std::optional<Finding> find_collision_timing(
   const TrajectoryData & ref_trajectory, const TrajectoryData & test_trajectory,
-  double pet_threshold, double time_resolution)
+  double positive_pet_threshold, double negative_pet_threshold, double time_resolution)
 {
+  const double before_pet_threshold = std::abs(negative_pet_threshold);
+  const double after_pet_threshold = std::max(0.0, positive_pet_threshold);
+  const double max_pet_threshold = std::max(before_pet_threshold, after_pet_threshold);
+
   if (!boost::geometry::intersects(
         ref_trajectory.get_or_compute_overall_envelope(),
         test_trajectory.get_or_compute_envelope(TimeRange{
-          ref_trajectory.getTimes().front(), ref_trajectory.getTimes().back() + pet_threshold}))) {
+          ref_trajectory.getTimes().front() - before_pet_threshold,
+          ref_trajectory.getTimes().back() + after_pet_threshold}))) {
     return std::nullopt;
   }
 
@@ -1075,7 +1081,7 @@ std::optional<Finding> find_collision_timing(
     const Polygon2d & ref_convex = ref_trajectory.get_or_compute_convex(ref_index_range);
 
     const double current_pet_limit =
-      candidate_finding.has_value() ? std::abs(candidate_finding->pet) : pet_threshold;
+      candidate_finding.has_value() ? std::abs(candidate_finding->pet) : max_pet_threshold;
 
     if (!boost::geometry::intersects(
           ref_envelope, test_trajectory.get_or_compute_envelope(TimeRange{
@@ -1096,10 +1102,12 @@ std::optional<Finding> find_collision_timing(
 
     for (double pet_range = 0.0; pet_range < current_pet_limit; pet_range += time_resolution) {
       const TimeRange test_time_range_before{ref_start_time - pet_range, ref_end_time - pet_range};
-      const bool has_intersects_before = has_intersects(test_time_range_before);
+      const bool has_intersects_before =
+        pet_range <= before_pet_threshold && has_intersects(test_time_range_before);
 
       const TimeRange test_time_range_after{ref_start_time + pet_range, ref_end_time + pet_range};
-      const bool has_intersects_after = has_intersects(test_time_range_after);
+      const bool has_intersects_after =
+        pet_range <= after_pet_threshold && has_intersects(test_time_range_after);
 
       if (!has_intersects_before && !has_intersects_after) {
         continue;
@@ -1147,8 +1155,9 @@ std::vector<Finding> assess_planned_speed_collision_timing(
     }
 
     auto finding = find_collision_timing(
-      ego_trajectory, object_trajectory, pet_collision_params.collision_time_threshold,
-      time_resolution);
+      ego_trajectory, object_trajectory,
+      pet_collision_params.warn.collision_time_threshold_positive,
+      pet_collision_params.warn.collision_time_threshold_negative, time_resolution);
     if (finding.has_value()) {
       findings.push_back(std::move(finding.value()));
     }
@@ -1249,7 +1258,7 @@ Result assess(
   // drac_params.collision_time_threshold)
   const double required_time_horizon =
     rclcpp::Duration(traj_points.back().time_from_start).seconds() +
-    pet_collision_params.collision_time_threshold;
+    std::max(0.0, pet_collision_params.warn.collision_time_threshold_positive);
   const auto nominal_speed_object_trajectories = generate_object_trajectories(
     context, required_time_horizon, -1.0, global_setting.time_resolution,
     required_trajectory_types);
@@ -1479,17 +1488,39 @@ CollisionCheckFilter::result_t CollisionCheckFilter::is_feasible(
         .safety_factors(safety_factors);
     planning_factors.factors.push_back(std::move(factor));
   };
+  const auto log_collision_messages = [&](const uint8_t level, const std::string & messages) {
+    if (messages.empty()) {
+      return;
+    }
+    if (level == MetricReport::ERROR) {
+      RCLCPP_ERROR(
+        rclcpp::get_logger("CollisionCheckFilter"), "Not feasible: %s", messages.c_str());
+      return;
+    }
+    RCLCPP_WARN(rclcpp::get_logger("CollisionCheckFilter"), "Warning: %s", messages.c_str());
+  };
 
   const auto collision_timing_result = collision_timing_assessment::assess(
     traj_points, context, pet_collision_params_, drac_params_, global_setting_, *vehicle_info_ptr_);
 
+  const auto is_pet_error = [this](const collision_timing_assessment::Finding & finding) {
+    return finding.pet <= pet_collision_params_.error.collision_time_threshold_positive &&
+           finding.pet >= pet_collision_params_.error.collision_time_threshold_negative;
+  };
+
   pet_continuous_times_.update(
     current_time, collision_timing_result.planned_speed_findings,
     [](const auto & finding) { return finding.object_identification.trajectory_id_string(); });
+  std::string pet_error_msg{};
+  uint8_t pet_log_level = MetricReport::WARN;
   for (const auto & finding : collision_timing_result.planned_speed_findings) {
-    // Mark as infeasible if any finding exists
-    is_feasible = false;
     const auto & obj_id = finding.object_identification;
+    const bool pet_error = is_pet_error(finding);
+    const uint8_t pet_level = pet_error ? MetricReport::ERROR : MetricReport::WARN;
+    if (pet_error) {
+      is_feasible = false;
+      pet_log_level = MetricReport::ERROR;
+    }
 
     // Record metrics for PET and TTC for each finding
     metrics.push_back(autoware_trajectory_validator::build<MetricReport>()
@@ -1498,35 +1529,47 @@ CollisionCheckFilter::result_t CollisionCheckFilter::is_feasible(
                         .metric_name(fmt::format(
                           "check_PET_{}_{}", obj_id.trajectory_id_string(), obj_id.classification))
                         .metric_value(finding.pet)
-                        .level(MetricReport::ERROR));
+                        .level(pet_level));
     metrics.push_back(autoware_trajectory_validator::build<MetricReport>()
                         .validator_name(get_name())
                         .validator_category(category())
                         .metric_name(fmt::format(
                           "check_TTC_{}_{}", obj_id.trajectory_id_string(), obj_id.classification))
                         .metric_value(finding.ttc)
-                        .level(MetricReport::ERROR));
+                        .level(pet_level));
 
     const double detection_duration = pet_continuous_times_.get_time(obj_id.trajectory_id_string());
-    error_msg += fmt::format(
-      "PET collision, classification: {}, ID: {}, PET: {}, TTC: {}, duration: {}, stamp: {}.{}; \n",
+    pet_error_msg += fmt::format(
+      "PET collision, classification: {}, ID: {}, PET: {}, TTC: {}, duration: {}, stamp: {}.{};",
       obj_id.classification, obj_id.trajectory_id_string(), finding.pet, finding.ttc,
       detection_duration, obj_id.stamp.sec, obj_id.stamp.nanosec);
     add_debug_markers(
       context.odometry->header.stamp, "planned_speed_collision", obj_id.trajectory_id_string(),
       finding.ego_trajectory, finding.object_trajectory, finding.ego_hull, finding.object_hull);
-    add_collision_planning_factor(finding, "PET");
+    if (pet_error) {
+      add_collision_planning_factor(finding, "PET");
+    }
   }
+  error_msg += pet_error_msg;
+  log_collision_messages(pet_log_level, pet_error_msg);
 
   drac_continuous_times_.update(
     current_time, collision_timing_result.drac_findings,
     [](const auto & finding) { return finding.object_identification.trajectory_id_string(); });
-  if (
+  const bool drac_warn =
     collision_timing_result.drac == std::nullopt ||
-    collision_timing_result.drac.value() >= -drac_params_.ego_deceleration_threshold) {
+    collision_timing_result.drac.value() >= -drac_params_.warn.ego_deceleration_threshold;
+  const bool drac_error =
+    collision_timing_result.drac == std::nullopt ||
+    collision_timing_result.drac.value() >= -drac_params_.error.ego_deceleration_threshold;
+  std::string drac_error_msg{};
+  if (drac_warn) {
+    const uint8_t drac_level = drac_error ? MetricReport::ERROR : MetricReport::WARN;
     for (const auto & finding : collision_timing_result.drac_findings) {
       const auto & obj_id = finding.object_identification;
-      is_feasible = false;
+      if (drac_error) {
+        is_feasible = false;
+      }
 
       metrics.push_back(autoware_trajectory_validator::build<MetricReport>()
                           .validator_name(get_name())
@@ -1535,9 +1578,9 @@ CollisionCheckFilter::result_t CollisionCheckFilter::is_feasible(
                             "check_DRAC_{}_{}_{}", obj_id.trajectory_id_string(),
                             obj_id.classification, obj_id.trajectory_type))
                           .metric_value(collision_timing_result.drac.value_or(0.0))
-                          .level(MetricReport::ERROR));
-      error_msg += fmt::format(
-        "DRAC collision, ID: {}, PET: {}, TTC: {}, DRAC: {}, stamp: {}.{}; \n",
+                          .level(drac_level));
+      drac_error_msg += fmt::format(
+        "DRAC collision, ID: {}, PET: {}, TTC: {}, DRAC: {}, stamp: {}.{};",
         obj_id.trajectory_id_string(), finding.pet, finding.ttc,
         collision_timing_result.drac.has_value()
           ? std::to_string(collision_timing_result.drac.value())
@@ -1546,9 +1589,13 @@ CollisionCheckFilter::result_t CollisionCheckFilter::is_feasible(
       add_debug_markers(
         context.odometry->header.stamp, "drac_collision", obj_id.trajectory_id_string(),
         finding.ego_trajectory, finding.object_trajectory, finding.ego_hull, finding.object_hull);
-      add_collision_planning_factor(finding, "DRAC");
+      if (drac_error) {
+        add_collision_planning_factor(finding, "DRAC");
+      }
     }
   }
+  error_msg += drac_error_msg;
+  log_collision_messages(drac_error ? MetricReport::ERROR : MetricReport::WARN, drac_error_msg);
 
   if (rss_params_.enable_assessment) {
     const auto rss_result = rss_deceleration::assess(
@@ -1556,6 +1603,7 @@ CollisionCheckFilter::result_t CollisionCheckFilter::is_feasible(
     rss_continuous_times_.update(current_time, rss_result.violations, [](const auto & violation) {
       return violation.object.object_id_string();
     });
+    std::string rss_error_msg{};
     for (const auto & violation : rss_result.violations) {
       const auto object_id = violation.object.object_id_string();
       // Mark as infeasible if any RSS violation exists
@@ -1570,18 +1618,19 @@ CollisionCheckFilter::result_t CollisionCheckFilter::is_feasible(
           .metric_value(violation.required_deceleration)
           .level(MetricReport::ERROR));
       const double detection_duration = rss_continuous_times_.get_time(object_id);
-      error_msg += fmt::format(
+      rss_error_msg += fmt::format(
         "RSS collision, classification: {}, ID: {}, duration: {}, required deceleration: {}, "
         "stamp: "
-        "{}.{}; \n",
+        "{}.{};",
         violation.object.classification, object_id, detection_duration,
         violation.required_deceleration, violation.object.stamp.sec,
         violation.object.stamp.nanosec);
     }
+    error_msg += rss_error_msg;
+    log_collision_messages(MetricReport::ERROR, rss_error_msg);
   }
 
   if (!error_msg.empty()) {
-    RCLCPP_WARN(rclcpp::get_logger("CollisionCheckFilter"), "Not feasible: %s", error_msg.c_str());
     add_error_text_marker(context.odometry->header.stamp, context.odometry->pose.pose, error_msg);
   }
 

--- a/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter.cpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter.cpp
@@ -864,9 +864,9 @@ Assessment assess_required_deceleration(
   const double obj_long_vel = std::clamp(
     rss_deceleration::compute_longitudinal_velocity(ego_trajectory.getPoses(), object), 0.0, 30.0);
   const double safe_distance =
-    distance_to_collision.value() - rss_params.stop_margin +
-    obj_long_vel * obj_long_vel * 0.5 / -rss_params.object_assumed_deceleration -
-    ego_long_vel * rss_params.ego_reaction_time;
+    distance_to_collision.value() - rss_params.stop_distance_margin +
+    obj_long_vel * obj_long_vel * 0.5 / -rss_params.object_assumed_acceleration -
+    ego_long_vel * rss_params.ego_total_braking_delay;
 
   // compute required deceleration
   const double required_deceleration = safe_distance <= 0.0
@@ -902,7 +902,7 @@ Result assess(
       result.worst_assessment = assessment;
     }
 
-    if (assessment.required_deceleration > -rss_params.ego_deceleration_threshold) {
+    if (assessment.required_deceleration > -rss_params.error_threshold.ego_acceleration) {
       result.has_violation = true;
       result.violations.push_back(assessment);
     }
@@ -946,9 +946,9 @@ struct ObjectTrajectoryGenerationOptions
   template <typename ParamsT>
   explicit ObjectTrajectoryGenerationOptions(const ParamsT & params)
   {
-    predicted_path_trajectory = params.predicted_path_trajectory;
-    constant_curvature_trajectory = params.constant_curvature_trajectory;
-    diffusion_based_trajectory = params.diffusion_based_trajectory;
+    predicted_path_trajectory = params.assessment_trajectories.map_based;
+    constant_curvature_trajectory = params.assessment_trajectories.constant_curvature;
+    diffusion_based_trajectory = params.assessment_trajectories.diffusion_based;
   }
 
   void merge_with(const ObjectTrajectoryGenerationOptions & other)
@@ -1137,8 +1137,8 @@ std::vector<Finding> assess_planned_speed_collision_timing(
   const std::vector<TrajectoryData> & object_trajectories)
 {
   const double ego_time_horizon_for_pet = std::abs(context.odometry->twist.twist.linear.x) * 0.5 /
-                                            -pet_collision_params.ego_assumed_deceleration +
-                                          pet_collision_params.ego_reaction_time;
+                                            -pet_collision_params.ego_assumed_acceleration +
+                                          pet_collision_params.ego_total_braking_delay;
   auto ego_trajectory = trajectory::generate_ego_trajectory(
     traj_points, context, ego_time_horizon_for_pet, time_resolution, vehicle_info);
 
@@ -1154,8 +1154,8 @@ std::vector<Finding> assess_planned_speed_collision_timing(
 
     auto finding = find_collision_timing(
       ego_trajectory, object_trajectory,
-      pet_collision_params.warn.collision_time_threshold_positive,
-      pet_collision_params.warn.collision_time_threshold_negative, time_resolution);
+      pet_collision_params.warn_threshold.ego_first_passing_time_gap,
+      -pet_collision_params.warn_threshold.object_first_passing_time_gap, time_resolution);
     if (finding.has_value()) {
       findings.push_back(std::move(finding.value()));
     }
@@ -1187,10 +1187,9 @@ DracAssessment assess_drac(
           global_setting.time_resolution, traj_points, vehicle_info);
       }
       // todo: prepare parameter
-      constexpr double drac_params_ego_braking_delay = 0.4;
       return trajectory::generate_ego_trajectory(
-        context.odometry->twist.twist, drac_params_ego_braking_delay, -ego_dec, ego_time_horizon,
-        global_setting.time_resolution, traj_points, vehicle_info);
+        context.odometry->twist.twist, drac_params.ego_total_braking_delay, -ego_dec,
+        ego_time_horizon, global_setting.time_resolution, traj_points, vehicle_info);
     }();
 
     std::vector<Finding> findings{};
@@ -1205,7 +1204,7 @@ DracAssessment assess_drac(
       constexpr double drac_params_collision_time_threshold = 1.0;
       auto finding_nominal_object_motion = find_collision_timing(
         ego_deceleration_trajectory, object_trajectory, drac_params_collision_time_threshold,
-        global_setting.time_resolution);
+        -drac_params_collision_time_threshold, global_setting.time_resolution);
       if (!finding_nominal_object_motion.has_value()) {
         continue;
       }
@@ -1219,7 +1218,8 @@ DracAssessment assess_drac(
 
       auto finding_dec_object_motion = find_collision_timing(
         ego_deceleration_trajectory, object_deceleration_trajectory,
-        drac_params_collision_time_threshold, global_setting.time_resolution);
+        drac_params_collision_time_threshold, -drac_params_collision_time_threshold,
+        global_setting.time_resolution);
       if (!finding_dec_object_motion.has_value()) {
         continue;
       }
@@ -1257,8 +1257,8 @@ Result assess(
   const double required_time_horizon =
     rclcpp::Duration(traj_points.back().time_from_start).seconds() +
     std::max(
-      std::abs(pet_collision_params.warn.collision_time_threshold_negative),
-      std::max(0.0, pet_collision_params.warn.collision_time_threshold_positive));
+      pet_collision_params.warn_threshold.object_first_passing_time_gap,
+      std::max(0.0, pet_collision_params.warn_threshold.ego_first_passing_time_gap));
   const auto nominal_speed_object_trajectories = generate_object_trajectories(
     context, required_time_horizon, -1.0, global_setting.time_resolution,
     required_trajectory_types);
@@ -1510,8 +1510,8 @@ CollisionCheckFilter::result_t CollisionCheckFilter::is_feasible(
     traj_points, context, pet_collision_params_, drac_params_, global_setting_, *vehicle_info_ptr_);
 
   const auto is_pet_error = [this](const collision_timing_assessment::Finding & finding) {
-    return finding.pet <= pet_collision_params_.error.collision_time_threshold_positive &&
-           finding.pet >= pet_collision_params_.error.collision_time_threshold_negative;
+    return finding.pet <= pet_collision_params_.error_threshold.ego_first_passing_time_gap &&
+           finding.pet >= -pet_collision_params_.error_threshold.object_first_passing_time_gap;
   };
 
   pet_continuous_times_.update(
@@ -1567,10 +1567,10 @@ CollisionCheckFilter::result_t CollisionCheckFilter::is_feasible(
     [](const auto & finding) { return finding.object_identification.trajectory_id_string(); });
   const bool drac_warn =
     collision_timing_result.drac == std::nullopt ||
-    collision_timing_result.drac.value() >= -drac_params_.warn.ego_deceleration_threshold;
+    collision_timing_result.drac.value() >= -drac_params_.warn_threshold.ego_acceleration;
   const bool drac_error =
     collision_timing_result.drac == std::nullopt ||
-    collision_timing_result.drac.value() >= -drac_params_.error.ego_deceleration_threshold;
+    collision_timing_result.drac.value() >= -drac_params_.error_threshold.ego_acceleration;
   std::string drac_error_msg{};
   std::string drac_marker_msg{};
   if (drac_warn) {

--- a/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter.cpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter.cpp
@@ -32,6 +32,7 @@
 #include <any>
 #include <cmath>
 #include <cstdint>
+#include <functional>
 #include <iterator>
 #include <limits>
 #include <memory>
@@ -45,6 +46,17 @@
 
 namespace autoware::trajectory_validator::plugin::safety
 {
+namespace
+{
+struct EvaluationArtifacts
+{
+  bool is_feasible{true};
+  std::string error_msg{};
+  std::vector<MetricReport> metrics{};
+  autoware_internal_planning_msgs::msg::PlanningFactorArray planning_factors{};
+};
+}  // namespace
+
 // Trajectory generation helpers.
 namespace trajectory::time_distance
 {
@@ -1438,218 +1450,291 @@ void CollisionCheckFilter::add_error_text_marker(
   debug_markers_.markers.push_back(std::move(m));
 }
 
-// todo: refactor to each metric, including debug marker generation
+void CollisionCheckFilter::clear_detection_times()
+{
+  pet_continuous_times_.clear();
+  rss_continuous_times_.clear();
+  drac_continuous_times_.clear();
+}
+
+void log_collision_messages(const uint8_t level, const std::string & messages)
+{
+  if (messages.empty()) {
+    return;
+  }
+  if (level == MetricReport::ERROR) {
+    RCLCPP_ERROR(rclcpp::get_logger("CollisionCheckFilter"), "Not feasible: %s", messages.c_str());
+    return;
+  }
+  RCLCPP_WARN(rclcpp::get_logger("CollisionCheckFilter"), "Warning: %s", messages.c_str());
+}
+
+void append_text_marker_message(std::string & text, const std::string & message)
+{
+  if (!message.empty()) {
+    text += message + "\n";
+  }
+}
+
+using AddDebugMarkers = std::function<void(
+  const rclcpp::Time &, const std::string &, const std::string &, const PoseTrajectory &,
+  const PoseTrajectory &, const Polygon2d &, const Polygon2d &)>;
+
+using AddPlanningFactor = std::function<void(
+  const builtin_interfaces::msg::Time &, const geometry_msgs::msg::Pose &,
+  const collision_timing_assessment::Finding &, const std::string &,
+  autoware_internal_planning_msgs::msg::PlanningFactorArray &)>;
+
+void add_collision_planning_factor(
+  const double time_resolution, const builtin_interfaces::msg::Time & stamp,
+  const geometry_msgs::msg::Pose & ego_pose, const collision_timing_assessment::Finding & finding,
+  const std::string & collision_type,
+  autoware_internal_planning_msgs::msg::PlanningFactorArray & planning_factors)
+{
+  const auto safety_factors =
+    make_safety_factor_array(stamp, finding, collision_type, time_resolution);
+  const auto control_point =
+    autoware_internal_planning_msgs::build<autoware_internal_planning_msgs::msg::ControlPoint>()
+      .pose(ego_pose)
+      .velocity(0.0)
+      .shift_length(0.0)
+      .distance(0.0);
+  auto factor =
+    autoware_internal_planning_msgs::build<autoware_internal_planning_msgs::msg::PlanningFactor>()
+      .module("")
+      .is_driving_forward(true)
+      .control_points({control_point})
+      .behavior(autoware_internal_planning_msgs::msg::PlanningFactor::STOP)
+      .detail(collision_type)
+      .safety_factors(safety_factors);
+  planning_factors.factors.push_back(std::move(factor));
+}
+
+void process_pet_findings(
+  const std::string & validator_name, const std::string & validator_category,
+  const validator::Params::CollisionCheck::PetCollision & pet_collision_params,
+  ContinuousDetectionTimes & pet_continuous_times, const rclcpp::Time & current_time,
+  const builtin_interfaces::msg::Time & stamp, const geometry_msgs::msg::Pose & ego_pose,
+  const std::vector<collision_timing_assessment::Finding> & findings,
+  EvaluationArtifacts & artifacts, const AddDebugMarkers & add_debug_markers,
+  const AddPlanningFactor & add_planning_factor)
+{
+  pet_continuous_times.update(current_time, findings, [](const auto & finding) {
+    return finding.object_identification.trajectory_id_string();
+  });
+
+  std::string log_messages{};
+  std::string marker_messages{};
+  uint8_t log_level = MetricReport::WARN;
+  for (const auto & finding : findings) {
+    const auto & obj_id = finding.object_identification;
+    const bool is_error =
+      finding.pet <= pet_collision_params.error_threshold.ego_first_passing_time_gap &&
+      finding.pet >= -pet_collision_params.error_threshold.object_first_passing_time_gap;
+    const uint8_t metric_level = is_error ? MetricReport::ERROR : MetricReport::WARN;
+    if (is_error) {
+      artifacts.is_feasible = false;
+      log_level = MetricReport::ERROR;
+    }
+
+    artifacts.metrics.push_back(
+      autoware_trajectory_validator::build<MetricReport>()
+        .validator_name(validator_name)
+        .validator_category(validator_category)
+        .metric_name(
+          fmt::format("check_PET_{}_{}", obj_id.trajectory_id_string(), obj_id.classification))
+        .metric_value(finding.pet)
+        .level(metric_level));
+    artifacts.metrics.push_back(
+      autoware_trajectory_validator::build<MetricReport>()
+        .validator_name(validator_name)
+        .validator_category(validator_category)
+        .metric_name(
+          fmt::format("check_TTC_{}_{}", obj_id.trajectory_id_string(), obj_id.classification))
+        .metric_value(finding.ttc)
+        .level(metric_level));
+
+    const auto finding_msg = fmt::format(
+      "PET collision, classification: {}, ID: {}, PET: {}, TTC: {}, duration: {}, stamp: {}.{};",
+      obj_id.classification, obj_id.trajectory_id_string(), finding.pet, finding.ttc,
+      pet_continuous_times.get_time(obj_id.trajectory_id_string()), obj_id.stamp.sec,
+      obj_id.stamp.nanosec);
+    log_messages += finding_msg;
+    append_text_marker_message(marker_messages, finding_msg);
+    add_debug_markers(
+      stamp, "planned_speed_collision", obj_id.trajectory_id_string(), finding.ego_trajectory,
+      finding.object_trajectory, finding.ego_hull, finding.object_hull);
+    if (is_error) {
+      add_planning_factor(stamp, ego_pose, finding, "PET", artifacts.planning_factors);
+    }
+  }
+
+  artifacts.error_msg += marker_messages;
+  log_collision_messages(log_level, log_messages);
+}
+
+void process_drac_findings(
+  const std::string & validator_name, const std::string & validator_category,
+  const validator::Params::CollisionCheck::Drac & drac_params,
+  ContinuousDetectionTimes & drac_continuous_times, const rclcpp::Time & current_time,
+  const builtin_interfaces::msg::Time & stamp, const geometry_msgs::msg::Pose & ego_pose,
+  const collision_timing_assessment::Result & collision_timing_result,
+  EvaluationArtifacts & artifacts, const AddDebugMarkers & add_debug_markers,
+  const AddPlanningFactor & add_planning_factor)
+{
+  drac_continuous_times.update(
+    current_time, collision_timing_result.drac_findings,
+    [](const auto & finding) { return finding.object_identification.trajectory_id_string(); });
+
+  const bool is_warn =
+    collision_timing_result.drac == std::nullopt ||
+    collision_timing_result.drac.value() >= -drac_params.warn_threshold.ego_acceleration;
+  const bool is_error =
+    collision_timing_result.drac == std::nullopt ||
+    collision_timing_result.drac.value() >= -drac_params.error_threshold.ego_acceleration;
+  if (!is_warn) {
+    return;
+  }
+
+  std::string log_messages{};
+  std::string marker_messages{};
+  const uint8_t metric_level = is_error ? MetricReport::ERROR : MetricReport::WARN;
+  for (const auto & finding : collision_timing_result.drac_findings) {
+    const auto & obj_id = finding.object_identification;
+    if (is_error) {
+      artifacts.is_feasible = false;
+    }
+
+    artifacts.metrics.push_back(autoware_trajectory_validator::build<MetricReport>()
+                                  .validator_name(validator_name)
+                                  .validator_category(validator_category)
+                                  .metric_name(fmt::format(
+                                    "check_DRAC_{}_{}_{}", obj_id.trajectory_id_string(),
+                                    obj_id.classification, obj_id.trajectory_type))
+                                  .metric_value(collision_timing_result.drac.value_or(0.0))
+                                  .level(metric_level));
+
+    const auto finding_msg = fmt::format(
+      "DRAC collision, ID: {}, PET: {}, TTC: {}, DRAC: {}, stamp: {}.{};",
+      obj_id.trajectory_id_string(), finding.pet, finding.ttc,
+      collision_timing_result.drac.has_value()
+        ? std::to_string(collision_timing_result.drac.value())
+        : "Cant be avoided",
+      obj_id.stamp.sec, obj_id.stamp.nanosec);
+    log_messages += finding_msg;
+    append_text_marker_message(marker_messages, finding_msg);
+    add_debug_markers(
+      stamp, "drac_collision", obj_id.trajectory_id_string(), finding.ego_trajectory,
+      finding.object_trajectory, finding.ego_hull, finding.object_hull);
+    if (is_error) {
+      add_planning_factor(stamp, ego_pose, finding, "DRAC", artifacts.planning_factors);
+    }
+  }
+
+  artifacts.error_msg += marker_messages;
+  log_collision_messages(metric_level, log_messages);
+}
+
+void process_rss_violations(
+  const std::string & validator_name, const std::string & validator_category,
+  const validator::Params::CollisionCheck::GlobalSetting & global_setting,
+  const validator::Params::CollisionCheck::Rss & rss_params, const TrajectoryPoints & traj_points,
+  const FilterContext & context, VehicleInfo & vehicle_info,
+  ContinuousDetectionTimes & rss_continuous_times, const rclcpp::Time & current_time,
+  EvaluationArtifacts & artifacts)
+{
+  if (!rss_params.enable_assessment) {
+    return;
+  }
+
+  const auto rss_result = rss_deceleration::assess(
+    traj_points, context, rss_params, global_setting.time_resolution, vehicle_info);
+  rss_continuous_times.update(current_time, rss_result.violations, [](const auto & violation) {
+    return violation.object.object_id_string();
+  });
+
+  std::string log_messages{};
+  std::string marker_messages{};
+  for (const auto & violation : rss_result.violations) {
+    const auto object_id = violation.object.object_id_string();
+    artifacts.is_feasible = false;
+    artifacts.metrics.push_back(
+      autoware_trajectory_validator::build<MetricReport>()
+        .validator_name(validator_name)
+        .validator_category(validator_category)
+        .metric_name(fmt::format("check_RSS_{}_{}", violation.object.classification, object_id))
+        .metric_value(violation.required_deceleration)
+        .level(MetricReport::ERROR));
+
+    const auto finding_msg = fmt::format(
+      "RSS collision, classification: {}, ID: {}, duration: {}, required deceleration: {}, "
+      "stamp: {}.{};",
+      violation.object.classification, object_id, rss_continuous_times.get_time(object_id),
+      violation.required_deceleration, violation.object.stamp.sec, violation.object.stamp.nanosec);
+    log_messages += finding_msg;
+    append_text_marker_message(marker_messages, finding_msg);
+  }
+
+  artifacts.error_msg += marker_messages;
+  log_collision_messages(MetricReport::ERROR, log_messages);
+}
 
 CollisionCheckFilter::result_t CollisionCheckFilter::is_feasible(
   const TrajectoryPoints & traj_points, const FilterContext & context)
 {
-  std::string error_msg{};
-
   if (
     (!context.predicted_objects || context.predicted_objects->objects.empty()) &&
     (!context.neural_network_predicted_objects ||
      context.neural_network_predicted_objects->objects.empty())) {
-    pet_continuous_times_.clear();
-    rss_continuous_times_.clear();
-    drac_continuous_times_.clear();
+    clear_detection_times();
     return {};  // No objects to check collision with
   }
 
   if (traj_points.empty()) {
-    pet_continuous_times_.clear();
-    rss_continuous_times_.clear();
-    drac_continuous_times_.clear();
+    clear_detection_times();
     return {};  // No trajectory to check
   }
 
-  bool is_feasible = true;
-  std::vector<MetricReport> metrics;
-  autoware_internal_planning_msgs::msg::PlanningFactorArray planning_factors;
-
+  EvaluationArtifacts artifacts{};
   const rclcpp::Time current_time = context.odometry->header.stamp;
-  const auto add_collision_planning_factor = [&](
-                                               const collision_timing_assessment::Finding & finding,
-                                               const std::string & collision_type) {
-    const auto safety_factors = make_safety_factor_array(
-      context.odometry->header.stamp, finding, collision_type, global_setting_.time_resolution);
-    const auto control_point =
-      autoware_internal_planning_msgs::build<autoware_internal_planning_msgs::msg::ControlPoint>()
-        .pose(context.odometry->pose.pose)
-        .velocity(0.0)
-        .shift_length(0.0)
-        .distance(0.0);
-    auto factor =
-      autoware_internal_planning_msgs::build<autoware_internal_planning_msgs::msg::PlanningFactor>()
-        .module("")
-        .is_driving_forward(true)
-        .control_points({control_point})
-        .behavior(autoware_internal_planning_msgs::msg::PlanningFactor::STOP)
-        .detail(collision_type)
-        .safety_factors(safety_factors);
-    planning_factors.factors.push_back(std::move(factor));
-  };
-  const auto log_collision_messages = [&](const uint8_t level, const std::string & messages) {
-    if (messages.empty()) {
-      return;
-    }
-    if (level == MetricReport::ERROR) {
-      RCLCPP_ERROR(
-        rclcpp::get_logger("CollisionCheckFilter"), "Not feasible: %s", messages.c_str());
-      return;
-    }
-    RCLCPP_WARN(rclcpp::get_logger("CollisionCheckFilter"), "Warning: %s", messages.c_str());
-  };
-  const auto append_text_marker_message = [](std::string & text, const std::string & message) {
-    if (message.empty()) {
-      return;
-    }
-    text += message + "\n";
-  };
-
   const auto collision_timing_result = collision_timing_assessment::assess(
     traj_points, context, pet_collision_params_, drac_params_, global_setting_, *vehicle_info_ptr_);
-
-  const auto is_pet_error = [this](const collision_timing_assessment::Finding & finding) {
-    return finding.pet <= pet_collision_params_.error_threshold.ego_first_passing_time_gap &&
-           finding.pet >= -pet_collision_params_.error_threshold.object_first_passing_time_gap;
-  };
-
-  pet_continuous_times_.update(
-    current_time, collision_timing_result.planned_speed_findings,
-    [](const auto & finding) { return finding.object_identification.trajectory_id_string(); });
-  std::string pet_error_msg{};
-  std::string pet_marker_msg{};
-  uint8_t pet_log_level = MetricReport::WARN;
-  for (const auto & finding : collision_timing_result.planned_speed_findings) {
-    const auto & obj_id = finding.object_identification;
-    const bool pet_error = is_pet_error(finding);
-    const uint8_t pet_level = pet_error ? MetricReport::ERROR : MetricReport::WARN;
-    if (pet_error) {
-      is_feasible = false;
-      pet_log_level = MetricReport::ERROR;
-    }
-
-    // Record metrics for PET and TTC for each finding
-    metrics.push_back(autoware_trajectory_validator::build<MetricReport>()
-                        .validator_name(get_name())
-                        .validator_category(category())
-                        .metric_name(fmt::format(
-                          "check_PET_{}_{}", obj_id.trajectory_id_string(), obj_id.classification))
-                        .metric_value(finding.pet)
-                        .level(pet_level));
-    metrics.push_back(autoware_trajectory_validator::build<MetricReport>()
-                        .validator_name(get_name())
-                        .validator_category(category())
-                        .metric_name(fmt::format(
-                          "check_TTC_{}_{}", obj_id.trajectory_id_string(), obj_id.classification))
-                        .metric_value(finding.ttc)
-                        .level(pet_level));
-
-    const double detection_duration = pet_continuous_times_.get_time(obj_id.trajectory_id_string());
-    const auto finding_msg = fmt::format(
-      "PET collision, classification: {}, ID: {}, PET: {}, TTC: {}, duration: {}, stamp: {}.{};",
-      obj_id.classification, obj_id.trajectory_id_string(), finding.pet, finding.ttc,
-      detection_duration, obj_id.stamp.sec, obj_id.stamp.nanosec);
-    pet_error_msg += finding_msg;
-    append_text_marker_message(pet_marker_msg, finding_msg);
-    add_debug_markers(
-      context.odometry->header.stamp, "planned_speed_collision", obj_id.trajectory_id_string(),
-      finding.ego_trajectory, finding.object_trajectory, finding.ego_hull, finding.object_hull);
-    if (pet_error) {
-      add_collision_planning_factor(finding, "PET");
-    }
-  }
-  error_msg += pet_marker_msg;
-  log_collision_messages(pet_log_level, pet_error_msg);
-
-  drac_continuous_times_.update(
-    current_time, collision_timing_result.drac_findings,
-    [](const auto & finding) { return finding.object_identification.trajectory_id_string(); });
-  const bool drac_warn =
-    collision_timing_result.drac == std::nullopt ||
-    collision_timing_result.drac.value() >= -drac_params_.warn_threshold.ego_acceleration;
-  const bool drac_error =
-    collision_timing_result.drac == std::nullopt ||
-    collision_timing_result.drac.value() >= -drac_params_.error_threshold.ego_acceleration;
-  std::string drac_error_msg{};
-  std::string drac_marker_msg{};
-  if (drac_warn) {
-    const uint8_t drac_level = drac_error ? MetricReport::ERROR : MetricReport::WARN;
-    for (const auto & finding : collision_timing_result.drac_findings) {
-      const auto & obj_id = finding.object_identification;
-      if (drac_error) {
-        is_feasible = false;
-      }
-
-      metrics.push_back(autoware_trajectory_validator::build<MetricReport>()
-                          .validator_name(get_name())
-                          .validator_category(category())
-                          .metric_name(fmt::format(
-                            "check_DRAC_{}_{}_{}", obj_id.trajectory_id_string(),
-                            obj_id.classification, obj_id.trajectory_type))
-                          .metric_value(collision_timing_result.drac.value_or(0.0))
-                          .level(drac_level));
-      const auto finding_msg = fmt::format(
-        "DRAC collision, ID: {}, PET: {}, TTC: {}, DRAC: {}, stamp: {}.{};",
-        obj_id.trajectory_id_string(), finding.pet, finding.ttc,
-        collision_timing_result.drac.has_value()
-          ? std::to_string(collision_timing_result.drac.value())
-          : "Cant be avoided",
-        obj_id.stamp.sec, obj_id.stamp.nanosec);
-      drac_error_msg += finding_msg;
-      append_text_marker_message(drac_marker_msg, finding_msg);
+  const auto add_debug_markers_cb =
+    [this](
+      const rclcpp::Time & stamp, const std::string & ns, const std::string & trajectory_id,
+      const PoseTrajectory & ego_trajectory, const PoseTrajectory & object_trajectory,
+      const Polygon2d & ego_hull, const Polygon2d & object_hull) {
       add_debug_markers(
-        context.odometry->header.stamp, "drac_collision", obj_id.trajectory_id_string(),
-        finding.ego_trajectory, finding.object_trajectory, finding.ego_hull, finding.object_hull);
-      if (drac_error) {
-        add_collision_planning_factor(finding, "DRAC");
-      }
-    }
-  }
-  error_msg += drac_marker_msg;
-  log_collision_messages(drac_error ? MetricReport::ERROR : MetricReport::WARN, drac_error_msg);
-
-  if (rss_params_.enable_assessment) {
-    const auto rss_result = rss_deceleration::assess(
-      traj_points, context, rss_params_, global_setting_.time_resolution, *vehicle_info_ptr_);
-    rss_continuous_times_.update(current_time, rss_result.violations, [](const auto & violation) {
-      return violation.object.object_id_string();
-    });
-    std::string rss_error_msg{};
-    std::string rss_marker_msg{};
-    for (const auto & violation : rss_result.violations) {
-      const auto object_id = violation.object.object_id_string();
-      // Mark as infeasible if any RSS violation exists
-      is_feasible = false;
-
-      // Record metrics for each RSS violation
-      metrics.push_back(
-        autoware_trajectory_validator::build<MetricReport>()
-          .validator_name(get_name())
-          .validator_category(category())
-          .metric_name(fmt::format("check_RSS_{}_{}", violation.object.classification, object_id))
-          .metric_value(violation.required_deceleration)
-          .level(MetricReport::ERROR));
-      const double detection_duration = rss_continuous_times_.get_time(object_id);
-      const auto finding_msg = fmt::format(
-        "RSS collision, classification: {}, ID: {}, duration: {}, required deceleration: {}, "
-        "stamp: "
-        "{}.{};",
-        violation.object.classification, object_id, detection_duration,
-        violation.required_deceleration, violation.object.stamp.sec,
-        violation.object.stamp.nanosec);
-      rss_error_msg += finding_msg;
-      append_text_marker_message(rss_marker_msg, finding_msg);
-    }
-    error_msg += rss_marker_msg;
-    log_collision_messages(MetricReport::ERROR, rss_error_msg);
+        stamp, ns, trajectory_id, ego_trajectory, object_trajectory, ego_hull, object_hull);
+    };
+  const auto add_planning_factor_cb =
+    [this](
+      const builtin_interfaces::msg::Time & stamp, const geometry_msgs::msg::Pose & ego_pose,
+      const collision_timing_assessment::Finding & finding, const std::string & collision_type,
+      autoware_internal_planning_msgs::msg::PlanningFactorArray & planning_factors) {
+      add_collision_planning_factor(
+        global_setting_.time_resolution, stamp, ego_pose, finding, collision_type,
+        planning_factors);
+    };
+  process_pet_findings(
+    get_name(), category(), pet_collision_params_, pet_continuous_times_, current_time,
+    context.odometry->header.stamp, context.odometry->pose.pose,
+    collision_timing_result.planned_speed_findings, artifacts, add_debug_markers_cb,
+    add_planning_factor_cb);
+  process_drac_findings(
+    get_name(), category(), drac_params_, drac_continuous_times_, current_time,
+    context.odometry->header.stamp, context.odometry->pose.pose, collision_timing_result, artifacts,
+    add_debug_markers_cb, add_planning_factor_cb);
+  process_rss_violations(
+    get_name(), category(), global_setting_, rss_params_, traj_points, context, *vehicle_info_ptr_,
+    rss_continuous_times_, current_time, artifacts);
+  if (!artifacts.error_msg.empty()) {
+    add_error_text_marker(
+      context.odometry->header.stamp, context.odometry->pose.pose, artifacts.error_msg);
   }
 
-  if (!error_msg.empty()) {
-    add_error_text_marker(context.odometry->header.stamp, context.odometry->pose.pose, error_msg);
-  }
-
-  return ValidationResult{is_feasible, std::move(metrics), std::move(planning_factors)};
+  return ValidationResult{
+    artifacts.is_feasible, std::move(artifacts.metrics), std::move(artifacts.planning_factors)};
 }
 
 }  // namespace autoware::trajectory_validator::plugin::safety

--- a/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter.cpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter.cpp
@@ -1198,7 +1198,6 @@ DracAssessment assess_drac(
           context.odometry->twist.twist, 0.0, -ego_dec, ego_time_horizon,
           global_setting.time_resolution, traj_points, vehicle_info);
       }
-      // todo: prepare parameter
       return trajectory::generate_ego_trajectory(
         context.odometry->twist.twist, drac_params.ego_total_braking_delay, -ego_dec,
         ego_time_horizon, global_setting.time_resolution, traj_points, vehicle_info);

--- a/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter.cpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter.cpp
@@ -862,9 +862,10 @@ Assessment assess_required_deceleration(
   // compute safe distance
   const double obj_long_vel = std::clamp(
     rss_deceleration::compute_longitudinal_velocity(ego_trajectory.getPoses(), object), 0.0, 30.0);
-  const double safe_distance = distance_to_collision.value() - rss_params.stop_margin +
-                               obj_long_vel * obj_long_vel * 0.5 / -rss_params.object_acceleration -
-                               ego_long_vel * rss_params.ego_reaction_time;
+  const double safe_distance =
+    distance_to_collision.value() - rss_params.stop_margin +
+    obj_long_vel * obj_long_vel * 0.5 / -rss_params.object_assumed_deceleration -
+    ego_long_vel * rss_params.ego_reaction_time;
 
   // compute required deceleration
   const double required_deceleration = safe_distance <= 0.0
@@ -900,7 +901,7 @@ Result assess(
       result.worst_assessment = assessment;
     }
 
-    if (assessment.required_deceleration > rss_params.ego_deceleration_threshold) {
+    if (assessment.required_deceleration > -rss_params.ego_deceleration_threshold) {
       result.has_violation = true;
       result.violations.push_back(assessment);
     }
@@ -1130,8 +1131,8 @@ std::vector<Finding> assess_planned_speed_collision_timing(
   const std::vector<TrajectoryData> & object_trajectories)
 {
   const double ego_time_horizon_for_pet = std::abs(context.odometry->twist.twist.linear.x) * 0.5 /
-                                            -pet_collision_params.ego_assumed_acceleration +
-                                          pet_collision_params.ego_braking_delay;
+                                            -pet_collision_params.ego_assumed_deceleration +
+                                          pet_collision_params.ego_reaction_time;
   auto ego_trajectory = trajectory::generate_ego_trajectory(
     traj_points, context, ego_time_horizon_for_pet, time_resolution, vehicle_info);
 
@@ -1155,7 +1156,6 @@ std::vector<Finding> assess_planned_speed_collision_timing(
 
   return findings;
 }
-
 DracAssessment assess_drac(
   const TrajectoryPoints & traj_points, const FilterContext & context,
   const validator::Params::CollisionCheck::Drac & drac_params, VehicleInfo & vehicle_info,
@@ -1523,7 +1523,7 @@ CollisionCheckFilter::result_t CollisionCheckFilter::is_feasible(
     [](const auto & finding) { return finding.object_identification.trajectory_id_string(); });
   if (
     collision_timing_result.drac == std::nullopt ||
-    collision_timing_result.drac.value() >= -pet_collision_params_.ego_assumed_acceleration) {
+    collision_timing_result.drac.value() >= -drac_params_.ego_deceleration_threshold) {
     for (const auto & finding : collision_timing_result.drac_findings) {
       const auto & obj_id = finding.object_identification;
       is_feasible = false;

--- a/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter.cpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter.cpp
@@ -1175,6 +1175,7 @@ std::vector<Finding> assess_planned_speed_collision_timing(
 
   return findings;
 }
+
 DracAssessment assess_drac(
   const TrajectoryPoints & traj_points, const FilterContext & context,
   const validator::Params::CollisionCheck::Drac & drac_params, VehicleInfo & vehicle_info,
@@ -1267,9 +1268,7 @@ Result assess(
   // drac_params.collision_time_threshold)
   const double required_time_horizon =
     rclcpp::Duration(traj_points.back().time_from_start).seconds() +
-    std::max(
-      pet_collision_params.warn_threshold.object_first_passing_time_gap,
-      std::max(0.0, pet_collision_params.warn_threshold.ego_first_passing_time_gap));
+    pet_collision_params.warn_threshold.ego_first_passing_time_gap;
   const auto nominal_speed_object_trajectories = generate_object_trajectories(
     context, required_time_horizon, -1.0, global_setting.time_resolution,
     required_trajectory_types);

--- a/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter.cpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter.cpp
@@ -1102,12 +1102,10 @@ std::optional<Finding> find_collision_timing(
 
     for (double pet_range = 0.0; pet_range < current_pet_limit; pet_range += time_resolution) {
       const TimeRange test_time_range_before{ref_start_time - pet_range, ref_end_time - pet_range};
-      const bool has_intersects_before =
-        pet_range <= before_pet_threshold && has_intersects(test_time_range_before);
+      const bool has_intersects_before = has_intersects(test_time_range_before);
 
       const TimeRange test_time_range_after{ref_start_time + pet_range, ref_end_time + pet_range};
-      const bool has_intersects_after =
-        pet_range <= after_pet_threshold && has_intersects(test_time_range_after);
+      const bool has_intersects_after = has_intersects(test_time_range_after);
 
       if (!has_intersects_before && !has_intersects_after) {
         continue;
@@ -1258,7 +1256,9 @@ Result assess(
   // drac_params.collision_time_threshold)
   const double required_time_horizon =
     rclcpp::Duration(traj_points.back().time_from_start).seconds() +
-    std::max(0.0, pet_collision_params.warn.collision_time_threshold_positive);
+    std::max(
+      std::abs(pet_collision_params.warn.collision_time_threshold_negative),
+      std::max(0.0, pet_collision_params.warn.collision_time_threshold_positive));
   const auto nominal_speed_object_trajectories = generate_object_trajectories(
     context, required_time_horizon, -1.0, global_setting.time_resolution,
     required_trajectory_types);

--- a/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter.cpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter.cpp
@@ -1499,6 +1499,12 @@ CollisionCheckFilter::result_t CollisionCheckFilter::is_feasible(
     }
     RCLCPP_WARN(rclcpp::get_logger("CollisionCheckFilter"), "Warning: %s", messages.c_str());
   };
+  const auto append_text_marker_message = [](std::string & text, const std::string & message) {
+    if (message.empty()) {
+      return;
+    }
+    text += message + "\n";
+  };
 
   const auto collision_timing_result = collision_timing_assessment::assess(
     traj_points, context, pet_collision_params_, drac_params_, global_setting_, *vehicle_info_ptr_);
@@ -1512,6 +1518,7 @@ CollisionCheckFilter::result_t CollisionCheckFilter::is_feasible(
     current_time, collision_timing_result.planned_speed_findings,
     [](const auto & finding) { return finding.object_identification.trajectory_id_string(); });
   std::string pet_error_msg{};
+  std::string pet_marker_msg{};
   uint8_t pet_log_level = MetricReport::WARN;
   for (const auto & finding : collision_timing_result.planned_speed_findings) {
     const auto & obj_id = finding.object_identification;
@@ -1539,10 +1546,12 @@ CollisionCheckFilter::result_t CollisionCheckFilter::is_feasible(
                         .level(pet_level));
 
     const double detection_duration = pet_continuous_times_.get_time(obj_id.trajectory_id_string());
-    pet_error_msg += fmt::format(
+    const auto finding_msg = fmt::format(
       "PET collision, classification: {}, ID: {}, PET: {}, TTC: {}, duration: {}, stamp: {}.{};",
       obj_id.classification, obj_id.trajectory_id_string(), finding.pet, finding.ttc,
       detection_duration, obj_id.stamp.sec, obj_id.stamp.nanosec);
+    pet_error_msg += finding_msg;
+    append_text_marker_message(pet_marker_msg, finding_msg);
     add_debug_markers(
       context.odometry->header.stamp, "planned_speed_collision", obj_id.trajectory_id_string(),
       finding.ego_trajectory, finding.object_trajectory, finding.ego_hull, finding.object_hull);
@@ -1550,7 +1559,7 @@ CollisionCheckFilter::result_t CollisionCheckFilter::is_feasible(
       add_collision_planning_factor(finding, "PET");
     }
   }
-  error_msg += pet_error_msg;
+  error_msg += pet_marker_msg;
   log_collision_messages(pet_log_level, pet_error_msg);
 
   drac_continuous_times_.update(
@@ -1563,6 +1572,7 @@ CollisionCheckFilter::result_t CollisionCheckFilter::is_feasible(
     collision_timing_result.drac == std::nullopt ||
     collision_timing_result.drac.value() >= -drac_params_.error.ego_deceleration_threshold;
   std::string drac_error_msg{};
+  std::string drac_marker_msg{};
   if (drac_warn) {
     const uint8_t drac_level = drac_error ? MetricReport::ERROR : MetricReport::WARN;
     for (const auto & finding : collision_timing_result.drac_findings) {
@@ -1579,13 +1589,15 @@ CollisionCheckFilter::result_t CollisionCheckFilter::is_feasible(
                             obj_id.classification, obj_id.trajectory_type))
                           .metric_value(collision_timing_result.drac.value_or(0.0))
                           .level(drac_level));
-      drac_error_msg += fmt::format(
+      const auto finding_msg = fmt::format(
         "DRAC collision, ID: {}, PET: {}, TTC: {}, DRAC: {}, stamp: {}.{};",
         obj_id.trajectory_id_string(), finding.pet, finding.ttc,
         collision_timing_result.drac.has_value()
           ? std::to_string(collision_timing_result.drac.value())
           : "Cant be avoided",
         obj_id.stamp.sec, obj_id.stamp.nanosec);
+      drac_error_msg += finding_msg;
+      append_text_marker_message(drac_marker_msg, finding_msg);
       add_debug_markers(
         context.odometry->header.stamp, "drac_collision", obj_id.trajectory_id_string(),
         finding.ego_trajectory, finding.object_trajectory, finding.ego_hull, finding.object_hull);
@@ -1594,7 +1606,7 @@ CollisionCheckFilter::result_t CollisionCheckFilter::is_feasible(
       }
     }
   }
-  error_msg += drac_error_msg;
+  error_msg += drac_marker_msg;
   log_collision_messages(drac_error ? MetricReport::ERROR : MetricReport::WARN, drac_error_msg);
 
   if (rss_params_.enable_assessment) {
@@ -1604,6 +1616,7 @@ CollisionCheckFilter::result_t CollisionCheckFilter::is_feasible(
       return violation.object.object_id_string();
     });
     std::string rss_error_msg{};
+    std::string rss_marker_msg{};
     for (const auto & violation : rss_result.violations) {
       const auto object_id = violation.object.object_id_string();
       // Mark as infeasible if any RSS violation exists
@@ -1618,15 +1631,17 @@ CollisionCheckFilter::result_t CollisionCheckFilter::is_feasible(
           .metric_value(violation.required_deceleration)
           .level(MetricReport::ERROR));
       const double detection_duration = rss_continuous_times_.get_time(object_id);
-      rss_error_msg += fmt::format(
+      const auto finding_msg = fmt::format(
         "RSS collision, classification: {}, ID: {}, duration: {}, required deceleration: {}, "
         "stamp: "
         "{}.{};",
         violation.object.classification, object_id, detection_duration,
         violation.required_deceleration, violation.object.stamp.sec,
         violation.object.stamp.nanosec);
+      rss_error_msg += finding_msg;
+      append_text_marker_message(rss_marker_msg, finding_msg);
     }
-    error_msg += rss_error_msg;
+    error_msg += rss_marker_msg;
     log_collision_messages(MetricReport::ERROR, rss_error_msg);
   }
 

--- a/planning/autoware_trajectory_validator/test/collision_check_filter/test_collision_check_filter.cpp
+++ b/planning/autoware_trajectory_validator/test/collision_check_filter/test_collision_check_filter.cpp
@@ -184,15 +184,15 @@ protected:
     validator::Params params;
     params.collision_check.drac.enable_assessment = false;
     params.collision_check.rss.enable_assessment = false;
-    params.collision_check.pet_collision.predicted_path_trajectory = true;
-    params.collision_check.pet_collision.constant_curvature_trajectory = false;
-    params.collision_check.pet_collision.diffusion_based_trajectory = false;
-    params.collision_check.pet_collision.warn.collision_time_threshold_positive = 1.0;
-    params.collision_check.pet_collision.warn.collision_time_threshold_negative = -1.0;
-    params.collision_check.pet_collision.error.collision_time_threshold_positive =
+    params.collision_check.pet_collision.assessment_trajectories.map_based = true;
+    params.collision_check.pet_collision.assessment_trajectories.constant_curvature = false;
+    params.collision_check.pet_collision.assessment_trajectories.diffusion_based = false;
+    params.collision_check.pet_collision.warn_threshold.ego_first_passing_time_gap = 1.0;
+    params.collision_check.pet_collision.warn_threshold.object_first_passing_time_gap = 1.0;
+    params.collision_check.pet_collision.error_threshold.ego_first_passing_time_gap =
       error_threshold_positive;
-    params.collision_check.pet_collision.error.collision_time_threshold_negative =
-      error_threshold_negative;
+    params.collision_check.pet_collision.error_threshold.object_first_passing_time_gap =
+      -error_threshold_negative;
     return params;
   }
 
@@ -201,11 +201,11 @@ protected:
     validator::Params params;
     params.collision_check.pet_collision.enable_assessment = false;
     params.collision_check.rss.enable_assessment = false;
-    params.collision_check.drac.predicted_path_trajectory = true;
-    params.collision_check.drac.constant_curvature_trajectory = false;
-    params.collision_check.drac.diffusion_based_trajectory = false;
-    params.collision_check.drac.warn.ego_deceleration_threshold = -3.0;
-    params.collision_check.drac.error.ego_deceleration_threshold = error_deceleration_threshold;
+    params.collision_check.drac.assessment_trajectories.map_based = true;
+    params.collision_check.drac.assessment_trajectories.constant_curvature = false;
+    params.collision_check.drac.assessment_trajectories.diffusion_based = false;
+    params.collision_check.drac.warn_threshold.ego_acceleration = -3.0;
+    params.collision_check.drac.error_threshold.ego_acceleration = error_deceleration_threshold;
     return params;
   }
 
@@ -322,13 +322,13 @@ TEST_F(CollisionCheckFilterTest, ObjectTrajectoryTypesCanBeConfiguredIndependent
   vehicle_info.vehicle_width_m = 2.0;
 
   validator::Params::CollisionCheck::PetCollision pet_collision_params;
-  pet_collision_params.predicted_path_trajectory = false;
-  pet_collision_params.constant_curvature_trajectory = false;
-  pet_collision_params.diffusion_based_trajectory = false;
+  pet_collision_params.assessment_trajectories.map_based = false;
+  pet_collision_params.assessment_trajectories.constant_curvature = false;
+  pet_collision_params.assessment_trajectories.diffusion_based = false;
   validator::Params::CollisionCheck::Drac drac_params;
-  drac_params.predicted_path_trajectory = false;
-  drac_params.constant_curvature_trajectory = false;
-  drac_params.diffusion_based_trajectory = true;
+  drac_params.assessment_trajectories.map_based = false;
+  drac_params.assessment_trajectories.constant_curvature = false;
+  drac_params.assessment_trajectories.diffusion_based = true;
 
   const auto result = collision_timing_assessment::assess(
     ego_path, context, pet_collision_params, drac_params,

--- a/planning/autoware_trajectory_validator/test/collision_check_filter/test_collision_check_filter.cpp
+++ b/planning/autoware_trajectory_validator/test/collision_check_filter/test_collision_check_filter.cpp
@@ -16,6 +16,8 @@
 
 #include <gtest/gtest.h>
 
+#include <algorithm>
+#include <cstdint>
 #include <memory>
 #include <string>
 #include <vector>
@@ -134,6 +136,91 @@ protected:
     obj.existence_probability = 1.0;
 
     return obj;
+  }
+
+  FilterContext create_crossing_pet_context()
+  {
+    FilterContext context;
+
+    auto odom_msg = std::make_shared<nav_msgs::msg::Odometry>();
+    odom_msg->pose.pose = create_pose(0.0, 0.0, 0.0);
+    odom_msg->twist.twist = create_twist(10.0, 0.0);
+    context.odometry = odom_msg;
+
+    auto predicted_objects_msg =
+      std::make_shared<autoware_perception_msgs::msg::PredictedObjects>();
+    auto pose = create_pose(10.0, -14.0, M_PI_2);
+    auto twist = create_twist(10.0, 0.0);
+    predicted_objects_msg->objects.push_back(create_dummy_object(
+      pose, twist, create_predicted_path(pose, twist), create_object_shape(1.0, 1.0)));
+    context.predicted_objects = predicted_objects_msg;
+
+    return context;
+  }
+
+  FilterContext create_drac_context()
+  {
+    FilterContext context;
+
+    auto odom_msg = std::make_shared<nav_msgs::msg::Odometry>();
+    odom_msg->pose.pose = create_pose(0.0, 0.0, 0.0);
+    odom_msg->twist.twist = create_twist(10.0, 0.0);
+    context.odometry = odom_msg;
+
+    auto predicted_objects_msg =
+      std::make_shared<autoware_perception_msgs::msg::PredictedObjects>();
+    auto pose = create_pose(20.0, -10.0, M_PI_2);
+    auto twist = create_twist(10.0, 0.0);
+    predicted_objects_msg->objects.push_back(create_dummy_object(
+      pose, twist, create_predicted_path(pose, twist), create_object_shape(5.0, 1.0)));
+    context.predicted_objects = predicted_objects_msg;
+
+    return context;
+  }
+
+  validator::Params create_pet_only_params(
+    double error_threshold_positive, double error_threshold_negative)
+  {
+    validator::Params params;
+    params.collision_check.drac.enable_assessment = false;
+    params.collision_check.rss.enable_assessment = false;
+    params.collision_check.pet_collision.predicted_path_trajectory = true;
+    params.collision_check.pet_collision.constant_curvature_trajectory = false;
+    params.collision_check.pet_collision.diffusion_based_trajectory = false;
+    params.collision_check.pet_collision.warn.collision_time_threshold_positive = 1.0;
+    params.collision_check.pet_collision.warn.collision_time_threshold_negative = -1.0;
+    params.collision_check.pet_collision.error.collision_time_threshold_positive =
+      error_threshold_positive;
+    params.collision_check.pet_collision.error.collision_time_threshold_negative =
+      error_threshold_negative;
+    return params;
+  }
+
+  validator::Params create_drac_only_params(double error_deceleration_threshold)
+  {
+    validator::Params params;
+    params.collision_check.pet_collision.enable_assessment = false;
+    params.collision_check.rss.enable_assessment = false;
+    params.collision_check.drac.predicted_path_trajectory = true;
+    params.collision_check.drac.constant_curvature_trajectory = false;
+    params.collision_check.drac.diffusion_based_trajectory = false;
+    params.collision_check.drac.warn.ego_deceleration_threshold = -3.0;
+    params.collision_check.drac.error.ego_deceleration_threshold = error_deceleration_threshold;
+    return params;
+  }
+
+  bool has_pet_metric_with_level(const std::vector<MetricReport> & metrics, uint8_t level) const
+  {
+    return std::any_of(metrics.begin(), metrics.end(), [level](const auto & metric) {
+      return metric.metric_name.find("check_PET_") != std::string::npos && metric.level == level;
+    });
+  }
+
+  bool has_drac_metric_with_level(const std::vector<MetricReport> & metrics, uint8_t level) const
+  {
+    return std::any_of(metrics.begin(), metrics.end(), [level](const auto & metric) {
+      return metric.metric_name.find("check_DRAC_") != std::string::npos && metric.level == level;
+    });
   }
 };
 
@@ -306,24 +393,86 @@ TEST_F(CollisionCheckFilterTest, ObjectWillEnterPath)
 {
   const auto ego_path = create_ego_path();
 
-  FilterContext context;
-
-  auto odom_msg = std::make_shared<nav_msgs::msg::Odometry>();
-  odom_msg->pose.pose = create_pose(0.0, 0.0, 0.0);
-  odom_msg->twist.twist = create_twist(10.0, 0.0);
-  context.odometry = odom_msg;
-
-  auto predicted_objects_msg = std::make_shared<autoware_perception_msgs::msg::PredictedObjects>();
-  auto pose = create_pose(20.0, -10.0, M_PI_2);
-  auto twist = create_twist(10.0, 0.0);
-  predicted_objects_msg->objects.push_back(create_dummy_object(
-    pose, twist, create_predicted_path(pose, twist), create_object_shape(5.0, 1.0)));
-  context.predicted_objects = predicted_objects_msg;
+  auto context = create_crossing_pet_context();
 
   const auto result = filter_->is_feasible(ego_path, context);
 
   ASSERT_TRUE(result.has_value());
   EXPECT_FALSE(result.value().is_feasible);
+}
+
+TEST_F(CollisionCheckFilterTest, PetCollisionWarnDoesNotRejectTrajectory)
+{
+  const auto ego_path = create_ego_path();
+  auto context = create_crossing_pet_context();
+  filter_->update_parameters(create_pet_only_params(0.1, -0.1));
+
+  const auto result = filter_->is_feasible(ego_path, context);
+
+  ASSERT_TRUE(result.has_value());
+  EXPECT_TRUE(result.value().is_feasible);
+  EXPECT_TRUE(has_pet_metric_with_level(result.value().metrics, MetricReport::WARN));
+  EXPECT_FALSE(has_pet_metric_with_level(result.value().metrics, MetricReport::ERROR));
+  EXPECT_TRUE(result.value().planning_factors.factors.empty());
+
+  const auto markers = filter_->take_debug_markers();
+  const auto text_marker =
+    std::find_if(markers.markers.begin(), markers.markers.end(), [](auto marker) {
+      return marker.type == visualization_msgs::msg::Marker::TEXT_VIEW_FACING &&
+             marker.text.find("PET collision") != std::string::npos;
+    });
+  EXPECT_NE(text_marker, markers.markers.end());
+}
+
+TEST_F(CollisionCheckFilterTest, PetCollisionErrorRejectsTrajectory)
+{
+  const auto ego_path = create_ego_path();
+  auto context = create_crossing_pet_context();
+  filter_->update_parameters(create_pet_only_params(0.6, -0.3));
+
+  const auto result = filter_->is_feasible(ego_path, context);
+
+  ASSERT_TRUE(result.has_value());
+  EXPECT_FALSE(result.value().is_feasible);
+  EXPECT_TRUE(has_pet_metric_with_level(result.value().metrics, MetricReport::ERROR));
+  EXPECT_FALSE(result.value().planning_factors.factors.empty());
+
+  const auto markers = filter_->take_debug_markers();
+  const auto text_marker =
+    std::find_if(markers.markers.begin(), markers.markers.end(), [](auto marker) {
+      return marker.type == visualization_msgs::msg::Marker::TEXT_VIEW_FACING &&
+             marker.text.find("PET collision") != std::string::npos;
+    });
+  EXPECT_NE(text_marker, markers.markers.end());
+}
+
+TEST_F(CollisionCheckFilterTest, DracWarnDoesNotRejectTrajectory)
+{
+  const auto ego_path = create_ego_path();
+  auto context = create_drac_context();
+  filter_->update_parameters(create_drac_only_params(-6.0));
+
+  const auto result = filter_->is_feasible(ego_path, context);
+
+  ASSERT_TRUE(result.has_value());
+  EXPECT_TRUE(result.value().is_feasible);
+  EXPECT_TRUE(has_drac_metric_with_level(result.value().metrics, MetricReport::WARN));
+  EXPECT_FALSE(has_drac_metric_with_level(result.value().metrics, MetricReport::ERROR));
+  EXPECT_TRUE(result.value().planning_factors.factors.empty());
+}
+
+TEST_F(CollisionCheckFilterTest, DracErrorRejectsTrajectory)
+{
+  const auto ego_path = create_ego_path();
+  auto context = create_drac_context();
+  filter_->update_parameters(create_drac_only_params(-5.0));
+
+  const auto result = filter_->is_feasible(ego_path, context);
+
+  ASSERT_TRUE(result.has_value());
+  EXPECT_FALSE(result.value().is_feasible);
+  EXPECT_TRUE(has_drac_metric_with_level(result.value().metrics, MetricReport::ERROR));
+  EXPECT_FALSE(result.value().planning_factors.factors.empty());
 }
 
 }  // namespace autoware::trajectory_validator::plugin::safety

--- a/planning/autoware_trajectory_validator/test/collision_check_filter/test_trajectory_utilities.cpp
+++ b/planning/autoware_trajectory_validator/test/collision_check_filter/test_trajectory_utilities.cpp
@@ -628,14 +628,14 @@ TEST(TrajectoryUtilitiesTest, ObjectTrajectoryGenerationOptionsMergeWithCombines
 TEST(TrajectoryUtilitiesTest, ObjectTrajectoryGenerationOptionsCanBeConstructedFromParams)
 {
   validator::Params::CollisionCheck::PetCollision pet_params{};
-  pet_params.predicted_path_trajectory = true;
-  pet_params.constant_curvature_trajectory = false;
-  pet_params.diffusion_based_trajectory = true;
+  pet_params.assessment_trajectories.map_based = true;
+  pet_params.assessment_trajectories.constant_curvature = false;
+  pet_params.assessment_trajectories.diffusion_based = true;
 
   validator::Params::CollisionCheck::Drac drac_params{};
-  drac_params.predicted_path_trajectory = false;
-  drac_params.constant_curvature_trajectory = true;
-  drac_params.diffusion_based_trajectory = false;
+  drac_params.assessment_trajectories.map_based = false;
+  drac_params.assessment_trajectories.constant_curvature = true;
+  drac_params.assessment_trajectories.diffusion_based = false;
 
   const auto pet_options =
     collision_timing_assessment::ObjectTrajectoryGenerationOptions{pet_params};


### PR DESCRIPTION
• ## Description

  This PR updates the trajectory validation and related planning stack behavior on top of `feat/v0.48/e2e`.

  The main trajectory validator changes are focused on the Collision Check Filter:

  - Add configurable collision-check sampling resolution via `collision_check.global_setting.time_resolution`.
  - Add independent enable switches for PET, DRAC, and RSS assessments.
  - Add independent object trajectory selection for PET and DRAC:
    - `predicted_path_trajectory`
    - `constant_curvature_trajectory`
    - `diffusion_based_trajectory`
  - Refactor object trajectory generation so `predicted_objects` and `neural_network_predicted_objects` are handled in a parallel, configurable way.
  - Split PET and DRAC thresholds into `warn` and `error` levels.
  - Make warning-level PET/DRAC findings publish metrics, logs, and debug text markers without marking the trajectory infeasible.
  - Make error-level PET/DRAC findings mark the trajectory infeasible and publish planning factors.
  - Publish planning factors only for ERROR-level collision findings.
  - Use negative-valued deceleration parameters consistently for trajectory validator collision checks.
  - Add DRAC deceleration thresholds for both warning and error levels.
  - Improve collision logs so messages are grouped per metric evaluation and emitted at WARN or ERROR level according to the finding severity.
  - Improve RViz text marker output so each collision finding is displayed on a separate line.
  - Keep debug trajectory markers for PET/DRAC collision findings, including ego and object trajectories.

  ## How was this PR tested?

  - Built `autoware_trajectory_validator` successfully from the workspace root:
    - `colcon build --packages-select autoware_trajectory_validator --cmake-args -DCMAKE_BUILD_TYPE=Release`
 - [TIER IV INTERNAL LINK (Processing time analysis by ART)
](http://10.0.12.96:3000/d/dejny32qvz5z4f/planning-control-metrics?orgId=1&from=now-6h&to=now&timezone=browser&var-job_id=202781c3-692d-5d70-87f9-d192a2b039ff&var-group_level=catalog&var-report_id=a97d4d87-e02f-4580-a9fe-69b6bc80b00a&var-abnormal_stop_check=detection_area&var-min_acc_thr=-1.5&var-max_acc_thr=1.2&var-processing_time_check=collision_check_filter&var-processing_time_thr=50&var-lateral_deviation_thr=1.0&var-lateral_trajectory_displacement_thr=0.1&var-steer_angle_thr=0.64&var-steer_rate_thr=1.0&var-yaw_deviation_thr=1.0&var-closest_object_distance_thr=1.0&var-goal_longitudinal_deviation_thr=0.5&var-goal_lateral_deviation_thr=0.15&var-goal_yaw_deviation_thr=0.174533&var-stop_deviation_check=stop_line&var-stop_deviation_thr=0.1&var-ttc_thr=3&var-pet_thr=3&var-drac_thr=3&var-e2e_trajectory_metric_choice=&var-trajectory_generator=DiffusionPlanner_batch_0&var-trajectory_validation_filter=all_validators&refresh=1h)
  ## Interface changes

  ### ROS Parameter Changes

  #### Trajectory validator additions and modifications

  | Change type | Parameter Name | Type | Default Value | Description |
  |:--|:--|:--|:--|:--|
  | Added | `collision_check.global_setting.time_resolution` | `double` | `0.1` | Sampling interval used by collision-check trajectory generation. |
  | Added | `collision_check.drac.enable_assessment` | `bool` | `true` | Enables DRAC assessment. |
  | Added | `collision_check.drac.predicted_path_trajectory` | `bool` | `true` | Uses predicted-path object trajectories for DRAC. |
  | Added | `collision_check.drac.constant_curvature_trajectory` | `bool` | `true` | Uses constant-curvature object trajectories for DRAC. |
  | Added | `collision_check.drac.diffusion_based_trajectory` | `bool` | `true` | Uses diffusion-based object trajectories for DRAC. |
  | Added | `collision_check.drac.warn.ego_deceleration_threshold` | `double` | `-3.0` | DRAC warning threshold. Negative deceleration value. |
  | Added | `collision_check.drac.error.ego_deceleration_threshold` | `double` | `-5.0` | DRAC error threshold. Negative deceleration value. |
  | Added | `collision_check.pet_collision.enable_assessment` | `bool` | `true` | Enables PET assessment. |
  | Added | `collision_check.pet_collision.predicted_path_trajectory` | `bool` | `true` | Uses predicted-path object trajectories for PET. |
  | Added | `collision_check.pet_collision.constant_curvature_trajectory` | `bool` | `true` | Uses constant-curvature object trajectories for PET. |
  | Added | `collision_check.pet_collision.diffusion_based_trajectory` | `bool` | `true` | Uses diffusion-based object trajectories for PET. |
  | Modified | `collision_check.pet_collision.ego_braking_delay` -> `collision_check.pet_collision.ego_reaction_time` | `double` | `0.4` | Renamed for readability. |
  | Modified | `collision_check.pet_collision.ego_assumed_acceleration` -> `collision_check.pet_collision.ego_assumed_deceleration` | `double` | `-5.0` | Renamed and uses negative deceleration convention. |
  | Modified | `collision_check.pet_collision.collision_time_threshold` -> `collision_check.pet_collision.warn/error.collision_time_threshold_positive/negative` | `double` | varies | Splits PET threshold into

  ## Notes for reviewers

 
