### PR TITLE
feat(trajectory_validator): add object deceleration assumption

### DIFF
--- a/planning/autoware_trajectory_validator/include/autoware/trajectory_validator/filters/safety/collision_check_filter.hpp
+++ b/planning/autoware_trajectory_validator/include/autoware/trajectory_validator/filters/safety/collision_check_filter.hpp
@@ -19,8 +19,11 @@
 
 #include <autoware/motion_utils/trajectory/interpolation.hpp>
 #include <autoware/motion_utils/trajectory/trajectory.hpp>
+#include <autoware/object_recognition_utils/object_classification.hpp>
+#include <autoware/object_recognition_utils/object_recognition_utils.hpp>
 #include <autoware/universe_utils/geometry/geometry.hpp>
 #include <autoware_utils_geometry/geometry.hpp>
+#include <autoware_utils_uuid/uuid_helper.hpp>
 #include <builtin_interfaces/msg/time.hpp>
 #include <rclcpp/duration.hpp>
 #include <rclcpp/time.hpp>
@@ -65,12 +68,32 @@ using TimeRange = std::pair<double, double>;
 
 static constexpr double TIME_INDEX_EPSILON = 1e-3;
 
-struct ObjectIdentification
+struct TrajectoryIdentification
 {
   std::string classification;
   builtin_interfaces::msg::Time stamp{};
   unique_identifier_msgs::msg::UUID uuid{};
-  std::string trajectory_suffix{};
+  std::string trajectory_type{};
+
+  TrajectoryIdentification() = default;
+  explicit TrajectoryIdentification(std::string classification)
+  : classification(std::move(classification))
+  {
+  }
+
+  TrajectoryIdentification(
+    const autoware_perception_msgs::msg::PredictedObject & object,
+    const builtin_interfaces::msg::Time stamp, std::string trajectory_type = {})
+  : classification(autoware::object_recognition_utils::convertLabelToString(
+      autoware::object_recognition_utils::getHighestProbLabel(object.classification))),
+    stamp(stamp),
+    uuid(object.object_id),
+    trajectory_type(std::move(trajectory_type))
+  {
+  }
+
+  std::string object_id_string() const { return autoware_utils_uuid::to_hex_string(uuid); }
+  std::string trajectory_id_string() const { return object_id_string() + "_" + trajectory_type; }
 };
 
 namespace geometry
@@ -83,7 +106,7 @@ Polygon2d to_polygon2d(
 class TrajectoryData
 {
 private:
-  ObjectIdentification object_identification_;
+  TrajectoryIdentification object_identification_;
   TimeTrajectory times_;
   TravelDistanceTrajectory distances_;
   PoseTrajectory poses_;
@@ -150,7 +173,7 @@ private:
 
 public:
   TrajectoryData(
-    ObjectIdentification object_identification, TimeTrajectory times,
+    TrajectoryIdentification object_identification, TimeTrajectory times,
     TravelDistanceTrajectory distances, PoseTrajectory poses, FootprintTrajectory footprints)
   : object_identification_(std::move(object_identification)),
     times_(std::move(times)),
@@ -181,7 +204,10 @@ public:
 
   TrajectoryData() = delete;
 
-  const ObjectIdentification & getObjectIdentification() const { return object_identification_; }
+  const TrajectoryIdentification & getObjectIdentification() const
+  {
+    return object_identification_;
+  }
   const TimeTrajectory & getTimes() const { return times_; }
   const TravelDistanceTrajectory & getDistances() const { return distances_; }
   const PoseTrajectory & getPoses() const { return poses_; }

--- a/planning/autoware_trajectory_validator/include/autoware/trajectory_validator/filters/safety/collision_check_filter.hpp
+++ b/planning/autoware_trajectory_validator/include/autoware/trajectory_validator/filters/safety/collision_check_filter.hpp
@@ -74,6 +74,7 @@ struct TrajectoryIdentification
   builtin_interfaces::msg::Time stamp{};
   unique_identifier_msgs::msg::UUID uuid{};
   std::string trajectory_type{};
+  double acceleration{};
 
   TrajectoryIdentification() = default;
   explicit TrajectoryIdentification(std::string classification)
@@ -83,17 +84,18 @@ struct TrajectoryIdentification
 
   TrajectoryIdentification(
     const autoware_perception_msgs::msg::PredictedObject & object,
-    const builtin_interfaces::msg::Time stamp, std::string trajectory_type = {})
+    const builtin_interfaces::msg::Time stamp, std::string trajectory_type = {}, double acceleration = 0.0)
   : classification(autoware::object_recognition_utils::convertLabelToString(
       autoware::object_recognition_utils::getHighestProbLabel(object.classification))),
     stamp(stamp),
     uuid(object.object_id),
-    trajectory_type(std::move(trajectory_type))
+    trajectory_type(std::move(trajectory_type)),
+    acceleration(acceleration)
   {
   }
 
   std::string object_id_string() const { return autoware_utils_uuid::to_hex_string(uuid); }
-  std::string trajectory_id_string() const { return object_id_string() + "_" + trajectory_type; }
+  std::string trajectory_id_string() const { return object_id_string() + "_" + trajectory_type +  " acc: " + std::to_string(acceleration); }
 };
 
 namespace geometry
@@ -204,10 +206,7 @@ public:
 
   TrajectoryData() = delete;
 
-  const TrajectoryIdentification & getObjectIdentification() const
-  {
-    return identification_;
-  }
+  const TrajectoryIdentification & getObjectIdentification() const { return identification_; }
   const TimeTrajectory & getTimes() const { return times_; }
   const TravelDistanceTrajectory & getDistances() const { return distances_; }
   const PoseTrajectory & getPoses() const { return poses_; }

--- a/planning/autoware_trajectory_validator/include/autoware/trajectory_validator/filters/safety/collision_check_filter.hpp
+++ b/planning/autoware_trajectory_validator/include/autoware/trajectory_validator/filters/safety/collision_check_filter.hpp
@@ -84,7 +84,8 @@ struct TrajectoryIdentification
 
   TrajectoryIdentification(
     const autoware_perception_msgs::msg::PredictedObject & object,
-    const builtin_interfaces::msg::Time stamp, std::string trajectory_type = {}, double acceleration = 0.0)
+    const builtin_interfaces::msg::Time stamp, std::string trajectory_type = {},
+    double acceleration = 0.0)
   : classification(autoware::object_recognition_utils::convertLabelToString(
       autoware::object_recognition_utils::getHighestProbLabel(object.classification))),
     stamp(stamp),
@@ -95,7 +96,10 @@ struct TrajectoryIdentification
   }
 
   std::string object_id_string() const { return autoware_utils_uuid::to_hex_string(uuid); }
-  std::string trajectory_id_string() const { return object_id_string() + "_" + trajectory_type +  " acc: " + std::to_string(acceleration); }
+  std::string trajectory_id_string() const
+  {
+    return object_id_string() + "_" + trajectory_type + " acc: " + std::to_string(acceleration);
+  }
 };
 
 namespace geometry

--- a/planning/autoware_trajectory_validator/include/autoware/trajectory_validator/filters/safety/collision_check_filter.hpp
+++ b/planning/autoware_trajectory_validator/include/autoware/trajectory_validator/filters/safety/collision_check_filter.hpp
@@ -106,7 +106,7 @@ Polygon2d to_polygon2d(
 class TrajectoryData
 {
 private:
-  TrajectoryIdentification object_identification_;
+  TrajectoryIdentification identification_;
   TimeTrajectory times_;
   TravelDistanceTrajectory distances_;
   PoseTrajectory poses_;
@@ -173,9 +173,9 @@ private:
 
 public:
   TrajectoryData(
-    TrajectoryIdentification object_identification, TimeTrajectory times,
+    TrajectoryIdentification trajectory_identification, TimeTrajectory times,
     TravelDistanceTrajectory distances, PoseTrajectory poses, FootprintTrajectory footprints)
-  : object_identification_(std::move(object_identification)),
+  : identification_(std::move(trajectory_identification)),
     times_(std::move(times)),
     distances_(std::move(distances)),
     poses_(std::move(poses)),
@@ -183,22 +183,22 @@ public:
   {
     if (times_.empty()) {
       throw std::invalid_argument(
-        "Trajectory must not be empty classification: " + object_identification_.classification);
+        "Trajectory must not be empty classification: " + identification_.classification);
     }
     if (times_.size() != distances_.size()) {
       throw std::invalid_argument(
         "Trajectory sizes mismatch (times vs distances) classification: " +
-        object_identification_.classification);
+        identification_.classification);
     }
     if (times_.size() != poses_.size()) {
       throw std::invalid_argument(
         "Trajectory sizes mismatch (times vs poses) classification: " +
-        object_identification_.classification);
+        identification_.classification);
     }
     if (times_.size() != footprints_.size()) {
       throw std::invalid_argument(
         "Trajectory sizes mismatch (times vs footprints) classification: " +
-        object_identification_.classification);
+        identification_.classification);
     }
   }
 
