### PR TITLE
fix(boundary_departure_prevention): clear boundar_departure diag in manual mode

### DIFF
--- a/planning/motion_velocity_planner/autoware_motion_velocity_boundary_departure_prevention_module/src/boundary_departure_prevention_module.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_boundary_departure_prevention_module/src/boundary_departure_prevention_module.cpp
@@ -394,6 +394,9 @@ BoundaryDeparturePreventionModule::plan_velocities(
   }
 
   if (!is_autonomous_mode()) {
+    // Override / manual mode: planning is skipped but diagnostic_updater still runs
+    // (`plan()` calls `force_update()`). Clear stale ERROR so MRM / diagnostics do not latch.
+    output_.diag_status = {DiagStatus::OK, "not in autonomous mode"};
     return tl::make_unexpected("Not in autonomous mode.");
   }
 

--- a/planning/motion_velocity_planner/autoware_motion_velocity_boundary_departure_prevention_module/src/boundary_departure_prevention_module.cpp
+++ b/planning/motion_velocity_planner/autoware_motion_velocity_boundary_departure_prevention_module/src/boundary_departure_prevention_module.cpp
@@ -394,8 +394,6 @@ BoundaryDeparturePreventionModule::plan_velocities(
   }
 
   if (!is_autonomous_mode()) {
-    // Override / manual mode: planning is skipped but diagnostic_updater still runs
-    // (`plan()` calls `force_update()`). Clear stale ERROR so MRM / diagnostics do not latch.
     output_.diag_status = {DiagStatus::OK, "not in autonomous mode"};
     return tl::make_unexpected("Not in autonomous mode.");
   }


### PR DESCRIPTION
When the driver overrides (leaves autonomous control), the boundary departure diagnostic status is not refreshed. The last published ERROR level therefore remains latched, and the MRM error state can stay active even though the situation that caused it no longer applies.

Clear the diagnostic status when override/non-autonomous mode is detected so the diagnostic updater publishes a healthy (OK) state instead of stale failure information, allowing MRM to recover appropriately.