### PR TITLE
feat(autoware_dummy_perception_publisher): add empty traffic light group array publisher

### DIFF
--- a/simulator/autoware_dummy_perception_publisher/CMakeLists.txt
+++ b/simulator/autoware_dummy_perception_publisher/CMakeLists.txt
@@ -57,6 +57,10 @@ ament_auto_add_executable(empty_objects_publisher
   src/empty_objects_publisher.cpp
 )
 
+ament_auto_add_executable(empty_traffic_light_group_array_publisher
+  src/empty_traffic_light_group_array_publisher.cpp
+)
+
 if(BUILD_TESTING)
   ament_add_ros_isolated_gtest(signed_distance_function-test
     test/src/test_signed_distance_function.cpp

--- a/simulator/autoware_dummy_perception_publisher/README.md
+++ b/simulator/autoware_dummy_perception_publisher/README.md
@@ -46,4 +46,32 @@ None.
 
 ## Assumptions / Known limits
 
-TBD.
+| Name                               | Type   | Default Value | Explanation                                                             |
+| ---------------------------------- | ------ | ------------- | ----------------------------------------------------------------------- |
+| `min_predicted_path_keep_duration` | double | 3.0           | minimum time (seconds) to keep using same prediction                    |
+| `switch_time_threshold`            | double | 2.0           | time threshold (seconds) to switch from straight-line to predicted path |
+
+#### Common Remapping Parameters
+
+The plugin uses `CommonParameters` for both vehicle and pedestrian object types. Each parameter is prefixed with either `vehicle.` or `pedestrian.`:
+
+| Parameter Name               | Type   | Explanation                                               |
+| ---------------------------- | ------ | --------------------------------------------------------- |
+| `max_remapping_distance`     | double | maximum distance (meters) for remapping validation        |
+| `max_speed_difference_ratio` | double | maximum speed difference ratio tolerance                  |
+| `min_speed_ratio`            | double | minimum speed ratio relative to dummy object speed        |
+| `max_speed_ratio`            | double | maximum speed ratio relative to dummy object speed        |
+| `speed_check_threshold`      | double | speed threshold (m/s) above which speed checks apply      |
+| `path_selection_strategy`    | string | path selection strategy: "highest_confidence" or "random" |
+
+## Auxiliary Nodes
+
+### empty_objects_publisher
+
+A simple node that publishes empty `PredictedObjects` messages at 10 Hz on `~/output/objects`. This is used as a fallback when no object recognition is running, ensuring downstream nodes still receive the expected topic.
+
+### empty_traffic_light_group_array_publisher
+
+A simple node that publishes empty `TrafficLightGroupArray` messages at 10 Hz on `~/output/traffic_light_group_array`. This is used as a fallback when no traffic light recognition is running, ensuring downstream nodes still receive the expected topic.
+
+In the launch file, this node is enabled by the `use_empty_traffic_light_recognition` argument (default: `true`) and remaps its output to `/perception/traffic_light_recognition/traffic_signals`.

--- a/simulator/autoware_dummy_perception_publisher/launch/dummy_perception_publisher.launch.xml
+++ b/simulator/autoware_dummy_perception_publisher/launch/dummy_perception_publisher.launch.xml
@@ -4,6 +4,7 @@
   <arg name="visible_range" default="300.0"/>
   <arg name="real" default="true"/>
   <arg name="use_object_recognition" default="true"/>
+  <arg name="use_empty_traffic_light_recognition" default="true"/>
   <arg name="use_base_link_z" default="true"/>
 
   <group>
@@ -41,6 +42,12 @@
         <param name="enable_ray_tracing" value="false"/>
         <param name="use_object_recognition" value="$(var use_object_recognition)"/>
         <param name="use_base_link_z" value="$(var use_base_link_z)"/>
+      </node>
+    </group>
+
+    <group if="$(var use_empty_traffic_light_recognition)">
+      <node pkg="autoware_dummy_perception_publisher" exec="empty_traffic_light_group_array_publisher" name="empty_traffic_light_group_array_publisher" output="screen">
+        <remap from="~/output/traffic_light_group_array" to="/perception/traffic_light_recognition/traffic_signals"/>
       </node>
     </group>
 

--- a/simulator/autoware_dummy_perception_publisher/src/empty_traffic_light_group_array_publisher.cpp
+++ b/simulator/autoware_dummy_perception_publisher/src/empty_traffic_light_group_array_publisher.cpp
@@ -1,0 +1,66 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <rclcpp/rclcpp.hpp>
+
+#include <autoware_perception_msgs/msg/traffic_light_group_array.hpp>
+
+#include <memory>
+
+namespace autoware::dummy_perception_publisher
+{
+
+class EmptyTrafficLightGroupArrayPublisher : public rclcpp::Node
+{
+public:
+  EmptyTrafficLightGroupArrayPublisher() : Node("empty_traffic_light_group_array_publisher")
+  {
+    empty_traffic_light_group_array_pub_ =
+      this->create_publisher<autoware_perception_msgs::msg::TrafficLightGroupArray>(
+        "~/output/traffic_light_group_array", 1);
+
+    using std::chrono_literals::operator""ms;
+    timer_ = rclcpp::create_timer(
+      this, get_clock(), 100ms,
+      std::bind(&EmptyTrafficLightGroupArrayPublisher::timerCallback, this));
+  }
+
+private:
+  rclcpp::Publisher<autoware_perception_msgs::msg::TrafficLightGroupArray>::SharedPtr
+    empty_traffic_light_group_array_pub_;
+  rclcpp::TimerBase::SharedPtr timer_;
+
+  void timerCallback()
+  {
+    const auto topic_name = empty_traffic_light_group_array_pub_->get_topic_name();
+    if (this->count_publishers(topic_name) > 1) {
+      return;
+    }
+
+    autoware_perception_msgs::msg::TrafficLightGroupArray empty_traffic_light_group_array;
+    empty_traffic_light_group_array.stamp = this->now();
+    empty_traffic_light_group_array_pub_->publish(empty_traffic_light_group_array);
+  }
+};
+
+}  // namespace autoware::dummy_perception_publisher
+
+int main(int argc, char ** argv)
+{
+  rclcpp::init(argc, argv);
+  rclcpp::spin(
+    std::make_shared<autoware::dummy_perception_publisher::EmptyTrafficLightGroupArrayPublisher>());
+  rclcpp::shutdown();
+  return 0;
+}


### PR DESCRIPTION
## Summary
- Cherry-picks the simulator-only changes from #2839 to `beta/x2/v4.3.3`.
- Adds an empty `TrafficLightGroupArray` publisher in `autoware_dummy_perception_publisher`, with conditional publishing to avoid conflicts when another publisher exists.
- Includes README and launch file updates.

## Original commits (squashed)
- feat(dummy_perception_publisher): add publisher for empty traffic light group array (`2725ae278f`)
- feat(dummy_perception_publisher): update README.md (`3c5e03ac36`)
- style(pre-commit): autofix (`fa59b67528`)
- Update empty_traffic_light_group_array_publisher.cpp (`2406715a5a`)
- fix(dummy_perception_publisher): disable publish if there is another publisher (`9214b368d9`)

## Test plan
- [x] Build `autoware_dummy_perception_publisher` package successfully
- [x] Launch simulator and verify the empty traffic light group array topic is published when no other publisher exists
- [x] Verify no double-publishing occurs when another publisher is active

🤖 Generated with [Claude Code](https://claude.com/claude-code)