### PR TITLE
feat(minimum_rule_based_planner): feat rss stop

### DIFF
--- a/planning/autoware_minimum_rule_based_planner/config/minimum_rule_based_planner.param.yaml
+++ b/planning/autoware_minimum_rule_based_planner/config/minimum_rule_based_planner.param.yaml
@@ -45,7 +45,23 @@
 
       objects:
         object_types: ["car", "truck", "bus", "trailer", "motorcycle", "bicycle", "pedestrian", "unknown"] # object types to consider for obstacle stop
-        max_velocity_th: 1.0      # maximum velocity threshold for target object [m/s]
+        max_velocity_th: 1.0     # maximum velocity threshold for target object [m/s]
+        stopped_velocity_th: 0.25 # velocity threshold for target object to be considered as stopped [m/s]
+
+      rss_params:
+        enable: true
+        object_decel:
+          car: 1.5
+          truck: 1.5
+          bus: 1.5
+          trailer: 1.5
+          motorcycle: 3.0
+          bicycle: 5.0
+          pedestrian: 5.0
+        ego_decel: 4.0           # [m/s^2]
+        reaction_time: 0.2       # [s]
+        safety_margin: 2.0       # [m]
+        lookahead_horizon: 1.5   # [s]
 
       pointcloud:
         height_buffer: 0.5  # height buffer to add above ego height [m]

--- a/planning/autoware_minimum_rule_based_planner/config/minimum_rule_based_planner.param.yaml
+++ b/planning/autoware_minimum_rule_based_planner/config/minimum_rule_based_planner.param.yaml
@@ -42,6 +42,7 @@
       on_time_buffer: 0.5 # [s]
       off_time_buffer: 1.0 # [s]
       lateral_margin: 0.5     # lateral margin on top of ego width from trajectory to consider for obstacle stop [m]
+      longitudinal_margin: 10.0 # longitudinal margin applied to each trajectory-point footprint [m]
 
       objects:
         object_types: ["car", "truck", "bus", "trailer", "motorcycle", "bicycle", "pedestrian", "unknown"] # object types to consider for obstacle stop

--- a/planning/autoware_minimum_rule_based_planner/package.xml
+++ b/planning/autoware_minimum_rule_based_planner/package.xml
@@ -17,6 +17,7 @@
 
   <build_depend>generate_parameter_library</build_depend>
 
+  <depend>autoware_internal_debug_msgs</depend>
   <depend>autoware_internal_planning_msgs</depend>
   <depend>autoware_lanelet2_extension</depend>
   <depend>autoware_map_msgs</depend>

--- a/planning/autoware_minimum_rule_based_planner/param/minimum_rule_based_planner_parameters.yaml
+++ b/planning/autoware_minimum_rule_based_planner/param/minimum_rule_based_planner_parameters.yaml
@@ -138,6 +138,10 @@ minimum_rule_based_planner:
       type: double
       default_value: 0.5
       description: lateral margin for obstacle stop [m]
+    detection_range:
+      type: double
+      default_value: 200.0
+      description: max detection range for obstacle stop [m] (capped by remaining trajectory length)
     objects:
       object_types:
         type: string_array
@@ -147,6 +151,60 @@ minimum_rule_based_planner:
         type: double
         default_value: 1.0
         description: maximum velocity threshold for target object [m/s]
+      stopped_velocity_th:
+        type: double
+        default_value: 0.25
+        description: velocity threshold for target object to be considered as stopped [m/s]
+    rss_params:
+      enable:
+        type: bool
+        default_value: true
+        description: enable the use of RSS parameters for obstacle stop
+      object_decel:
+        car:
+          type: double
+          default_value: 1.5
+          description: deceleration for car type objects [m/s^2]
+        truck:
+          type: double
+          default_value: 1.5
+          description: deceleration for truck type objects [m/s^2]
+        bus:
+          type: double
+          default_value: 1.5
+          description: deceleration for bus type objects [m/s^2]
+        trailer:
+          type: double
+          default_value: 1.5
+          description: deceleration for trailer type objects [m/s^2]
+        motorcycle:
+          type: double
+          default_value: 3.0
+          description: deceleration for motorcycle type objects [m/s^2]
+        bicycle:
+          type: double
+          default_value: 5.0
+          description: deceleration for bicycle type objects [m/s^2]
+        pedestrian:
+          type: double
+          default_value: 5.0
+          description: deceleration for pedestrian type objects [m/s^2]
+      ego_decel:
+        type: double
+        default_value: 4.0
+        description: deceleration for ego vehicle used in RSS calculation [m/s^2]
+      reaction_time:
+        type: double
+        default_value: 0.2
+        description: reaction time used in RSS calculation [s]
+      safety_margin:
+        type: double
+        default_value: 2.0
+        description: safety margin used in RSS calculation [m]
+      lookahead_horizon:
+        type: double
+        default_value: 1.5
+        description: lookahead horizon used in RSS calculation [s]
     pointcloud:
       height_buffer:
         type: double

