### PR TITLE
fix(dummy_diag_publisher): support dummy diags with at most one period when default is specified

### DIFF
--- a/system/autoware_dummy_diag_publisher/src/dummy_diag_publisher_core.cpp
+++ b/system/autoware_dummy_diag_publisher/src/dummy_diag_publisher_core.cpp
@@ -83,9 +83,8 @@ void DummyDiagPublisher::loadRequiredDiags()
   const std::string required_diags_prefix = param_key + std::string(".");
   static const std::string is_active_suffix = ".is_active";
   static const std::string status_suffix = ".status";
-  const auto ends_with = [](const std::string & s, const std::string & suf) {
-    return s.size() > suf.size() &&
-           s.compare(s.size() - suf.size(), suf.size(), suf) == 0;
+  const auto ends_with = [](const std::string & s, const std::string & suffix) {
+    return s.size() > suffix.size() && s.compare(s.size() - suffix.size(), suffix.size(), suffix) == 0;
   };
 
   for (const auto & param_name : param_names) {
@@ -108,10 +107,10 @@ void DummyDiagPublisher::loadRequiredDiags()
 
     diag_names.insert(diag_name_with_prefix);
 
-    const auto is_active_key = diag_name_with_prefix + std::string(".is_active");
+    const auto is_active_key = diag_name_with_prefix + is_active_suffix;
     std::string is_active_str;
     this->get_parameter_or(is_active_key, is_active_str, std::string("true"));
-    const auto status_key = diag_name_with_prefix + std::string(".status");
+    const auto status_key = diag_name_with_prefix + status_suffix;
     std::string status_str;
     this->get_parameter_or(status_key, status_str, std::string("OK"));
 

--- a/system/autoware_dummy_diag_publisher/src/dummy_diag_publisher_core.cpp
+++ b/system/autoware_dummy_diag_publisher/src/dummy_diag_publisher_core.cpp
@@ -84,7 +84,8 @@ void DummyDiagPublisher::loadRequiredDiags()
   static const std::string is_active_suffix = ".is_active";
   static const std::string status_suffix = ".status";
   const auto ends_with = [](const std::string & s, const std::string & suffix) {
-    return s.size() > suffix.size() && s.compare(s.size() - suffix.size(), suffix.size(), suffix) == 0;
+    return s.size() > suffix.size() &&
+           s.compare(s.size() - suffix.size(), suffix.size(), suffix) == 0;
   };
 
   for (const auto & param_name : param_names) {

--- a/system/autoware_dummy_diag_publisher/src/dummy_diag_publisher_core.cpp
+++ b/system/autoware_dummy_diag_publisher/src/dummy_diag_publisher_core.cpp
@@ -26,17 +26,6 @@
 
 namespace autoware::dummy_diag_publisher
 {
-std::vector<std::string> split(const std::string & str, const char delim)
-{
-  std::vector<std::string> elems;
-  std::stringstream ss(str);
-  std::string item;
-  while (std::getline(ss, item, delim)) {
-    elems.push_back(item);
-  }
-  return elems;
-}
-
 std::optional<DummyDiagPublisher::Status> DummyDiagPublisher::convertStrToStatus(
   const std::string & status_str)
 {
@@ -91,12 +80,27 @@ void DummyDiagPublisher::loadRequiredDiags()
 
   std::set<std::string> diag_names;
 
-  for (const auto & param_name : param_names) {
-    const auto split_names = split(param_name, '.');
-    const auto & param_required_diags = split_names.at(0);
-    const auto & param_diag = split_names.at(1);
+  const std::string required_diags_prefix = param_key + std::string(".");
+  static const std::string is_active_suffix = ".is_active";
+  static const std::string status_suffix = ".status";
+  const auto ends_with = [](const std::string & s, const std::string & suf) {
+    return s.size() > suf.size() &&
+           s.compare(s.size() - suf.size(), suf.size(), suf) == 0;
+  };
 
-    const auto diag_name_with_prefix = fmt::format("{0}.{1}", param_required_diags, param_diag);
+  for (const auto & param_name : param_names) {
+    if (param_name.rfind(required_diags_prefix, 0) != 0) {
+      continue;
+    }
+
+    std::string param_diag = param_name.substr(required_diags_prefix.size());
+    if (ends_with(param_diag, is_active_suffix)) {
+      param_diag.resize(param_diag.size() - is_active_suffix.size());
+    } else if (ends_with(param_diag, status_suffix)) {
+      param_diag.resize(param_diag.size() - status_suffix.size());
+    }
+
+    const auto diag_name_with_prefix = required_diags_prefix + param_diag;
 
     if (diag_names.count(diag_name_with_prefix) != 0) {
       continue;

--- a/system/autoware_dummy_diag_publisher/src/dummy_diag_publisher_core.cpp
+++ b/system/autoware_dummy_diag_publisher/src/dummy_diag_publisher_core.cpp
@@ -88,7 +88,7 @@ void DummyDiagPublisher::loadRequiredDiags()
   };
 
   for (const auto & param_name : param_names) {
-    if (param_name.rfind(required_diags_prefix, 0) != 0) {
+    if (param_name.find(required_diags_prefix, 0) != 0) {
       continue;
     }
 


### PR DESCRIPTION
As discussed in [this thread](https://star4.slack.com/archives/C07K9RBUQR3/p1776850396485159?thread_ts=1776389439.767639&cid=C07K9RBUQR3), this PR ports the changes from [the PR](https://github.com/autowarefoundation/autoware_universe/pull/12498) to autowarefoundation.

## Description
The dummy diag publisher was designed to publish a dummy diagnostic by truncating the diagnostic name at the first period (`.`) if one existed in the diagnostic name. This PR updates this behavior to allow publishing of diagnostics that contain at most one period.

#### Key Changes
- Modified the logic to support diagnostic names containing at most one period so that they can be properly published instead of being truncated.

- Added special handling for `.is_active` and `.status` suffixes: Since only these two strings can be used to indicate the state of a dummy diagnostic, if a diagnostic name ends with either of them, the part preceding the suffix is recognized as the diagnostic name.

#### Limitations
It has been confirmed that specifying `is_active` or `status` attributes for diagnostics containing a period results in the publishing of incorrect diagnostic names. Since this issue does not occur when `default` is specified, the following two constraints are applied when a diagnostic name includes a period:

- A diagnostic name must contain no more than one period.

- If a diagnostic name contains a period, only the `default` setting must be used.


#### Notes
This PR is specifically intended to enable the publishing dummy diagnostics for diagnostic names that already contain a period in their existing implementation.

Please note that using periods for sub-components is considered a departure from ROS naming conventions ([reference](https://ros.org/reps/rep-0107.html)). This practice can lead to compatibility issues with various tools and internal specifications. Therefore, it is highly recommended to use `diagnostic_updater` and define diagnostic names without periods for standard diagnostic outputs.

## Related links

**Parent Issue:**

- [TIER IV internal link](https://star4.slack.com/archives/CRUE57C30/p1775624637363469?thread_ts=1775122298.158069&cid=CRUE57C30)

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?
To verify this PR, I performed the following steps:

1. Ran the planning-simulator with this PR applied.

2. Configured `dummy_diag_publisher.param.yaml` to include a diagnostic name containing a period: `"test1.test2": default`.

3. Monitored the diagnostic output using rqt_runtime_monitor.

4. Confirmed that the diagnostic `test1.test2` was output with the expected OK status message under the `default` setting. Additionally, I have verified that this change does not affect any other diagnostics.

<img width="1535" height="330" alt="image" src="https://github.com/user-attachments/assets/3969f439-4c2d-4c4c-8079-7c146423db41" />


## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