@@ -206,7 +206,7 @@ public:
 
   const TrajectoryIdentification & getObjectIdentification() const
   {
-    return object_identification_;
+    return identification_;
   }
   const TimeTrajectory & getTimes() const { return times_; }
   const TravelDistanceTrajectory & getDistances() const { return distances_; }

--- a/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter.cpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter.cpp
@@ -509,8 +509,9 @@ TrajectoryData generate_predicted_path_trajectory(
   auto footprints = footprint::compute_footprint_trajectory(poses, predicted_object.shape);
 
   return TrajectoryData(
-    TrajectoryIdentification{predicted_object, stamp, "map_based_predicted_path"}, std::move(times),
-    std::move(distances), std::move(poses), std::move(footprints));
+    TrajectoryIdentification{
+      predicted_object, stamp, "map_based_predicted_path", assumed_acceleration},
+    std::move(times), std::move(distances), std::move(poses), std::move(footprints));
 }
 
 TrajectoryData generate_diffusion_based_trajectory(
@@ -547,7 +548,7 @@ TrajectoryData generate_diffusion_based_trajectory(
   auto footprints = footprint::compute_footprint_trajectory(poses, predicted_object.shape);
 
   return TrajectoryData(
-    TrajectoryIdentification{predicted_object, stamp, "diffusion_based_trajectory"},
+    TrajectoryIdentification{predicted_object, stamp, "diffusion_based_trajectory", 0.0},
     std::move(times), std::move(distances), std::move(poses), std::move(footprints));
 }
 
@@ -566,8 +567,9 @@ TrajectoryData generate_constant_curvature_trajectory(
   auto footprints = footprint::compute_footprint_trajectory(poses, predicted_object.shape);
 
   return TrajectoryData(
-    TrajectoryIdentification{predicted_object, stamp, "constant_curvature_path"}, std::move(times),
-    std::move(distances), std::move(poses), std::move(footprints));
+    TrajectoryIdentification{
+      predicted_object, stamp, "constant_curvature_path", assumed_acceleration},
+    std::move(times), std::move(distances), std::move(poses), std::move(footprints));
 }
 
 // todo: refactor with generate_object_trajectories().