--- a/planning/autoware_minimum_rule_based_planner/param/minimum_rule_based_planner_parameters.yaml
+++ b/planning/autoware_minimum_rule_based_planner/param/minimum_rule_based_planner_parameters.yaml
@@ -138,10 +138,10 @@ minimum_rule_based_planner:
       type: double
       default_value: 0.5
       description: lateral margin for obstacle stop [m]
-    detection_range:
+    longitudinal_margin:
       type: double
-      default_value: 200.0
-      description: max detection range for obstacle stop [m] (capped by remaining trajectory length)
+      default_value: 10.0
+      description: longitudinal margin applied to each trajectory-point footprint; also acts as a floor on the detection corridor length to prevent chatter as ego decelerates [m]
     objects:
       object_types:
         type: string_array

--- a/planning/autoware_minimum_rule_based_planner/plugins/obstacle_stop.cpp
+++ b/planning/autoware_minimum_rule_based_planner/plugins/obstacle_stop.cpp
@@ -83,6 +83,7 @@ void ObstacleStop::run(TrajectoryPoints & traj_points)
 bool ObstacleStop::is_obstacle_detected(const TrajectoryPoints & traj_points)
 {
   debug_data_ = DebugData();
+  safety_factors_ = SafetyFactorArray{};
   debug_data_.trajectory_shape = get_trajectory_shape(
     traj_points, data_->odometry_ptr->pose.pose, vehicle_info_,
     data_->odometry_ptr->twist.twist.linear.x, data_->acceleration_ptr->accel.accel.linear.x,
@@ -93,6 +94,26 @@ bool ObstacleStop::is_obstacle_detected(const TrajectoryPoints & traj_points)
   const auto collision_point_objects = check_predicted_objects(traj_points);
   update_collision_points_buffer(
     collision_points_buffer_.objects, traj_points, collision_point_objects);
+
+  const auto make_safety_factor =
+    [](const geometry_msgs::msg::Point & point, const SafetyFactor::_type_type type) {
+      SafetyFactor factor;
+      factor.type = type;
+      factor.points.emplace_back(point);
+      factor.is_safe = false;
+      return factor;
+    };
+  if (collision_point_objects && debug_data_.colliding_object) {
+    auto factor = make_safety_factor(
+      debug_data_.colliding_object->kinematics.initial_pose_with_covariance.pose.position,
+      SafetyFactor::OBJECT);
+    factor.object_id = debug_data_.colliding_object->object_id;
+    safety_factors_.factors.push_back(factor);
+  }
+  if (collision_point_pcd) {
+    safety_factors_.factors.push_back(
+      make_safety_factor(collision_point_pcd->point, SafetyFactor::POINTCLOUD));
+  }
 
   nearest_collision_point_ = get_nearest_collision_point();
   debug_data_.active_collision_point =
@@ -118,8 +139,7 @@ void ObstacleStop::set_stop_point(TrajectoryPoints & traj_points)
   const auto & stop_pose = traj_points.at(*stop_index).pose;
   const auto & ego_pose = data_->odometry_ptr->pose.pose;
   planning_factor_interface_->add(
-    traj_points, ego_pose, stop_pose, PlanningFactor::STOP,
-    autoware_internal_planning_msgs::msg::SafetyFactorArray{});
+    traj_points, ego_pose, stop_pose, PlanningFactor::STOP, safety_factors_);
 
   RCLCPP_WARN_THROTTLE(
     get_node_ptr()->get_logger(), *get_clock(), 500,

--- a/planning/autoware_minimum_rule_based_planner/plugins/obstacle_stop.cpp
+++ b/planning/autoware_minimum_rule_based_planner/plugins/obstacle_stop.cpp
@@ -14,7 +14,6 @@
 
 #include "obstacle_stop.hpp"
 
-#include <autoware/motion_utils/distance/distance.hpp>
 #include <autoware/planning_factor_interface/planning_factor_interface.hpp>
 #include <autoware/trajectory_modifier/trajectory_modifier_utils/obstacle_stop_utils.hpp>
 #include <autoware_utils/ros/marker_helper.hpp>
@@ -125,13 +124,8 @@ bool ObstacleStop::is_obstacle_detected(const TrajectoryPoints & traj_points)
 void ObstacleStop::set_stop_point(TrajectoryPoints & traj_points)
 {
   const auto stop_margin = params_.stop_margin + vehicle_info_.max_longitudinal_offset_m;
-  auto min_stopping_distance = motion_utils::calculate_stop_distance(
-    data_->odometry_ptr->twist.twist.linear.x, data_->acceleration_ptr->accel.accel.linear.x,
-    params_.maximum_stopping_decel, params_.stopping_jerk, 0.0);
-  if (!min_stopping_distance) min_stopping_distance = 0.0;
-  const auto target_stop_point_arc_length = std::clamp(
-    nearest_collision_point_->arc_length - stop_margin, min_stopping_distance.value(),
-    debug_data_.trajectory_shape.trajectory_length);
+  const auto target_stop_point_arc_length =
+    std::max(nearest_collision_point_->arc_length - stop_margin, 0.0);
 
   const auto stop_index = motion_utils::insertStopPoint(target_stop_point_arc_length, traj_points);
   if (!stop_index) return;

--- a/planning/autoware_minimum_rule_based_planner/plugins/obstacle_stop.cpp
+++ b/planning/autoware_minimum_rule_based_planner/plugins/obstacle_stop.cpp
@@ -14,6 +14,7 @@
 
 #include "obstacle_stop.hpp"
 
+#include <autoware/motion_utils/distance/distance.hpp>
 #include <autoware/planning_factor_interface/planning_factor_interface.hpp>
 #include <autoware/trajectory_modifier/trajectory_modifier_utils/obstacle_stop_utils.hpp>
 #include <autoware_utils/transform/transforms.hpp>
@@ -46,6 +47,8 @@ void ObstacleStop::on_initialize([[maybe_unused]] const MinimumRuleBasedPlannerP
 
   object_filter_ = std::make_unique<trajectory_modifier::utils::obstacle_stop::ObjectFilter>(
     params_.objects.object_types, params_.objects.max_velocity_th);
+
+  update_object_decel_map();
 }
 
 void ObstacleStop::run(TrajectoryPoints & traj_points)
@@ -69,7 +72,7 @@ bool ObstacleStop::is_obstacle_detected(const TrajectoryPoints & traj_points)
     traj_points, data_->odometry_ptr->pose.pose, vehicle_info_,
     data_->odometry_ptr->twist.twist.linear.x, data_->acceleration_ptr->accel.accel.linear.x,
     params_.nominal_stopping_decel, params_.stopping_jerk, params_.stop_margin,
-    params_.lateral_margin);
+    params_.lateral_margin, params_.detection_range);
   const auto collision_point_pcd = check_pointcloud(traj_points);
   update_collision_points_buffer(collision_points_buffer_.pcd, traj_points, collision_point_pcd);
   const auto collision_point_objects = check_predicted_objects(traj_points);
@@ -86,8 +89,13 @@ bool ObstacleStop::is_obstacle_detected(const TrajectoryPoints & traj_points)
 void ObstacleStop::set_stop_point(TrajectoryPoints & traj_points)
 {
   const auto stop_margin = params_.stop_margin + vehicle_info_.max_longitudinal_offset_m;
-  const auto target_stop_point_arc_length =
-    std::max(nearest_collision_point_->arc_length - stop_margin, 0.0);
+  auto min_stopping_distance = motion_utils::calculate_stop_distance(
+    data_->odometry_ptr->twist.twist.linear.x, data_->acceleration_ptr->accel.accel.linear.x,
+    params_.maximum_stopping_decel, params_.stopping_jerk, 0.0);
+  if (!min_stopping_distance) min_stopping_distance = 0.0;
+  const auto target_stop_point_arc_length = std::clamp(
+    nearest_collision_point_->arc_length - stop_margin, min_stopping_distance.value(),
+    debug_data_.trajectory_shape.trajectory_length);
 
   const auto stop_index = motion_utils::insertStopPoint(target_stop_point_arc_length, traj_points);
   if (!stop_index) return;
@@ -115,9 +123,18 @@ std::optional<CollisionPoint> ObstacleStop::check_predicted_objects(
   object_filter_->filter_objects(predicted_objects);
 
   autoware_perception_msgs::msg::PredictedObject colliding_object;
-  auto collision_point = get_nearest_object_collision(
-    traj_points, debug_data_.trajectory_shape, predicted_objects, debug_data_.target_polygons,
-    colliding_object);
+  auto collision_point = std::invoke([&]() -> std::optional<CollisionPoint> {
+    if (!params_.rss_params.enable) {
+      return get_nearest_object_collision(
+        traj_points, debug_data_.trajectory_shape, predicted_objects, debug_data_.target_polygons,
+        colliding_object);
+    }
+    return get_nearest_object_collision(
+      traj_points, debug_data_.trajectory_shape, vehicle_info_, predicted_objects,
+      object_decel_map_, params_.rss_params.ego_decel, params_.rss_params.reaction_time,
+      params_.rss_params.safety_margin, params_.objects.stopped_velocity_th,
+      params_.rss_params.lookahead_horizon, debug_data_.target_polygons, colliding_object);
+  });
   if (collision_point) debug_data_.colliding_object = colliding_object;
   return collision_point;
 }

--- a/planning/autoware_minimum_rule_based_planner/plugins/obstacle_stop.cpp
+++ b/planning/autoware_minimum_rule_based_planner/plugins/obstacle_stop.cpp
@@ -17,12 +17,16 @@
 #include <autoware/motion_utils/distance/distance.hpp>
 #include <autoware/planning_factor_interface/planning_factor_interface.hpp>
 #include <autoware/trajectory_modifier/trajectory_modifier_utils/obstacle_stop_utils.hpp>
+#include <autoware_utils/ros/marker_helper.hpp>
 #include <autoware_utils/transform/transforms.hpp>
 #include <tf2_eigen/tf2_eigen.hpp>
 
 #include <algorithm>
+#include <iomanip>
 #include <limits>
 #include <memory>
+#include <sstream>
+#include <string>
 #include <vector>
 
 namespace autoware::minimum_rule_based_planner::plugin
@@ -48,18 +52,29 @@ void ObstacleStop::on_initialize([[maybe_unused]] const MinimumRuleBasedPlannerP
   object_filter_ = std::make_unique<trajectory_modifier::utils::obstacle_stop::ObjectFilter>(
     params_.objects.object_types, params_.objects.max_velocity_th);
 
+  pub_clustered_pointcloud_ =
+    get_node_ptr()->create_publisher<PointCloud2>("~/obstacle_stop/debug/cluster_points", 1);
+  debug_viz_pub_ = get_node_ptr()->create_publisher<MarkerArray>("~/obstacle_stop/debug/marker", 1);
+  pub_debug_text_ =
+    get_node_ptr()->create_publisher<StringStamped>("~/obstacle_stop/debug/text", 1);
+
   update_object_decel_map();
 }
 
 void ObstacleStop::run(TrajectoryPoints & traj_points)
 {
-  if (!params_.enable || !is_obstacle_detected(traj_points)) return;
+  if (!params_.enable) return;
 
+  const auto detected = is_obstacle_detected(traj_points);
+  publish_debug_string(!detected);
+  publish_debug_data("obstacle_stop");
+
+  if (!detected) return;
   if (!nearest_collision_point_) return;
 
   RCLCPP_WARN_THROTTLE(
     get_node_ptr()->get_logger(), *get_clock(), 500,
-    "[MRBP ObstacleStop] Detected collision point at arc length %f m",
+    "[Backup Planner ObstacleStop] Detected collision point at arc length %f m",
     nearest_collision_point_->arc_length);
 
   set_stop_point(traj_points);
@@ -72,7 +87,7 @@ bool ObstacleStop::is_obstacle_detected(const TrajectoryPoints & traj_points)
     traj_points, data_->odometry_ptr->pose.pose, vehicle_info_,
     data_->odometry_ptr->twist.twist.linear.x, data_->acceleration_ptr->accel.accel.linear.x,
     params_.nominal_stopping_decel, params_.stopping_jerk, params_.stop_margin,
-    params_.lateral_margin, params_.detection_range);
+    params_.lateral_margin, params_.longitudinal_margin);
   const auto collision_point_pcd = check_pointcloud(traj_points);
   update_collision_points_buffer(collision_points_buffer_.pcd, traj_points, collision_point_pcd);
   const auto collision_point_objects = check_predicted_objects(traj_points);
@@ -108,7 +123,8 @@ void ObstacleStop::set_stop_point(TrajectoryPoints & traj_points)
 
   RCLCPP_WARN_THROTTLE(
     get_node_ptr()->get_logger(), *get_clock(), 500,
-    "[MRBP ObstacleStop] Inserted stop point at arc length %f m", target_stop_point_arc_length);
+    "[Backup Planner ObstacleStop] Inserted stop point at arc length %f m",
+    target_stop_point_arc_length);
 }
 
 std::optional<CollisionPoint> ObstacleStop::check_predicted_objects(
@@ -282,6 +298,98 @@ std::optional<CollisionPoint> ObstacleStop::get_nearest_collision_point() const
   }
 
   return nearest_collision_point;
