### PR TITLE
feat(label_based_cluster): publish objects as polygon

### DIFF
--- a/perception/autoware_euclidean_cluster/config/label_based_euclidean_cluster.param.yaml
+++ b/perception/autoware_euclidean_cluster/config/label_based_euclidean_cluster.param.yaml
@@ -19,23 +19,23 @@
       vegetation: ignore
       car: car
       bus: bus
-      emergency_vehicle: ignore
-      train: ignore
+      emergency_vehicle: car
+      train: unknown
       truck: truck
-      tractor_unit: ignore
-      semi_trailer: ignore
-      construction_vehicle: ignore
-      forklift: ignore
-      kart: ignore
+      tractor_unit: trailer
+      semi_trailer: trailer
+      construction_vehicle: truck
+      forklift: car
+      kart: car
       motorcycle: motorcycle
       bicycle: bicycle
       pedestrian: pedestrian
-      personal_mobility: ignore
-      animal: ignore
-      pushable_pullable: ignore
-      traffic_cone: ignore
-      debris: ignore
-      stroller: ignore
+      personal_mobility: pedestrian
+      animal: animal
+      pushable_pullable: unknown
+      traffic_cone: unknown
+      debris: unknown
+      stroller: pedestrian
       other_stuff: ignore
       noise+ghost_point: ignore
 

--- a/perception/autoware_euclidean_cluster/src/label_based_euclidean_cluster_node.cpp
+++ b/perception/autoware_euclidean_cluster/src/label_based_euclidean_cluster_node.cpp
@@ -173,22 +173,22 @@ DetectedObject create_box_object(
   autoware::shape_estimation::ShapeEstimator & shape_estimator)
 {
   DetectedObject object;
-  object.existence_probability = probability;
-
-  const auto classification =
-    autoware_perception_msgs::build<ObjectClassification>().label(label).probability(probability);
-  object.classification.push_back(classification);
-
   autoware_perception_msgs::msg::Shape shape;
   geometry_msgs::msg::Pose pose;
+  // NOTE: Force to use UNKNOWN label to estimate the shape as polygon for non-pedestrian objects.
+  const std::uint8_t shape_label =
+    (label == ObjectClassification::PEDESTRIAN) ? label : ObjectClassification::UNKNOWN;
   const bool estimated = shape_estimator.estimateShapeAndPose(
-    label, cluster, boost::none, boost::none, boost::none, shape, pose);
+    shape_label, cluster, boost::none, boost::none, boost::none, shape, pose);
 
   if (!estimated) {
     std::tie(shape, pose) = create_fallback_shape_and_pose(cluster, label);
   }
 
   object.shape = shape;
+  object.existence_probability = probability;
+  object.classification.push_back(
+    autoware_perception_msgs::build<ObjectClassification>().label(label).probability(probability));
   object.kinematics.pose_with_covariance.pose = pose;
   object.kinematics.orientation_availability =
     autoware_perception_msgs::msg::DetectedObjectKinematics::UNAVAILABLE;

--- a/perception/autoware_euclidean_cluster/src/label_based_euclidean_cluster_node.cpp
+++ b/perception/autoware_euclidean_cluster/src/label_based_euclidean_cluster_node.cpp
@@ -123,6 +123,12 @@ std::optional<std::uint8_t> to_object_label(const std::string & mapped_label)
   if (mapped_label == "pedestrian") {
     return ObjectClassification::PEDESTRIAN;
   }
+  if (mapped_label == "animal") {
+    return ObjectClassification::ANIMAL;
+  }
+  if (mapped_label == "unknown") {
+    return ObjectClassification::UNKNOWN;
+  }
   return std::nullopt;
 }
 


### PR DESCRIPTION
## What

This pull request updates the label mapping and object classification logic in the `label_based_euclidean_cluster` component to improve how various detected objects are categorized and processed. The main changes include expanding the label mappings to cover more object types, handling new classifications in the code, and adjusting shape estimation for non-pedestrian objects.

**Label mapping and classification improvements:**

* Updated `label_mapping` in `label_based_euclidean_cluster.param.yaml` to map more specific labels (like `emergency_vehicle`, `tractor_unit`, `semi_trailer`, etc.) to broader categories such as `car`, `trailer`, `truck`, and `unknown` instead of ignoring them. Some previously ignored classes (like `personal_mobility`, `stroller`) are now mapped to `pedestrian`.
* Added support in `to_object_label` for new mapped labels: `animal` and `unknown`, enabling these to be classified instead of ignored.

**Shape estimation logic:**

* Modified `create_box_object` so that for non-pedestrian objects, the shape estimator is forced to use the `UNKNOWN` label, which results in polygonal shape estimation instead of using the object's specific label. This change helps generalize shape estimation for a wider range of object types.