### PR TITLE
fix(boundary_departure): fix false negative when ego overlap with boundary on front or rear segment.

### DIFF
--- a/common/autoware_boundary_departure_checker/include/autoware/boundary_departure_checker/geometry_projection.hpp
+++ b/common/autoware_boundary_departure_checker/include/autoware/boundary_departure_checker/geometry_projection.hpp
@@ -46,14 +46,15 @@ std::optional<ProjectionToBound> calc_nearest_projection(
 /**
  * @brief Find the nearest boundary segment to an ego side segment.
  * @param[in] ego_side_seg side segment of the ego footprint
+ * @param[in] ego_front_seg front segment of the ego footprint
  * @param[in] ego_rear_seg rear segment of the ego footprint
  * @param[in] curr_fp_idx index of the current footprint
  * @param[in] boundary_segments candidate boundary segments
  * @return closest projection data
  */
 ProjectionToBound find_closest_segment(
-  const Segment2d & ego_side_seg, const Segment2d & ego_rear_seg, const size_t curr_fp_idx,
-  const std::vector<SegmentWithIdx> & boundary_segments);
+  const Segment2d & ego_side_seg, const Segment2d & ego_front_seg, const Segment2d & ego_rear_seg,
+  const size_t curr_fp_idx, const std::vector<SegmentWithIdx> & boundary_segments);
 
 /**
  * @brief Calculate signed lateral distance to a boundary.

--- a/common/autoware_boundary_departure_checker/src/geometry_projection.cpp
+++ b/common/autoware_boundary_departure_checker/src/geometry_projection.cpp
@@ -105,13 +105,39 @@ std::optional<ProjectionToBound> calc_nearest_projection(
 }
 
 ProjectionToBound find_closest_segment(
-  const Segment2d & ego_side_seg, const Segment2d & ego_rear_seg, const size_t curr_fp_idx,
-  const std::vector<SegmentWithIdx> & boundary_segments)
+  const Segment2d & ego_side_seg, const Segment2d & ego_front_seg, const Segment2d & ego_rear_seg,
+  const size_t curr_fp_idx, const std::vector<SegmentWithIdx> & boundary_segments)
 {
   std::optional<ProjectionToBound> closest_proj;
+
+  const auto is_intersecting =
+    [&ego_side_seg, curr_fp_idx](
+      const Segment2d & ego_seg,
+      const Segment2d & boundary_seg) -> std::optional<ProjectionToBound> {
+    const auto & [ego_lr, ego_rr] = ego_seg;
+    const auto & [seg_f, seg_r] = boundary_seg;
+    if (
+      const auto is_intersecting_rear = autoware_utils_geometry::intersect(
+        to_geom_pt(ego_lr), to_geom_pt(ego_rr), to_geom_pt(seg_f), to_geom_pt(seg_r))) {
+      Point2d point(is_intersecting_rear->x, is_intersecting_rear->y);
+      const auto front_to_proj_offset =
+        boost::geometry::distance(ego_side_seg.first, ego_side_seg.second);
+      return ProjectionToBound{point, point, boundary_seg, 0.0, front_to_proj_offset, curr_fp_idx};
+    }
+    return std::nullopt;
+  };
+
   for (const auto & [seg, id] : boundary_segments) {
-    const auto & [ego_lr, ego_rr] = ego_rear_seg;
-    const auto & [seg_f, seg_r] = seg;
+    if (const auto intersecting_front = is_intersecting(ego_front_seg, seg)) {
+      closest_proj = intersecting_front;
+      break;
+    }
+
+    if (const auto intersecting_rear = is_intersecting(ego_rear_seg, seg)) {
+      closest_proj = intersecting_rear;
+      break;
+    }
+
     if (const auto proj_opt = calc_nearest_projection(ego_side_seg, seg, curr_fp_idx)) {
       if (!closest_proj || proj_opt->lat_dist < closest_proj->lat_dist) {
         closest_proj = *proj_opt;
@@ -119,20 +145,6 @@ ProjectionToBound find_closest_segment(
     }
     if (closest_proj) {
       continue;
-    }
-
-    if (
-      const auto is_intersecting_rear = autoware_utils_geometry::intersect(
-        to_geom_pt(ego_lr), to_geom_pt(ego_rr), to_geom_pt(seg_f), to_geom_pt(seg_r))) {
-      Point2d point(is_intersecting_rear->x, is_intersecting_rear->y);
-      closest_proj =
-        ProjectionToBound{point,
-                          point,
-                          seg,
-                          0.0,
-                          boost::geometry::distance(ego_side_seg.first, ego_side_seg.second),
-                          curr_fp_idx};
-      break;
     }
   }
 

--- a/common/autoware_boundary_departure_checker/test/utils/test_boundary_utils.cpp
+++ b/common/autoware_boundary_departure_checker/test/utils/test_boundary_utils.cpp
@@ -83,6 +83,7 @@ TEST(UncrossableBoundaryUtilsTest, TestFindClosestSegmentRearIntersection)
   // Arrange:
   Segment2d ego_side_seg{{0.0, 4.0}, {0.0, 2.0}};
   Segment2d ego_rear_seg{{0.0, 0.0}, {2.0, 0.0}};
+  Segment2d ego_front_seg{{0.0, 4.0}, {2.0, 4.0}};
   size_t curr_fp_idx = 42;
 
   std::vector<SegmentWithIdx> boundary_segments;
@@ -91,7 +92,7 @@ TEST(UncrossableBoundaryUtilsTest, TestFindClosestSegmentRearIntersection)
 
   // Act:
   auto result = geometry_projection::find_closest_segment(
-    ego_side_seg, ego_rear_seg, curr_fp_idx, boundary_segments);
+    ego_side_seg, ego_front_seg, ego_rear_seg, curr_fp_idx, boundary_segments);
 
   // Assert:
   EXPECT_EQ(result.pose_index, curr_fp_idx);
@@ -100,11 +101,36 @@ TEST(UncrossableBoundaryUtilsTest, TestFindClosestSegmentRearIntersection)
   EXPECT_DOUBLE_EQ(result.pt_on_ego.y(), 0.0);
 }
 
+TEST(UncrossableBoundaryUtilsTest, TestFindClosestSegmentFrontIntersection)
+{
+  // Arrange:
+  Segment2d ego_side_seg{{0.0, 4.0}, {0.0, 2.0}};
+  Segment2d ego_rear_seg{{0.0, -4.0}, {2.0, -4.0}};
+  Segment2d ego_front_seg{{0.0, 4.0}, {2.0, 4.0}};
+  size_t curr_fp_idx = 42;
+
+  std::vector<SegmentWithIdx> boundary_segments;
+  IdxForRTreeSegment id{1, 0, 1};
+  boundary_segments.emplace_back(Segment2d{{1.0, 5.0}, {1.0, 3.0}}, id);
+
+  // Act:
+  auto result = geometry_projection::find_closest_segment(
+    ego_side_seg, ego_front_seg, ego_rear_seg, curr_fp_idx, boundary_segments);
+
+  // Assert:
+  EXPECT_EQ(result.pose_index, curr_fp_idx);
+  EXPECT_DOUBLE_EQ(result.lat_dist, 0.0);
+  EXPECT_DOUBLE_EQ(result.pt_on_ego.x(), 1.0);
+  EXPECT_DOUBLE_EQ(result.pt_on_ego.y(), 4.0);
+}
+
 TEST(UncrossableBoundaryUtilsTest, TestFindClosestSegmentFallback)
 {
   // Arrange:
   Segment2d ego_side_seg{{0.0, 4.0}, {0.0, 2.0}};
   Segment2d ego_rear_seg{{0.0, 0.0}, {2.0, 0.0}};
+  Segment2d ego_front_seg{{0.0, 4.0}, {2.0, 4.0}};
+
   size_t curr_fp_idx = 99;
 
   std::vector<SegmentWithIdx> boundary_segments;
@@ -113,7 +139,7 @@ TEST(UncrossableBoundaryUtilsTest, TestFindClosestSegmentFallback)
 
   // Act:
   auto result = geometry_projection::find_closest_segment(
-    ego_side_seg, ego_rear_seg, curr_fp_idx, boundary_segments);
+    ego_side_seg, ego_front_seg, ego_rear_seg, curr_fp_idx, boundary_segments);
 
   // Assert:
   EXPECT_EQ(result.pose_index, curr_fp_idx);


### PR DESCRIPTION
Tuesday 2026/04/21 Experiment Item number 11 and 13 [TIER IV Internal Link](https://tier4.atlassian.net/wiki/spaces/CB/pages/4995809285/Experiment+Analysis#981cb06b-a6df-4153-887a-e841da0d7ec3)