+}
+
+void ObstacleStop::publish_debug_string(bool is_safe) const
+{
+  const auto cluster_pcd_size =
+    debug_data_.cluster_points ? debug_data_.cluster_points->data.size() : 0;
+  std::ostringstream ss;
+  ss << std::fixed << std::setprecision(2) << std::boolalpha;
+  ss << "OBSTACLE STOP (Backup Planner):" << "\n";
+  ss << "\t\t" << "SAFE: " << is_safe << "\n";
+  ss << "\t\t" << "OBJECTS: " << debug_data_.filtered_objects.objects.size() << " --> "
+     << debug_data_.target_polygons.size() << "\n";
+  ss << "\t\t" << "POINTCLOUD: " << cluster_pcd_size << " --> "
+     << debug_data_.target_pcd_points.size() << "\n";
+  if (nearest_collision_point_) {
+    ss << "\t\t" << "DISTANCE TO COLLISION: " << nearest_collision_point_->arc_length << " m"
+       << "\n";
+  }
+
+  StringStamped string_stamp;
+  string_stamp.stamp = get_clock()->now();
+  string_stamp.data = ss.str();
+  pub_debug_text_->publish(string_stamp);
+}
+
+void ObstacleStop::publish_debug_data(const std::string & ns) const
+{
+  if (debug_data_.cluster_points) pub_clustered_pointcloud_->publish(*debug_data_.cluster_points);
+
+  MarkerArray marker_array;
+  const auto ego_z = data_->odometry_ptr->pose.pose.position.z;
+  const auto white = autoware_utils::create_marker_color(1.0, 1.0, 1.0, 1.0);
+  const auto yellow = autoware_utils::create_marker_color(1.0, 1.0, 0.0, 1.0);
+  const auto magenta = autoware_utils::create_marker_color(1.0, 0.0, 1.0, 1.0);
+
+  auto add_point_marker = [&](
+                            const geometry_msgs::msg::Point & point, const std::string & marker_ns,
+                            const int id, const std_msgs::msg::ColorRGBA & color,
+                            const double scale = 0.1) {
+    Marker marker = autoware_utils::create_default_marker(
+      "map", get_clock()->now(), marker_ns, id, Marker::SPHERE,
+      autoware_utils::create_marker_scale(scale, scale, scale), color);
+    marker.lifetime = rclcpp::Duration::from_seconds(0.2);
+    marker.pose.position = point;
+    marker_array.markers.push_back(marker);
+  };
+
+  auto add_polygon_marker = [&](
+                              const Polygon2d & polygon, const std::string & marker_ns,
+                              const int id, const std_msgs::msg::ColorRGBA & color) {
+    Marker marker = autoware_utils::create_default_marker(
+      "map", get_clock()->now(), marker_ns, id, Marker::LINE_STRIP,
+      autoware_utils::create_marker_scale(0.1, 0.1, 0.1), color);
+    marker.lifetime = rclcpp::Duration::from_seconds(0.2);
+
+    for (const auto & p : polygon.outer()) {
+      marker.points.push_back(autoware_utils::create_point(p.x(), p.y(), ego_z));
+    }
+    if (!marker.points.empty()) {
+      marker.points.push_back(marker.points.front());
+    }
+    marker_array.markers.push_back(marker);
+  };
+
+  int id = 0;
+  for (const auto & traj_polygon : debug_data_.trajectory_shape.polygon) {
+    add_polygon_marker(traj_polygon, ns + "/traj_polygon", id, yellow);
+    id++;
+  }
+
+  {
+    const auto & bounding_box = debug_data_.trajectory_shape.bounding_box;
+    Polygon2d polygon;
+    polygon.outer().emplace_back(bounding_box.min_corner());
+    polygon.outer().emplace_back(bounding_box.min_corner().x(), bounding_box.max_corner().y());
+    polygon.outer().emplace_back(bounding_box.max_corner());
+    polygon.outer().emplace_back(bounding_box.max_corner().x(), bounding_box.min_corner().y());
+    add_polygon_marker(polygon, ns + "/traj_bounding_box", id, white);
+    id++;
+  }
+
+  for (const auto & target_polygon : debug_data_.target_polygons) {
+    add_polygon_marker(target_polygon, ns + "/target_objects", id, magenta);
+    id++;
+  }
+
+  for (const auto & target_pcd_point : debug_data_.target_pcd_points) {
+    add_point_marker(target_pcd_point, ns + "/target_pcd", id, magenta, 0.25);
+    id++;
+  }
+
+  debug_viz_pub_->publish(marker_array);
 }
 
 }  // namespace autoware::minimum_rule_based_planner::plugin

