### PR TITLE
feat(command_mode_decider, switcher): use velocity only and steer only conditions (#11811)

### DIFF
--- a/system/autoware_command_mode_decider/src/command_mode_decider_base.cpp
+++ b/system/autoware_command_mode_decider/src/command_mode_decider_base.cpp
@@ -183,7 +183,10 @@ void CommandModeDeciderBase::on_control_mode(const ControlModeReport & msg)
 {
   const auto is_changed = prev_control_mode_ != msg.mode;
   prev_control_mode_ = msg.mode;
-  curr_autoware_control_ = (msg.mode == ControlModeReport::AUTONOMOUS);
+  curr_autoware_control_ =
+    (msg.mode == ControlModeReport::AUTONOMOUS ||
+     msg.mode == ControlModeReport::AUTONOMOUS_VELOCITY_ONLY ||
+     msg.mode == ControlModeReport::AUTONOMOUS_STEER_ONLY);
   curr_manual_control_ = (msg.mode == ControlModeReport::MANUAL);
 
   // Check override.

--- a/system/autoware_command_mode_switcher/src/common/selector_interface.cpp
+++ b/system/autoware_command_mode_switcher/src/common/selector_interface.cpp
@@ -112,7 +112,10 @@ bool ControlGateInterface::is_in_transition() const
 
 bool VehicleGateInterface::is_autoware_control() const
 {
-  return status_.mode == ControlModeReport::AUTONOMOUS;
+  return (
+    status_.mode == ControlModeReport::AUTONOMOUS ||
+    status_.mode == ControlModeReport::AUTONOMOUS_VELOCITY_ONLY ||
+    status_.mode == ControlModeReport::AUTONOMOUS_STEER_ONLY);
 }
 
 bool VehicleGateInterface::is_manual_control() const
@@ -128,7 +131,10 @@ bool ControlGateInterface::is_selected(const CommandPlugin & plugin) const
 bool VehicleGateInterface::is_selected(const CommandPlugin & plugin) const
 {
   if (plugin.autoware_control()) {
-    return status_.mode == ControlModeReport::AUTONOMOUS;
+    return (
+      status_.mode == ControlModeReport::AUTONOMOUS ||
+      status_.mode == ControlModeReport::AUTONOMOUS_VELOCITY_ONLY ||
+      status_.mode == ControlModeReport::AUTONOMOUS_STEER_ONLY);
   } else {
     return status_.mode == ControlModeReport::MANUAL;
   }


### PR DESCRIPTION
backport from https://github.com/autowarefoundation/autoware_universe/pull/11811

Related slack: https://star4.slack.com/archives/CRUE57C30/p1777013625038519?thread_ts=1777012711.789729&cid=CRUE57C30