@@ -619,6 +621,7 @@ TrajectoryData generate_object_trajectory(
       rclcpp::Time(context.neural_network_predicted_objects->header.stamp) -
       rclcpp::Time(context.odometry->header.stamp);
     // ここでのgenerate_predicted_path_trajectoryの呼び出しは意図したもの。pathとして解釈して、速度プロファイルは上書きしたい。
+    // todo: trajectoryのラベルstringがdiffusionではなく、map_baseadになる課題がある
     return trajectory::generate_predicted_path_trajectory(
       predicted_object, 0.0, acc, objects_reference_time, time_horizon,
       context.neural_network_predicted_objects->header.stamp, time_resolution);
@@ -1196,22 +1199,26 @@ DracAssessment assess_drac(
       auto finding_nominal_object_motion = find_collision_timing(
         ego_deceleration_trajectory, object_trajectory, drac_params_collision_time_threshold,
         global_setting.time_resolution);
-      if (finding_nominal_object_motion.has_value()) {
-        const auto & traj_type_str = object_trajectory.getObjectIdentification().trajectory_type;
-        const auto & object_id = object_trajectory.getObjectIdentification().uuid;
-        const auto object_deceleration_trajectory = trajectory::generate_object_trajectory(
-          context, object_id, traj_type_str, -ego_dec, global_setting.time_resolution,
-          ego_time_horizon + drac_params_collision_time_threshold);
-
-        auto finding_dec_object_motion = find_collision_timing(
-          ego_deceleration_trajectory, object_deceleration_trajectory,
-          drac_params_collision_time_threshold, global_setting.time_resolution);
-        if (!finding_dec_object_motion.has_value()) {
-          continue;
-        }
-        findings.push_back(std::move(finding_nominal_object_motion.value()));
-        findings.push_back(std::move(finding_dec_object_motion.value()));
+      if (!finding_nominal_object_motion.has_value()) {
+        continue;
       }
+
+      const auto & traj_type_str = object_trajectory.getObjectIdentification().trajectory_type;
+      const auto & object_id = object_trajectory.getObjectIdentification().uuid;
+
+      const auto object_deceleration_trajectory = trajectory::generate_object_trajectory(
+        context, object_id, traj_type_str, -ego_dec, global_setting.time_resolution,
+        ego_time_horizon + drac_params_collision_time_threshold);
+
+      auto finding_dec_object_motion = find_collision_timing(
+        ego_deceleration_trajectory, object_deceleration_trajectory,
+        drac_params_collision_time_threshold, global_setting.time_resolution);
+      if (!finding_dec_object_motion.has_value()) {
+        continue;
+      }
+
+      findings.push_back(std::move(finding_nominal_object_motion.value()));
+      findings.push_back(std::move(finding_dec_object_motion.value()));
     }
     if (findings.empty()) {
       return DracAssessment{ego_dec, std::move(last_findings)};

--- a/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter.cpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter.cpp
@@ -550,6 +550,7 @@ TrajectoryData generate_diffusion_based_trajectory(
     TrajectoryIdentification{predicted_object, stamp, "diffusion_based_trajectory"},
     std::move(times), std::move(distances), std::move(poses), std::move(footprints));
 }
+
 TrajectoryData generate_constant_curvature_trajectory(
   const autoware_perception_msgs::msg::PredictedObject & predicted_object, double braking_lag,
   double assumed_acceleration, rclcpp::Duration start_time, double max_time,
@@ -568,6 +569,65 @@ TrajectoryData generate_constant_curvature_trajectory(
     TrajectoryIdentification{predicted_object, stamp, "constant_curvature_path"}, std::move(times),
     std::move(distances), std::move(poses), std::move(footprints));
 }
+
+// todo: refactor with generate_object_trajectories().
+TrajectoryData generate_object_trajectory(
+  const FilterContext & context, const unique_identifier_msgs::msg::UUID object_id,
+  const std::string & traj_type_str, const double acc, const double time_resolution,
+  const double time_horizon)
+{
+  // todo: remove this lamda from generate_object_trajectory()
+  const auto find_predicted_object =
+    [&object_id](
+      const auto & predicted_objects) -> const autoware_perception_msgs::msg::PredictedObject & {
+    auto it = std::find_if(
+      predicted_objects.begin(), predicted_objects.end(),
+      [&object_id](const auto & object) { return object.object_id == object_id; });
+    assert(it != predicted_objects.end());
+    return *it;
+  };
+
+  if (traj_type_str.find("map_based_predicted_path") != std::string::npos) {
+    assert(context.predicted_objects);
+    const auto & predicted_object = find_predicted_object(context.predicted_objects->objects);
+    const rclcpp::Duration objects_reference_time =
+      rclcpp::Time(context.predicted_objects->header.stamp) -
+      rclcpp::Time(context.odometry->header.stamp);
+    return trajectory::generate_predicted_path_trajectory(
+      predicted_object, 0.0, acc, objects_reference_time, time_horizon,
+      context.predicted_objects->header.stamp, time_resolution);
+  }
+
+  if (traj_type_str.find("constant_curvature_path") != std::string::npos) {
+    assert(context.predicted_objects);
+    const auto & predicted_object = find_predicted_object(context.predicted_objects->objects);
+    const rclcpp::Duration objects_reference_time =
+      rclcpp::Time(context.predicted_objects->header.stamp) -
+      rclcpp::Time(context.odometry->header.stamp);
+    return trajectory::generate_constant_curvature_trajectory(
+      predicted_object, 0.0, acc, objects_reference_time, time_horizon,
+      context.predicted_objects->header.stamp, time_resolution);
+  }
+
+  if (traj_type_str.find("diffusion_based") != std::string::npos) {
+    assert(context.neural_network_predicted_objects);
+    const auto & predicted_object =
+      find_predicted_object(context.neural_network_predicted_objects->objects);
+    // todo(takagi):
+    // ここでのobjects_reference_timeの使用は不適当。perceptionから出力された時刻と位置で整形すること
+    const rclcpp::Duration objects_reference_time =
+      rclcpp::Time(context.neural_network_predicted_objects->header.stamp) -
+      rclcpp::Time(context.odometry->header.stamp);
+    // ここでのgenerate_predicted_path_trajectoryの呼び出しは意図したもの。pathとして解釈して、速度プロファイルは上書きしたい。
+    return trajectory::generate_predicted_path_trajectory(
+      predicted_object, 0.0, acc, objects_reference_time, time_horizon,
+      context.neural_network_predicted_objects->header.stamp, time_resolution);
+  }
+
+  assert(false);
+  throw std::logic_error("Unsupported trajectory type in DRAC assessment: " + traj_type_str);
+}
+
 }  // namespace trajectory
 
 // Geometry helpers for overlap checks.
@@ -1137,65 +1197,12 @@ DracAssessment assess_drac(
         ego_deceleration_trajectory, object_trajectory, drac_params_collision_time_threshold,
         global_setting.time_resolution);
       if (finding_nominal_object_motion.has_value()) {
-        // todo(takagi):
-        // object_deceleration_trajectoryを関数として分離して、共通化する。同じような処理がちらばっており、メンテナンスができていない
-        const auto object_deceleration_trajectory = [&]() {
-          const auto & traj_type_str = object_trajectory.getObjectIdentification().trajectory_type;
-          const auto & object_id = object_trajectory.getObjectIdentification().uuid;
+        const auto & traj_type_str = object_trajectory.getObjectIdentification().trajectory_type;
+        const auto & object_id = object_trajectory.getObjectIdentification().uuid;
+        const auto object_deceleration_trajectory = trajectory::generate_object_trajectory(
+          context, object_id, traj_type_str, -ego_dec, global_setting.time_resolution,
+          ego_time_horizon + drac_params_collision_time_threshold);
 
-          const auto find_predicted_object = [&object_id](const auto & predicted_objects)
-            -> const autoware_perception_msgs::msg::PredictedObject & {
-            auto it = std::find_if(
-              predicted_objects.begin(), predicted_objects.end(),
-              [&object_id](const auto & object) { return object.object_id == object_id; });
-            assert(it != predicted_objects.end());
-            return *it;
-          };
-
-          if (traj_type_str.find("map_based_predicted_path") != std::string::npos) {
-            assert(context.predicted_objects);
-            const auto & predicted_object =
-              find_predicted_object(context.predicted_objects->objects);
-            const rclcpp::Duration objects_reference_time =
-              rclcpp::Time(context.predicted_objects->header.stamp) -
-              rclcpp::Time(context.odometry->header.stamp);
-            return trajectory::generate_predicted_path_trajectory(
-              predicted_object, 0.0, -ego_dec, objects_reference_time, ego_time_horizon,
-              context.predicted_objects->header.stamp, global_setting.time_resolution);
-          }
-
-          if (traj_type_str.find("constant_curvature_path") != std::string::npos) {
-            assert(context.predicted_objects);
-            const auto & predicted_object =
-              find_predicted_object(context.predicted_objects->objects);
-            const rclcpp::Duration objects_reference_time =
-              rclcpp::Time(context.predicted_objects->header.stamp) -
-              rclcpp::Time(context.odometry->header.stamp);
-            return trajectory::generate_constant_curvature_trajectory(
-              predicted_object, 0.0, -ego_dec, objects_reference_time, ego_time_horizon,
-              context.predicted_objects->header.stamp, global_setting.time_resolution);
-          }
-
-          if (traj_type_str.find("diffusion_based") != std::string::npos) {
-            assert(context.neural_network_predicted_objects);
-            const auto & predicted_object =
-              find_predicted_object(context.neural_network_predicted_objects->objects);
-            // todo(takagi):
-            // ここでのobjects_reference_timeの使用は不適当。perceptionから出力された時刻と位置で整形すること
-            const rclcpp::Duration objects_reference_time =
-              rclcpp::Time(context.neural_network_predicted_objects->header.stamp) -
-              rclcpp::Time(context.odometry->header.stamp);
-            // ここでのgenerate_predicted_path_trajectoryの呼び出しは意図したもの。pathとして解釈して、速度プロファイルは上書きしたい。
-            return trajectory::generate_predicted_path_trajectory(
-              predicted_object, 0.0, -ego_dec, objects_reference_time, ego_time_horizon,
-              context.neural_network_predicted_objects->header.stamp,
-              global_setting.time_resolution);
-          }
-
-          assert(false);
-          throw std::logic_error(
-            "Unsupported trajectory type in DRAC assessment: " + traj_type_str);
-        }();
         auto finding_dec_object_motion = find_collision_timing(
           ego_deceleration_trajectory, object_deceleration_trajectory,
           drac_params_collision_time_threshold, global_setting.time_resolution);

--- a/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter.cpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter.cpp
@@ -15,11 +15,8 @@
 #include "autoware/trajectory_validator/filters/safety/collision_check_filter.hpp"
 
 #include <autoware/interpolation/linear_interpolation.hpp>
-#include <autoware/object_recognition_utils/object_classification.hpp>
-#include <autoware/object_recognition_utils/object_recognition_utils.hpp>
 #include <autoware/universe_utils/geometry/pose_deviation.hpp>
 #include <autoware_utils_geometry/boost_polygon_utils.hpp>
-#include <autoware_utils_uuid/uuid_helper.hpp>
 
 #include <autoware_internal_planning_msgs/msg/control_point.hpp>
 #include <autoware_internal_planning_msgs/msg/planning_factor.hpp>
@@ -47,36 +44,6 @@
 
 namespace autoware::trajectory_validator::plugin::safety
 {
-using autoware::object_recognition_utils::convertLabelToString;
-using autoware::object_recognition_utils::getHighestProbLabel;
-
-ObjectIdentification make_object_identification(
-  const autoware_perception_msgs::msg::PredictedObject & object,
-  const builtin_interfaces::msg::Time & stamp)
-{
-  return {
-    convertLabelToString(getHighestProbLabel(object.classification)), stamp, object.object_id};
-}
-
-ObjectIdentification make_trajectory_identification(
-  const autoware_perception_msgs::msg::PredictedObject & object, const std::string & suffix,
-  const builtin_interfaces::msg::Time & stamp)
-{
-  return {
-    convertLabelToString(getHighestProbLabel(object.classification)), stamp, object.object_id,
-    suffix};
-}
-
-std::string to_object_id_string(const ObjectIdentification & object)
-{
-  return autoware_utils_uuid::to_hex_string(object.uuid);
-}
-
-std::string to_trajectory_id_string(const ObjectIdentification & object)
-{
-  return to_object_id_string(object) + object.trajectory_suffix;
-}
-
 // Trajectory generation helpers.
 namespace trajectory::time_distance
 {
@@ -485,7 +452,7 @@ TrajectoryData generate_ego_trajectory(
   auto footprints = footprint::compute_footprint_trajectory(poses, vehicle_info);
 
   return TrajectoryData(
-    ObjectIdentification{"EGO"}, std::move(times), std::move(distances), std::move(poses),
+    TrajectoryIdentification{"EGO"}, std::move(times), std::move(distances), std::move(poses),
     std::move(footprints));
 }
 
@@ -516,8 +483,8 @@ TrajectoryData generate_ego_trajectory(
   auto footprints = footprint::compute_footprint_trajectory(poses, vehicle_info);
 
   return TrajectoryData(
-    ObjectIdentification{"EGO"}, std::move(relative_times), std::move(distances), std::move(poses),
-    std::move(footprints));
+    TrajectoryIdentification{"EGO"}, std::move(relative_times), std::move(distances),
+    std::move(poses), std::move(footprints));
 }
 
 TrajectoryData generate_predicted_path_trajectory(
@@ -542,7 +509,7 @@ TrajectoryData generate_predicted_path_trajectory(
   auto footprints = footprint::compute_footprint_trajectory(poses, predicted_object.shape);
 
   return TrajectoryData(
-    make_trajectory_identification(predicted_object, "_predicted_path", stamp), std::move(times),
+    TrajectoryIdentification{predicted_object, stamp, "map_based_predicted_path"}, std::move(times),
     std::move(distances), std::move(poses), std::move(footprints));
 }
 
@@ -580,7 +547,7 @@ TrajectoryData generate_diffusion_based_trajectory(
   auto footprints = footprint::compute_footprint_trajectory(poses, predicted_object.shape);
 
   return TrajectoryData(
-    make_trajectory_identification(predicted_object, "_diffusion_based_trajectory", stamp),
+    TrajectoryIdentification{predicted_object, stamp, "diffusion_based_trajectory"},
     std::move(times), std::move(distances), std::move(poses), std::move(footprints));
 }
 TrajectoryData generate_constant_curvature_trajectory(
@@ -598,8 +565,8 @@ TrajectoryData generate_constant_curvature_trajectory(
   auto footprints = footprint::compute_footprint_trajectory(poses, predicted_object.shape);
 
   return TrajectoryData(
-    make_trajectory_identification(predicted_object, "_constant_curvature_path", stamp),
-    std::move(times), std::move(distances), std::move(poses), std::move(footprints));
+    TrajectoryIdentification{predicted_object, stamp, "constant_curvature_path"}, std::move(times),
+    std::move(distances), std::move(poses), std::move(footprints));
 }
 }  // namespace trajectory
 
@@ -737,7 +704,7 @@ namespace rss_deceleration
 {
 struct Assessment
 {
-  ObjectIdentification object;
+  TrajectoryIdentification object;
   double required_deceleration;
 };
 
@@ -819,14 +786,14 @@ Assessment assess_required_deceleration(
 {
   const auto ego_long_vel = ego_twist.linear.x;
   if (ego_long_vel <= 0.0) {
-    return Assessment{make_object_identification(object, stamp), 0.0};
+    return Assessment{TrajectoryIdentification{object, stamp}, 0.0};
   }
 
   // compute current distance
   const auto distance_to_collision =
     rss_deceleration::compute_distance_to_collision(ego_trajectory, object);
   if (!distance_to_collision.has_value()) {
-    return Assessment{make_object_identification(object, stamp), 0.0};
+    return Assessment{TrajectoryIdentification{object, stamp}, 0.0};
   }
 
   // compute safe distance
@@ -841,7 +808,7 @@ Assessment assess_required_deceleration(
                                          ? std::numeric_limits<double>::infinity()
                                          : ego_long_vel * ego_long_vel * 0.5 / safe_distance;
 
-  return Assessment{make_object_identification(object, stamp), required_deceleration};
+  return Assessment{TrajectoryIdentification{object, stamp}, required_deceleration};
 }
 
 Result assess(
@@ -887,8 +854,7 @@ namespace collision_timing_assessment
 
 struct Finding
 {
-  std::string trajectory_id;
-  ObjectIdentification object;
+  TrajectoryIdentification object_identification;
   double pet;
   double ttc;
   PoseTrajectory ego_trajectory;
@@ -929,12 +895,29 @@ struct ObjectTrajectoryGenerationOptions
   }
 };
 
+bool is_target_trajectory_type(
+  const ObjectTrajectoryGenerationOptions & options, const std::string & trajectory_type)
+{
+  // Match by trajectory family so this stays robust across small label variants.
+  if (trajectory_type.find("diffusion_based_trajectory") != std::string::npos) {
+    return options.diffusion_based_trajectory;
+  }
+  if (trajectory_type.find("constant_curvature_path") != std::string::npos) {
+    return options.constant_curvature_trajectory;
+  }
+  if (trajectory_type.find("map_based_predicted_path") != std::string::npos) {
+    return options.predicted_path_trajectory;
+  }
+  return false;
+}
+
 struct DracAssessment
 {
   std::optional<double> drac{0.0};
   std::vector<Finding> findings;
 };
 
+// todo: remove for loop
 std::vector<TrajectoryData> generate_object_trajectories(
   const FilterContext & context, double required_time_horizon, double object_assumed_acceleration,
   double time_resolution, const ObjectTrajectoryGenerationOptions & options)
@@ -1008,7 +991,6 @@ std::optional<Finding> find_collision_timing(
   const auto make_finding = [&](const CandidateFinding & candidate) -> Finding {
     const auto & object_identification = test_trajectory.getObjectIdentification();
     return Finding{
-      to_trajectory_id_string(object_identification),
       object_identification,
       candidate.pet,
       candidate.ttc,
@@ -1078,15 +1060,28 @@ std::optional<Finding> find_collision_timing(
   return make_finding(candidate_finding.value());
 }
 
-std::vector<Finding> assess_collision_timing(
-  const TrajectoryData & ego_trajectory, const std::vector<TrajectoryData> & object_trajectories,
+std::vector<Finding> assess_planned_speed_collision_timing(
+  const TrajectoryPoints & traj_points, const FilterContext & context,
   const validator::Params::CollisionCheck::PetCollision & pet_collision_params,
-  double time_resolution)
+  double time_resolution, VehicleInfo & vehicle_info,
+  const std::vector<TrajectoryData> & object_trajectories)
 {
+  const double ego_time_horizon_for_pet = std::abs(context.odometry->twist.twist.linear.x) * 0.5 /
+                                            -pet_collision_params.ego_assumed_acceleration +
+                                          pet_collision_params.ego_braking_delay;
+  auto ego_trajectory = trajectory::generate_ego_trajectory(
+    traj_points, context, ego_time_horizon_for_pet, time_resolution, vehicle_info);
+
   std::vector<Finding> findings{};
   findings.reserve(object_trajectories.size());
 
   for (const auto & object_trajectory : object_trajectories) {
+    if (!is_target_trajectory_type(
+          ObjectTrajectoryGenerationOptions{pet_collision_params},
+          object_trajectory.getObjectIdentification().trajectory_type)) {
+      continue;
+    }
+
     auto finding = find_collision_timing(
       ego_trajectory, object_trajectory, pet_collision_params.collision_time_threshold,
       time_resolution);
@@ -1098,53 +1093,117 @@ std::vector<Finding> assess_collision_timing(
   return findings;
 }
 
-std::vector<Finding> assess_planned_speed_collision_timing(
-  const TrajectoryPoints & traj_points, const FilterContext & context,
-  const validator::Params::CollisionCheck::PetCollision & pet_collision_params,
-  double time_resolution, VehicleInfo & vehicle_info,
-  const std::vector<TrajectoryData> & object_trajectories)
-{
-  const double ego_time_horizon_for_pet = std::abs(context.odometry->twist.twist.linear.x) * 0.5 /
-                                            -pet_collision_params.ego_assumed_acceleration +
-                                          pet_collision_params.ego_braking_delay;
-
-  auto ego_trajectory = trajectory::generate_ego_trajectory(
-    traj_points, context, ego_time_horizon_for_pet, time_resolution, vehicle_info);
-
-  return assess_collision_timing(
-    ego_trajectory, object_trajectories, pet_collision_params, time_resolution);
-}
-
 DracAssessment assess_drac(
   const TrajectoryPoints & traj_points, const FilterContext & context,
-  const validator::Params::CollisionCheck::PetCollision & pet_collision_params,
-  double time_resolution, VehicleInfo & vehicle_info,
-  const std::vector<TrajectoryData> & object_trajectories)
+  const validator::Params::CollisionCheck::Drac & drac_params, VehicleInfo & vehicle_info,
+  const std::vector<TrajectoryData> & object_trajectories,
+  const validator::Params::CollisionCheck::GlobalSetting & global_setting)
 {
   const double ego_time_horizon = rclcpp::Duration(traj_points.back().time_from_start).seconds();
 
   constexpr double DEFAULT_EGO_DECELERATION_STEP = 1.0;
   constexpr double DEFAULT_MAX_EGO_DECELERATION = 6.0;
-  std::vector<Finding> last_findings;
+  std::vector<Finding> last_findings{};
 
-  for (double ego_dec = 0.0; ego_dec <= DEFAULT_MAX_EGO_DECELERATION;
+  for (double ego_dec = 0.0; ego_dec < DEFAULT_MAX_EGO_DECELERATION + 1e-3;
        ego_dec += DEFAULT_EGO_DECELERATION_STEP) {
     const auto ego_deceleration_trajectory = [&]() {
       if (ego_dec == 0.0) {
         return trajectory::generate_ego_trajectory(
-          traj_points, context, ego_time_horizon, time_resolution, vehicle_info);
+          traj_points, context, ego_time_horizon, global_setting.time_resolution, vehicle_info);
       } else if (ego_dec > DEFAULT_MAX_EGO_DECELERATION - 1e-3) {
         return trajectory::generate_ego_trajectory(
-          context.odometry->twist.twist, 0.0, -ego_dec, ego_time_horizon, time_resolution,
-          traj_points, vehicle_info);
+          context.odometry->twist.twist, 0.0, -ego_dec, ego_time_horizon,
+          global_setting.time_resolution, traj_points, vehicle_info);
       }
+      constexpr double drac_params_ego_braking_delay = 0.4;
       return trajectory::generate_ego_trajectory(
-        context.odometry->twist.twist, pet_collision_params.ego_braking_delay, -ego_dec,
-        ego_time_horizon, time_resolution, traj_points, vehicle_info);
+        context.odometry->twist.twist, drac_params_ego_braking_delay, -ego_dec, ego_time_horizon,
+        global_setting.time_resolution, traj_points, vehicle_info);
     }();
 
-    auto findings = assess_collision_timing(
-      ego_deceleration_trajectory, object_trajectories, pet_collision_params, time_resolution);
+    std::vector<Finding> findings{};
+    findings.reserve(object_trajectories.size());
+    for (const auto & object_trajectory : object_trajectories) {
+      if (!is_target_trajectory_type(
+            ObjectTrajectoryGenerationOptions{drac_params},
+            object_trajectory.getObjectIdentification().trajectory_type)) {
+        continue;
+      }
+      const double drac_params_collision_time_threshold = 1.0;
+      auto finding_nominal_object_motion = find_collision_timing(
+        ego_deceleration_trajectory, object_trajectory, drac_params_collision_time_threshold,
+        global_setting.time_resolution);
+      if (finding_nominal_object_motion.has_value()) {
+        // todo(takagi):
+        // object_deceleration_trajectoryを関数として分離して、共通化する。同じような処理がちらばっており、メンテナンスができていない
+        const auto object_deceleration_trajectory = [&]() {
+          const auto & traj_type_str = object_trajectory.getObjectIdentification().trajectory_type;
+          const auto & object_id = object_trajectory.getObjectIdentification().uuid;
+
+          const auto find_predicted_object = [&object_id](const auto & predicted_objects)
+            -> const autoware_perception_msgs::msg::PredictedObject & {
+            auto it = std::find_if(
+              predicted_objects.begin(), predicted_objects.end(),
+              [&object_id](const auto & object) { return object.object_id == object_id; });
+            assert(it != predicted_objects.end());
+            return *it;
+          };
+
+          if (traj_type_str.find("map_based_predicted_path") != std::string::npos) {
+            assert(context.predicted_objects);
+            const auto & predicted_object =
+              find_predicted_object(context.predicted_objects->objects);
+            const rclcpp::Duration objects_reference_time =
+              rclcpp::Time(context.predicted_objects->header.stamp) -
+              rclcpp::Time(context.odometry->header.stamp);
+            return trajectory::generate_predicted_path_trajectory(
+              predicted_object, 0.0, -ego_dec, objects_reference_time, ego_time_horizon,
+              context.predicted_objects->header.stamp, global_setting.time_resolution);
+          }
+
+          if (traj_type_str.find("constant_curvature_path") != std::string::npos) {
+            assert(context.predicted_objects);
+            const auto & predicted_object =
+              find_predicted_object(context.predicted_objects->objects);
+            const rclcpp::Duration objects_reference_time =
+              rclcpp::Time(context.predicted_objects->header.stamp) -
+              rclcpp::Time(context.odometry->header.stamp);
+            return trajectory::generate_constant_curvature_trajectory(
+              predicted_object, 0.0, -ego_dec, objects_reference_time, ego_time_horizon,
+              context.predicted_objects->header.stamp, global_setting.time_resolution);
+          }
+
+          if (traj_type_str.find("diffusion_based") != std::string::npos) {
+            assert(context.neural_network_predicted_objects);
+            const auto & predicted_object =
+              find_predicted_object(context.neural_network_predicted_objects->objects);
+            // todo(takagi):
+            // ここでのobjects_reference_timeの使用は不適当。perceptionから出力された時刻と位置で整形すること
+            const rclcpp::Duration objects_reference_time =
+              rclcpp::Time(context.neural_network_predicted_objects->header.stamp) -
+              rclcpp::Time(context.odometry->header.stamp);
+            // ここでのgenerate_predicted_path_trajectoryの呼び出しは意図したもの
+            return trajectory::generate_predicted_path_trajectory(
+              predicted_object, 0.0, -ego_dec, objects_reference_time, ego_time_horizon,
+              context.neural_network_predicted_objects->header.stamp,
+              global_setting.time_resolution);
+          }
+
+          assert(false);
+          throw std::logic_error(
+            "Unsupported trajectory type in DRAC assessment: " + traj_type_str);
+        }();
+        auto finding_dec_object_motion = find_collision_timing(
+          ego_deceleration_trajectory, object_deceleration_trajectory,
+          drac_params_collision_time_threshold, global_setting.time_resolution);
+        if (!finding_dec_object_motion.has_value()) {
+          continue;
+        }
+        findings.push_back(std::move(finding_nominal_object_motion.value()));
+        findings.push_back(std::move(finding_dec_object_motion.value()));
+      }
+    }
     if (findings.empty()) {
       return DracAssessment{ego_dec, std::move(last_findings)};
     }
@@ -1194,8 +1253,8 @@ Result assess(
     result.drac = drac_assessment.drac;
   } else {
     const auto drac_assessment = assess_drac(
-      traj_points, context, pet_collision_params, global_setting.time_resolution, vehicle_info,
-      nominal_speed_object_trajectories);
+      traj_points, context, drac_params, vehicle_info, nominal_speed_object_trajectories,
+      global_setting);
     result.drac_findings = drac_assessment.findings;
     result.drac = drac_assessment.drac;
   }
@@ -1221,7 +1280,7 @@ autoware_internal_planning_msgs::msg::SafetyFactorArray make_safety_factor_array
 
   SafetyFactor safety_factor;
   safety_factor.type = SafetyFactor::OBJECT;
-  safety_factor.object_id = finding.object.uuid;
+  safety_factor.object_id = finding.object_identification.uuid;
   safety_factor.ttc_begin = static_cast<float>(finding.ttc);
   safety_factor.ttc_end = static_cast<float>(finding.ttc + time_resolution);
   safety_factor.is_safe = false;
@@ -1410,68 +1469,66 @@ CollisionCheckFilter::result_t CollisionCheckFilter::is_feasible(
 
   pet_continuous_times_.update(
     current_time, collision_timing_result.planned_speed_findings,
-    [](const auto & finding) { return finding.trajectory_id; });
+    [](const auto & finding) { return finding.object_identification.trajectory_id_string(); });
   for (const auto & finding : collision_timing_result.planned_speed_findings) {
-    const auto object_id = to_object_id_string(finding.object);
     // Mark as infeasible if any finding exists
     is_feasible = false;
+    const auto & obj_id = finding.object_identification;
 
     // Record metrics for PET and TTC for each finding
-    metrics.push_back(
-      autoware_trajectory_validator::build<MetricReport>()
-        .validator_name(get_name())
-        .validator_category(category())
-        .metric_name(fmt::format(
-          "check_PET_{}_{}_{}", finding.trajectory_id, finding.object.classification, object_id))
-        .metric_value(finding.pet)
-        .level(MetricReport::ERROR));
-    metrics.push_back(
-      autoware_trajectory_validator::build<MetricReport>()
-        .validator_name(get_name())
-        .validator_category(category())
-        .metric_name(fmt::format(
-          "check_TTC_{}_{}_{}", finding.trajectory_id, finding.object.classification, object_id))
-        .metric_value(finding.ttc)
-        .level(MetricReport::ERROR));
+    metrics.push_back(autoware_trajectory_validator::build<MetricReport>()
+                        .validator_name(get_name())
+                        .validator_category(category())
+                        .metric_name(fmt::format(
+                          "check_PET_{}_{}", obj_id.trajectory_id_string(), obj_id.classification))
+                        .metric_value(finding.pet)
+                        .level(MetricReport::ERROR));
+    metrics.push_back(autoware_trajectory_validator::build<MetricReport>()
+                        .validator_name(get_name())
+                        .validator_category(category())
+                        .metric_name(fmt::format(
+                          "check_TTC_{}_{}", obj_id.trajectory_id_string(), obj_id.classification))
+                        .metric_value(finding.ttc)
+                        .level(MetricReport::ERROR));
 
-    const double detection_duration = pet_continuous_times_.get_time(finding.trajectory_id);
+    const double detection_duration = pet_continuous_times_.get_time(obj_id.trajectory_id_string());
     error_msg += fmt::format(
       "PET collision, classification: {}, ID: {}, PET: {}, TTC: {}, duration: {}, stamp: {}.{}; \n",
-      finding.object.classification, finding.trajectory_id, finding.pet, finding.ttc,
-      detection_duration, finding.object.stamp.sec, finding.object.stamp.nanosec);
+      obj_id.classification, obj_id.trajectory_id_string(), finding.pet, finding.ttc,
+      detection_duration, obj_id.stamp.sec, obj_id.stamp.nanosec);
     add_debug_markers(
-      context.odometry->header.stamp, "planned_speed_collision", finding.trajectory_id,
+      context.odometry->header.stamp, "planned_speed_collision", obj_id.trajectory_id_string(),
       finding.ego_trajectory, finding.object_trajectory, finding.ego_hull, finding.object_hull);
     add_collision_planning_factor(finding, "PET");
   }
 
   drac_continuous_times_.update(
     current_time, collision_timing_result.drac_findings,
-    [](const auto & finding) { return finding.trajectory_id; });
+    [](const auto & finding) { return finding.object_identification.trajectory_id_string(); });
   if (
     collision_timing_result.drac == std::nullopt ||
     collision_timing_result.drac.value() >= -pet_collision_params_.ego_assumed_acceleration) {
     for (const auto & finding : collision_timing_result.drac_findings) {
-      const auto object_id = to_object_id_string(finding.object);
+      const auto & obj_id = finding.object_identification;
       is_feasible = false;
 
-      metrics.push_back(
-        autoware_trajectory_validator::build<MetricReport>()
-          .validator_name(get_name())
-          .validator_category(category())
-          .metric_name(fmt::format(
-            "check_DRAC_{}_{}_{}", finding.trajectory_id, finding.object.classification, object_id))
-          .metric_value(collision_timing_result.drac.value_or(0.0))
-          .level(MetricReport::ERROR));
+      metrics.push_back(autoware_trajectory_validator::build<MetricReport>()
+                          .validator_name(get_name())
+                          .validator_category(category())
+                          .metric_name(fmt::format(
+                            "check_DRAC_{}_{}_{}", obj_id.trajectory_id_string(),
+                            obj_id.classification, obj_id.trajectory_type))
+                          .metric_value(collision_timing_result.drac.value_or(0.0))
+                          .level(MetricReport::ERROR));
       error_msg += fmt::format(
         "DRAC collision, ID: {}, PET: {}, TTC: {}, DRAC: {}, stamp: {}.{}; \n",
-        finding.trajectory_id, finding.pet, finding.ttc,
+        obj_id.trajectory_id_string(), finding.pet, finding.ttc,
         collision_timing_result.drac.has_value()
           ? std::to_string(collision_timing_result.drac.value())
           : "Cant be avoided",
-        finding.object.stamp.sec, finding.object.stamp.nanosec);
+        obj_id.stamp.sec, obj_id.stamp.nanosec);
       add_debug_markers(
-        context.odometry->header.stamp, "drac_collision", finding.trajectory_id,
+        context.odometry->header.stamp, "drac_collision", obj_id.trajectory_id_string(),
         finding.ego_trajectory, finding.object_trajectory, finding.ego_hull, finding.object_hull);
       add_collision_planning_factor(finding, "DRAC");
     }
@@ -1481,10 +1538,10 @@ CollisionCheckFilter::result_t CollisionCheckFilter::is_feasible(
     const auto rss_result = rss_deceleration::assess(
       traj_points, context, rss_params_, global_setting_.time_resolution, *vehicle_info_ptr_);
     rss_continuous_times_.update(current_time, rss_result.violations, [](const auto & violation) {
-      return to_object_id_string(violation.object);
+      return violation.object.object_id_string();
     });
     for (const auto & violation : rss_result.violations) {
-      const auto object_id = to_object_id_string(violation.object);
+      const auto object_id = violation.object.object_id_string();
       // Mark as infeasible if any RSS violation exists
       is_feasible = false;
 

--- a/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter.cpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter.cpp
@@ -1116,6 +1116,7 @@ DracAssessment assess_drac(
           context.odometry->twist.twist, 0.0, -ego_dec, ego_time_horizon,
           global_setting.time_resolution, traj_points, vehicle_info);
       }
+      //todo: prepare parameter
       constexpr double drac_params_ego_braking_delay = 0.4;
       return trajectory::generate_ego_trajectory(
         context.odometry->twist.twist, drac_params_ego_braking_delay, -ego_dec, ego_time_horizon,
@@ -1130,7 +1131,8 @@ DracAssessment assess_drac(
             object_trajectory.getObjectIdentification().trajectory_type)) {
         continue;
       }
-      const double drac_params_collision_time_threshold = 1.0;
+      //todo: prepare parameter
+      constexpr double drac_params_collision_time_threshold = 1.0;
       auto finding_nominal_object_motion = find_collision_timing(
         ego_deceleration_trajectory, object_trajectory, drac_params_collision_time_threshold,
         global_setting.time_resolution);
@@ -1183,7 +1185,7 @@ DracAssessment assess_drac(
             const rclcpp::Duration objects_reference_time =
               rclcpp::Time(context.neural_network_predicted_objects->header.stamp) -
               rclcpp::Time(context.odometry->header.stamp);
-            // ここでのgenerate_predicted_path_trajectoryの呼び出しは意図したもの
+            // ここでのgenerate_predicted_path_trajectoryの呼び出しは意図したもの。pathとして解釈して、速度プロファイルは上書きしたい。
             return trajectory::generate_predicted_path_trajectory(
               predicted_object, 0.0, -ego_dec, objects_reference_time, ego_time_horizon,
               context.neural_network_predicted_objects->header.stamp,

--- a/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter.cpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter.cpp
@@ -1116,7 +1116,7 @@ DracAssessment assess_drac(
           context.odometry->twist.twist, 0.0, -ego_dec, ego_time_horizon,
           global_setting.time_resolution, traj_points, vehicle_info);
       }
-      //todo: prepare parameter
+      // todo: prepare parameter
       constexpr double drac_params_ego_braking_delay = 0.4;
       return trajectory::generate_ego_trajectory(
         context.odometry->twist.twist, drac_params_ego_braking_delay, -ego_dec, ego_time_horizon,
@@ -1131,7 +1131,7 @@ DracAssessment assess_drac(
             object_trajectory.getObjectIdentification().trajectory_type)) {
         continue;
       }
-      //todo: prepare parameter
+      // todo: prepare parameter
       constexpr double drac_params_collision_time_threshold = 1.0;
       auto finding_nominal_object_motion = find_collision_timing(
         ego_deceleration_trajectory, object_trajectory, drac_params_collision_time_threshold,

--- a/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter.cpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter.cpp
@@ -906,9 +906,27 @@ struct Result
 
 struct ObjectTrajectoryGenerationOptions
 {
-  bool predicted_path_trajectory{true};
-  bool constant_curvature_trajectory{true};
-  bool diffusion_based_trajectory{true};
+  bool predicted_path_trajectory{false};
+  bool constant_curvature_trajectory{false};
+  bool diffusion_based_trajectory{false};
+
+  ObjectTrajectoryGenerationOptions() = default;
+
+  template <typename ParamsT>
+  explicit ObjectTrajectoryGenerationOptions(const ParamsT & params)
+  {
+    predicted_path_trajectory = params.predicted_path_trajectory;
+    constant_curvature_trajectory = params.constant_curvature_trajectory;
+    diffusion_based_trajectory = params.diffusion_based_trajectory;
+  }
+
+  void merge_with(const ObjectTrajectoryGenerationOptions & other)
+  {
+    predicted_path_trajectory = predicted_path_trajectory || other.predicted_path_trajectory;
+    constant_curvature_trajectory =
+      constant_curvature_trajectory || other.constant_curvature_trajectory;
+    diffusion_based_trajectory = diffusion_based_trajectory || other.diffusion_based_trajectory;
+  }
 };
 
 struct DracAssessment
@@ -1144,29 +1162,30 @@ Result assess(
   const validator::Params::CollisionCheck::GlobalSetting & global_setting,
   VehicleInfo & vehicle_info)
 {
-  const auto pet_trajectory_options = ObjectTrajectoryGenerationOptions{
-    pet_collision_params.predicted_path_trajectory,
-    pet_collision_params.constant_curvature_trajectory,
-    pet_collision_params.diffusion_based_trajectory};
-  const auto drac_trajectory_options = ObjectTrajectoryGenerationOptions{
-    drac_params.predicted_path_trajectory, drac_params.constant_curvature_trajectory,
-    drac_params.diffusion_based_trajectory};
-  const double ego_time_horizon_for_pet = std::abs(context.odometry->twist.twist.linear.x) * 0.5 /
-                                            -pet_collision_params.ego_assumed_acceleration +
-                                          pet_collision_params.ego_braking_delay;
-  const double ego_time_horizon_for_drac =
-    rclcpp::Duration(traj_points.back().time_from_start).seconds();
+  ObjectTrajectoryGenerationOptions required_trajectory_types;
+  if (pet_collision_params.enable_assessment) {
+    required_trajectory_types.merge_with(ObjectTrajectoryGenerationOptions{pet_collision_params});
+  }
+  if (drac_params.enable_assessment) {
+    required_trajectory_types.merge_with(ObjectTrajectoryGenerationOptions{drac_params});
+  }
+
+  // todo: std::max(pet_collision_params.collision_time_threshold,
+  // drac_params.collision_time_threshold)
+  const double required_time_horizon =
+    rclcpp::Duration(traj_points.back().time_from_start).seconds() +
+    pet_collision_params.collision_time_threshold;
+  const auto nominal_speed_object_trajectories = generate_object_trajectories(
+    context, required_time_horizon, -1.0, global_setting.time_resolution,
+    required_trajectory_types);
 
   Result result{};
   if (!pet_collision_params.enable_assessment) {
     result.planned_speed_findings = {};
   } else {
-    const auto pet_object_trajectories = generate_object_trajectories(
-      context, ego_time_horizon_for_pet + pet_collision_params.collision_time_threshold, -1.0,
-      global_setting.time_resolution, pet_trajectory_options);
     result.planned_speed_findings = assess_planned_speed_collision_timing(
       traj_points, context, pet_collision_params, global_setting.time_resolution, vehicle_info,
-      pet_object_trajectories);
+      nominal_speed_object_trajectories);
   }
 
   if (!drac_params.enable_assessment) {
@@ -1174,12 +1193,9 @@ Result assess(
     result.drac_findings = drac_assessment.findings;
     result.drac = drac_assessment.drac;
   } else {
-    const auto drac_object_trajectories = generate_object_trajectories(
-      context, ego_time_horizon_for_drac + pet_collision_params.collision_time_threshold, -1.0,
-      global_setting.time_resolution, drac_trajectory_options);
     const auto drac_assessment = assess_drac(
       traj_points, context, pet_collision_params, global_setting.time_resolution, vehicle_info,
-      drac_object_trajectories);
+      nominal_speed_object_trajectories);
     result.drac_findings = drac_assessment.findings;
     result.drac = drac_assessment.drac;
   }

--- a/planning/autoware_trajectory_validator/test/collision_check_filter/test_collision_check_filter.cpp
+++ b/planning/autoware_trajectory_validator/test/collision_check_filter/test_collision_check_filter.cpp
@@ -249,7 +249,9 @@ TEST_F(CollisionCheckFilterTest, ObjectTrajectoryTypesCanBeConfiguredIndependent
 
   EXPECT_TRUE(result.planned_speed_findings.empty());
   ASSERT_FALSE(result.drac_findings.empty());
-  EXPECT_EQ(result.drac_findings.front().object.trajectory_suffix, "_diffusion_based_trajectory");
+  EXPECT_EQ(
+    result.drac_findings.front().object_identification.trajectory_type,
+    "diffusion_based_trajectory");
 }
 
 TEST_F(CollisionCheckFilterTest, StoppedObjectInPath)

--- a/planning/autoware_trajectory_validator/test/collision_check_filter/test_trajectory_utilities.cpp
+++ b/planning/autoware_trajectory_validator/test/collision_check_filter/test_trajectory_utilities.cpp
@@ -273,6 +273,46 @@ TEST(TrajectoryUtilitiesTest, ComputeFootprintTrajectoryForVehicleMatchesUtility
                           -vehicle_info.min_longitudinal_offset_m, vehicle_info.vehicle_width_m));
 }
 
+TEST(TrajectoryUtilitiesTest, ObjectIdentificationClassificationConstructorSetsDefaults)
+{
+  const auto identification = TrajectoryIdentification{"EGO"};
+
+  EXPECT_EQ(identification.classification, "EGO");
+  EXPECT_EQ(identification.stamp.sec, 0);
+  EXPECT_EQ(identification.stamp.nanosec, 0u);
+  EXPECT_TRUE(identification.trajectory_type.empty());
+  EXPECT_EQ(identification.trajectory_id_string(), identification.object_id_string() + "_");
+}
+
+TEST(TrajectoryUtilitiesTest, ObjectIdentificationObjectConstructorBuildsIdsFromObject)
+{
+  auto object = create_predicted_object(
+    create_pose(0.0, 0.0, 0.0), create_twist(1.0), create_bounding_box_shape(), {});
+  object.classification.resize(2);
+  object.classification.at(0).label = autoware_perception_msgs::msg::ObjectClassification::UNKNOWN;
+  object.classification.at(0).probability = 0.1F;
+  object.classification.at(1).label = autoware_perception_msgs::msg::ObjectClassification::CAR;
+  object.classification.at(1).probability = 0.9F;
+
+  builtin_interfaces::msg::Time stamp;
+  stamp.sec = 12;
+  stamp.nanosec = 34;
+
+  const auto identification =
+    TrajectoryIdentification{object, stamp, "map_based_predicted_path"};
+
+  EXPECT_EQ(
+    identification.classification,
+    autoware::object_recognition_utils::convertLabelToString(
+      autoware::object_recognition_utils::getHighestProbLabel(object.classification)));
+  EXPECT_EQ(identification.stamp.sec, stamp.sec);
+  EXPECT_EQ(identification.stamp.nanosec, stamp.nanosec);
+  EXPECT_EQ(identification.object_id_string(), autoware_utils_uuid::to_hex_string(object.object_id));
+  EXPECT_EQ(
+    identification.trajectory_id_string(),
+    autoware_utils_uuid::to_hex_string(object.object_id) + "_map_based_predicted_path");
+}
+
 TEST(TrajectoryUtilitiesTest, GenerateEgoTrajectoryBuildsConsistentTrajectoryData)
 {
   auto vehicle_info = create_vehicle_info();
@@ -283,7 +323,7 @@ TEST(TrajectoryUtilitiesTest, GenerateEgoTrajectoryBuildsConsistentTrajectoryDat
     initial_twist, 0.0, 0.0, 1.05, kDefaultTimeResolution, traj_points, vehicle_info);
 
   ASSERT_EQ(trajectory_data.getObjectIdentification().classification, "EGO");
-  ASSERT_TRUE(trajectory_data.getObjectIdentification().trajectory_suffix.empty());
+  ASSERT_TRUE(trajectory_data.getObjectIdentification().trajectory_type.empty());
   EXPECT_DOUBLE_EQ(trajectory_data.getTimes().front(), 0.0);
   EXPECT_NEAR(trajectory_data.getTimes().back(), 1.05, 1e-6);
   EXPECT_NEAR(trajectory_data.getDistances().back(), 2.1, 1e-6);
@@ -417,7 +457,7 @@ TEST(TrajectoryUtilitiesTest, GeneratePredictedPathTrajectoryUsesHighestConfiden
     object, 0.0, 0.0, rclcpp::Duration::from_seconds(0.1), 0.35, builtin_interfaces::msg::Time{},
     kDefaultTimeResolution);
 
-  EXPECT_EQ(trajectory_data.getObjectIdentification().trajectory_suffix, "_predicted_path");
+  EXPECT_EQ(trajectory_data.getObjectIdentification().trajectory_type, "map_based_predicted_path");
   EXPECT_NEAR(trajectory_data.getTimes().front(), 0.1, 1e-6);
   EXPECT_NEAR(trajectory_data.getTimes().back(), 0.35, 1e-6);
   EXPECT_NEAR(trajectory_data.getPoses().at(0).position.x, 0.1, 1e-6);
@@ -480,7 +520,7 @@ TEST(TrajectoryUtilitiesTest, GenerateConstantCurvaturePathTrajectoryMatchesPred
 
   ASSERT_EQ(trajectory_data.size(), expected_times.size());
   EXPECT_EQ(
-    trajectory_data.getObjectIdentification().trajectory_suffix, "_constant_curvature_path");
+    trajectory_data.getObjectIdentification().trajectory_type, "constant_curvature_path");
   for (size_t i = 0; i < expected_times.size(); ++i) {
     EXPECT_NEAR(trajectory_data.getTimes().at(i), expected_times.at(i), 1e-6);
     EXPECT_NEAR(trajectory_data.getPoses().at(i).position.x, expected_poses.at(i).position.x, 1e-6);
@@ -507,7 +547,7 @@ TEST(TrajectoryUtilitiesTest, GenerateTimeInterpolatedPredictedPathTrajectoryUse
 
   ASSERT_EQ(trajectory_data.size(), 6u);
   EXPECT_EQ(
-    trajectory_data.getObjectIdentification().trajectory_suffix, "_diffusion_based_trajectory");
+    trajectory_data.getObjectIdentification().trajectory_type, "diffusion_based_trajectory");
   EXPECT_NEAR(trajectory_data.getTimes().at(0), -0.15, 1e-6);
   EXPECT_NEAR(trajectory_data.getTimes().at(1), -0.1, 1e-6);
   EXPECT_NEAR(trajectory_data.getTimes().at(2), 0.0, 1e-6);
@@ -551,33 +591,33 @@ TEST(TrajectoryUtilitiesTest, GenerateObjectTrajectoriesRespectsEnabledTypes)
   context.predicted_objects = predicted_objects;
   context.neural_network_predicted_objects = neural_network_predicted_objects;
 
-  const auto count_suffix =
-    [](const std::vector<TrajectoryData> & trajectories, const std::string & suffix) {
+  const auto count_trajectory_type =
+    [](const std::vector<TrajectoryData> & trajectories, const std::string & trajectory_type) {
       return std::count_if(trajectories.begin(), trajectories.end(), [&](const auto & trajectory) {
-        return trajectory.getObjectIdentification().trajectory_suffix == suffix;
+        return trajectory.getObjectIdentification().trajectory_type == trajectory_type;
       });
     };
 
   const auto all_enabled = collision_timing_assessment::generate_object_trajectories(
     context, 0.2, 0.0, 0.1, make_object_trajectory_generation_options(true, true, true));
   EXPECT_EQ(all_enabled.size(), 3u);
-  EXPECT_EQ(count_suffix(all_enabled, "_predicted_path"), 1);
-  EXPECT_EQ(count_suffix(all_enabled, "_constant_curvature_path"), 1);
-  EXPECT_EQ(count_suffix(all_enabled, "_diffusion_based_trajectory"), 1);
+  EXPECT_EQ(count_trajectory_type(all_enabled, "map_based_predicted_path"), 1);
+  EXPECT_EQ(count_trajectory_type(all_enabled, "constant_curvature_path"), 1);
+  EXPECT_EQ(count_trajectory_type(all_enabled, "diffusion_based_trajectory"), 1);
 
   const auto constant_curvature_only = collision_timing_assessment::generate_object_trajectories(
     context, 0.2, 0.0, 0.1, make_object_trajectory_generation_options(false, true, false));
   ASSERT_EQ(constant_curvature_only.size(), 1u);
   EXPECT_EQ(
-    constant_curvature_only.front().getObjectIdentification().trajectory_suffix,
-    "_constant_curvature_path");
+    constant_curvature_only.front().getObjectIdentification().trajectory_type,
+    "constant_curvature_path");
 
   const auto predicted_path_and_diffusion =
     collision_timing_assessment::generate_object_trajectories(
       context, 0.2, 0.0, 0.1, make_object_trajectory_generation_options(true, false, true));
   EXPECT_EQ(predicted_path_and_diffusion.size(), 2u);
-  EXPECT_EQ(count_suffix(predicted_path_and_diffusion, "_predicted_path"), 1);
-  EXPECT_EQ(count_suffix(predicted_path_and_diffusion, "_diffusion_based_trajectory"), 1);
+  EXPECT_EQ(count_trajectory_type(predicted_path_and_diffusion, "map_based_predicted_path"), 1);
+  EXPECT_EQ(count_trajectory_type(predicted_path_and_diffusion, "diffusion_based_trajectory"), 1);
 }
 
 TEST(TrajectoryUtilitiesTest, ObjectTrajectoryGenerationOptionsMergeWithCombinesEnabledTypes)

--- a/planning/autoware_trajectory_validator/test/collision_check_filter/test_trajectory_utilities.cpp
+++ b/planning/autoware_trajectory_validator/test/collision_check_filter/test_trajectory_utilities.cpp
@@ -298,8 +298,7 @@ TEST(TrajectoryUtilitiesTest, ObjectIdentificationObjectConstructorBuildsIdsFrom
   stamp.sec = 12;
   stamp.nanosec = 34;
 
-  const auto identification =
-    TrajectoryIdentification{object, stamp, "map_based_predicted_path"};
+  const auto identification = TrajectoryIdentification{object, stamp, "map_based_predicted_path"};
 
   EXPECT_EQ(
     identification.classification,
@@ -307,7 +306,8 @@ TEST(TrajectoryUtilitiesTest, ObjectIdentificationObjectConstructorBuildsIdsFrom
       autoware::object_recognition_utils::getHighestProbLabel(object.classification)));
   EXPECT_EQ(identification.stamp.sec, stamp.sec);
   EXPECT_EQ(identification.stamp.nanosec, stamp.nanosec);
-  EXPECT_EQ(identification.object_id_string(), autoware_utils_uuid::to_hex_string(object.object_id));
+  EXPECT_EQ(
+    identification.object_id_string(), autoware_utils_uuid::to_hex_string(object.object_id));
   EXPECT_EQ(
     identification.trajectory_id_string(),
     autoware_utils_uuid::to_hex_string(object.object_id) + "_map_based_predicted_path");
@@ -519,8 +519,7 @@ TEST(TrajectoryUtilitiesTest, GenerateConstantCurvaturePathTrajectoryMatchesPred
     initial_pose, initial_twist, expected_distances);
 
   ASSERT_EQ(trajectory_data.size(), expected_times.size());
-  EXPECT_EQ(
-    trajectory_data.getObjectIdentification().trajectory_type, "constant_curvature_path");
+  EXPECT_EQ(trajectory_data.getObjectIdentification().trajectory_type, "constant_curvature_path");
   for (size_t i = 0; i < expected_times.size(); ++i) {
     EXPECT_NEAR(trajectory_data.getTimes().at(i), expected_times.at(i), 1e-6);
     EXPECT_NEAR(trajectory_data.getPoses().at(i).position.x, expected_poses.at(i).position.x, 1e-6);

--- a/planning/autoware_trajectory_validator/test/collision_check_filter/test_trajectory_utilities.cpp
+++ b/planning/autoware_trajectory_validator/test/collision_check_filter/test_trajectory_utilities.cpp
@@ -99,6 +99,18 @@ FilterContext create_filter_context(const nav_msgs::msg::Odometry::ConstSharedPt
   return context;
 }
 
+collision_timing_assessment::ObjectTrajectoryGenerationOptions
+make_object_trajectory_generation_options(
+  const bool predicted_path_trajectory, const bool constant_curvature_trajectory,
+  const bool diffusion_based_trajectory)
+{
+  auto options = collision_timing_assessment::ObjectTrajectoryGenerationOptions{};
+  options.predicted_path_trajectory = predicted_path_trajectory;
+  options.constant_curvature_trajectory = constant_curvature_trajectory;
+  options.diffusion_based_trajectory = diffusion_based_trajectory;
+  return options;
+}
+
 autoware_perception_msgs::msg::Shape create_bounding_box_shape(
   const double length = 4.0, const double width = 2.0)
 {
@@ -547,16 +559,14 @@ TEST(TrajectoryUtilitiesTest, GenerateObjectTrajectoriesRespectsEnabledTypes)
     };
 
   const auto all_enabled = collision_timing_assessment::generate_object_trajectories(
-    context, 0.2, 0.0, 0.1,
-    collision_timing_assessment::ObjectTrajectoryGenerationOptions{true, true, true});
+    context, 0.2, 0.0, 0.1, make_object_trajectory_generation_options(true, true, true));
   EXPECT_EQ(all_enabled.size(), 3u);
   EXPECT_EQ(count_suffix(all_enabled, "_predicted_path"), 1);
   EXPECT_EQ(count_suffix(all_enabled, "_constant_curvature_path"), 1);
   EXPECT_EQ(count_suffix(all_enabled, "_diffusion_based_trajectory"), 1);
 
   const auto constant_curvature_only = collision_timing_assessment::generate_object_trajectories(
-    context, 0.2, 0.0, 0.1,
-    collision_timing_assessment::ObjectTrajectoryGenerationOptions{false, true, false});
+    context, 0.2, 0.0, 0.1, make_object_trajectory_generation_options(false, true, false));
   ASSERT_EQ(constant_curvature_only.size(), 1u);
   EXPECT_EQ(
     constant_curvature_only.front().getObjectIdentification().trajectory_suffix,
@@ -564,11 +574,46 @@ TEST(TrajectoryUtilitiesTest, GenerateObjectTrajectoriesRespectsEnabledTypes)
 
   const auto predicted_path_and_diffusion =
     collision_timing_assessment::generate_object_trajectories(
-      context, 0.2, 0.0, 0.1,
-      collision_timing_assessment::ObjectTrajectoryGenerationOptions{true, false, true});
+      context, 0.2, 0.0, 0.1, make_object_trajectory_generation_options(true, false, true));
   EXPECT_EQ(predicted_path_and_diffusion.size(), 2u);
   EXPECT_EQ(count_suffix(predicted_path_and_diffusion, "_predicted_path"), 1);
   EXPECT_EQ(count_suffix(predicted_path_and_diffusion, "_diffusion_based_trajectory"), 1);
+}
+
+TEST(TrajectoryUtilitiesTest, ObjectTrajectoryGenerationOptionsMergeWithCombinesEnabledTypes)
+{
+  auto merged = make_object_trajectory_generation_options(true, false, false);
+  merged.merge_with(make_object_trajectory_generation_options(false, true, true));
+
+  EXPECT_TRUE(merged.predicted_path_trajectory);
+  EXPECT_TRUE(merged.constant_curvature_trajectory);
+  EXPECT_TRUE(merged.diffusion_based_trajectory);
+}
+
+TEST(TrajectoryUtilitiesTest, ObjectTrajectoryGenerationOptionsCanBeConstructedFromParams)
+{
+  validator::Params::CollisionCheck::PetCollision pet_params{};
+  pet_params.predicted_path_trajectory = true;
+  pet_params.constant_curvature_trajectory = false;
+  pet_params.diffusion_based_trajectory = true;
+
+  validator::Params::CollisionCheck::Drac drac_params{};
+  drac_params.predicted_path_trajectory = false;
+  drac_params.constant_curvature_trajectory = true;
+  drac_params.diffusion_based_trajectory = false;
+
+  const auto pet_options =
+    collision_timing_assessment::ObjectTrajectoryGenerationOptions{pet_params};
+  const auto drac_options =
+    collision_timing_assessment::ObjectTrajectoryGenerationOptions{drac_params};
+
+  EXPECT_TRUE(pet_options.predicted_path_trajectory);
+  EXPECT_FALSE(pet_options.constant_curvature_trajectory);
+  EXPECT_TRUE(pet_options.diffusion_based_trajectory);
+
+  EXPECT_FALSE(drac_options.predicted_path_trajectory);
+  EXPECT_TRUE(drac_options.constant_curvature_trajectory);
+  EXPECT_FALSE(drac_options.diffusion_based_trajectory);
 }
 
 }  // namespace autoware::trajectory_validator::plugin::safety

--- a/planning/autoware_trajectory_validator/test/collision_check_filter/test_trajectory_utilities.cpp
+++ b/planning/autoware_trajectory_validator/test/collision_check_filter/test_trajectory_utilities.cpp
@@ -281,7 +281,6 @@ TEST(TrajectoryUtilitiesTest, ObjectIdentificationClassificationConstructorSetsD
   EXPECT_EQ(identification.stamp.sec, 0);
   EXPECT_EQ(identification.stamp.nanosec, 0u);
   EXPECT_TRUE(identification.trajectory_type.empty());
-  EXPECT_EQ(identification.trajectory_id_string(), identification.object_id_string() + "_");
 }
 
 TEST(TrajectoryUtilitiesTest, ObjectIdentificationObjectConstructorBuildsIdsFromObject)
@@ -308,9 +307,6 @@ TEST(TrajectoryUtilitiesTest, ObjectIdentificationObjectConstructorBuildsIdsFrom
   EXPECT_EQ(identification.stamp.nanosec, stamp.nanosec);
   EXPECT_EQ(
     identification.object_id_string(), autoware_utils_uuid::to_hex_string(object.object_id));
-  EXPECT_EQ(
-    identification.trajectory_id_string(),
-    autoware_utils_uuid::to_hex_string(object.object_id) + "_map_based_predicted_path");
 }
 
 TEST(TrajectoryUtilitiesTest, GenerateEgoTrajectoryBuildsConsistentTrajectoryData)


### PR DESCRIPTION
- 各objectに対するTrajectoryDataの再利用が崩れていたので、再利用できるように戻しました。
- ObjectIdentification周りが崩れていたので整理しました。あわせて、TrajectoryIdentificationに改名しました。
- DRACの計算において、自身が発揮する減速度と同程度の減速度を他の物体も発揮しうるという仮定を加えました。

注記：減速仮定のもとでのdiffusion_trajectoryのラベルがmap_based_predicted_pathになってしまう課題があります。
<img width="2383" height="326" alt="image" src="https://github.com/user-attachments/assets/7fe5329a-d679-496c-8ce7-44990afb9b9a" />