--- a/planning/autoware_minimum_rule_based_planner/plugins/obstacle_stop.cpp
+++ b/planning/autoware_minimum_rule_based_planner/plugins/obstacle_stop.cpp
@@ -35,8 +35,10 @@ using autoware::trajectory_modifier::utils::obstacle_stop::get_nearest_pcd_colli
 using autoware::trajectory_modifier::utils::obstacle_stop::get_trajectory_shape;
 using autoware::trajectory_modifier::utils::obstacle_stop::PointCloud;
 
-void ObstacleStop::on_initialize([[maybe_unused]] const MinimumRuleBasedPlannerParams & params)
+void ObstacleStop::on_initialize(const MinimumRuleBasedPlannerParams & params)
 {
+  params_ = params.obstacle_stop;
+
   planning_factor_interface_ =
     std::make_unique<autoware::planning_factor_interface::PlanningFactorInterface>(
       get_node_ptr(), "backup_planner_obstacle_stop");

--- a/planning/autoware_minimum_rule_based_planner/plugins/obstacle_stop.hpp
+++ b/planning/autoware_minimum_rule_based_planner/plugins/obstacle_stop.hpp
@@ -21,6 +21,7 @@
 #include <autoware_utils_rclcpp/polling_subscriber.hpp>
 #include <rclcpp/rclcpp.hpp>
 
+#include <autoware_internal_debug_msgs/msg/string_stamped.hpp>
 #include <visualization_msgs/msg/marker_array.hpp>
 
 #include <memory>
@@ -29,6 +30,7 @@
 
 namespace autoware::minimum_rule_based_planner::plugin
 {
+using autoware_internal_debug_msgs::msg::StringStamped;
 using autoware_planning_msgs::msg::TrajectoryPoint;
 using autoware_utils_geometry::MultiPolygon2d;
 using autoware_utils_geometry::Polygon2d;
@@ -93,6 +95,10 @@ private:
 
   ObjectDecelMap object_decel_map_;
 
+  rclcpp::Publisher<MarkerArray>::SharedPtr debug_viz_pub_;
+  rclcpp::Publisher<PointCloud2>::SharedPtr pub_clustered_pointcloud_;
+  rclcpp::Publisher<StringStamped>::SharedPtr pub_debug_text_;
+
   void update_object_decel_map()
   {
     const auto & p = params_.rss_params;
@@ -118,6 +124,9 @@ private:
   std::optional<CollisionPoint> get_nearest_collision_point() const;
 
   void set_stop_point(TrajectoryPoints & traj_points);
+
+  void publish_debug_string(bool is_safe) const;
+  void publish_debug_data(const std::string & ns) const;
 };
 
 }  // namespace autoware::minimum_rule_based_planner::plugin

--- a/planning/autoware_minimum_rule_based_planner/plugins/obstacle_stop.hpp
+++ b/planning/autoware_minimum_rule_based_planner/plugins/obstacle_stop.hpp
@@ -31,6 +31,8 @@
 namespace autoware::minimum_rule_based_planner::plugin
 {
 using autoware_internal_debug_msgs::msg::StringStamped;
+using autoware_internal_planning_msgs::msg::SafetyFactor;
+using autoware_internal_planning_msgs::msg::SafetyFactorArray;
 using autoware_planning_msgs::msg::TrajectoryPoint;
 using autoware_utils_geometry::MultiPolygon2d;
 using autoware_utils_geometry::Polygon2d;
@@ -86,6 +88,8 @@ private:
   } collision_points_buffer_;
 
   std::optional<CollisionPoint> nearest_collision_point_;
+
+  SafetyFactorArray safety_factors_;
 
   DebugData debug_data_;
 

--- a/planning/autoware_minimum_rule_based_planner/plugins/obstacle_stop.hpp
+++ b/planning/autoware_minimum_rule_based_planner/plugins/obstacle_stop.hpp
@@ -34,6 +34,8 @@ using autoware_utils_geometry::MultiPolygon2d;
 using autoware_utils_geometry::Polygon2d;
 using trajectory_modifier::utils::obstacle_stop::CollisionPoint;
 using trajectory_modifier::utils::obstacle_stop::DebugData;
+using trajectory_modifier::utils::obstacle_stop::ObjectDecelMap;
+using trajectory_modifier::utils::obstacle_stop::ObjectType;
 using visualization_msgs::msg::Marker;
 using visualization_msgs::msg::MarkerArray;
 using TrajectoryPoints = std::vector<TrajectoryPoint>;
@@ -62,6 +64,8 @@ public:
         p.voxel_grid_filter.min_size, p.clustering.tolerance, p.clustering.min_size,
         p.clustering.max_size);
     }
+
+    update_object_decel_map();
   }
   const MinimumRuleBasedPlannerParams::ObstacleStop & get_params() const { return params_; }
 
@@ -86,6 +90,21 @@ private:
   std::unique_ptr<trajectory_modifier::utils::obstacle_stop::PointCloudFilter> pointcloud_filter_;
 
   std::unique_ptr<trajectory_modifier::utils::obstacle_stop::ObjectFilter> object_filter_;
+
+  ObjectDecelMap object_decel_map_;
+
+  void update_object_decel_map()
+  {
+    const auto & p = params_.rss_params;
+    object_decel_map_ = {
+      {ObjectType::CAR, p.object_decel.car},
+      {ObjectType::TRUCK, p.object_decel.truck},
+      {ObjectType::BUS, p.object_decel.bus},
+      {ObjectType::TRAILER, p.object_decel.trailer},
+      {ObjectType::MOTORCYCLE, p.object_decel.motorcycle},
+      {ObjectType::BICYCLE, p.object_decel.bicycle},
+      {ObjectType::PEDESTRIAN, p.object_decel.pedestrian}};
+  }
 
   bool is_obstacle_detected(const TrajectoryPoints & traj_points);
 

--- a/planning/autoware_minimum_rule_based_planner/schema/minimum_rule_based_planner.schema.json
+++ b/planning/autoware_minimum_rule_based_planner/schema/minimum_rule_based_planner.schema.json
@@ -210,6 +210,12 @@
               "default": 0.5,
               "minimum": 0.0
             },
+            "longitudinal_margin": {
+              "type": "number",
+              "description": "Longitudinal margin applied to each trajectory-point footprint; also acts as a floor on the detection corridor length to prevent chatter as ego decelerates [m]",
+              "default": 10.0,
+              "minimum": 0.0
+            },
             "objects": {
               "type": "object",
               "properties": {
@@ -234,6 +240,97 @@
                   "type": "number",
                   "description": "Max velocity threshold [m/s]",
                   "default": 1.0,
+                  "minimum": 0.0
+                },
+                "stopped_velocity_th": {
+                  "type": "number",
+                  "description": "Velocity threshold for target object to be considered as stopped [m/s]",
+                  "default": 0.25,
+                  "minimum": 0.0
+                }
+              },
+              "required": [],
+              "additionalProperties": false
+            },
+            "rss_params": {
+              "type": "object",
+              "properties": {
+                "enable": {
+                  "type": "boolean",
+                  "description": "Enable RSS-based stop logic",
+                  "default": true
+                },
+                "object_decel": {
+                  "type": "object",
+                  "properties": {
+                    "car": {
+                      "type": "number",
+                      "description": "Deceleration for car type objects [m/s^2]",
+                      "default": 1.5,
+                      "minimum": 0.0
+                    },
+                    "truck": {
+                      "type": "number",
+                      "description": "Deceleration for truck type objects [m/s^2]",
+                      "default": 1.5,
+                      "minimum": 0.0
+                    },
+                    "bus": {
+                      "type": "number",
+                      "description": "Deceleration for bus type objects [m/s^2]",
+                      "default": 1.5,
+                      "minimum": 0.0
+                    },
+                    "trailer": {
+                      "type": "number",
+                      "description": "Deceleration for trailer type objects [m/s^2]",
+                      "default": 1.5,
+                      "minimum": 0.0
+                    },
+                    "motorcycle": {
+                      "type": "number",
+                      "description": "Deceleration for motorcycle type objects [m/s^2]",
+                      "default": 3.0,
+                      "minimum": 0.0
+                    },
+                    "bicycle": {
+                      "type": "number",
+                      "description": "Deceleration for bicycle type objects [m/s^2]",
+                      "default": 5.0,
+                      "minimum": 0.0
+                    },
+                    "pedestrian": {
+                      "type": "number",
+                      "description": "Deceleration for pedestrian type objects [m/s^2]",
+                      "default": 5.0,
+                      "minimum": 0.0
+                    }
+                  },
+                  "required": [],
+                  "additionalProperties": false
+                },
+                "ego_decel": {
+                  "type": "number",
+                  "description": "Deceleration for ego vehicle used in RSS calculation [m/s^2]",
+                  "default": 4.0,
+                  "minimum": 0.0
+                },
+                "reaction_time": {
+                  "type": "number",
+                  "description": "Reaction time used in RSS calculation [s]",
+                  "default": 0.2,
+                  "minimum": 0.0
+                },
+                "safety_margin": {
+                  "type": "number",
+                  "description": "Safety margin used in RSS calculation [m]",
+                  "default": 2.0,
+                  "minimum": 0.0
+                },
+                "lookahead_horizon": {
+                  "type": "number",
+                  "description": "Lookahead horizon used in RSS calculation [s]",
+                  "default": 1.5,
                   "minimum": 0.0
                 }
               },

--- a/planning/autoware_minimum_rule_based_planner/src/minimum_rule_based_planner.cpp
+++ b/planning/autoware_minimum_rule_based_planner/src/minimum_rule_based_planner.cpp
@@ -69,10 +69,10 @@ MinimumRuleBasedPlannerNode::MinimumRuleBasedPlannerNode(const rclcpp::NodeOptio
   time_keeper_ =
     std::make_shared<autoware_utils_debug::TimeKeeper>(debug_processing_time_detail_pub_);
 
+  params_ = param_listener_->get_params();
+
   load_optimizer_plugins();
   load_modifier_plugins();
-
-  params_ = param_listener_->get_params();
 
   path_planner_ =
     std::make_unique<PathPlanner>(get_logger(), get_clock(), time_keeper_, params_, vehicle_info_);


### PR DESCRIPTION
This PR changes
- Port the RSS-based obstacle stop logic introduced in [this PR](https://github.com/tier4/autoware_universe/pull/2880) to `autoware_minimum_rule_based_planner`.  
- Publish debug markers in the same format as the trajectory_modifier's obstacle stop plugin.
- Populate `SafetyFactor` with the colliding object / pointcloud information.

requires: https://github.com/tier4/autoware_launch.x2/pull/2177