### PR TITLE
feat(object_merger): add a new merger

### DIFF
--- a/perception/autoware_euclidean_cluster/CMakeLists.txt
+++ b/perception/autoware_euclidean_cluster/CMakeLists.txt
@@ -77,6 +77,8 @@ ament_target_dependencies(${PROJECT_NAME}_label_based_node_core
 rclcpp_components_register_node(${PROJECT_NAME}_label_based_node_core
   PLUGIN "autoware::euclidean_cluster::LabelBasedEuclideanClusterNode"
   EXECUTABLE label_based_euclidean_cluster_node
+  AGNOCAST_EXECUTOR CallbackIsolatedAgnocastExecutor
+  ROS2_EXECUTOR SingleThreadedExecutor
 )
 
 if(BUILD_TESTING)

--- a/perception/autoware_euclidean_cluster/CMakeLists.txt
+++ b/perception/autoware_euclidean_cluster/CMakeLists.txt
@@ -71,10 +71,12 @@ target_link_libraries(${PROJECT_NAME}_label_based_node_core
   ${PROJECT_NAME}_lib
 )
 ament_target_dependencies(${PROJECT_NAME}_label_based_node_core
+  autoware_agnocast_wrapper
   autoware_shape_estimation
 )
+autoware_agnocast_wrapper_setup(${PROJECT_NAME}_label_based_node_core)
 
-rclcpp_components_register_node(${PROJECT_NAME}_label_based_node_core
+autoware_agnocast_wrapper_register_node(${PROJECT_NAME}_label_based_node_core
   PLUGIN "autoware::euclidean_cluster::LabelBasedEuclideanClusterNode"
   EXECUTABLE label_based_euclidean_cluster_node
   AGNOCAST_EXECUTOR CallbackIsolatedAgnocastExecutor

--- a/perception/autoware_euclidean_cluster/README.md
+++ b/perception/autoware_euclidean_cluster/README.md
@@ -53,7 +53,7 @@ This package has two clustering methods: `euclidean_cluster` and `voxel_grid_bas
 | `min_cluster_size`                  | int    | minimum number of points required to keep a cluster                                           |
 | `max_cluster_size`                  | int    | maximum number of points allowed in a cluster                                                 |
 | `tolerance`                         | float  | Euclidean clustering tolerance                                                                |
-| `min_probability`                   | float  | minimum point probability to keep a point                                                     |
+| `min_probability`                   | float  | minimum point probability to keep a point when the input has a `probability` field            |
 | `class_names.<original_class_name>` | string | mapped label keyed by original class name; YAML declaration order is used as input `class_id` |
 | `use_shape_estimation_corrector`    | bool   | pass clusters through the standard shape estimation corrector                                 |
 | `use_shape_estimation_filter`       | bool   | pass estimated boxes through the standard shape estimation filter                             |
@@ -105,4 +105,6 @@ The `use_height` option of `voxel_grid_based_euclidean_cluster` isn't implemente
 
 `label_based_euclidean_cluster` reads `class_names.<original_class_name>` in YAML declaration order and uses that order as `class_id`. Classes mapped to `car`, `bus`, `truck`, `motorcycle`, `bicycle`, or `pedestrian` are kept, and classes mapped to `ignore` are skipped.
 
-The node requires `probability` in the input pointcloud. Messages without that field are skipped.
+If the input pointcloud has no `probability` field, the node skips probability filtering and treats each point as probability `1.0`.
+
+If the input pointcloud has no `class_id` field, the node clusters all points together as `UNKNOWN` and runs shape estimation with the `UNKNOWN` label.

--- a/perception/autoware_euclidean_cluster/config/label_based_euclidean_cluster.param.yaml
+++ b/perception/autoware_euclidean_cluster/config/label_based_euclidean_cluster.param.yaml
@@ -19,23 +19,23 @@
       vegetation: ignore
       car: car
       bus: bus
-      emergency_vehicle: ignore
-      train: ignore
+      emergency_vehicle: car
+      train: unknown
       truck: truck
-      tractor_unit: ignore
-      semi_trailer: ignore
-      construction_vehicle: ignore
-      forklift: ignore
-      kart: ignore
+      tractor_unit: trailer
+      semi_trailer: trailer
+      construction_vehicle: truck
+      forklift: car
+      kart: car
       motorcycle: motorcycle
       bicycle: bicycle
       pedestrian: pedestrian
-      personal_mobility: ignore
-      animal: ignore
-      pushable_pullable: ignore
-      traffic_cone: ignore
-      debris: ignore
-      stroller: ignore
+      personal_mobility: pedestrian
+      animal: animal
+      pushable_pullable: unknown
+      traffic_cone: unknown
+      debris: unknown
+      stroller: pedestrian
       other_stuff: ignore
       noise+ghost_point: ignore
 

--- a/perception/autoware_euclidean_cluster/config/label_based_euclidean_cluster.param.yaml
+++ b/perception/autoware_euclidean_cluster/config/label_based_euclidean_cluster.param.yaml
@@ -43,3 +43,5 @@
     use_shape_estimation_corrector: false
     use_shape_estimation_filter: false
     use_boost_bbox_optimizer: false
+    # 0: ALL_POLYGON, 1: LABEL_DEPEND
+    shape_policy: 0

--- a/perception/autoware_euclidean_cluster/src/label_based_euclidean_cluster_node.cpp
+++ b/perception/autoware_euclidean_cluster/src/label_based_euclidean_cluster_node.cpp
@@ -173,22 +173,22 @@ DetectedObject create_box_object(
   autoware::shape_estimation::ShapeEstimator & shape_estimator)
 {
   DetectedObject object;
-  object.existence_probability = probability;
-
-  const auto classification =
-    autoware_perception_msgs::build<ObjectClassification>().label(label).probability(probability);
-  object.classification.push_back(classification);
-
   autoware_perception_msgs::msg::Shape shape;
   geometry_msgs::msg::Pose pose;
+  // NOTE: Force to use UNKNOWN label to estimate the shape as polygon for non-pedestrian objects.
+  const std::uint8_t shape_label =
+    (label == ObjectClassification::PEDESTRIAN) ? label : ObjectClassification::UNKNOWN;
   const bool estimated = shape_estimator.estimateShapeAndPose(
-    label, cluster, boost::none, boost::none, boost::none, shape, pose);
+    shape_label, cluster, boost::none, boost::none, boost::none, shape, pose);
 
   if (!estimated) {
     std::tie(shape, pose) = create_fallback_shape_and_pose(cluster, label);
   }
 
   object.shape = shape;
+  object.existence_probability = probability;
+  object.classification.push_back(
+    autoware_perception_msgs::build<ObjectClassification>().label(label).probability(probability));
   object.kinematics.pose_with_covariance.pose = pose;
   object.kinematics.orientation_availability =
     autoware_perception_msgs::msg::DetectedObjectKinematics::UNAVAILABLE;

--- a/perception/autoware_euclidean_cluster/src/label_based_euclidean_cluster_node.cpp
+++ b/perception/autoware_euclidean_cluster/src/label_based_euclidean_cluster_node.cpp
@@ -123,6 +123,12 @@ std::optional<std::uint8_t> to_object_label(const std::string & mapped_label)
   if (mapped_label == "pedestrian") {
     return ObjectClassification::PEDESTRIAN;
   }
+  if (mapped_label == "animal") {
+    return ObjectClassification::ANIMAL;
+  }
+  if (mapped_label == "unknown") {
+    return ObjectClassification::UNKNOWN;
+  }
   return std::nullopt;
 }
 

--- a/perception/autoware_euclidean_cluster/src/label_based_euclidean_cluster_node.cpp
+++ b/perception/autoware_euclidean_cluster/src/label_based_euclidean_cluster_node.cpp
@@ -78,6 +78,20 @@ bool is_ignored_mapping(const std::string & mapped_label)
   return mapped_label == "ignore";
 }
 
+/// @brief Convert an integer parameter into a validated shape policy.
+ShapePolicy to_shape_policy(const std::uint8_t value)
+{
+  switch (value) {
+    case ShapePolicy::ALL_POLYGON:
+      return ShapePolicy::ALL_POLYGON;
+    case ShapePolicy::LABEL_DEPEND:
+      return ShapePolicy::LABEL_DEPEND;
+    default:
+      throw std::runtime_error(
+        "shape_policy must be 0 (ALL_POLYGON) or 1 (LABEL_DEPEND)");
+  }
+}
+
 /// @brief Extract ordered class mappings from parameter overrides.
 std::vector<std::pair<std::string, std::string>> extract_class_mappings(
   const rclcpp::NodeOptions & options)
@@ -167,21 +181,35 @@ std::pair<Shape, geometry_msgs::msg::Pose> create_fallback_shape_and_pose(
   return {shape, pose};
 }
 
+/// @brief Return true when the estimator populated a usable shape output.
+bool has_usable_estimated_shape(const Shape & shape)
+{
+  switch (shape.type) {
+    case Shape::BOUNDING_BOX:
+    case Shape::CYLINDER:
+      return shape.dimensions.x > 0.0 && shape.dimensions.y > 0.0 && shape.dimensions.z > 0.0;
+    case Shape::POLYGON:
+      return !shape.footprint.points.empty() && shape.dimensions.z > 0.0;
+    default:
+      return false;
+  }
+}
+
 /// @brief Build a detected object with estimated or fallback shape and pose.
-DetectedObject create_box_object(
+DetectedObject create_detected_object(
   const pcl::PointCloud<pcl::PointXYZ> & cluster, const std::uint8_t label, const float probability,
-  autoware::shape_estimation::ShapeEstimator & shape_estimator)
+  const ShapePolicy shape_policy, autoware::shape_estimation::ShapeEstimator & shape_estimator)
 {
   DetectedObject object;
   autoware_perception_msgs::msg::Shape shape;
   geometry_msgs::msg::Pose pose;
-  // NOTE: Force to use UNKNOWN label to estimate the shape as polygon for non-pedestrian objects.
+  // UNKNOWN uses the convex hull model, which is the polygon path in ShapeEstimator.
   const std::uint8_t shape_label =
-    (label == ObjectClassification::PEDESTRIAN) ? label : ObjectClassification::UNKNOWN;
-  const bool estimated = shape_estimator.estimateShapeAndPose(
+    (shape_policy == ShapePolicy::LABEL_DEPEND) ? label : ObjectClassification::UNKNOWN;
+  shape_estimator.estimateShapeAndPose(
     shape_label, cluster, boost::none, boost::none, boost::none, shape, pose);
 
-  if (!estimated) {
+  if (!has_usable_estimated_shape(shape)) {
     std::tie(shape, pose) = create_fallback_shape_and_pose(cluster, label);
   }
 
@@ -245,6 +273,8 @@ LabelBasedEuclideanClusterNode::LabelBasedEuclideanClusterNode(const rclcpp::Nod
 {
   min_probability_ = static_cast<float>(
     autoware_utils_rclcpp::get_or_declare_parameter<double>(*this, "min_probability"));
+  shape_policy_ = to_shape_policy(
+    autoware_utils_rclcpp::get_or_declare_parameter<uint8_t>(*this, "shape_policy"));
 
   const auto class_mappings = extract_class_mappings(options);
   if (!update_target_label_map(class_mappings)) {
@@ -357,7 +387,8 @@ void LabelBasedEuclideanClusterNode::on_pointcloud(
       }
 
       output_msg.objects.push_back(
-        create_box_object(cluster, label, label_probability, *shape_estimator_));
+        create_detected_object(
+          cluster, label, label_probability, shape_policy_, *shape_estimator_));
     }
   }
 

--- a/perception/autoware_euclidean_cluster/src/label_based_euclidean_cluster_node.cpp
+++ b/perception/autoware_euclidean_cluster/src/label_based_euclidean_cluster_node.cpp
@@ -87,8 +87,7 @@ ShapePolicy to_shape_policy(const std::uint8_t value)
     case ShapePolicy::LABEL_DEPEND:
       return ShapePolicy::LABEL_DEPEND;
     default:
-      throw std::runtime_error(
-        "shape_policy must be 0 (ALL_POLYGON) or 1 (LABEL_DEPEND)");
+      throw std::runtime_error("shape_policy must be 0 (ALL_POLYGON) or 1 (LABEL_DEPEND)");
   }
 }
 
@@ -225,7 +224,7 @@ DetectedObject create_detected_object(
 }
 
 /// @brief Split semantic points into buckets keyed by mapped object label.
-std::unordered_map<std::uint8_t, std::vector<SemanticPoint>> split_by_label(
+std::unordered_map<std::uint8_t, std::vector<SemanticPoint>> split_pointcloud(
   const sensor_msgs::msg::PointCloud2 & pointcloud,
   const std::unordered_map<std::uint8_t, std::uint8_t> & class_id_to_object_label,
   const float min_probability)
@@ -235,20 +234,60 @@ std::unordered_map<std::uint8_t, std::vector<SemanticPoint>> split_by_label(
   sensor_msgs::PointCloud2ConstIterator<float> iter_x(pointcloud, "x");
   sensor_msgs::PointCloud2ConstIterator<float> iter_y(pointcloud, "y");
   sensor_msgs::PointCloud2ConstIterator<float> iter_z(pointcloud, "z");
-  sensor_msgs::PointCloud2ConstIterator<std::uint8_t> iter_class(pointcloud, "class_id");
-  sensor_msgs::PointCloud2ConstIterator<float> iter_probability(pointcloud, "probability");
-  for (; iter_x != iter_x.end(); ++iter_x, ++iter_y, ++iter_z, ++iter_class, ++iter_probability) {
-    if (*iter_probability < min_probability) {
-      continue;
-    }
 
-    const auto mapping = class_id_to_object_label.find(*iter_class);
-    if (mapping == class_id_to_object_label.end()) {
-      continue;
-    }
+  const bool has_class_id = has_field(pointcloud, "class_id", sensor_msgs::msg::PointField::UINT8);
+  const bool has_probability =
+    has_field(pointcloud, "probability", sensor_msgs::msg::PointField::FLOAT32);
 
-    buckets[mapping->second].push_back(
-      SemanticPoint{pcl::PointXYZ(*iter_x, *iter_y, *iter_z), *iter_probability});
+  if (has_class_id && has_probability) {
+    sensor_msgs::PointCloud2ConstIterator<std::uint8_t> iter_class(pointcloud, "class_id");
+    sensor_msgs::PointCloud2ConstIterator<float> iter_probability(pointcloud, "probability");
+    for (; iter_x != iter_x.end(); ++iter_x, ++iter_y, ++iter_z, ++iter_class, ++iter_probability) {
+      if (*iter_probability < min_probability) {
+        continue;
+      }
+
+      const auto mapping = class_id_to_object_label.find(*iter_class);
+      if (mapping == class_id_to_object_label.end()) {
+        continue;
+      }
+
+      buckets[mapping->second].push_back(
+        SemanticPoint{pcl::PointXYZ(*iter_x, *iter_y, *iter_z), *iter_probability});
+    }
+    return buckets;
+  }
+
+  if (has_class_id) {
+    sensor_msgs::PointCloud2ConstIterator<std::uint8_t> iter_class(pointcloud, "class_id");
+    for (; iter_x != iter_x.end(); ++iter_x, ++iter_y, ++iter_z, ++iter_class) {
+      const auto mapping = class_id_to_object_label.find(*iter_class);
+      if (mapping == class_id_to_object_label.end()) {
+        continue;
+      }
+
+      buckets[mapping->second].push_back(
+        SemanticPoint{pcl::PointXYZ(*iter_x, *iter_y, *iter_z), 1.0F});
+    }
+    return buckets;
+  }
+
+  if (has_probability) {
+    sensor_msgs::PointCloud2ConstIterator<float> iter_probability(pointcloud, "probability");
+    for (; iter_x != iter_x.end(); ++iter_x, ++iter_y, ++iter_z, ++iter_probability) {
+      if (*iter_probability < min_probability) {
+        continue;
+      }
+
+      buckets[ObjectClassification::UNKNOWN].push_back(
+        SemanticPoint{pcl::PointXYZ(*iter_x, *iter_y, *iter_z), *iter_probability});
+    }
+    return buckets;
+  }
+
+  for (; iter_x != iter_x.end(); ++iter_x, ++iter_y, ++iter_z) {
+    buckets[ObjectClassification::UNKNOWN].push_back(
+      SemanticPoint{pcl::PointXYZ(*iter_x, *iter_y, *iter_z), 1.0F});
   }
 
   return buckets;
@@ -355,17 +394,14 @@ void LabelBasedEuclideanClusterNode::on_pointcloud(
   if (
     !has_field(*input_msg, "x", sensor_msgs::msg::PointField::FLOAT32) ||
     !has_field(*input_msg, "y", sensor_msgs::msg::PointField::FLOAT32) ||
-    !has_field(*input_msg, "z", sensor_msgs::msg::PointField::FLOAT32) ||
-    !has_field(*input_msg, "class_id", sensor_msgs::msg::PointField::UINT8) ||
-    !has_field(*input_msg, "probability", sensor_msgs::msg::PointField::FLOAT32)) {
+    !has_field(*input_msg, "z", sensor_msgs::msg::PointField::FLOAT32)) {
     RCLCPP_WARN_THROTTLE(
-      get_logger(), *get_clock(), 5000,
-      "Skipping pointcloud without required fields: x, y, z, class_id, probability");
+      get_logger(), *get_clock(), 5000, "Skipping pointcloud without required fields: x, y, z");
     return;
   }
 
   // 1. Split points by label and filter by probability
-  auto split_points = split_by_label(*input_msg, class_id_to_object_label_, min_probability_);
+  auto split_points = split_pointcloud(*input_msg, class_id_to_object_label_, min_probability_);
 
   DetectedObjects output_msg;
   output_msg.header = input_msg->header;
@@ -386,9 +422,8 @@ void LabelBasedEuclideanClusterNode::on_pointcloud(
         continue;
       }
 
-      output_msg.objects.push_back(
-        create_detected_object(
-          cluster, label, label_probability, shape_policy_, *shape_estimator_));
+      output_msg.objects.push_back(create_detected_object(
+        cluster, label, label_probability, shape_policy_, *shape_estimator_));
     }
   }
 

--- a/perception/autoware_euclidean_cluster/src/label_based_euclidean_cluster_node.hpp
+++ b/perception/autoware_euclidean_cluster/src/label_based_euclidean_cluster_node.hpp
@@ -49,7 +49,7 @@ public:
 
 private:
   /// @brief Process an input semantic point cloud and publish detected objects.
-  /// @param input_msg Input point cloud containing xyz, class_id, and probability fields.
+  /// @param input_msg Input point cloud containing xyz and optionally class_id / probability.
   void on_pointcloud(sensor_msgs::msg::PointCloud2::ConstSharedPtr input_msg);
 
   /// @brief Build the mapping from semantic class IDs to Autoware object labels.

--- a/perception/autoware_euclidean_cluster/src/label_based_euclidean_cluster_node.hpp
+++ b/perception/autoware_euclidean_cluster/src/label_based_euclidean_cluster_node.hpp
@@ -28,12 +28,17 @@
 #include <cstdint>
 #include <memory>
 #include <string>
-#include <utility>
 #include <unordered_map>
+#include <utility>
 #include <vector>
 
 namespace autoware::euclidean_cluster
 {
+enum ShapePolicy : uint8_t {
+  ALL_POLYGON = 0,
+  LABEL_DEPEND = 1,
+};
+
 /// @brief ROS 2 node that performs euclidean clustering on semantic point clouds grouped by label.
 class LabelBasedEuclideanClusterNode : public rclcpp::Node
 {
@@ -63,5 +68,7 @@ private:
 
   std::unordered_map<std::uint8_t, std::uint8_t> class_id_to_object_label_;
   float min_probability_;
+
+  ShapePolicy shape_policy_;
 };
 }  // namespace autoware::euclidean_cluster

--- a/perception/autoware_object_merger/CMakeLists.txt
+++ b/perception/autoware_object_merger/CMakeLists.txt
@@ -14,6 +14,7 @@ find_package(eigen3_cmake_module REQUIRED)
 find_package(Eigen3 REQUIRED)
 
 include_directories(
+  include
   SYSTEM
     ${EIGEN3_INCLUDE_DIR}
 )
@@ -21,6 +22,7 @@ include_directories(
 ament_auto_add_library(${PROJECT_NAME} SHARED
   src/association/data_association.cpp
   src/association/solver/mu_successive_shortest_path_wrapper.cpp
+  src/object_fusion_merger_node.cpp
   src/object_association_merger_node.cpp
 )
 
@@ -35,7 +37,24 @@ autoware_agnocast_wrapper_register_node(${PROJECT_NAME}
   AGNOCAST_EXECUTOR CallbackIsolatedAgnocastExecutor
 )
 
+autoware_agnocast_wrapper_register_node(${PROJECT_NAME}
+  PLUGIN "autoware::object_merger::ObjectFusionMergerNode"
+  EXECUTABLE object_fusion_merger_node
+  ROS2_EXECUTOR SingleThreadedExecutor
+  AGNOCAST_EXECUTOR CallbackIsolatedAgnocastExecutor
+)
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+
+  ament_auto_add_gtest(object_fusion_merger_node_tests
+    test/test_object_fusion_merger_node.cpp
+  )
+endif()
+
 ament_auto_package(INSTALL_TO_SHARE
   launch
   config
+  docs
 )

--- a/perception/autoware_object_merger/config/object_fusion_merger.param.yaml
+++ b/perception/autoware_object_merger/config/object_fusion_merger.param.yaml
@@ -1,0 +1,4 @@
+/**:
+  ros__parameters:
+    sync_queue_size: 20
+    base_link_frame_id: base_link

--- a/perception/autoware_object_merger/docs/object_fusion_merger.md
+++ b/perception/autoware_object_merger/docs/object_fusion_merger.md
@@ -20,7 +20,8 @@ The node is stateless across frames and reuses the existing association logic fr
 
 | Name            | Type                                             | Description                                                       |
 | --------------- | ------------------------------------------------ | ----------------------------------------------------------------- |
-| `output/object` | `autoware_perception_msgs::msg::DetectedObjects` | Main-based detected objects after association and shape expansion |
+| `output/objects` | `autoware_perception_msgs::msg::DetectedObjects` | Main-based detected objects after association and shape expansion |
+| `output/other_objects` | `autoware_perception_msgs::msg::DetectedObjects` | Sub detected objects that did not match any main object |
 
 ## Processing Flow
 
@@ -30,7 +31,7 @@ The node is stateless across frames and reuses the existing association logic fr
 4. Solve one-to-one assignment with the same GNN solver used by `object_association_merger`.
 5. For each matched pair, copy the main object and expand only its shape so that the main/sub union is enclosed.
 6. Keep unmatched main objects unchanged.
-7. Discard unmatched sub objects.
+7. Publish unmatched sub objects on `output/other_objects`.
 
 ## Shape Update Rule
 
@@ -67,7 +68,7 @@ In practice, this means the pair must satisfy all of the following:
 - the yaw difference is within `max_rad_matrix` when that gate is enabled
 - the 2D IoU is above `min_iou_matrix`
 
-If a pair does not pass those gates, the main object is treated as unmatched and remains unchanged, and the sub object is discarded.
+If a pair does not pass those gates, the main object remains in `output/objects` unchanged, and the sub object is published via `output/other_objects`.
 
 ## Parameter
 
@@ -80,14 +81,14 @@ With the default configuration:
 
 - matched main/sub pairs produce one output object based on the main object
 - unmatched main objects remain in the output
-- unmatched sub objects are not emitted
+- unmatched sub objects are emitted on `output/other_objects`
 
 ## Test Coverage
 
 The current focused test suite covers the following cases:
 
 - matched `BOUNDING_BOX` pair expands the main box while keeping main pose and metadata
-- unmatched main objects remain in the output and unmatched sub objects are dropped
+- unmatched main objects remain in the output and unmatched sub objects are published separately
 - `BOUNDING_BOX` main object can enclose a larger sub `POLYGON`
 - `CYLINDER` main object expands to cover the union footprint
 - `POLYGON` main object rebuilds its footprint from the union convex hull

--- a/perception/autoware_object_merger/docs/object_fusion_merger.md
+++ b/perception/autoware_object_merger/docs/object_fusion_merger.md
@@ -1,0 +1,104 @@
+# object_fusion_merger
+
+## Purpose
+
+`object_fusion_merger` associates two detected-object streams and keeps the main stream as the base output.
+For each matched pair, it expands the main object's shape so that the union of the main and sub regions is enclosed by the main shape type.
+
+The node is stateless across frames and reuses the existing association logic from `autoware_object_merger::DataAssociation`.
+
+## Inputs / Outputs
+
+### Input
+
+| Name                | Type                                             | Description           |
+| ------------------- | ------------------------------------------------ | --------------------- |
+| `input/main_object` | `autoware_perception_msgs::msg::DetectedObjects` | Main detected objects |
+| `input/sub_object`  | `autoware_perception_msgs::msg::DetectedObjects` | Sub detected objects  |
+
+### Output
+
+| Name            | Type                                             | Description                                                       |
+| --------------- | ------------------------------------------------ | ----------------------------------------------------------------- |
+| `output/object` | `autoware_perception_msgs::msg::DetectedObjects` | Main-based detected objects after association and shape expansion |
+
+## Processing Flow
+
+1. Synchronize the two input topics with `ApproximateTime`.
+2. Transform both object lists into `base_link_frame_id`.
+3. Build the association score matrix using the existing distance, angle, and IoU gates.
+4. Solve one-to-one assignment with the same GNN solver used by `object_association_merger`.
+5. For each matched pair, copy the main object and expand only its shape so that the main/sub union is enclosed.
+6. Keep unmatched main objects unchanged.
+7. Discard unmatched sub objects.
+
+## Shape Update Rule
+
+Only the shape is updated for matched pairs.
+All other fields remain main-object values.
+
+- Pose is kept from the main object.
+- Orientation is kept from the main object.
+- Twist is kept from the main object.
+- Classification is kept from the main object.
+- Existence probability is kept from the main object.
+
+The enclosing shape is generated using the main object's shape type.
+
+- `BOUNDING_BOX`: enlarge local x/y extents around the main pose to cover the union footprint.
+- `CYLINDER`: enlarge radius to cover the farthest union point.
+- `POLYGON`: build a convex hull from the union footprint points in the main local frame.
+
+The height dimension is updated so the output encloses the full z-extent of both objects.
+
+### Notes Per Shape Type
+
+- `BOUNDING_BOX` main objects remain axis-aligned in the main-object local frame. The box can grow conservatively when the sub object is laterally offset from the main pose.
+- `CYLINDER` main objects are expanded isotropically in x/y because the enclosing radius is computed from the farthest union point. The resulting diameter is identical for `dimensions.x` and `dimensions.y`.
+- `POLYGON` main objects keep polygon output and rebuild the footprint from the convex hull of the combined main/sub footprint points. Concavities in the original input footprints are not preserved.
+
+## Association Preconditions
+
+Shape expansion happens only when the main/sub pair passes the existing `DataAssociation` gates.
+In practice, this means the pair must satisfy all of the following:
+
+- the class pair is allowed by `can_assign_matrix`
+- the center distance is within `max_dist_matrix`
+- the yaw difference is within `max_rad_matrix` when that gate is enabled
+- the 2D IoU is above `min_iou_matrix`
+
+If a pair does not pass those gates, the main object is treated as unmatched and remains unchanged, and the sub object is discarded.
+
+## Parameter
+
+- `shape_fusion_policy: 0`
+  This implementation supports only `union_enclosing_main_shape`.
+
+## Default Behavior
+
+With the default configuration:
+
+- matched main/sub pairs produce one output object based on the main object
+- unmatched main objects remain in the output
+- unmatched sub objects are not emitted
+
+## Test Coverage
+
+The current focused test suite covers the following cases:
+
+- matched `BOUNDING_BOX` pair expands the main box while keeping main pose and metadata
+- unmatched main objects remain in the output and unmatched sub objects are dropped
+- `BOUNDING_BOX` main object can enclose a larger sub `POLYGON`
+- `CYLINDER` main object expands to cover the union footprint
+- `POLYGON` main object rebuilds its footprint from the union convex hull
+
+## Known Limits
+
+- There is no temporal fusion across messages.
+- The node does not maintain track IDs or track existence over time.
+- The output pose is always the main object pose, so the enclosing shape may become conservative when the sub object center is offset.
+- Because matching depends on the existing association gates, some geometrically plausible pairs may still remain unmatched if their class-specific IoU threshold is not met.
+
+## Intended Usage
+
+This node is intended for cases where the main detector should stay authoritative, while the sub detector is used only to expand the geometric extent of matched objects.

--- a/perception/autoware_object_merger/docs/object_fusion_merger.md
+++ b/perception/autoware_object_merger/docs/object_fusion_merger.md
@@ -2,10 +2,10 @@
 
 ## Purpose
 
-`object_fusion_merger` associates two detected-object streams and keeps the main stream as the base output.
-For each matched pair, it expands the main object's shape so that the union of the main and sub regions is enclosed by the main shape type.
+`object_fusion_merger` groups sub detected objects by footprint overlap with main detected objects and keeps the main stream as the base output.
+For each main object, it expands the main object's shape so that the main region and all uniquely overlapped sub regions are enclosed by the main shape type.
 
-The node is stateless across frames and reuses the existing association logic from `autoware_object_merger::DataAssociation`.
+The node is stateless across frames.
 
 ## Inputs / Outputs
 
@@ -23,72 +23,86 @@ The node is stateless across frames and reuses the existing association logic fr
 | `output/objects` | `autoware_perception_msgs::msg::DetectedObjects` | Main-based detected objects after association and shape expansion |
 | `output/other_objects` | `autoware_perception_msgs::msg::DetectedObjects` | Sub detected objects that did not match any main object |
 
+The packaged launch file remaps these by default to the following topics:
+
+- `output/objects` -> `fusion/objects`
+- `output/other_objects` -> `others/objects`
+
 ## Processing Flow
 
 1. Synchronize the two input topics with `ApproximateTime`.
 2. Transform both object lists into `base_link_frame_id`.
-3. Build the association score matrix using the existing distance, angle, and IoU gates.
-4. Solve one-to-one assignment with the same GNN solver used by `object_association_merger`.
-5. For each matched pair, copy the main object and expand only its shape so that the main/sub union is enclosed.
-6. Keep unmatched main objects unchanged.
-7. Publish unmatched sub objects on `output/other_objects`.
+3. For each sub object, check whether its footprint overlaps each main object footprint.
+4. If the sub object overlaps exactly one main object, add it to that main object's sub group.
+5. If the sub object overlaps multiple main objects, ignore it.
+6. If the sub object overlaps no main objects, publish it on `output/other_objects`.
+7. For each main object, expand its shape to enclose the main object and all grouped sub objects.
+8. Publish all main objects, expanded or unchanged, on `output/objects`.
 
 ## Shape Update Rule
 
-Only the shape is updated for matched pairs.
-All other fields remain main-object values.
+The output object is always based on the main object, but the geometry-related fields can move to fit the covered region.
 
-- Pose is kept from the main object.
 - Orientation is kept from the main object.
 - Twist is kept from the main object.
 - Classification is kept from the main object.
 - Existence probability is kept from the main object.
 
+Pose handling depends on the enclosing shape.
+
+- `BOUNDING_BOX`: x/y center is moved so the box tightly fits the union of the main object and grouped sub objects.
+- `CYLINDER`: x/y center remains the main-object center, while the radius expands to cover the union.
+- `POLYGON`: x/y pose remains the main-object pose and the footprint is rebuilt in the main local frame.
+- For all shape types, the z center and height are updated to fit the full z-range of the main object and grouped sub objects.
+
 The enclosing shape is generated using the main object's shape type.
 
-- `BOUNDING_BOX`: enlarge local x/y extents around the main pose to cover the union footprint.
+- `BOUNDING_BOX`: compute the union bounds in the main local frame, shift the box center to the union center, and set dimensions to the exact x/y span.
 - `CYLINDER`: enlarge radius to cover the farthest union point.
 - `POLYGON`: build a convex hull from the union footprint points in the main local frame.
 
-The height dimension is updated so the output encloses the full z-extent of both objects.
+The height dimension is updated so the output encloses the full z-extent of the main object and all grouped sub objects.
 
 ### Notes Per Shape Type
 
-- `BOUNDING_BOX` main objects remain axis-aligned in the main-object local frame. The box can grow conservatively when the sub object is laterally offset from the main pose.
+- `BOUNDING_BOX` main objects remain axis-aligned in the main-object local frame, but the output center is shifted to tightly fit the union instead of expanding symmetrically around the original main pose.
 - `CYLINDER` main objects are expanded isotropically in x/y because the enclosing radius is computed from the farthest union point. The resulting diameter is identical for `dimensions.x` and `dimensions.y`.
 - `POLYGON` main objects keep polygon output and rebuild the footprint from the convex hull of the combined main/sub footprint points. Concavities in the original input footprints are not preserved.
 
 ## Association Preconditions
 
-Shape expansion happens only when the main/sub pair passes the existing `DataAssociation` gates.
-In practice, this means the pair must satisfy all of the following:
+Grouping happens only by 2D footprint overlap.
 
-- the class pair is allowed by `can_assign_matrix`
-- the center distance is within `max_dist_matrix`
-- the yaw difference is within `max_rad_matrix` when that gate is enabled
-- the 2D IoU is above `min_iou_matrix`
+![Association rule overview](./object_fusion_merger_association_rules.drawio.svg)
 
-If a pair does not pass those gates, the main object remains in `output/objects` unchanged, and the sub object is published via `output/other_objects`.
+- If a sub object overlaps exactly one main object, it contributes to that main object's expanded shape.
+- If a sub object overlaps multiple main objects, it is ignored and is not published.
+- If a sub object overlaps no main objects, it is published via `output/other_objects`.
 
-## Parameter
+## Parameters
 
-- `shape_fusion_policy: 0`
-  This implementation supports only `union_enclosing_main_shape`.
+Current parameters in `config/object_fusion_merger.param.yaml` are:
+
+- `sync_queue_size`
+- `base_link_frame_id`
 
 ## Default Behavior
 
 With the default configuration:
 
-- matched main/sub pairs produce one output object based on the main object
+- each main object always produces one output object based on the main object
 - unmatched main objects remain in the output
-- unmatched sub objects are emitted on `output/other_objects`
+- sub objects that overlap no main objects are emitted on `output/other_objects`
+- sub objects that overlap multiple main objects are ignored
 
 ## Test Coverage
 
 The current focused test suite covers the following cases:
 
-- matched `BOUNDING_BOX` pair expands the main box while keeping main pose and metadata
-- unmatched main objects remain in the output and unmatched sub objects are published separately
+- uniquely overlapped `BOUNDING_BOX` pair shifts and expands the main box to fit the union
+- unmatched main objects remain in the output and non-overlapping sub objects are published separately
+- sub objects that overlap multiple main objects are ignored
+- multiple sub objects can expand one main object together
 - `BOUNDING_BOX` main object can enclose a larger sub `POLYGON`
 - `CYLINDER` main object expands to cover the union footprint
 - `POLYGON` main object rebuilds its footprint from the union convex hull
@@ -97,8 +111,8 @@ The current focused test suite covers the following cases:
 
 - There is no temporal fusion across messages.
 - The node does not maintain track IDs or track existence over time.
-- The output pose is always the main object pose, so the enclosing shape may become conservative when the sub object center is offset.
-- Because matching depends on the existing association gates, some geometrically plausible pairs may still remain unmatched if their class-specific IoU threshold is not met.
+- `CYLINDER` and `POLYGON` keep the main object's x/y pose, so their enclosing geometry can still be conservative compared with a fully re-centered fit.
+- Sub objects that bridge multiple main objects are intentionally ignored rather than split.
 
 ## Intended Usage
 

--- a/perception/autoware_object_merger/docs/object_fusion_merger_association_rules.drawio.svg
+++ b/perception/autoware_object_merger/docs/object_fusion_merger_association_rules.drawio.svg
@@ -1,0 +1,888 @@
+<svg host="65bd71144e" xmlns="http://www.w3.org/2000/svg" style="background: transparent; background-color: transparent;" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="1600px" height="1020px" viewBox="-0.5 -0.5 1600 1020" content="&lt;mxfile&gt;&lt;diagram id=&quot;assoc-rules&quot; name=&quot;Page-1&quot;&gt;7V1bc6M4Fv41rpp92CkQVz920p2erppUujY9NY9bAmSsGQweLrnsr19dAIN04mSmBaRDXhIjybb4js7t0xHeOJeHh88lPu6vi4RkG2QlDxvn4wYh27ND9o+3PLYtlu/JlrSkSdt2aril/yPdwLa1oQmpRgProshqehw3xkWek7geteGyLO7Hw3ZFNv7WI06J1nAb40xv/Z0m9b5t9S3r1PELoem++2oLtT0H3I1uG6o9Tor7QZPzaeNclkVRy1eHh0uScfg6YOT7rp7o7WdWkrx+yRuiVL7jDmdNe3ftxOrH7nbZHI/8ZSmwvNjXh4xd2exlVZfFn+SyyIqSteRFzoZd7GiWdU0b5OzcnU1C1q5PrZ3tHSlr8jBoaqf6mRQHUpePbMg9BPMehBi3wk37d59un71oEYDRqGnNbloF5Cb6g935VVPRIr8mZUpK1v+hqoqY4pq1sav/NBlbkCpw7K7+LmBtE85omrPLjOz4J3CEKFt/H9rmA02STLy1yOtWPxy3u24nYLfXA1nYO4QR+U5ZtL1+i3erxI4vLweSCnxAUK4BMVVNBEvqGlMujUIIrBLaTvjfpt4XJa2ZtO7Iz6zhE473XFRN1I/mH8/fEWe4quiOkoR35Rm/44j/QR+FqSjqY0lzPrxgWGX4yD8/Zd9b8TYs5nkYTePnZdeFHerrwN16rocnWQdhqK0D2w6BhYD8718IGUlJnnzFOfcwz5mxsmjyhCQt4riMO4DYzV3c72lNbo845i33zG+N5aPatN0u2YWa3FiPQxwsNFH2dO4BTYK17SIdbBcC20ahKbS/gZr3q+hbdqWjmS3gVpGG7+rSQIAwHAMmUMpC2rsZF34UJG5iQQvf9jziO9rC5yIp2KfTmqPkepMgjyzd+fjh1MB/42v7rAcaO4xFnUCgq4LjuJYbmBGIHfiKRLa6LoBewDUlklvuzOf0AUG823qQKmwvvEvLekYVPEOq4FpL6wIDHlSF23F0tRJNcMPFNYFlKiSZVRfigFhRAsZDnh859jO6gL43PWx7A7S0LgjoQW349HDEAu5TetDUx4YN9DO+diOWVPopf1UMO6/6XOYtK01oqUpja4JDUCjVBcDfL7mbes/z+jmVJkwCEoFKY3thuJtJaWxr8WhKYA9qzW/5AdfxXqhNm62/TGv4J/53Fbpj67EXoDwgFWNAeWJcEXu1CTgKAdbLhlI+xwDbIbCG0+9L1rXhgnc+nDRF8lOc1CIPOK4FlcWXceeBVpyrO5ZOU7nuRLm6lBtk3m6ENNj9MpEUgqocUpKVkBS/iT8KETEwo8aH4MNJhlbKtOooJ4isrMjT7jURHKdqJl+0NDhF+m0/+BIighc+vC42fF/lTnDgbD6U/29yWuRL05wTm1l1Abm65nugkTWl+B/pHU1eEqJ02zUZFVhqFjLxYhKjqSykmo86W4AV02Gyt6Zw+pKzEOBXHAEeSXQtvEzD5+0etzrMX5iJDpSUiCmEJo6pslEhjrVSlBrwgMEAeYCtqajstonsWZE/w4hFXjwbI4bscTzsesCWlAUkNJ6BPZIOeTQr8lfB5dVrQN5VkO/W8hB5BwHIm7I2wsLD/Mtoy/cU/7RbvNfszi6BcImHOxHLJk9B2LW9sAfxdI/h+b7jR9MYrj6qGaaTYI5jSn0+8BIdTYD/7mQyAfwxg4uFVn+z0ALKOo1EUN5YiwLdcziA+TJRWSHwvxEsChxC3bQMy5piqH5H/UwMtZ0yhlotoe8GSAmiAFvkQfUOtqkoSi74tUaxnpLNuT7g0aEo1jflDCT+oEv/2kQZrfY9dUFOWyzcSau+vN7juiMvRG2Y+DLBn3T88tJU8cSuXVUn0LWDFSuGpInWwxSHztJUMTpLFaMnqOJDw+uos478W1gj5qaJQ7WqFeKJp6rpkkKDLN2XXW/kpMCikiYpEYTsPU9RKsJuG9cDyrankC83HXEsTB0VDLEodcWHiKZN0fAKVdVYfpPGUn6bGM2EVJTCUGJe6Ccb80KMOmZUVMSWHH9plduRj/d7UpI3zg1rqwYih6EI0RQ5jH4Qcti2g2XZYfTODo8W7nZZdliUS85LUr6SwDoM3THyEElpA1l+aMrRcOjRGqG3LcUIwQQxsOyNYf+l86Uzon+GI366XjXBwpPLD+QXX3Fdk5LbLx67WuFIQrahtH+rCgjaO4F4ZNsyZZieJpJvBmFYxRLOahB+dalnGyJdo6dJZdqfOKLDxfDqUs+LaTyNB+hcH0RPknqunFW2bdXXA7Sy5+sCMEUro3daWd1o8ZblldGJ21xlDGar5XxwEAaxm+YlsM5QzHlRGDy9BLinh3RAum5uBEai8P9q+AH9i1jixom0Mo1+4hQfp1u2W/mfRZr/EkB14ztncyM3nVWqhj+woKZ5Q3pCht2C/PLOScnmhN6pTcbnKAsABwRQUhbHI0memxtrHk3vVUY1xvbKFRPuQWdAwQO5hsIaZz2MumKsfU+HGibUTSUFzllC3XmCUM+LzXvBNfJ93bA7UxZcO2DyNjRq/cnEpCAnLhvvdrIV552J5uXQX/p0bcBva4ldmwa25dSbpw6kvHE6XBF9YCFN9O6U51GcH4QNV0ulA4jmgFyHKRV5J8PPFb4Fni6OKclwZ61FJhrwWyAJgE4ghqaCqFf07IBZ63W3wQj4sAufnsu+QlOW+mma1TpFUcf+1PQbr89RFWELnMS1wXI3U4qwcpLU7YDsFALpOcaUpbfOO0d6vvQW8slTUqTOuss/XX98oCO0AAcBemZD9RrOah/L4LvjUwBhV9E8V4GAc6bytn3KVVXjx0pPdfskV82P5ROBUplui5PErzM/nrkMF3Lzk+6FuushDdUy3PlZQ/csa+hK1rDdCdjjnjEc1aVvBpsES2rG0uW4EIsIUkmmWEQXNH8DifUkIs7upTE8lkXSxETaRTKwce1YwSbuOjGPqUjVYArCscnpX43kFPmjadOcrwq+dUMhTpINj/c4T8VGzaJWdOaiW4hm9KZ6ZpRYGz8IzagV3c7NM7rvPOO5Uqi5eUZ3rdnMtkPwHM8YTMgzuk/TXZ8Vdx8z9OVTM5l9kTWFYmCXgL3V2FhVDjA2hqy6KQrMXTkFptUJQhwYZJ5McWDuOwf2TJHJ3CSYu24SzEZKkVoIHAoE/UaX5xsSwHOHoEua0hxnG/j482t8rOzc5VnghkowEdPCH3gNZAdfxaPzdqV4ih9P4wi7oUctFbR2OMvE8YBcMGXqc/qYJGM2J0kfDFLEnjcQGeLpzObowKfs1Y9riqSVM3HiR1LaeamZrjw72qW75EDruv2xlHjxg56hvqAm/K2TbQAYApCP+AemmF2efgZK9A1+Tsv59H8=&lt;/diagram&gt;&lt;/mxfile&gt;">
+    <defs/>
+    <g>
+        <g>
+            <rect x="0" y="0" width="1600" height="1020" fill="#f4f1e8" stroke="none" pointer-events="all" style="fill: light-dark(rgb(244, 241, 232), rgb(33, 30, 22));"/>
+        </g>
+        <g>
+            <rect x="60" y="36" width="760" height="40" fill="none" stroke="none" pointer-events="all"/>
+        </g>
+        <g>
+            <g transform="translate(-0.5 -0.5)">
+                <switch>
+                    <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 1px; height: 1px; padding-top: 56px; margin-left: 62px;">
+                            <div style="box-sizing: border-box; font-size: 0; text-align: left; color: #1f2a2e; ">
+                                <div style="display: inline-block; font-size: 34px; font-family: &quot;Helvetica&quot;; color: light-dark(#1f2a2e, #c3cccf); line-height: 1.2; pointer-events: all; font-weight: bold; white-space: nowrap; ">
+                                    ObjectFusionMerger Association Rules
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text x="62" y="66" fill="#1f2a2e" font-family="&quot;Helvetica&quot;" font-size="34px" font-weight="bold">
+                        ObjectFusionMerger Association Rules
+                    </text>
+                </switch>
+            </g>
+        </g>
+        <g>
+            <rect x="60" y="88" width="1180" height="26" fill="none" stroke="none" pointer-events="all"/>
+        </g>
+        <g>
+            <g transform="translate(-0.5 -0.5)">
+                <switch>
+                    <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 1px; height: 1px; padding-top: 101px; margin-left: 62px;">
+                            <div style="box-sizing: border-box; font-size: 0; text-align: left; color: #49545a; ">
+                                <div style="display: inline-block; font-size: 18px; font-family: &quot;Helvetica&quot;; color: light-dark(#49545a, #9fa8ad); line-height: 1.2; pointer-events: all; white-space: nowrap; ">
+                                    Main objects are authoritative. Each sub object is classified only by 2D footprint overlap against all main objects.
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text x="62" y="106" fill="#49545a" font-family="&quot;Helvetica&quot;" font-size="18px">
+                        Main objects are authoritative. Each sub object is classified only by 2D footprint overlap against all main objects.
+                    </text>
+                </switch>
+            </g>
+        </g>
+        <g>
+            <rect x="60" y="142" width="1480" height="128" rx="15.36" ry="15.36" fill="#fffdf8" stroke="#3e3a34" stroke-width="2" pointer-events="all" style="fill: light-dark(rgb(255, 253, 248), rgb(22, 20, 16)); stroke: light-dark(rgb(62, 58, 52), rgb(189, 186, 181));"/>
+        </g>
+        <g>
+            <rect x="90" y="164" width="120" height="30" fill="none" stroke="none" pointer-events="all"/>
+        </g>
+        <g>
+            <g transform="translate(-0.5 -0.5)">
+                <switch>
+                    <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 1px; height: 1px; padding-top: 179px; margin-left: 92px;">
+                            <div style="box-sizing: border-box; font-size: 0; text-align: left; color: #1f2a2e; ">
+                                <div style="display: inline-block; font-size: 24px; font-family: &quot;Helvetica&quot;; color: light-dark(#1f2a2e, #c3cccf); line-height: 1.2; pointer-events: all; font-weight: bold; white-space: nowrap; ">
+                                    Legend
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text x="92" y="186" fill="#1f2a2e" font-family="&quot;Helvetica&quot;" font-size="24px" font-weight="bold">
+                        Legend
+                    </text>
+                </switch>
+            </g>
+        </g>
+        <g>
+            <rect x="90" y="206" width="68" height="30" rx="3.6" ry="3.6" fill-opacity="0.45" fill="#b7d4d0" stroke="#155e63" stroke-opacity="0.45" stroke-width="4" pointer-events="all" style="fill: light-dark(rgb(183, 212, 208), rgb(41, 66, 63)); stroke: light-dark(rgb(21, 94, 99), rgb(119, 182, 186));"/>
+        </g>
+        <g>
+            <rect x="176" y="209" width="180" height="24" fill="none" stroke="none" pointer-events="all"/>
+        </g>
+        <g>
+            <g transform="translate(-0.5 -0.5)">
+                <switch>
+                    <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 1px; height: 1px; padding-top: 221px; margin-left: 178px;">
+                            <div style="box-sizing: border-box; font-size: 0; text-align: left; color: #334047; ">
+                                <div style="display: inline-block; font-size: 17px; font-family: &quot;Helvetica&quot;; color: light-dark(#334047, #afbac0); line-height: 1.2; pointer-events: all; white-space: nowrap; ">
+                                    Main object footprint
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text x="178" y="226" fill="#334047" font-family="&quot;Helvetica&quot;" font-size="17px">
+                        Main object footprint
+                    </text>
+                </switch>
+            </g>
+        </g>
+        <g>
+            <rect x="400" y="206" width="68" height="30" rx="3.6" ry="3.6" fill-opacity="0.55" fill="#f7cf95" stroke="#9b5c00" stroke-opacity="0.55" stroke-width="4" pointer-events="all" style="fill: light-dark(rgb(247, 207, 149), rgb(86, 52, 2)); stroke: light-dark(rgb(155, 92, 0), rgb(200, 146, 67));"/>
+        </g>
+        <g>
+            <rect x="486" y="209" width="180" height="24" fill="none" stroke="none" pointer-events="all"/>
+        </g>
+        <g>
+            <g transform="translate(-0.5 -0.5)">
+                <switch>
+                    <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 1px; height: 1px; padding-top: 221px; margin-left: 488px;">
+                            <div style="box-sizing: border-box; font-size: 0; text-align: left; color: #334047; ">
+                                <div style="display: inline-block; font-size: 17px; font-family: &quot;Helvetica&quot;; color: light-dark(#334047, #afbac0); line-height: 1.2; pointer-events: all; white-space: nowrap; ">
+                                    Sub object footprint
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text x="488" y="226" fill="#334047" font-family="&quot;Helvetica&quot;" font-size="17px">
+                        Sub object footprint
+                    </text>
+                </switch>
+            </g>
+        </g>
+        <g>
+            <rect x="720" y="206" width="68" height="30" rx="3.6" ry="3.6" fill-opacity="0.28" fill="#c7e0bd" stroke="#356b31" stroke-opacity="0.28" stroke-width="4" pointer-events="all" style="fill: light-dark(rgb(199, 224, 189), rgb(37, 58, 28)); stroke: light-dark(rgb(53, 107, 49), rgb(125, 172, 122));"/>
+        </g>
+        <g>
+            <rect x="806" y="201" width="220" height="42" fill="none" stroke="none" pointer-events="all"/>
+        </g>
+        <g>
+            <g transform="translate(-0.5 -0.5)">
+                <switch>
+                    <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 1px; height: 1px; padding-top: 222px; margin-left: 808px;">
+                            <div style="box-sizing: border-box; font-size: 0; text-align: left; color: #334047; ">
+                                <div style="display: inline-block; font-size: 17px; font-family: &quot;Helvetica&quot;; color: light-dark(#334047, #afbac0); line-height: 1.2; pointer-events: all; white-space: nowrap; ">
+                                    Expanded main output
+                                    <br/>
+                                    on output/objects
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text x="808" y="227" fill="#334047" font-family="&quot;Helvetica&quot;" font-size="17px">
+                        Expanded main output...
+                    </text>
+                </switch>
+            </g>
+        </g>
+        <g>
+            <rect x="1090" y="206" width="68" height="30" rx="3.6" ry="3.6" fill-opacity="0.28" fill="#c8d7eb" stroke="#31588f" stroke-opacity="0.28" stroke-width="4" pointer-events="all" style="fill: light-dark(rgb(200, 215, 235), rgb(42, 55, 72)); stroke: light-dark(rgb(49, 88, 143), rgb(135, 169, 216));"/>
+        </g>
+        <g>
+            <rect x="1176" y="201" width="260" height="42" fill="none" stroke="none" pointer-events="all"/>
+        </g>
+        <g>
+            <g transform="translate(-0.5 -0.5)">
+                <switch>
+                    <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 1px; height: 1px; padding-top: 222px; margin-left: 1178px;">
+                            <div style="box-sizing: border-box; font-size: 0; text-align: left; color: #334047; ">
+                                <div style="display: inline-block; font-size: 17px; font-family: &quot;Helvetica&quot;; color: light-dark(#334047, #afbac0); line-height: 1.2; pointer-events: all; white-space: nowrap; ">
+                                    Unmatched sub output
+                                    <br/>
+                                    on output/other_objects
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text x="1178" y="227" fill="#334047" font-family="&quot;Helvetica&quot;" font-size="17px">
+                        Unmatched sub output...
+                    </text>
+                </switch>
+            </g>
+        </g>
+        <g>
+            <rect x="60" y="286" width="710" height="336" rx="40.32" ry="40.32" fill="#fffdf8" stroke="#3e3a34" stroke-width="2" pointer-events="all" style="fill: light-dark(rgb(255, 253, 248), rgb(22, 20, 16)); stroke: light-dark(rgb(62, 58, 52), rgb(189, 186, 181));"/>
+        </g>
+        <g>
+            <rect x="90" y="308" width="440" height="30" fill="none" stroke="none" pointer-events="all"/>
+        </g>
+        <g>
+            <g transform="translate(-0.5 -0.5)">
+                <switch>
+                    <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 1px; height: 1px; padding-top: 323px; margin-left: 92px;">
+                            <div style="box-sizing: border-box; font-size: 0; text-align: left; color: #1f2a2e; ">
+                                <div style="display: inline-block; font-size: 24px; font-family: &quot;Helvetica&quot;; color: light-dark(#1f2a2e, #c3cccf); line-height: 1.2; pointer-events: all; font-weight: bold; white-space: nowrap; ">
+                                    Case 1: sub overlaps exactly one main
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text x="92" y="330" fill="#1f2a2e" font-family="&quot;Helvetica&quot;" font-size="24px" font-weight="bold">
+                        Case 1: sub overlaps exactly one main
+                    </text>
+                </switch>
+            </g>
+        </g>
+        <g>
+            <rect x="90" y="346" width="560" height="46" fill="none" stroke="none" pointer-events="all"/>
+        </g>
+        <g>
+            <g transform="translate(-0.5 -0.5)">
+                <switch>
+                    <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 1px; height: 1px; padding-top: 369px; margin-left: 92px;">
+                            <div style="box-sizing: border-box; font-size: 0; text-align: left; color: #334047; ">
+                                <div style="display: inline-block; font-size: 17px; font-family: &quot;Helvetica&quot;; color: light-dark(#334047, #afbac0); line-height: 1.2; pointer-events: all; white-space: nowrap; ">
+                                    One or more sub objects may join the same main group as long as each
+                                    <br/>
+                                    sub overlaps exactly one main. The main expands to cover their union.
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text x="92" y="374" fill="#334047" font-family="&quot;Helvetica&quot;" font-size="17px">
+                        One or more sub objects may join the same main group as long as ea...
+                    </text>
+                </switch>
+            </g>
+        </g>
+        <g>
+            <path d="M 400 492 L 401 492" fill="none" stroke="#d5cec2" stroke-width="2" stroke-miterlimit="10" pointer-events="all" style="stroke: light-dark(rgb(213, 206, 194), rgb(65, 59, 49));"/>
+        </g>
+        <g>
+            <rect x="120" y="404" width="80" height="24" fill="none" stroke="none" pointer-events="all"/>
+        </g>
+        <g>
+            <g transform="translate(-0.5 -0.5)">
+                <switch>
+                    <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 1px; height: 1px; padding-top: 416px; margin-left: 122px;">
+                            <div style="box-sizing: border-box; font-size: 0; text-align: left; color: #223036; ">
+                                <div style="display: inline-block; font-size: 18px; font-family: &quot;Helvetica&quot;; color: light-dark(#223036, #bcc8cd); line-height: 1.2; pointer-events: all; font-weight: bold; white-space: nowrap; ">
+                                    Input
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text x="122" y="421" fill="#223036" font-family="&quot;Helvetica&quot;" font-size="18px" font-weight="bold">
+                        Input
+                    </text>
+                </switch>
+            </g>
+        </g>
+        <g>
+            <rect x="120" y="446" width="180" height="92" rx="11.04" ry="11.04" fill-opacity="0.45" fill="#b7d4d0" stroke="#155e63" stroke-opacity="0.45" stroke-width="4" pointer-events="all" style="fill: light-dark(rgb(183, 212, 208), rgb(41, 66, 63)); stroke: light-dark(rgb(21, 94, 99), rgb(119, 182, 186));"/>
+        </g>
+        <g>
+            <rect x="216" y="458" width="108" height="58" rx="6.96" ry="6.96" fill-opacity="0.55" fill="#f7cf95" stroke="#9b5c00" stroke-opacity="0.55" stroke-width="4" pointer-events="all" style="fill: light-dark(rgb(247, 207, 149), rgb(86, 52, 2)); stroke: light-dark(rgb(155, 92, 0), rgb(200, 146, 67));"/>
+        </g>
+        <g>
+            <rect x="246" y="492" width="132" height="54" rx="6.48" ry="6.48" fill-opacity="0.55" fill="#f7cf95" stroke="#9b5c00" stroke-opacity="0.55" stroke-width="4" pointer-events="all" style="fill: light-dark(rgb(247, 207, 149), rgb(86, 52, 2)); stroke: light-dark(rgb(155, 92, 0), rgb(200, 146, 67));"/>
+        </g>
+        <g>
+            <rect x="120" y="560" width="210" height="38" fill="none" stroke="none" pointer-events="all"/>
+        </g>
+        <g>
+            <g transform="translate(-0.5 -0.5)">
+                <switch>
+                    <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 1px; height: 1px; padding-top: 579px; margin-left: 122px;">
+                            <div style="box-sizing: border-box; font-size: 0; text-align: left; color: #56636b; ">
+                                <div style="display: inline-block; font-size: 15px; font-family: &quot;Helvetica&quot;; color: light-dark(#56636b, #919ca3); line-height: 1.2; pointer-events: all; white-space: nowrap; ">
+                                    Each sub overlaps only M1,
+                                    <br/>
+                                    so both join M1
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text x="122" y="584" fill="#56636b" font-family="&quot;Helvetica&quot;" font-size="15px">
+                        Each sub overlaps only M1,...
+                    </text>
+                </switch>
+            </g>
+        </g>
+        <g>
+            <rect x="405" y="476" width="38" height="40" fill="none" stroke="none" pointer-events="all"/>
+        </g>
+        <g>
+            <g transform="translate(-0.5 -0.5)">
+                <switch>
+                    <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 496px; margin-left: 424px;">
+                            <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #3e3a34; ">
+                                <div style="display: inline-block; font-size: 34px; font-family: &quot;Helvetica&quot;; color: light-dark(#3e3a34, #bdbab5); line-height: 1.2; pointer-events: all; white-space: nowrap; ">
+                                    -&gt;
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text x="424" y="506" fill="#3e3a34" font-family="&quot;Helvetica&quot;" font-size="34px" text-anchor="middle">
+                        -&gt;
+                    </text>
+                </switch>
+            </g>
+        </g>
+        <g>
+            <rect x="480" y="404" width="90" height="24" fill="none" stroke="none" pointer-events="all"/>
+        </g>
+        <g>
+            <g transform="translate(-0.5 -0.5)">
+                <switch>
+                    <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 1px; height: 1px; padding-top: 416px; margin-left: 482px;">
+                            <div style="box-sizing: border-box; font-size: 0; text-align: left; color: #223036; ">
+                                <div style="display: inline-block; font-size: 18px; font-family: &quot;Helvetica&quot;; color: light-dark(#223036, #bcc8cd); line-height: 1.2; pointer-events: all; font-weight: bold; white-space: nowrap; ">
+                                    Output
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text x="482" y="421" fill="#223036" font-family="&quot;Helvetica&quot;" font-size="18px" font-weight="bold">
+                        Output
+                    </text>
+                </switch>
+            </g>
+        </g>
+        <g>
+            <rect x="472" y="440" width="250" height="112" rx="13.44" ry="13.44" fill-opacity="0.28" fill="#c7e0bd" stroke="#356b31" stroke-opacity="0.28" stroke-width="4" pointer-events="all" style="fill: light-dark(rgb(199, 224, 189), rgb(37, 58, 28)); stroke: light-dark(rgb(53, 107, 49), rgb(125, 172, 122));"/>
+        </g>
+        <g>
+            <rect x="500" y="462" width="180" height="68" rx="8.16" ry="8.16" fill-opacity="0.45" fill="#b7d4d0" stroke="#155e63" stroke-opacity="0.45" stroke-width="4" pointer-events="all" style="fill: light-dark(rgb(183, 212, 208), rgb(41, 66, 63)); stroke: light-dark(rgb(21, 94, 99), rgb(119, 182, 186));"/>
+        </g>
+        <g>
+            <rect x="472" y="560" width="220" height="38" fill="none" stroke="none" pointer-events="all"/>
+        </g>
+        <g>
+            <g transform="translate(-0.5 -0.5)">
+                <switch>
+                    <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 1px; height: 1px; padding-top: 579px; margin-left: 474px;">
+                            <div style="box-sizing: border-box; font-size: 0; text-align: left; color: #56636b; ">
+                                <div style="display: inline-block; font-size: 15px; font-family: &quot;Helvetica&quot;; color: light-dark(#56636b, #919ca3); line-height: 1.2; pointer-events: all; white-space: nowrap; ">
+                                    Publish one expanded M1
+                                    <br/>
+                                    that covers all grouped subs
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text x="474" y="584" fill="#56636b" font-family="&quot;Helvetica&quot;" font-size="15px">
+                        Publish one expanded M1...
+                    </text>
+                </switch>
+            </g>
+        </g>
+        <g>
+            <rect x="830" y="286" width="710" height="336" rx="40.32" ry="40.32" fill="#fffdf8" stroke="#3e3a34" stroke-width="2" pointer-events="all" style="fill: light-dark(rgb(255, 253, 248), rgb(22, 20, 16)); stroke: light-dark(rgb(62, 58, 52), rgb(189, 186, 181));"/>
+        </g>
+        <g>
+            <rect x="860" y="308" width="420" height="30" fill="none" stroke="none" pointer-events="all"/>
+        </g>
+        <g>
+            <g transform="translate(-0.5 -0.5)">
+                <switch>
+                    <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 1px; height: 1px; padding-top: 323px; margin-left: 862px;">
+                            <div style="box-sizing: border-box; font-size: 0; text-align: left; color: #1f2a2e; ">
+                                <div style="display: inline-block; font-size: 24px; font-family: &quot;Helvetica&quot;; color: light-dark(#1f2a2e, #c3cccf); line-height: 1.2; pointer-events: all; font-weight: bold; white-space: nowrap; ">
+                                    Case 2: sub overlaps multiple mains
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text x="862" y="330" fill="#1f2a2e" font-family="&quot;Helvetica&quot;" font-size="24px" font-weight="bold">
+                        Case 2: sub overlaps multiple mains
+                    </text>
+                </switch>
+            </g>
+        </g>
+        <g>
+            <rect x="860" y="346" width="590" height="46" fill="none" stroke="none" pointer-events="all"/>
+        </g>
+        <g>
+            <g transform="translate(-0.5 -0.5)">
+                <switch>
+                    <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 1px; height: 1px; padding-top: 369px; margin-left: 862px;">
+                            <div style="box-sizing: border-box; font-size: 0; text-align: left; color: #334047; ">
+                                <div style="display: inline-block; font-size: 17px; font-family: &quot;Helvetica&quot;; color: light-dark(#334047, #afbac0); line-height: 1.2; pointer-events: all; white-space: nowrap; ">
+                                    If one sub bridges two separate main objects, the grouping is ambiguous.
+                                    <br/>
+                                    That sub is ignored and is not split or published anywhere.
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text x="862" y="374" fill="#334047" font-family="&quot;Helvetica&quot;" font-size="17px">
+                        If one sub bridges two separate main objects, the grouping is ambiguo...
+                    </text>
+                </switch>
+            </g>
+        </g>
+        <g>
+            <path d="M 1170 492 L 1171 492" fill="none" stroke="#d5cec2" stroke-width="2" stroke-miterlimit="10" pointer-events="all" style="stroke: light-dark(rgb(213, 206, 194), rgb(65, 59, 49));"/>
+        </g>
+        <g>
+            <rect x="890" y="404" width="80" height="24" fill="none" stroke="none" pointer-events="all"/>
+        </g>
+        <g>
+            <g transform="translate(-0.5 -0.5)">
+                <switch>
+                    <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 1px; height: 1px; padding-top: 416px; margin-left: 892px;">
+                            <div style="box-sizing: border-box; font-size: 0; text-align: left; color: #223036; ">
+                                <div style="display: inline-block; font-size: 18px; font-family: &quot;Helvetica&quot;; color: light-dark(#223036, #bcc8cd); line-height: 1.2; pointer-events: all; font-weight: bold; white-space: nowrap; ">
+                                    Input
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text x="892" y="421" fill="#223036" font-family="&quot;Helvetica&quot;" font-size="18px" font-weight="bold">
+                        Input
+                    </text>
+                </switch>
+            </g>
+        </g>
+        <g>
+            <rect x="884" y="458" width="118" height="80" rx="9.6" ry="9.6" fill-opacity="0.45" fill="#b7d4d0" stroke="#155e63" stroke-opacity="0.45" stroke-width="4" pointer-events="all" style="fill: light-dark(rgb(183, 212, 208), rgb(41, 66, 63)); stroke: light-dark(rgb(21, 94, 99), rgb(119, 182, 186));"/>
+        </g>
+        <g>
+            <rect x="1070" y="458" width="100" height="80" rx="9.6" ry="9.6" fill-opacity="0.45" fill="#b7d4d0" stroke="#155e63" stroke-opacity="0.45" stroke-width="4" pointer-events="all" style="fill: light-dark(rgb(183, 212, 208), rgb(41, 66, 63)); stroke: light-dark(rgb(21, 94, 99), rgb(119, 182, 186));"/>
+        </g>
+        <g>
+            <rect x="970" y="446" width="132" height="104" rx="12.48" ry="12.48" fill-opacity="0.18" fill="#f7cf95" stroke="#9b5c00" stroke-opacity="0.18" stroke-width="4" stroke-dasharray="40 32" pointer-events="all" style="fill: light-dark(rgb(247, 207, 149), rgb(86, 52, 2)); stroke: light-dark(rgb(155, 92, 0), rgb(200, 146, 67));"/>
+        </g>
+        <g>
+            <rect x="890" y="558" width="230" height="38" fill="none" stroke="none" pointer-events="all"/>
+        </g>
+        <g>
+            <g transform="translate(-0.5 -0.5)">
+                <switch>
+                    <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 1px; height: 1px; padding-top: 577px; margin-left: 892px;">
+                            <div style="box-sizing: border-box; font-size: 0; text-align: left; color: #56636B; ">
+                                <div style="display: inline-block; font-size: 15px; font-family: &quot;Helvetica&quot;; color: light-dark(#56636B, #919ca3); line-height: 1.2; pointer-events: all; white-space: nowrap; ">
+                                    One sub spans separated M1 and M2,
+                                    <br/>
+                                    so it is ignored
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text x="892" y="582" fill="#56636B" font-family="&quot;Helvetica&quot;" font-size="15px">
+                        One sub spans separated M1 and...
+                    </text>
+                </switch>
+            </g>
+        </g>
+        <g>
+            <rect x="1190" y="476" width="56" height="40" fill="none" stroke="none" pointer-events="all"/>
+        </g>
+        <g>
+            <g transform="translate(-0.5 -0.5)">
+                <switch>
+                    <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 496px; margin-left: 1218px;">
+                            <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #3e3a34; ">
+                                <div style="display: inline-block; font-size: 34px; font-family: &quot;Helvetica&quot;; color: light-dark(#3e3a34, #bdbab5); line-height: 1.2; pointer-events: all; white-space: nowrap; ">
+                                    -&gt;
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text x="1218" y="506" fill="#3e3a34" font-family="&quot;Helvetica&quot;" font-size="34px" text-anchor="middle">
+                        -&gt;
+                    </text>
+                </switch>
+            </g>
+        </g>
+        <g>
+            <rect x="1250" y="404" width="90" height="24" fill="none" stroke="none" pointer-events="all"/>
+        </g>
+        <g>
+            <g transform="translate(-0.5 -0.5)">
+                <switch>
+                    <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 1px; height: 1px; padding-top: 416px; margin-left: 1252px;">
+                            <div style="box-sizing: border-box; font-size: 0; text-align: left; color: #223036; ">
+                                <div style="display: inline-block; font-size: 18px; font-family: &quot;Helvetica&quot;; color: light-dark(#223036, #bcc8cd); line-height: 1.2; pointer-events: all; font-weight: bold; white-space: nowrap; ">
+                                    Output
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text x="1252" y="421" fill="#223036" font-family="&quot;Helvetica&quot;" font-size="18px" font-weight="bold">
+                        Output
+                    </text>
+                </switch>
+            </g>
+        </g>
+        <g>
+            <rect x="1260" y="458" width="110" height="64" rx="7.68" ry="7.68" fill-opacity="0.45" fill="#b7d4d0" stroke="#155e63" stroke-opacity="0.45" stroke-width="4" pointer-events="all" style="fill: light-dark(rgb(183, 212, 208), rgb(41, 66, 63)); stroke: light-dark(rgb(21, 94, 99), rgb(119, 182, 186));"/>
+        </g>
+        <g>
+            <rect x="1384" y="458" width="110" height="64" rx="7.68" ry="7.68" fill-opacity="0.45" fill="#b7d4d0" stroke="#155e63" stroke-opacity="0.45" stroke-width="4" pointer-events="all" style="fill: light-dark(rgb(183, 212, 208), rgb(41, 66, 63)); stroke: light-dark(rgb(21, 94, 99), rgb(119, 182, 186));"/>
+        </g>
+        <g>
+            <rect x="1250" y="564" width="180" height="18" fill="none" stroke="none" pointer-events="all"/>
+        </g>
+        <g>
+            <g transform="translate(-0.5 -0.5)">
+                <switch>
+                    <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 1px; height: 1px; padding-top: 573px; margin-left: 1252px;">
+                            <div style="box-sizing: border-box; font-size: 0; text-align: left; color: #56636b; ">
+                                <div style="display: inline-block; font-size: 15px; font-family: &quot;Helvetica&quot;; color: light-dark(#56636b, #919ca3); line-height: 1.2; pointer-events: all; white-space: nowrap; ">
+                                    <font style="color: light-dark(rgb(86, 99, 107), rgb(145, 156, 163));">
+                                        Only main objects continue.
+                                    </font>
+                                    <div>
+                                        <font style="color: light-dark(rgb(86, 99, 107), rgb(145, 156, 163));">
+                                            The sub is dropped.
+                                        </font>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text x="1252" y="578" fill="#56636b" font-family="&quot;Helvetica&quot;" font-size="15px">
+                        Only main objects contin...
+                    </text>
+                </switch>
+            </g>
+        </g>
+        <g>
+            <rect x="60" y="654" width="710" height="304" rx="36.48" ry="36.48" fill="#fffdf8" stroke="#3e3a34" stroke-width="2" pointer-events="all" style="fill: light-dark(rgb(255, 253, 248), rgb(22, 20, 16)); stroke: light-dark(rgb(62, 58, 52), rgb(189, 186, 181));"/>
+        </g>
+        <g>
+            <rect x="90" y="668" width="340" height="30" fill="none" stroke="none" pointer-events="all"/>
+        </g>
+        <g>
+            <g transform="translate(-0.5 -0.5)">
+                <switch>
+                    <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 1px; height: 1px; padding-top: 683px; margin-left: 92px;">
+                            <div style="box-sizing: border-box; font-size: 0; text-align: left; color: #1f2a2e; ">
+                                <div style="display: inline-block; font-size: 24px; font-family: &quot;Helvetica&quot;; color: light-dark(#1f2a2e, #c3cccf); line-height: 1.2; pointer-events: all; font-weight: bold; white-space: nowrap; ">
+                                    Case 3: sub overlaps no main
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text x="92" y="690" fill="#1f2a2e" font-family="&quot;Helvetica&quot;" font-size="24px" font-weight="bold">
+                        Case 3: sub overlaps no main
+                    </text>
+                </switch>
+            </g>
+        </g>
+        <g>
+            <rect x="90" y="702" width="460" height="42" fill="none" stroke="none" pointer-events="all"/>
+        </g>
+        <g>
+            <g transform="translate(-0.5 -0.5)">
+                <switch>
+                    <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 1px; height: 1px; padding-top: 723px; margin-left: 92px;">
+                            <div style="box-sizing: border-box; font-size: 0; text-align: left; color: #334047; ">
+                                <div style="display: inline-block; font-size: 17px; font-family: &quot;Helvetica&quot;; color: light-dark(#334047, #afbac0); line-height: 1.2; pointer-events: all; white-space: nowrap; ">
+                                    The sub object does not affect any main. It is published
+                                    <br/>
+                                    separately on output/other_objects.
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text x="92" y="728" fill="#334047" font-family="&quot;Helvetica&quot;" font-size="17px">
+                        The sub object does not affect any main. It is publish...
+                    </text>
+                </switch>
+            </g>
+        </g>
+        <g>
+            <path d="M 400 836 L 401 836" fill="none" stroke="#d5cec2" stroke-width="2" stroke-miterlimit="10" pointer-events="all" style="stroke: light-dark(rgb(213, 206, 194), rgb(65, 59, 49));"/>
+        </g>
+        <g>
+            <rect x="120" y="756" width="80" height="24" fill="none" stroke="none" pointer-events="all"/>
+        </g>
+        <g>
+            <g transform="translate(-0.5 -0.5)">
+                <switch>
+                    <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 1px; height: 1px; padding-top: 768px; margin-left: 122px;">
+                            <div style="box-sizing: border-box; font-size: 0; text-align: left; color: #223036; ">
+                                <div style="display: inline-block; font-size: 18px; font-family: &quot;Helvetica&quot;; color: light-dark(#223036, #bcc8cd); line-height: 1.2; pointer-events: all; font-weight: bold; white-space: nowrap; ">
+                                    Input
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text x="122" y="773" fill="#223036" font-family="&quot;Helvetica&quot;" font-size="18px" font-weight="bold">
+                        Input
+                    </text>
+                </switch>
+            </g>
+        </g>
+        <g>
+            <rect x="120" y="798" width="168" height="88" rx="10.56" ry="10.56" fill-opacity="0.45" fill="#b7d4d0" stroke="#155e63" stroke-opacity="0.45" stroke-width="4" pointer-events="all" style="fill: light-dark(rgb(183, 212, 208), rgb(41, 66, 63)); stroke: light-dark(rgb(21, 94, 99), rgb(119, 182, 186));"/>
+        </g>
+        <g>
+            <rect x="297" y="810" width="110" height="82" rx="9.84" ry="9.84" fill-opacity="0.55" fill="#f7cf95" stroke="#9b5c00" stroke-opacity="0.55" stroke-width="4" pointer-events="all" style="fill: light-dark(rgb(247, 207, 149), rgb(86, 52, 2)); stroke: light-dark(rgb(155, 92, 0), rgb(200, 146, 67));"/>
+        </g>
+        <g>
+            <rect x="120" y="906" width="150" height="18" fill="none" stroke="none" pointer-events="all"/>
+        </g>
+        <g>
+            <g transform="translate(-0.5 -0.5)">
+                <switch>
+                    <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 1px; height: 1px; padding-top: 915px; margin-left: 122px;">
+                            <div style="box-sizing: border-box; font-size: 0; text-align: left; color: #56636b; ">
+                                <div style="display: inline-block; font-size: 15px; font-family: &quot;Helvetica&quot;; color: light-dark(#56636b, #919ca3); line-height: 1.2; pointer-events: all; white-space: nowrap; ">
+                                    0 overlapped mains
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text x="122" y="920" fill="#56636b" font-family="&quot;Helvetica&quot;" font-size="15px">
+                        0 overlapped mains
+                    </text>
+                </switch>
+            </g>
+        </g>
+        <g>
+            <rect x="418" y="824" width="38" height="40" fill="none" stroke="none" pointer-events="all"/>
+        </g>
+        <g>
+            <g transform="translate(-0.5 -0.5)">
+                <switch>
+                    <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 844px; margin-left: 437px;">
+                            <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #3e3a34; ">
+                                <div style="display: inline-block; font-size: 34px; font-family: &quot;Helvetica&quot;; color: light-dark(#3e3a34, #bdbab5); line-height: 1.2; pointer-events: all; white-space: nowrap; ">
+                                    -&gt;
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text x="437" y="854" fill="#3e3a34" font-family="&quot;Helvetica&quot;" font-size="34px" text-anchor="middle">
+                        -&gt;
+                    </text>
+                </switch>
+            </g>
+        </g>
+        <g>
+            <rect x="480" y="756" width="90" height="24" fill="none" stroke="none" pointer-events="all"/>
+        </g>
+        <g>
+            <g transform="translate(-0.5 -0.5)">
+                <switch>
+                    <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 1px; height: 1px; padding-top: 768px; margin-left: 482px;">
+                            <div style="box-sizing: border-box; font-size: 0; text-align: left; color: #223036; ">
+                                <div style="display: inline-block; font-size: 18px; font-family: &quot;Helvetica&quot;; color: light-dark(#223036, #bcc8cd); line-height: 1.2; pointer-events: all; font-weight: bold; white-space: nowrap; ">
+                                    Output
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text x="482" y="773" fill="#223036" font-family="&quot;Helvetica&quot;" font-size="18px" font-weight="bold">
+                        Output
+                    </text>
+                </switch>
+            </g>
+        </g>
+        <g>
+            <rect x="466" y="800" width="168" height="86" rx="10.32" ry="10.32" fill-opacity="0.45" fill="#b7d4d0" stroke="#155e63" stroke-opacity="0.45" stroke-width="4" pointer-events="all" style="fill: light-dark(rgb(183, 212, 208), rgb(41, 66, 63)); stroke: light-dark(rgb(21, 94, 99), rgb(119, 182, 186));"/>
+        </g>
+        <g>
+            <rect x="645" y="812" width="118" height="80" rx="9.6" ry="9.6" fill-opacity="0.28" fill="#c8d7eb" stroke="#31588f" stroke-opacity="0.28" stroke-width="4" pointer-events="all" style="fill: light-dark(rgb(200, 215, 235), rgb(42, 55, 72)); stroke: light-dark(rgb(49, 88, 143), rgb(135, 169, 216));"/>
+        </g>
+        <g>
+            <rect x="472" y="906" width="230" height="38" fill="none" stroke="none" pointer-events="all"/>
+        </g>
+        <g>
+            <g transform="translate(-0.5 -0.5)">
+                <switch>
+                    <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 1px; height: 1px; padding-top: 925px; margin-left: 474px;">
+                            <div style="box-sizing: border-box; font-size: 0; text-align: left; color: #56636b; ">
+                                <div style="display: inline-block; font-size: 15px; font-family: &quot;Helvetica&quot;; color: light-dark(#56636b, #919ca3); line-height: 1.2; pointer-events: all; white-space: nowrap; ">
+                                    Main stays on output/objects.
+                                    <br/>
+                                    Sub goes to output/other_objects.
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text x="474" y="930" fill="#56636b" font-family="&quot;Helvetica&quot;" font-size="15px">
+                        Main stays on output/objects....
+                    </text>
+                </switch>
+            </g>
+        </g>
+        <g>
+            <rect x="830" y="654" width="710" height="304" rx="36.48" ry="36.48" fill="#fffdf8" stroke="#3e3a34" stroke-width="2" pointer-events="all" style="fill: light-dark(rgb(255, 253, 248), rgb(22, 20, 16)); stroke: light-dark(rgb(62, 58, 52), rgb(189, 186, 181));"/>
+        </g>
+        <g>
+            <rect x="860" y="668" width="460" height="30" fill="none" stroke="none" pointer-events="all"/>
+        </g>
+        <g>
+            <g transform="translate(-0.5 -0.5)">
+                <switch>
+                    <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 1px; height: 1px; padding-top: 683px; margin-left: 862px;">
+                            <div style="box-sizing: border-box; font-size: 0; text-align: left; color: #1f2a2e; ">
+                                <div style="display: inline-block; font-size: 24px; font-family: &quot;Helvetica&quot;; color: light-dark(#1f2a2e, #c3cccf); line-height: 1.2; pointer-events: all; font-weight: bold; white-space: nowrap; ">
+                                    Case 4: main has no grouped sub objects
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text x="862" y="690" fill="#1f2a2e" font-family="&quot;Helvetica&quot;" font-size="24px" font-weight="bold">
+                        Case 4: main has no grouped sub objects
+                    </text>
+                </switch>
+            </g>
+        </g>
+        <g>
+            <rect x="860" y="702" width="520" height="42" fill="none" stroke="none" pointer-events="all"/>
+        </g>
+        <g>
+            <g transform="translate(-0.5 -0.5)">
+                <switch>
+                    <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 1px; height: 1px; padding-top: 723px; margin-left: 862px;">
+                            <div style="box-sizing: border-box; font-size: 0; text-align: left; color: #334047; ">
+                                <div style="display: inline-block; font-size: 17px; font-family: &quot;Helvetica&quot;; color: light-dark(#334047, #afbac0); line-height: 1.2; pointer-events: all; white-space: nowrap; ">
+                                    A main object always produces one output object. If no sub object
+                                    <br/>
+                                    is uniquely assigned, it is published unchanged.
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text x="862" y="728" fill="#334047" font-family="&quot;Helvetica&quot;" font-size="17px">
+                        A main object always produces one output object. If no sub ob...
+                    </text>
+                </switch>
+            </g>
+        </g>
+        <g>
+            <path d="M 1170 836 L 1171 836" fill="none" stroke="#d5cec2" stroke-width="2" stroke-miterlimit="10" pointer-events="all" style="stroke: light-dark(rgb(213, 206, 194), rgb(65, 59, 49));"/>
+        </g>
+        <g>
+            <rect x="890" y="756" width="80" height="24" fill="none" stroke="none" pointer-events="all"/>
+        </g>
+        <g>
+            <g transform="translate(-0.5 -0.5)">
+                <switch>
+                    <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 1px; height: 1px; padding-top: 768px; margin-left: 892px;">
+                            <div style="box-sizing: border-box; font-size: 0; text-align: left; color: #223036; ">
+                                <div style="display: inline-block; font-size: 18px; font-family: &quot;Helvetica&quot;; color: light-dark(#223036, #bcc8cd); line-height: 1.2; pointer-events: all; font-weight: bold; white-space: nowrap; ">
+                                    Input
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text x="892" y="773" fill="#223036" font-family="&quot;Helvetica&quot;" font-size="18px" font-weight="bold">
+                        Input
+                    </text>
+                </switch>
+            </g>
+        </g>
+        <g>
+            <rect x="924" y="798" width="178" height="88" rx="10.56" ry="10.56" fill-opacity="0.45" fill="#b7d4d0" stroke="#155e63" stroke-opacity="0.45" stroke-width="4" pointer-events="all" style="fill: light-dark(rgb(183, 212, 208), rgb(41, 66, 63)); stroke: light-dark(rgb(21, 94, 99), rgb(119, 182, 186));"/>
+        </g>
+        <g>
+            <rect x="890" y="906" width="220" height="18" fill="none" stroke="none" pointer-events="all"/>
+        </g>
+        <g>
+            <g transform="translate(-0.5 -0.5)">
+                <switch>
+                    <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 1px; height: 1px; padding-top: 915px; margin-left: 892px;">
+                            <div style="box-sizing: border-box; font-size: 0; text-align: left; color: #56636b; ">
+                                <div style="display: inline-block; font-size: 15px; font-family: &quot;Helvetica&quot;; color: light-dark(#56636b, #919ca3); line-height: 1.2; pointer-events: all; white-space: nowrap; ">
+                                    Grouped sub count for M1 = 0
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text x="892" y="920" fill="#56636b" font-family="&quot;Helvetica&quot;" font-size="15px">
+                        Grouped sub count for M1 = 0
+                    </text>
+                </switch>
+            </g>
+        </g>
+        <g>
+            <rect x="1190" y="824" width="80" height="40" fill="none" stroke="none" pointer-events="all"/>
+        </g>
+        <g>
+            <g transform="translate(-0.5 -0.5)">
+                <switch>
+                    <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 844px; margin-left: 1230px;">
+                            <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #3e3a34; ">
+                                <div style="display: inline-block; font-size: 34px; font-family: &quot;Helvetica&quot;; color: light-dark(#3e3a34, #bdbab5); line-height: 1.2; pointer-events: all; white-space: nowrap; ">
+                                    -&gt;
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text x="1230" y="854" fill="#3e3a34" font-family="&quot;Helvetica&quot;" font-size="34px" text-anchor="middle">
+                        -&gt;
+                    </text>
+                </switch>
+            </g>
+        </g>
+        <g>
+            <rect x="1250" y="756" width="90" height="24" fill="none" stroke="none" pointer-events="all"/>
+        </g>
+        <g>
+            <g transform="translate(-0.5 -0.5)">
+                <switch>
+                    <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 1px; height: 1px; padding-top: 768px; margin-left: 1252px;">
+                            <div style="box-sizing: border-box; font-size: 0; text-align: left; color: #223036; ">
+                                <div style="display: inline-block; font-size: 18px; font-family: &quot;Helvetica&quot;; color: light-dark(#223036, #bcc8cd); line-height: 1.2; pointer-events: all; font-weight: bold; white-space: nowrap; ">
+                                    Output
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text x="1252" y="773" fill="#223036" font-family="&quot;Helvetica&quot;" font-size="18px" font-weight="bold">
+                        Output
+                    </text>
+                </switch>
+            </g>
+        </g>
+        <g>
+            <rect x="1284" y="808" width="178" height="72" rx="8.64" ry="8.64" fill-opacity="0.45" fill="#b7d4d0" stroke="#155e63" stroke-opacity="0.45" stroke-width="4" pointer-events="all" style="fill: light-dark(rgb(183, 212, 208), rgb(41, 66, 63)); stroke: light-dark(rgb(21, 94, 99), rgb(119, 182, 186));"/>
+        </g>
+        <g>
+            <rect x="1250" y="906" width="170" height="38" fill="none" stroke="none" pointer-events="all"/>
+        </g>
+        <g>
+            <g transform="translate(-0.5 -0.5)">
+                <switch>
+                    <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 1px; height: 1px; padding-top: 925px; margin-left: 1252px;">
+                            <div style="box-sizing: border-box; font-size: 0; text-align: left; color: #56636b; ">
+                                <div style="display: inline-block; font-size: 15px; font-family: &quot;Helvetica&quot;; color: light-dark(#56636b, #919ca3); line-height: 1.2; pointer-events: all; white-space: nowrap; ">
+                                    Publish original M1
+                                    <br/>
+                                    on output/objects
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text x="1252" y="930" fill="#56636b" font-family="&quot;Helvetica&quot;" font-size="15px">
+                        Publish original M1...
+                    </text>
+                </switch>
+            </g>
+        </g>
+        <g>
+            <rect x="60" y="978" width="1460" height="24" fill="none" stroke="none" pointer-events="all"/>
+        </g>
+        <g>
+            <g transform="translate(-0.5 -0.5)">
+                <switch>
+                    <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 1px; height: 1px; padding-top: 990px; margin-left: 62px;">
+                            <div style="box-sizing: border-box; font-size: 0; text-align: left; color: #49545a; ">
+                                <div style="display: inline-block; font-size: 18px; font-family: &quot;Helvetica&quot;; color: light-dark(#49545a, #9fa8ad); line-height: 1.2; pointer-events: all; white-space: nowrap; ">
+                                    Per frame, every sub object falls into exactly one outcome: uniquely grouped, ignored as ambiguous, or published as other. Every main object is always emitted once.
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text x="62" y="995" fill="#49545a" font-family="&quot;Helvetica&quot;" font-size="18px">
+                        Per frame, every sub object falls into exactly one outcome: uniquely grouped, ignored as ambiguous, or published as other. Every main object is always emitted onc...
+                    </text>
+                </switch>
+            </g>
+        </g>
+    </g>
+    <switch>
+        <g requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"/>
+        <a transform="translate(0,-5)" xlink:href="https://www.drawio.com/doc/faq/svg-export-text-problems" target="_blank">
+            <text text-anchor="middle" font-size="10px" x="50%" y="100%">
+                Text is not SVG - cannot display
+            </text>
+        </a>
+    </switch>
+</svg>

--- a/perception/autoware_object_merger/include/autoware/object_merger/object_fusion_merger_node.hpp
+++ b/perception/autoware_object_merger/include/autoware/object_merger/object_fusion_merger_node.hpp
@@ -53,16 +53,23 @@ private:
     message_filters::sync_policies::ApproximateTime<DetectedObjects, DetectedObjects>;
   using Sync = message_filters::Synchronizer<SyncPolicy>;
 
+  struct FusionResult
+  {
+    DetectedObjects fused_objects;
+    DetectedObjects other_objects;
+  };
+
   void callback(
     const DetectedObjects::ConstSharedPtr & main_objects_msg,
     const DetectedObjects::ConstSharedPtr & sub_objects_msg);
 
-  DetectedObjects fuse_objects(
+  FusionResult fuse_objects(
     const DetectedObjects & main_objects_msg, const DetectedObjects & sub_objects_msg);
 
   tf2_ros::Buffer tf_buffer_;
   tf2_ros::TransformListener tf_listener_;
-  rclcpp::Publisher<DetectedObjects>::SharedPtr fused_object_pub_;
+  rclcpp::Publisher<DetectedObjects>::SharedPtr fused_objects_pub_;
+  rclcpp::Publisher<DetectedObjects>::SharedPtr other_objects_pub_;
   message_filters::Subscriber<DetectedObjects> main_object_sub_{};
   message_filters::Subscriber<DetectedObjects> sub_object_sub_{};
   std::shared_ptr<Sync> sync_ptr_;

--- a/perception/autoware_object_merger/include/autoware/object_merger/object_fusion_merger_node.hpp
+++ b/perception/autoware_object_merger/include/autoware/object_merger/object_fusion_merger_node.hpp
@@ -15,7 +15,6 @@
 #ifndef AUTOWARE__OBJECT_MERGER__OBJECT_FUSION_MERGER_NODE_HPP_
 #define AUTOWARE__OBJECT_MERGER__OBJECT_FUSION_MERGER_NODE_HPP_
 
-#include "autoware/object_merger/association/data_association.hpp"
 #include "autoware_utils/ros/debug_publisher.hpp"
 #include "autoware_utils/ros/published_time_publisher.hpp"
 #include "autoware_utils/system/stop_watch.hpp"
@@ -36,14 +35,21 @@
 #include <memory>
 #include <optional>
 #include <string>
-#include <unordered_map>
 #include <vector>
 
 namespace autoware::object_merger
 {
+/**
+ * @brief Merge two detected-object streams by expanding each main object with uniquely overlapped sub objects.
+ */
 class ObjectFusionMergerNode : public rclcpp::Node
 {
 public:
+  /**
+   * @brief Construct the object fusion merger node.
+   *
+   * @param node_options ROS node options used for component construction.
+   */
   explicit ObjectFusionMergerNode(const rclcpp::NodeOptions & node_options);
 
 private:
@@ -59,10 +65,23 @@ private:
     DetectedObjects other_objects;
   };
 
+  /**
+   * @brief Transform synchronized inputs, perform fusion, and publish both outputs.
+   *
+   * @param main_objects_msg Main detected objects input.
+   * @param sub_objects_msg Sub detected objects input.
+   */
   void callback(
     const DetectedObjects::ConstSharedPtr & main_objects_msg,
     const DetectedObjects::ConstSharedPtr & sub_objects_msg);
 
+  /**
+   * @brief Group sub objects by unique overlap and produce fused and unmatched outputs.
+   *
+   * @param main_objects_msg Main detected objects transformed into the base frame.
+   * @param sub_objects_msg Sub detected objects transformed into the base frame.
+   * @return Fusion result containing the main-based output and unmatched sub objects.
+   */
   FusionResult fuse_objects(
     const DetectedObjects & main_objects_msg, const DetectedObjects & sub_objects_msg);
 
@@ -74,7 +93,6 @@ private:
   message_filters::Subscriber<DetectedObjects> sub_object_sub_{};
   std::shared_ptr<Sync> sync_ptr_;
 
-  std::unique_ptr<DataAssociation> data_association_;
   std::string base_link_frame_id_;
 
   std::unique_ptr<autoware_utils::DebugPublisher> processing_time_publisher_;

--- a/perception/autoware_object_merger/include/autoware/object_merger/object_fusion_merger_node.hpp
+++ b/perception/autoware_object_merger/include/autoware/object_merger/object_fusion_merger_node.hpp
@@ -1,0 +1,79 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef AUTOWARE__OBJECT_MERGER__OBJECT_FUSION_MERGER_NODE_HPP_
+#define AUTOWARE__OBJECT_MERGER__OBJECT_FUSION_MERGER_NODE_HPP_
+
+#include "autoware/object_merger/association/data_association.hpp"
+#include "autoware_utils/ros/debug_publisher.hpp"
+#include "autoware_utils/ros/published_time_publisher.hpp"
+#include "autoware_utils/system/stop_watch.hpp"
+
+#include <autoware_utils/ros/diagnostics_interface.hpp>
+#include <rclcpp/rclcpp.hpp>
+
+#include "autoware_perception_msgs/msg/detected_object.hpp"
+#include "autoware_perception_msgs/msg/detected_objects.hpp"
+
+#include <message_filters/subscriber.h>
+#include <message_filters/sync_policies/approximate_time.h>
+#include <message_filters/synchronizer.h>
+#include <tf2_ros/buffer.h>
+#include <tf2_ros/transform_listener.h>
+
+#include <chrono>
+#include <memory>
+#include <optional>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace autoware::object_merger
+{
+class ObjectFusionMergerNode : public rclcpp::Node
+{
+public:
+  explicit ObjectFusionMergerNode(const rclcpp::NodeOptions & node_options);
+
+private:
+  using DetectedObject = autoware_perception_msgs::msg::DetectedObject;
+  using DetectedObjects = autoware_perception_msgs::msg::DetectedObjects;
+  using SyncPolicy =
+    message_filters::sync_policies::ApproximateTime<DetectedObjects, DetectedObjects>;
+  using Sync = message_filters::Synchronizer<SyncPolicy>;
+
+  void callback(
+    const DetectedObjects::ConstSharedPtr & main_objects_msg,
+    const DetectedObjects::ConstSharedPtr & sub_objects_msg);
+
+  DetectedObjects fuse_objects(
+    const DetectedObjects & main_objects_msg, const DetectedObjects & sub_objects_msg);
+
+  tf2_ros::Buffer tf_buffer_;
+  tf2_ros::TransformListener tf_listener_;
+  rclcpp::Publisher<DetectedObjects>::SharedPtr fused_object_pub_;
+  message_filters::Subscriber<DetectedObjects> main_object_sub_{};
+  message_filters::Subscriber<DetectedObjects> sub_object_sub_{};
+  std::shared_ptr<Sync> sync_ptr_;
+
+  std::unique_ptr<DataAssociation> data_association_;
+  std::string base_link_frame_id_;
+
+  std::unique_ptr<autoware_utils::DebugPublisher> processing_time_publisher_;
+  std::unique_ptr<autoware_utils::StopWatch<std::chrono::milliseconds>> stop_watch_ptr_;
+  std::unique_ptr<autoware_utils::PublishedTimePublisher> published_time_publisher_;
+};
+}  // namespace autoware::object_merger
+
+#endif  // AUTOWARE__OBJECT_MERGER__OBJECT_FUSION_MERGER_NODE_HPP_

--- a/perception/autoware_object_merger/launch/object_fusion_merger.launch.xml
+++ b/perception/autoware_object_merger/launch/object_fusion_merger.launch.xml
@@ -1,16 +1,16 @@
 <launch>
   <arg name="node_name" default="object_fusion_merger"/>
   <arg name="object_fusion_merger_param_path" default="$(find-pkg-share autoware_object_merger)/config/object_fusion_merger.param.yaml"/>
-  <arg name="data_association_matrix_path" default="$(find-pkg-share autoware_object_merger)/config/data_association_matrix.param.yaml"/>
-  <arg name="fusion/objects" default="fusion/objects"/>
-  <arg name="others/objects" default="others/objects"/>
+  <arg name="input/main_objects" default="input/main_objects"/>
+  <arg name="input/sub_objects" default="input/sub_objects"/>
+  <arg name="output/objects" default="output/objects"/>
+  <arg name="output/other_objects" default="output/other_objects"/>
 
   <node pkg="autoware_object_merger" exec="object_fusion_merger_node" name="$(var node_name)" output="screen">
     <param from="$(var object_fusion_merger_param_path)"/>
-    <param from="$(var data_association_matrix_path)"/>
-    <remap from="input/main_object" to="input/main_object"/>
-    <remap from="input/sub_object" to="input/sub_object"/>
-    <remap from="output/objects" to="$(var fusion/objects)"/>
-    <remap from="output/other_objects" to="$(var others/objects)"/>
+    <remap from="input/main_objects" to="$(var input/main_objects)"/>
+    <remap from="input/sub_objects" to="$(var input/sub_objects)"/>
+    <remap from="output/objects" to="$(var output/objects)"/>
+    <remap from="output/other_objects" to="$(var output/other_objects)"/>
   </node>
 </launch>

--- a/perception/autoware_object_merger/launch/object_fusion_merger.launch.xml
+++ b/perception/autoware_object_merger/launch/object_fusion_merger.launch.xml
@@ -1,0 +1,13 @@
+<launch>
+  <arg name="node_name" default="object_fusion_merger"/>
+  <arg name="object_fusion_merger_param_path" default="$(find-pkg-share autoware_object_merger)/config/object_fusion_merger.param.yaml"/>
+  <arg name="data_association_matrix_path" default="$(find-pkg-share autoware_object_merger)/config/data_association_matrix.param.yaml"/>
+
+  <node pkg="autoware_object_merger" exec="object_fusion_merger_node" name="$(var node_name)" output="screen">
+    <param from="$(var object_fusion_merger_param_path)"/>
+    <param from="$(var data_association_matrix_path)"/>
+    <remap from="input/main_object" to="input/main_object"/>
+    <remap from="input/sub_object" to="input/sub_object"/>
+    <remap from="output/object" to="output/object"/>
+  </node>
+</launch>

--- a/perception/autoware_object_merger/launch/object_fusion_merger.launch.xml
+++ b/perception/autoware_object_merger/launch/object_fusion_merger.launch.xml
@@ -2,12 +2,15 @@
   <arg name="node_name" default="object_fusion_merger"/>
   <arg name="object_fusion_merger_param_path" default="$(find-pkg-share autoware_object_merger)/config/object_fusion_merger.param.yaml"/>
   <arg name="data_association_matrix_path" default="$(find-pkg-share autoware_object_merger)/config/data_association_matrix.param.yaml"/>
+  <arg name="fusion/objects" default="fusion/objects"/>
+  <arg name="others/objects" default="others/objects"/>
 
   <node pkg="autoware_object_merger" exec="object_fusion_merger_node" name="$(var node_name)" output="screen">
     <param from="$(var object_fusion_merger_param_path)"/>
     <param from="$(var data_association_matrix_path)"/>
     <remap from="input/main_object" to="input/main_object"/>
     <remap from="input/sub_object" to="input/sub_object"/>
-    <remap from="output/object" to="output/object"/>
+    <remap from="output/objects" to="$(var fusion/objects)"/>
+    <remap from="output/other_objects" to="$(var others/objects)"/>
   </node>
 </launch>

--- a/perception/autoware_object_merger/package.xml
+++ b/perception/autoware_object_merger/package.xml
@@ -17,8 +17,10 @@
   <depend>autoware_agnocast_wrapper</depend>
   <depend>autoware_object_recognition_utils</depend>
   <depend>autoware_perception_msgs</depend>
+  <depend>autoware_test_utils</depend>
   <depend>autoware_utils</depend>
   <depend>eigen</depend>
+  <depend>geometry_msgs</depend>
   <depend>mussp</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>

--- a/perception/autoware_object_merger/src/object_fusion_merger_node.cpp
+++ b/perception/autoware_object_merger/src/object_fusion_merger_node.cpp
@@ -48,6 +48,21 @@ void update_shape_height(
   output.shape.dimensions.z = 2.0 * std::max(std::abs(min_local_z), std::abs(max_local_z));
 }
 
+void fit_shape_height(
+  DetectedObject & output, const DetectedObject & main_object, const DetectedObject & sub_object)
+{
+  const double main_half_z = main_object.shape.dimensions.z * 0.5;
+  const double sub_half_z = sub_object.shape.dimensions.z * 0.5;
+  const double main_min_z =
+    main_object.kinematics.pose_with_covariance.pose.position.z - main_half_z;
+  const double main_max_z =
+    main_object.kinematics.pose_with_covariance.pose.position.z + main_half_z;
+  const double sub_min_z = sub_object.kinematics.pose_with_covariance.pose.position.z - sub_half_z;
+  const double sub_max_z = sub_object.kinematics.pose_with_covariance.pose.position.z + sub_half_z;
+  output.kinematics.pose_with_covariance.pose.position.z = 0.5 * (std::min(main_min_z, sub_min_z) + std::max(main_max_z, sub_max_z));
+  output.shape.dimensions.z = std::max(main_max_z, sub_max_z) - std::min(main_min_z, sub_min_z);
+}
+
 MultiPoint2d collect_union_points_in_output_frame(
   const DetectedObject & output, const DetectedObject & main_object,
   const DetectedObject & sub_object)
@@ -85,15 +100,22 @@ DetectedObject enclose_union_with_main_shape(
   }
 
   if (main_object.shape.type == Shape::BOUNDING_BOX) {
-    double max_abs_x = 0.0;
-    double max_abs_y = 0.0;
+    double min_x = std::numeric_limits<double>::max();
+    double max_x = std::numeric_limits<double>::lowest();
+    double min_y = std::numeric_limits<double>::max();
+    double max_y = std::numeric_limits<double>::lowest();
     for (const auto & point : combined_points) {
-      max_abs_x = std::max(max_abs_x, std::abs(boost::geometry::get<0>(point)));
-      max_abs_y = std::max(max_abs_y, std::abs(boost::geometry::get<1>(point)));
+      min_x = std::min(min_x, boost::geometry::get<0>(point));
+      max_x = std::max(max_x, boost::geometry::get<0>(point));
+      min_y = std::min(min_y, boost::geometry::get<1>(point));
+      max_y = std::max(max_y, boost::geometry::get<1>(point));
     }
-    output.shape.dimensions.x = 2.0 * max_abs_x;
-    output.shape.dimensions.y = 2.0 * max_abs_y;
-    update_shape_height(output, main_object, sub_object);
+    output.kinematics.pose_with_covariance.pose = autoware_utils::calc_offset_pose(
+      output.kinematics.pose_with_covariance.pose, 0.5 * (min_x + max_x), 0.5 * (min_y + max_y),
+      0.0);
+    output.shape.dimensions.x = max_x - min_x;
+    output.shape.dimensions.y = max_y - min_y;
+    fit_shape_height(output, main_object, sub_object);
     return output;
   }
 

--- a/perception/autoware_object_merger/src/object_fusion_merger_node.cpp
+++ b/perception/autoware_object_merger/src/object_fusion_merger_node.cpp
@@ -21,7 +21,9 @@
 
 #include <algorithm>
 #include <cmath>
+#include <limits>
 #include <utility>
+#include <vector>
 
 namespace
 {
@@ -30,42 +32,64 @@ using Shape = autoware_perception_msgs::msg::Shape;
 using MultiPoint2d = autoware_utils::MultiPoint2d;
 using Point2d = autoware_utils::Point2d;
 using Polygon2d = autoware_utils::Polygon2d;
+using MultiPolygon2d = boost::geometry::model::multi_polygon<Polygon2d>;
 
-void update_shape_height(
-  DetectedObject & output, const DetectedObject & main_object, const DetectedObject & sub_object)
+/**
+ * @brief Compute the combined vertical extent of one main object and its grouped sub objects.
+ *
+ * @param main_object Main object used as the base of the fused output.
+ * @param sub_objects Sub objects uniquely grouped to the main object.
+ * @return Minimum and maximum z values covered by all input objects.
+ */
+std::pair<double, double> get_z_range(
+  const DetectedObject & main_object, const std::vector<DetectedObject> & sub_objects)
 {
-  const double output_center_z = output.kinematics.pose_with_covariance.pose.position.z;
   const double main_half_z = main_object.shape.dimensions.z * 0.5;
-  const double sub_half_z = sub_object.shape.dimensions.z * 0.5;
   const double main_min_z =
     main_object.kinematics.pose_with_covariance.pose.position.z - main_half_z;
   const double main_max_z =
     main_object.kinematics.pose_with_covariance.pose.position.z + main_half_z;
-  const double sub_min_z = sub_object.kinematics.pose_with_covariance.pose.position.z - sub_half_z;
-  const double sub_max_z = sub_object.kinematics.pose_with_covariance.pose.position.z + sub_half_z;
-  const double min_local_z = std::min(main_min_z, sub_min_z) - output_center_z;
-  const double max_local_z = std::max(main_max_z, sub_max_z) - output_center_z;
-  output.shape.dimensions.z = 2.0 * std::max(std::abs(min_local_z), std::abs(max_local_z));
+  double min_z = main_min_z;
+  double max_z = main_max_z;
+
+  for (const auto & sub_object : sub_objects) {
+    const double sub_half_z = sub_object.shape.dimensions.z * 0.5;
+    min_z =
+      std::min(min_z, sub_object.kinematics.pose_with_covariance.pose.position.z - sub_half_z);
+    max_z =
+      std::max(max_z, sub_object.kinematics.pose_with_covariance.pose.position.z + sub_half_z);
+  }
+
+  return {min_z, max_z};
 }
 
+/**
+ * @brief Update the output pose z and shape height to cover the full grouped z range.
+ *
+ * @param output Output object to update in place.
+ * @param main_object Main object used as the base of the fused output.
+ * @param sub_objects Sub objects uniquely grouped to the main object.
+ */
 void fit_shape_height(
-  DetectedObject & output, const DetectedObject & main_object, const DetectedObject & sub_object)
+  DetectedObject & output, const DetectedObject & main_object,
+  const std::vector<DetectedObject> & sub_objects)
 {
-  const double main_half_z = main_object.shape.dimensions.z * 0.5;
-  const double sub_half_z = sub_object.shape.dimensions.z * 0.5;
-  const double main_min_z =
-    main_object.kinematics.pose_with_covariance.pose.position.z - main_half_z;
-  const double main_max_z =
-    main_object.kinematics.pose_with_covariance.pose.position.z + main_half_z;
-  const double sub_min_z = sub_object.kinematics.pose_with_covariance.pose.position.z - sub_half_z;
-  const double sub_max_z = sub_object.kinematics.pose_with_covariance.pose.position.z + sub_half_z;
-  output.kinematics.pose_with_covariance.pose.position.z = 0.5 * (std::min(main_min_z, sub_min_z) + std::max(main_max_z, sub_max_z));
-  output.shape.dimensions.z = std::max(main_max_z, sub_max_z) - std::min(main_min_z, sub_min_z);
+  const auto [min_z, max_z] = get_z_range(main_object, sub_objects);
+  output.kinematics.pose_with_covariance.pose.position.z = 0.5 * (min_z + max_z);
+  output.shape.dimensions.z = max_z - min_z;
 }
 
+/**
+ * @brief Collect the footprint vertices of the main and grouped sub objects in the output frame.
+ *
+ * @param output Current output object that defines the local output frame.
+ * @param main_object Main object used as the base of the fused output.
+ * @param sub_objects Sub objects uniquely grouped to the main object.
+ * @return Combined footprint points expressed in the output local frame.
+ */
 MultiPoint2d collect_union_points_in_output_frame(
   const DetectedObject & output, const DetectedObject & main_object,
-  const DetectedObject & sub_object)
+  const std::vector<DetectedObject> & sub_objects)
 {
   const auto append_local_polygon_points =
     [&output](const Polygon2d & polygon, MultiPoint2d & combined_points) {
@@ -81,20 +105,52 @@ MultiPoint2d collect_union_points_in_output_frame(
     };
 
   const auto main_polygon = autoware_utils::to_polygon2d(main_object);
-  const auto sub_polygon = autoware_utils::to_polygon2d(sub_object);
   MultiPoint2d combined_points;
   append_local_polygon_points(main_polygon, combined_points);
-  append_local_polygon_points(sub_polygon, combined_points);
+  for (const auto & sub_object : sub_objects) {
+    append_local_polygon_points(autoware_utils::to_polygon2d(sub_object), combined_points);
+  }
   return combined_points;
 }
 
+/**
+ * @brief Calculate the 2D footprint intersection area between one main and one sub object.
+ *
+ * @param main_object Main object candidate.
+ * @param sub_object Sub object candidate.
+ * @return Overlapped footprint area in square meters.
+ */
+double get_intersection_area(const DetectedObject & main_object, const DetectedObject & sub_object)
+{
+  MultiPolygon2d intersections;
+  boost::geometry::intersection(
+    autoware_utils::to_polygon2d(main_object), autoware_utils::to_polygon2d(sub_object),
+    intersections);
+
+  double total_area = 0.0;
+  for (const auto & polygon : intersections) {
+    total_area += std::abs(boost::geometry::area(polygon));
+  }
+  return total_area;
+}
+
+/**
+ * @brief Expand a main object so its shape encloses the main and grouped sub objects.
+ *
+ * @param main_object Main object that defines the output shape type and metadata.
+ * @param sub_objects Sub objects uniquely grouped to the main object.
+ * @return Main-based object whose geometry encloses the full grouped union.
+ */
 DetectedObject enclose_union_with_main_shape(
-  const DetectedObject & main_object, const DetectedObject & sub_object)
+  const DetectedObject & main_object, const std::vector<DetectedObject> & sub_objects)
 {
   DetectedObject output = main_object;
   output.shape = main_object.shape;
+  if (sub_objects.empty()) {
+    return output;
+  }
   const auto combined_points =
-    collect_union_points_in_output_frame(output, main_object, sub_object);
+    collect_union_points_in_output_frame(output, main_object, sub_objects);
   if (combined_points.empty()) {
     return output;
   }
@@ -115,7 +171,7 @@ DetectedObject enclose_union_with_main_shape(
       0.0);
     output.shape.dimensions.x = max_x - min_x;
     output.shape.dimensions.y = max_y - min_y;
-    fit_shape_height(output, main_object, sub_object);
+    fit_shape_height(output, main_object, sub_objects);
     return output;
   }
 
@@ -127,7 +183,7 @@ DetectedObject enclose_union_with_main_shape(
     }
     output.shape.dimensions.x = 2.0 * max_radius;
     output.shape.dimensions.y = 2.0 * max_radius;
-    update_shape_height(output, main_object, sub_object);
+    fit_shape_height(output, main_object, sub_objects);
     return output;
   }
 
@@ -142,7 +198,7 @@ DetectedObject enclose_union_with_main_shape(
           .y(static_cast<float>(boost::geometry::get<1>(point)))
           .z(0.0f));
     }
-    update_shape_height(output, main_object, sub_object);
+    fit_shape_height(output, main_object, sub_objects);
   }
   return output;
 }
@@ -151,24 +207,21 @@ DetectedObject enclose_union_with_main_shape(
 
 namespace autoware::object_merger
 {
+/**
+ * @brief Construct the fusion node and initialize subscriptions, publishers, and debug utilities.
+ *
+ * @param node_options ROS node options used for component construction.
+ */
 ObjectFusionMergerNode::ObjectFusionMergerNode(const rclcpp::NodeOptions & node_options)
 : rclcpp::Node("object_fusion_merger_node", node_options),
   tf_buffer_(get_clock()),
   tf_listener_(tf_buffer_),
-  main_object_sub_(this, "input/main_object", rclcpp::QoS{1}.get_rmw_qos_profile()),
-  sub_object_sub_(this, "input/sub_object", rclcpp::QoS{1}.get_rmw_qos_profile())
+  main_object_sub_(this, "input/main_objects", rclcpp::QoS{1}.get_rmw_qos_profile()),
+  sub_object_sub_(this, "input/sub_objects", rclcpp::QoS{1}.get_rmw_qos_profile())
 {
-  // Get parameters for data association
+  // Get parameters
   base_link_frame_id_ = declare_parameter<std::string>("base_link_frame_id");
   const auto sync_queue_size = static_cast<int>(declare_parameter<int64_t>("sync_queue_size"));
-
-  const auto tmp = this->declare_parameter<std::vector<int64_t>>("can_assign_matrix");
-  const std::vector<int> can_assign_matrix(tmp.begin(), tmp.end());
-  const auto max_dist_matrix = this->declare_parameter<std::vector<double>>("max_dist_matrix");
-  const auto max_rad_matrix = this->declare_parameter<std::vector<double>>("max_rad_matrix");
-  const auto min_iou_matrix = this->declare_parameter<std::vector<double>>("min_iou_matrix");
-  data_association_ = std::make_unique<DataAssociation>(
-    can_assign_matrix, max_dist_matrix, max_rad_matrix, min_iou_matrix);
 
   // Set up publishers, subscribers, and synchronizer
   using std::placeholders::_1;
@@ -187,6 +240,12 @@ ObjectFusionMergerNode::ObjectFusionMergerNode(const rclcpp::NodeOptions & node_
   published_time_publisher_ = std::make_unique<autoware_utils::PublishedTimePublisher>(this);
 }
 
+/**
+ * @brief Transform both inputs, fuse overlapping objects, and publish the two output streams.
+ *
+ * @param main_objects_msg Main detected objects input message.
+ * @param sub_objects_msg Sub detected objects input message.
+ */
 void ObjectFusionMergerNode::callback(
   const DetectedObjects::ConstSharedPtr & main_objects_msg,
   const DetectedObjects::ConstSharedPtr & sub_objects_msg)
@@ -225,38 +284,54 @@ void ObjectFusionMergerNode::callback(
     "debug/processing_time_ms", stop_watch_ptr_->toc("processing_time", true));
 }
 
+/**
+ * @brief Group sub objects by unique overlap and build fused and unmatched outputs.
+ *
+ * @param main_objects_msg Main detected objects already transformed into the base frame.
+ * @param sub_objects_msg Sub detected objects already transformed into the base frame.
+ * @return Fused main-based objects and unmatched sub objects for separate publication.
+ */
 ObjectFusionMergerNode::FusionResult ObjectFusionMergerNode::fuse_objects(
   const DetectedObjects & main_objects_msg, const DetectedObjects & sub_objects_msg)
 {
-  // 1. Associate main and sub objects using the data association module
-  std::unordered_map<int, int> direct_assignment;
-  std::unordered_map<int, int> reverse_assignment;
-  Eigen::MatrixXd score_matrix =
-    data_association_->calcScoreMatrix(sub_objects_msg, main_objects_msg);
-  data_association_->assign(score_matrix, direct_assignment, reverse_assignment);
-
   const auto & main_objects = main_objects_msg.objects;
   const auto & sub_objects = sub_objects_msg.objects;
 
+  std::vector<std::vector<DetectedObject>> grouped_sub_objects(main_objects.size());
+  std::vector<DetectedObject> other_objects;
+  other_objects.reserve(sub_objects.size());
+
+  for (const auto & sub_object : sub_objects) {
+    std::vector<std::size_t> overlapped_main_indices;
+    for (std::size_t main_index = 0; main_index < main_objects.size(); ++main_index) {
+      if (get_intersection_area(main_objects.at(main_index), sub_object) > 1e-6) {
+        overlapped_main_indices.push_back(main_index);
+      }
+    }
+
+    // If sub-object does not overlap with any main object, treat it as a matched object
+    if (overlapped_main_indices.empty()) {
+      other_objects.push_back(sub_object);
+      continue;
+    }
+
+    // If sub-object overlaps with a single main object, group it with that main object
+    // If sub-object overlaps with multiple main objects, ignore it for fusion to avoid ambiguity
+    if (overlapped_main_indices.size() == 1U) {
+      grouped_sub_objects.at(overlapped_main_indices.front()).push_back(sub_object);
+    }
+  }
+
   std::vector<DetectedObject> matched_objects;
+  matched_objects.reserve(main_objects.size());
   for (std::size_t main_index = 0; main_index < main_objects.size(); ++main_index) {
     const auto & main_object = main_objects.at(main_index);
-    const auto direct_itr = direct_assignment.find(static_cast<int>(main_index));
-    if (direct_itr == direct_assignment.end()) {
-      // No matched sub object, keep the main object as it is
+    const auto & grouped_subs = grouped_sub_objects.at(main_index);
+    if (grouped_subs.empty()) {
       matched_objects.push_back(main_object);
       continue;
     }
-    matched_objects.push_back(
-      enclose_union_with_main_shape(main_object, sub_objects.at(direct_itr->second)));
-  }
-
-  std::vector<DetectedObject> unmatched_sub_objects;
-  unmatched_sub_objects.reserve(sub_objects.size());
-  for (std::size_t sub_index = 0; sub_index < sub_objects.size(); ++sub_index) {
-    if (reverse_assignment.find(static_cast<int>(sub_index)) == reverse_assignment.end()) {
-      unmatched_sub_objects.push_back(sub_objects.at(sub_index));
-    }
+    matched_objects.push_back(enclose_union_with_main_shape(main_object, grouped_subs));
   }
 
   const auto header = std_msgs::build<std_msgs::msg::Header>()
@@ -265,7 +340,7 @@ ObjectFusionMergerNode::FusionResult ObjectFusionMergerNode::fuse_objects(
 
   return FusionResult{
     autoware_perception_msgs::build<DetectedObjects>().header(header).objects(matched_objects),
-    autoware_perception_msgs::build<DetectedObjects>().header(header).objects(unmatched_sub_objects)};
+    autoware_perception_msgs::build<DetectedObjects>().header(header).objects(other_objects)};
 }
 
 }  // namespace autoware::object_merger

--- a/perception/autoware_object_merger/src/object_fusion_merger_node.cpp
+++ b/perception/autoware_object_merger/src/object_fusion_merger_node.cpp
@@ -1,0 +1,239 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/object_merger/object_fusion_merger_node.hpp"
+
+#include "autoware/object_recognition_utils/object_recognition_utils.hpp"
+#include "autoware_utils/geometry/geometry.hpp"
+
+#include <boost/geometry.hpp>
+
+#include <algorithm>
+#include <cmath>
+#include <utility>
+
+namespace
+{
+using DetectedObject = autoware_perception_msgs::msg::DetectedObject;
+using Shape = autoware_perception_msgs::msg::Shape;
+using MultiPoint2d = autoware_utils::MultiPoint2d;
+using Point2d = autoware_utils::Point2d;
+using Polygon2d = autoware_utils::Polygon2d;
+
+void update_shape_height(
+  DetectedObject & output, const DetectedObject & main_object, const DetectedObject & sub_object)
+{
+  const double output_center_z = output.kinematics.pose_with_covariance.pose.position.z;
+  const double main_half_z = main_object.shape.dimensions.z * 0.5;
+  const double sub_half_z = sub_object.shape.dimensions.z * 0.5;
+  const double main_min_z =
+    main_object.kinematics.pose_with_covariance.pose.position.z - main_half_z;
+  const double main_max_z =
+    main_object.kinematics.pose_with_covariance.pose.position.z + main_half_z;
+  const double sub_min_z = sub_object.kinematics.pose_with_covariance.pose.position.z - sub_half_z;
+  const double sub_max_z = sub_object.kinematics.pose_with_covariance.pose.position.z + sub_half_z;
+  const double min_local_z = std::min(main_min_z, sub_min_z) - output_center_z;
+  const double max_local_z = std::max(main_max_z, sub_max_z) - output_center_z;
+  output.shape.dimensions.z = 2.0 * std::max(std::abs(min_local_z), std::abs(max_local_z));
+}
+
+MultiPoint2d collect_union_points_in_output_frame(
+  const DetectedObject & output, const DetectedObject & main_object,
+  const DetectedObject & sub_object)
+{
+  const auto append_local_polygon_points =
+    [&output](const Polygon2d & polygon, MultiPoint2d & combined_points) {
+      for (const auto & point : polygon.outer()) {
+        geometry_msgs::msg::Point world_point;
+        world_point.x = boost::geometry::get<0>(point);
+        world_point.y = boost::geometry::get<1>(point);
+        world_point.z = output.kinematics.pose_with_covariance.pose.position.z;
+        const auto local_point = autoware_utils::inverse_transform_point(
+          world_point, output.kinematics.pose_with_covariance.pose);
+        combined_points.push_back(Point2d(local_point.x, local_point.y));
+      }
+    };
+
+  const auto main_polygon = autoware_utils::to_polygon2d(main_object);
+  const auto sub_polygon = autoware_utils::to_polygon2d(sub_object);
+  MultiPoint2d combined_points;
+  append_local_polygon_points(main_polygon, combined_points);
+  append_local_polygon_points(sub_polygon, combined_points);
+  return combined_points;
+}
+
+DetectedObject enclose_union_with_main_shape(
+  const DetectedObject & main_object, const DetectedObject & sub_object)
+{
+  DetectedObject output = main_object;
+  output.shape = main_object.shape;
+  const auto combined_points =
+    collect_union_points_in_output_frame(output, main_object, sub_object);
+  if (combined_points.empty()) {
+    return output;
+  }
+
+  if (main_object.shape.type == Shape::BOUNDING_BOX) {
+    double max_abs_x = 0.0;
+    double max_abs_y = 0.0;
+    for (const auto & point : combined_points) {
+      max_abs_x = std::max(max_abs_x, std::abs(boost::geometry::get<0>(point)));
+      max_abs_y = std::max(max_abs_y, std::abs(boost::geometry::get<1>(point)));
+    }
+    output.shape.dimensions.x = 2.0 * max_abs_x;
+    output.shape.dimensions.y = 2.0 * max_abs_y;
+    update_shape_height(output, main_object, sub_object);
+    return output;
+  }
+
+  if (main_object.shape.type == Shape::CYLINDER) {
+    double max_radius = 0.0;
+    for (const auto & point : combined_points) {
+      max_radius = std::max(
+        max_radius, std::hypot(boost::geometry::get<0>(point), boost::geometry::get<1>(point)));
+    }
+    output.shape.dimensions.x = 2.0 * max_radius;
+    output.shape.dimensions.y = 2.0 * max_radius;
+    update_shape_height(output, main_object, sub_object);
+    return output;
+  }
+
+  if (main_object.shape.type == Shape::POLYGON) {
+    Polygon2d hull_polygon;
+    boost::geometry::convex_hull(combined_points, hull_polygon);
+    output.shape.footprint.points.clear();
+    for (const auto & point : hull_polygon.outer()) {
+      output.shape.footprint.points.push_back(
+        geometry_msgs::build<geometry_msgs::msg::Point32>()
+          .x(static_cast<float>(boost::geometry::get<0>(point)))
+          .y(static_cast<float>(boost::geometry::get<1>(point)))
+          .z(0.0f));
+    }
+    update_shape_height(output, main_object, sub_object);
+  }
+  return output;
+}
+
+}  // namespace
+
+namespace autoware::object_merger
+{
+ObjectFusionMergerNode::ObjectFusionMergerNode(const rclcpp::NodeOptions & node_options)
+: rclcpp::Node("object_fusion_merger_node", node_options),
+  tf_buffer_(get_clock()),
+  tf_listener_(tf_buffer_),
+  main_object_sub_(this, "input/main_object", rclcpp::QoS{1}.get_rmw_qos_profile()),
+  sub_object_sub_(this, "input/sub_object", rclcpp::QoS{1}.get_rmw_qos_profile())
+{
+  // Get parameters for data association
+  base_link_frame_id_ = declare_parameter<std::string>("base_link_frame_id");
+  const auto sync_queue_size = static_cast<int>(declare_parameter<int64_t>("sync_queue_size"));
+
+  const auto tmp = this->declare_parameter<std::vector<int64_t>>("can_assign_matrix");
+  const std::vector<int> can_assign_matrix(tmp.begin(), tmp.end());
+  const auto max_dist_matrix = this->declare_parameter<std::vector<double>>("max_dist_matrix");
+  const auto max_rad_matrix = this->declare_parameter<std::vector<double>>("max_rad_matrix");
+  const auto min_iou_matrix = this->declare_parameter<std::vector<double>>("min_iou_matrix");
+  data_association_ = std::make_unique<DataAssociation>(
+    can_assign_matrix, max_dist_matrix, max_rad_matrix, min_iou_matrix);
+
+  // Set up publishers, subscribers, and synchronizer
+  using std::placeholders::_1;
+  using std::placeholders::_2;
+  sync_ptr_ =
+    std::make_shared<Sync>(SyncPolicy(sync_queue_size), main_object_sub_, sub_object_sub_);
+  sync_ptr_->registerCallback(std::bind(&ObjectFusionMergerNode::callback, this, _1, _2));
+
+  fused_object_pub_ = create_publisher<DetectedObjects>("output/object", rclcpp::QoS{1});
+
+  processing_time_publisher_ = std::make_unique<autoware_utils::DebugPublisher>(this, get_name());
+  stop_watch_ptr_ = std::make_unique<autoware_utils::StopWatch<std::chrono::milliseconds>>();
+  stop_watch_ptr_->tic("cyclic_time");
+  stop_watch_ptr_->tic("processing_time");
+  published_time_publisher_ = std::make_unique<autoware_utils::PublishedTimePublisher>(this);
+}
+
+void ObjectFusionMergerNode::callback(
+  const DetectedObjects::ConstSharedPtr & main_objects_msg,
+  const DetectedObjects::ConstSharedPtr & sub_objects_msg)
+{
+  stop_watch_ptr_->toc("processing_time", true);
+
+  if (fused_object_pub_->get_subscription_count() < 1) {
+    return;
+  }
+
+  DetectedObjects transformed_main_objects;
+  DetectedObjects transformed_sub_objects;
+  if (
+    !autoware::object_recognition_utils::transformObjects(
+      *main_objects_msg, base_link_frame_id_, tf_buffer_, transformed_main_objects) ||
+    !autoware::object_recognition_utils::transformObjects(
+      *sub_objects_msg, base_link_frame_id_, tf_buffer_, transformed_sub_objects)) {
+    RCLCPP_WARN(
+      get_logger(), "Failed to transform objects to %s frame. Skipping fusion.",
+      base_link_frame_id_.c_str());
+    return;
+  }
+
+  const auto fused_objects_msg = fuse_objects(transformed_main_objects, transformed_sub_objects);
+  fused_object_pub_->publish(fused_objects_msg);
+
+  // Publish debug info
+  published_time_publisher_->publish_if_subscribed(
+    fused_object_pub_, fused_objects_msg.header.stamp);
+  processing_time_publisher_->publish<autoware_internal_debug_msgs::msg::Float64Stamped>(
+    "debug/cyclic_time_ms", stop_watch_ptr_->toc("cyclic_time", true));
+  processing_time_publisher_->publish<autoware_internal_debug_msgs::msg::Float64Stamped>(
+    "debug/processing_time_ms", stop_watch_ptr_->toc("processing_time", true));
+}
+
+ObjectFusionMergerNode::DetectedObjects ObjectFusionMergerNode::fuse_objects(
+  const DetectedObjects & main_objects_msg, const DetectedObjects & sub_objects_msg)
+{
+  // 1. Associate main and sub objects using the data association module
+  std::unordered_map<int, int> direct_assignment;
+  std::unordered_map<int, int> reverse_assignment;
+  Eigen::MatrixXd score_matrix =
+    data_association_->calcScoreMatrix(sub_objects_msg, main_objects_msg);
+  data_association_->assign(score_matrix, direct_assignment, reverse_assignment);
+
+  const auto & main_objects = main_objects_msg.objects;
+  const auto & sub_objects = sub_objects_msg.objects;
+
+  // 2. Fuse matched objects and keep unmatched main objects as they are
+  std::vector<DetectedObject> matched_objects;
+  for (std::size_t main_index = 0; main_index < main_objects.size(); ++main_index) {
+    const auto & main_object = main_objects.at(main_index);
+    const auto direct_itr = direct_assignment.find(static_cast<int>(main_index));
+    if (direct_itr == direct_assignment.end()) {
+      // No matched sub object, keep the main object as it is
+      matched_objects.push_back(main_object);
+      continue;
+    }
+    matched_objects.push_back(
+      enclose_union_with_main_shape(main_object, sub_objects.at(direct_itr->second)));
+  }
+
+  return autoware_perception_msgs::build<DetectedObjects>()
+    .header(std_msgs::build<std_msgs::msg::Header>()
+              .stamp(main_objects_msg.header.stamp)
+              .frame_id(base_link_frame_id_))
+    .objects(matched_objects);
+}
+
+}  // namespace autoware::object_merger
+
+#include <rclcpp_components/register_node_macro.hpp>
+RCLCPP_COMPONENTS_REGISTER_NODE(autoware::object_merger::ObjectFusionMergerNode)

--- a/perception/autoware_object_merger/src/object_fusion_merger_node.cpp
+++ b/perception/autoware_object_merger/src/object_fusion_merger_node.cpp
@@ -155,7 +155,8 @@ ObjectFusionMergerNode::ObjectFusionMergerNode(const rclcpp::NodeOptions & node_
     std::make_shared<Sync>(SyncPolicy(sync_queue_size), main_object_sub_, sub_object_sub_);
   sync_ptr_->registerCallback(std::bind(&ObjectFusionMergerNode::callback, this, _1, _2));
 
-  fused_object_pub_ = create_publisher<DetectedObjects>("output/object", rclcpp::QoS{1});
+  fused_objects_pub_ = create_publisher<DetectedObjects>("output/objects", rclcpp::QoS{1});
+  other_objects_pub_ = create_publisher<DetectedObjects>("output/other_objects", rclcpp::QoS{1});
 
   processing_time_publisher_ = std::make_unique<autoware_utils::DebugPublisher>(this, get_name());
   stop_watch_ptr_ = std::make_unique<autoware_utils::StopWatch<std::chrono::milliseconds>>();
@@ -170,7 +171,9 @@ void ObjectFusionMergerNode::callback(
 {
   stop_watch_ptr_->toc("processing_time", true);
 
-  if (fused_object_pub_->get_subscription_count() < 1) {
+  if (
+    fused_objects_pub_->get_subscription_count() < 1 &&
+    other_objects_pub_->get_subscription_count() < 1) {
     return;
   }
 
@@ -187,19 +190,20 @@ void ObjectFusionMergerNode::callback(
     return;
   }
 
-  const auto fused_objects_msg = fuse_objects(transformed_main_objects, transformed_sub_objects);
-  fused_object_pub_->publish(fused_objects_msg);
+  const auto result = fuse_objects(transformed_main_objects, transformed_sub_objects);
+  fused_objects_pub_->publish(result.fused_objects);
+  other_objects_pub_->publish(result.other_objects);
 
   // Publish debug info
   published_time_publisher_->publish_if_subscribed(
-    fused_object_pub_, fused_objects_msg.header.stamp);
+    fused_objects_pub_, result.fused_objects.header.stamp);
   processing_time_publisher_->publish<autoware_internal_debug_msgs::msg::Float64Stamped>(
     "debug/cyclic_time_ms", stop_watch_ptr_->toc("cyclic_time", true));
   processing_time_publisher_->publish<autoware_internal_debug_msgs::msg::Float64Stamped>(
     "debug/processing_time_ms", stop_watch_ptr_->toc("processing_time", true));
 }
 
-ObjectFusionMergerNode::DetectedObjects ObjectFusionMergerNode::fuse_objects(
+ObjectFusionMergerNode::FusionResult ObjectFusionMergerNode::fuse_objects(
   const DetectedObjects & main_objects_msg, const DetectedObjects & sub_objects_msg)
 {
   // 1. Associate main and sub objects using the data association module
@@ -212,7 +216,6 @@ ObjectFusionMergerNode::DetectedObjects ObjectFusionMergerNode::fuse_objects(
   const auto & main_objects = main_objects_msg.objects;
   const auto & sub_objects = sub_objects_msg.objects;
 
-  // 2. Fuse matched objects and keep unmatched main objects as they are
   std::vector<DetectedObject> matched_objects;
   for (std::size_t main_index = 0; main_index < main_objects.size(); ++main_index) {
     const auto & main_object = main_objects.at(main_index);
@@ -226,11 +229,21 @@ ObjectFusionMergerNode::DetectedObjects ObjectFusionMergerNode::fuse_objects(
       enclose_union_with_main_shape(main_object, sub_objects.at(direct_itr->second)));
   }
 
-  return autoware_perception_msgs::build<DetectedObjects>()
-    .header(std_msgs::build<std_msgs::msg::Header>()
-              .stamp(main_objects_msg.header.stamp)
-              .frame_id(base_link_frame_id_))
-    .objects(matched_objects);
+  std::vector<DetectedObject> unmatched_sub_objects;
+  unmatched_sub_objects.reserve(sub_objects.size());
+  for (std::size_t sub_index = 0; sub_index < sub_objects.size(); ++sub_index) {
+    if (reverse_assignment.find(static_cast<int>(sub_index)) == reverse_assignment.end()) {
+      unmatched_sub_objects.push_back(sub_objects.at(sub_index));
+    }
+  }
+
+  const auto header = std_msgs::build<std_msgs::msg::Header>()
+                        .stamp(main_objects_msg.header.stamp)
+                        .frame_id(base_link_frame_id_);
+
+  return FusionResult{
+    autoware_perception_msgs::build<DetectedObjects>().header(header).objects(matched_objects),
+    autoware_perception_msgs::build<DetectedObjects>().header(header).objects(unmatched_sub_objects)};
 }
 
 }  // namespace autoware::object_merger

--- a/perception/autoware_object_merger/test/test_object_fusion_merger_node.cpp
+++ b/perception/autoware_object_merger/test/test_object_fusion_merger_node.cpp
@@ -14,7 +14,6 @@
 
 #include "autoware/object_merger/object_fusion_merger_node.hpp"
 
-#include <ament_index_cpp/get_package_share_directory.hpp>
 #include <autoware_test_utils/autoware_test_utils.hpp>
 
 #include <geometry_msgs/msg/point32.hpp>
@@ -22,6 +21,7 @@
 #include <gtest/gtest.h>
 #include <tf2_ros/static_transform_broadcaster.h>
 
+#include <filesystem>
 #include <memory>
 #include <string>
 #include <vector>
@@ -43,10 +43,10 @@ std::shared_ptr<autoware::test_utils::AutowareTestManager> generate_test_manager
 std::shared_ptr<ObjectFusionMergerNode> generate_node()
 {
   auto node_options = rclcpp::NodeOptions{};
-  const auto package_dir = ament_index_cpp::get_package_share_directory("autoware_object_merger");
+  const auto package_dir = std::filesystem::path(__FILE__).parent_path().parent_path();
   node_options.arguments(
-    {"--ros-args", "--params-file", package_dir + "/config/object_fusion_merger.param.yaml",
-     "--params-file", package_dir + "/config/data_association_matrix.param.yaml"});
+    {"--ros-args", "--params-file",
+     (package_dir / "config" / "object_fusion_merger.param.yaml").string()});
   return std::make_shared<ObjectFusionMergerNode>(node_options);
 }
 
@@ -161,8 +161,8 @@ TEST(ObjectFusionMergerNodeTest, testMatchedObjectsAreFused)
   sub_objects.header.frame_id = "base_link";
   sub_objects.objects.push_back(make_object(1.5, 1.0, 0.5, 2.0, ObjectClassification::CAR));
 
-  test_manager->test_pub_msg<DetectedObjects>(test_target_node, "input/main_object", main_objects);
-  test_manager->test_pub_msg<DetectedObjects>(test_target_node, "input/sub_object", sub_objects);
+  test_manager->test_pub_msg<DetectedObjects>(test_target_node, "input/main_objects", main_objects);
+  test_manager->test_pub_msg<DetectedObjects>(test_target_node, "input/sub_objects", sub_objects);
 
   ASSERT_EQ(latest_msg.objects.size(), 1U);
   EXPECT_TRUE(unmatched_sub_msg.objects.empty());
@@ -176,7 +176,7 @@ TEST(ObjectFusionMergerNodeTest, testMatchedObjectsAreFused)
   rclcpp::shutdown();
 }
 
-TEST(ObjectFusionMergerNodeTest, testUnmatchedMainIsKeptAndUnmatchedSubIsDiscarded)
+TEST(ObjectFusionMergerNodeTest, testUnmatchedMainIsKeptAndUnmatchedSubIsPublishedSeparately)
 {
   rclcpp::init(0, nullptr);
 
@@ -203,8 +203,8 @@ TEST(ObjectFusionMergerNodeTest, testUnmatchedMainIsKeptAndUnmatchedSubIsDiscard
   sub_objects.objects.push_back(make_object(1.5, 1.0, 0.5, 2.0, ObjectClassification::CAR));
   sub_objects.objects.push_back(make_object(20.0, 1.0, 0.5, 6.0, ObjectClassification::BUS));
 
-  test_manager->test_pub_msg<DetectedObjects>(test_target_node, "input/main_object", main_objects);
-  test_manager->test_pub_msg<DetectedObjects>(test_target_node, "input/sub_object", sub_objects);
+  test_manager->test_pub_msg<DetectedObjects>(test_target_node, "input/main_objects", main_objects);
+  test_manager->test_pub_msg<DetectedObjects>(test_target_node, "input/sub_objects", sub_objects);
 
   ASSERT_EQ(latest_msg.objects.size(), 2U);
   EXPECT_NEAR(latest_msg.objects.at(0).kinematics.pose_with_covariance.pose.position.x, 0.25, 1e-3);
@@ -222,7 +222,76 @@ TEST(ObjectFusionMergerNodeTest, testUnmatchedMainIsKeptAndUnmatchedSubIsDiscard
   rclcpp::shutdown();
 }
 
-TEST(ObjectFusionMergerNodeTest, testUnionCanBeEnclosedWithMainBoundingBox)
+TEST(ObjectFusionMergerNodeTest, testSubObjectOverlappingMultipleMainObjectsIsIgnored)
+{
+  rclcpp::init(0, nullptr);
+
+  auto test_manager = generate_test_manager();
+  auto test_target_node = generate_node();
+  auto tf_node = create_static_tf_broadcaster_node("map", "base_link");
+
+  DetectedObjects latest_msg;
+  DetectedObjects other_msg;
+  test_manager->set_subscriber<DetectedObjects>(
+    "/output/objects",
+    [&latest_msg](const DetectedObjects::ConstSharedPtr msg) { latest_msg = *msg; });
+  test_manager->set_subscriber<DetectedObjects>(
+    "/output/other_objects",
+    [&other_msg](const DetectedObjects::ConstSharedPtr msg) { other_msg = *msg; });
+
+  DetectedObjects main_objects;
+  main_objects.header.frame_id = "base_link";
+  main_objects.objects.push_back(make_object(-1.0, 1.0, 0.6, 3.0, ObjectClassification::CAR));
+  main_objects.objects.push_back(make_object(1.0, 1.0, 0.6, 3.0, ObjectClassification::CAR));
+
+  DetectedObjects sub_objects;
+  sub_objects.header.frame_id = "base_link";
+  sub_objects.objects.push_back(make_object(0.0, 1.0, 0.5, 2.0, ObjectClassification::CAR));
+
+  test_manager->test_pub_msg<DetectedObjects>(test_target_node, "input/main_objects", main_objects);
+  test_manager->test_pub_msg<DetectedObjects>(test_target_node, "input/sub_objects", sub_objects);
+
+  ASSERT_EQ(latest_msg.objects.size(), 2U);
+  EXPECT_NEAR(latest_msg.objects.at(0).shape.dimensions.x, 3.0, 1e-3);
+  EXPECT_NEAR(latest_msg.objects.at(1).shape.dimensions.x, 3.0, 1e-3);
+  EXPECT_TRUE(other_msg.objects.empty());
+
+  rclcpp::shutdown();
+}
+
+TEST(ObjectFusionMergerNodeTest, testMultipleSubObjectsCanExpandOneMainObject)
+{
+  rclcpp::init(0, nullptr);
+
+  auto test_manager = generate_test_manager();
+  auto test_target_node = generate_node();
+  auto tf_node = create_static_tf_broadcaster_node("map", "base_link");
+
+  DetectedObjects latest_msg;
+  test_manager->set_subscriber<DetectedObjects>(
+    "/output/objects",
+    [&latest_msg](const DetectedObjects::ConstSharedPtr msg) { latest_msg = *msg; });
+
+  DetectedObjects main_objects;
+  main_objects.header.frame_id = "base_link";
+  main_objects.objects.push_back(make_object(0.0, 1.0, 0.6, 2.0, ObjectClassification::CAR));
+
+  DetectedObjects sub_objects;
+  sub_objects.header.frame_id = "base_link";
+  sub_objects.objects.push_back(make_object(-0.9, 1.0, 0.5, 1.4, ObjectClassification::CAR));
+  sub_objects.objects.push_back(make_object(0.9, 1.0, 0.5, 1.4, ObjectClassification::CAR));
+
+  test_manager->test_pub_msg<DetectedObjects>(test_target_node, "input/main_objects", main_objects);
+  test_manager->test_pub_msg<DetectedObjects>(test_target_node, "input/sub_objects", sub_objects);
+
+  ASSERT_EQ(latest_msg.objects.size(), 1U);
+  EXPECT_NEAR(latest_msg.objects.front().kinematics.pose_with_covariance.pose.position.x, 0.0, 1e-3);
+  EXPECT_NEAR(latest_msg.objects.front().shape.dimensions.x, 3.2, 1e-3);
+
+  rclcpp::shutdown();
+}
+
+TEST(ObjectFusionMergerNodeTest, testPolygonSubCanExpandMainBoundingBox)
 {
   rclcpp::init(0, nullptr);
 
@@ -251,8 +320,8 @@ TEST(ObjectFusionMergerNodeTest, testUnionCanBeEnclosedWithMainBoundingBox)
     },
     ObjectClassification::CAR));
 
-  test_manager->test_pub_msg<DetectedObjects>(test_target_node, "input/main_object", main_objects);
-  test_manager->test_pub_msg<DetectedObjects>(test_target_node, "input/sub_object", sub_objects);
+  test_manager->test_pub_msg<DetectedObjects>(test_target_node, "input/main_objects", main_objects);
+  test_manager->test_pub_msg<DetectedObjects>(test_target_node, "input/sub_objects", sub_objects);
 
   ASSERT_EQ(latest_msg.objects.size(), 1U);
   EXPECT_EQ(latest_msg.objects.front().shape.type, Shape::BOUNDING_BOX);
@@ -293,8 +362,8 @@ TEST(ObjectFusionMergerNodeTest, testUnionCanBeEnclosedWithMainCylinder)
     },
     ObjectClassification::PEDESTRIAN));
 
-  test_manager->test_pub_msg<DetectedObjects>(test_target_node, "input/main_object", main_objects);
-  test_manager->test_pub_msg<DetectedObjects>(test_target_node, "input/sub_object", sub_objects);
+  test_manager->test_pub_msg<DetectedObjects>(test_target_node, "input/main_objects", main_objects);
+  test_manager->test_pub_msg<DetectedObjects>(test_target_node, "input/sub_objects", sub_objects);
 
   ASSERT_EQ(latest_msg.objects.size(), 1U);
   EXPECT_EQ(latest_msg.objects.front().shape.type, Shape::CYLINDER);
@@ -343,8 +412,8 @@ TEST(ObjectFusionMergerNodeTest, testUnionCanBeEnclosedWithMainPolygon)
     },
     ObjectClassification::CAR));
 
-  test_manager->test_pub_msg<DetectedObjects>(test_target_node, "input/main_object", main_objects);
-  test_manager->test_pub_msg<DetectedObjects>(test_target_node, "input/sub_object", sub_objects);
+  test_manager->test_pub_msg<DetectedObjects>(test_target_node, "input/main_objects", main_objects);
+  test_manager->test_pub_msg<DetectedObjects>(test_target_node, "input/sub_objects", sub_objects);
 
   ASSERT_EQ(latest_msg.objects.size(), 1U);
   EXPECT_EQ(latest_msg.objects.front().shape.type, Shape::POLYGON);

--- a/perception/autoware_object_merger/test/test_object_fusion_merger_node.cpp
+++ b/perception/autoware_object_merger/test/test_object_fusion_merger_node.cpp
@@ -1,0 +1,339 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/object_merger/object_fusion_merger_node.hpp"
+
+#include <ament_index_cpp/get_package_share_directory.hpp>
+#include <autoware_test_utils/autoware_test_utils.hpp>
+
+#include <geometry_msgs/msg/point32.hpp>
+
+#include <gtest/gtest.h>
+#include <tf2_ros/static_transform_broadcaster.h>
+
+#include <memory>
+#include <string>
+#include <vector>
+
+using autoware::object_merger::ObjectFusionMergerNode;
+using autoware_perception_msgs::msg::DetectedObject;
+using autoware_perception_msgs::msg::DetectedObjectKinematics;
+using autoware_perception_msgs::msg::DetectedObjects;
+using autoware_perception_msgs::msg::ObjectClassification;
+using autoware_perception_msgs::msg::Shape;
+
+namespace
+{
+std::shared_ptr<autoware::test_utils::AutowareTestManager> generate_test_manager()
+{
+  return std::make_shared<autoware::test_utils::AutowareTestManager>();
+}
+
+std::shared_ptr<ObjectFusionMergerNode> generate_node()
+{
+  auto node_options = rclcpp::NodeOptions{};
+  const auto package_dir = ament_index_cpp::get_package_share_directory("autoware_object_merger");
+  node_options.arguments(
+    {"--ros-args", "--params-file", package_dir + "/config/object_fusion_merger.param.yaml",
+     "--params-file", package_dir + "/config/data_association_matrix.param.yaml"});
+  return std::make_shared<ObjectFusionMergerNode>(node_options);
+}
+
+std::shared_ptr<rclcpp::Node> create_static_tf_broadcaster_node(
+  const std::string & parent_frame_id, const std::string & child_frame_id)
+{
+  auto broadcaster_node = std::make_shared<rclcpp::Node>("test_tf_broadcaster");
+  auto static_broadcaster = std::make_shared<tf2_ros::StaticTransformBroadcaster>(broadcaster_node);
+  geometry_msgs::msg::TransformStamped transform_stamped;
+  transform_stamped.header.stamp = broadcaster_node->get_clock()->now();
+  transform_stamped.header.frame_id = parent_frame_id;
+  transform_stamped.child_frame_id = child_frame_id;
+  transform_stamped.transform.rotation.w = 1.0;
+  static_broadcaster->sendTransform(transform_stamped);
+  return broadcaster_node;
+}
+
+DetectedObject make_object(
+  const double x, const double covariance_x, const double existence_probability,
+  const double shape_x, const uint8_t label)
+{
+  DetectedObject object;
+  object.existence_probability = static_cast<float>(existence_probability);
+  object.kinematics.pose_with_covariance.pose.position.x = x;
+  object.kinematics.pose_with_covariance.pose.orientation.w = 1.0;
+  object.kinematics.has_position_covariance = true;
+  object.kinematics.pose_with_covariance.covariance[0] = covariance_x;
+  object.kinematics.pose_with_covariance.covariance[7] = covariance_x;
+  object.kinematics.pose_with_covariance.covariance[14] = covariance_x;
+  object.kinematics.orientation_availability = DetectedObjectKinematics::AVAILABLE;
+  object.kinematics.has_twist = true;
+  object.kinematics.has_twist_covariance = true;
+  object.kinematics.twist_with_covariance.twist.linear.x = x;
+  object.kinematics.twist_with_covariance.covariance[0] = covariance_x;
+  object.shape.type = Shape::BOUNDING_BOX;
+  object.shape.dimensions.x = shape_x;
+  object.shape.dimensions.y = 2.0;
+  object.shape.dimensions.z = 1.0;
+  ObjectClassification classification;
+  classification.label = label;
+  classification.probability = 1.0f;
+  object.classification.push_back(classification);
+  return object;
+}
+
+DetectedObject make_polygon_object(
+  const double x, const double covariance_x, const double existence_probability,
+  const std::vector<geometry_msgs::msg::Point32> & footprint_points, const uint8_t label)
+{
+  auto object = make_object(x, covariance_x, existence_probability, 1.0, label);
+  object.shape.type = Shape::POLYGON;
+  object.shape.footprint.points = footprint_points;
+  object.shape.dimensions.x = 0.0;
+  object.shape.dimensions.y = 0.0;
+  object.shape.dimensions.z = 1.0;
+  return object;
+}
+
+DetectedObject make_cylinder_object(
+  const double x, const double covariance_x, const double existence_probability,
+  const double diameter, const uint8_t label)
+{
+  auto object = make_object(x, covariance_x, existence_probability, diameter, label);
+  object.shape.type = Shape::CYLINDER;
+  object.shape.dimensions.x = diameter;
+  object.shape.dimensions.y = diameter;
+  object.shape.dimensions.z = 1.0;
+  return object;
+}
+
+double max_abs_footprint_x(const DetectedObject & object)
+{
+  double max_abs_x = 0.0;
+  for (const auto & point : object.shape.footprint.points) {
+    max_abs_x = std::max(max_abs_x, std::abs(static_cast<double>(point.x)));
+  }
+  return max_abs_x;
+}
+
+double max_abs_footprint_y(const DetectedObject & object)
+{
+  double max_abs_y = 0.0;
+  for (const auto & point : object.shape.footprint.points) {
+    max_abs_y = std::max(max_abs_y, std::abs(static_cast<double>(point.y)));
+  }
+  return max_abs_y;
+}
+}  // namespace
+
+TEST(ObjectFusionMergerNodeTest, testMatchedObjectsAreFused)
+{
+  rclcpp::init(0, nullptr);
+
+  auto test_manager = generate_test_manager();
+  auto test_target_node = generate_node();
+  auto tf_node = create_static_tf_broadcaster_node("map", "base_link");
+
+  DetectedObjects latest_msg;
+  test_manager->set_subscriber<DetectedObjects>(
+    "/output/object",
+    [&latest_msg](const DetectedObjects::ConstSharedPtr msg) { latest_msg = *msg; });
+
+  DetectedObjects main_objects;
+  main_objects.header.frame_id = "base_link";
+  main_objects.objects.push_back(make_object(0.0, 4.0, 0.6, 4.0, ObjectClassification::CAR));
+
+  DetectedObjects sub_objects;
+  sub_objects.header.frame_id = "base_link";
+  sub_objects.objects.push_back(make_object(1.5, 1.0, 0.5, 2.0, ObjectClassification::CAR));
+
+  test_manager->test_pub_msg<DetectedObjects>(test_target_node, "input/main_object", main_objects);
+  test_manager->test_pub_msg<DetectedObjects>(test_target_node, "input/sub_object", sub_objects);
+
+  ASSERT_EQ(latest_msg.objects.size(), 1U);
+  EXPECT_NEAR(
+    latest_msg.objects.front().kinematics.pose_with_covariance.pose.position.x, 0.0, 1e-3);
+  EXPECT_NEAR(latest_msg.objects.front().shape.dimensions.x, 5.0, 1e-3);
+  EXPECT_NEAR(latest_msg.objects.front().existence_probability, 0.6, 1e-3);
+  ASSERT_EQ(latest_msg.objects.front().classification.size(), 1U);
+  EXPECT_EQ(latest_msg.objects.front().classification.front().label, ObjectClassification::CAR);
+
+  rclcpp::shutdown();
+}
+
+TEST(ObjectFusionMergerNodeTest, testUnmatchedMainIsKeptAndUnmatchedSubIsDiscarded)
+{
+  rclcpp::init(0, nullptr);
+
+  auto test_manager = generate_test_manager();
+  auto test_target_node = generate_node();
+  auto tf_node = create_static_tf_broadcaster_node("map", "base_link");
+
+  DetectedObjects latest_msg;
+  test_manager->set_subscriber<DetectedObjects>(
+    "/output/object",
+    [&latest_msg](const DetectedObjects::ConstSharedPtr msg) { latest_msg = *msg; });
+
+  DetectedObjects main_objects;
+  main_objects.header.frame_id = "base_link";
+  main_objects.objects.push_back(make_object(0.0, 4.0, 0.6, 4.0, ObjectClassification::CAR));
+  main_objects.objects.push_back(make_object(10.0, 4.0, 0.9, 3.0, ObjectClassification::TRUCK));
+
+  DetectedObjects sub_objects;
+  sub_objects.header.frame_id = "base_link";
+  sub_objects.objects.push_back(make_object(1.5, 1.0, 0.5, 2.0, ObjectClassification::CAR));
+  sub_objects.objects.push_back(make_object(20.0, 1.0, 0.5, 6.0, ObjectClassification::BUS));
+
+  test_manager->test_pub_msg<DetectedObjects>(test_target_node, "input/main_object", main_objects);
+  test_manager->test_pub_msg<DetectedObjects>(test_target_node, "input/sub_object", sub_objects);
+
+  ASSERT_EQ(latest_msg.objects.size(), 2U);
+  EXPECT_NEAR(latest_msg.objects.at(0).shape.dimensions.x, 5.0, 1e-3);
+  EXPECT_NEAR(latest_msg.objects.at(1).kinematics.pose_with_covariance.pose.position.x, 10.0, 1e-3);
+  ASSERT_EQ(latest_msg.objects.at(1).classification.size(), 1U);
+  EXPECT_EQ(latest_msg.objects.at(1).classification.front().label, ObjectClassification::TRUCK);
+
+  rclcpp::shutdown();
+}
+
+TEST(ObjectFusionMergerNodeTest, testUnionCanBeEnclosedWithMainBoundingBox)
+{
+  rclcpp::init(0, nullptr);
+
+  auto test_manager = generate_test_manager();
+  auto test_target_node = generate_node();
+  auto tf_node = create_static_tf_broadcaster_node("map", "base_link");
+
+  DetectedObjects latest_msg;
+  test_manager->set_subscriber<DetectedObjects>(
+    "/output/object",
+    [&latest_msg](const DetectedObjects::ConstSharedPtr msg) { latest_msg = *msg; });
+
+  DetectedObjects main_objects;
+  main_objects.header.frame_id = "base_link";
+  main_objects.objects.push_back(make_object(0.0, 4.0, 0.6, 4.0, ObjectClassification::CAR));
+
+  DetectedObjects sub_objects;
+  sub_objects.header.frame_id = "base_link";
+  sub_objects.objects.push_back(make_polygon_object(
+    1.0, 1.0, 0.5,
+    {
+      geometry_msgs::build<geometry_msgs::msg::Point32>().x(3.5).y(1.5).z(0.0),
+      geometry_msgs::build<geometry_msgs::msg::Point32>().x(3.5).y(-1.5).z(0.0),
+      geometry_msgs::build<geometry_msgs::msg::Point32>().x(-3.5).y(-1.5).z(0.0),
+      geometry_msgs::build<geometry_msgs::msg::Point32>().x(-3.5).y(1.5).z(0.0),
+    },
+    ObjectClassification::CAR));
+
+  test_manager->test_pub_msg<DetectedObjects>(test_target_node, "input/main_object", main_objects);
+  test_manager->test_pub_msg<DetectedObjects>(test_target_node, "input/sub_object", sub_objects);
+
+  ASSERT_EQ(latest_msg.objects.size(), 1U);
+  EXPECT_EQ(latest_msg.objects.front().shape.type, Shape::BOUNDING_BOX);
+  EXPECT_GT(latest_msg.objects.front().shape.dimensions.x, 6.5);
+  EXPECT_GT(latest_msg.objects.front().shape.dimensions.y, 2.9);
+
+  rclcpp::shutdown();
+}
+
+TEST(ObjectFusionMergerNodeTest, testUnionCanBeEnclosedWithMainCylinder)
+{
+  rclcpp::init(0, nullptr);
+
+  auto test_manager = generate_test_manager();
+  auto test_target_node = generate_node();
+  auto tf_node = create_static_tf_broadcaster_node("map", "base_link");
+
+  DetectedObjects latest_msg;
+  test_manager->set_subscriber<DetectedObjects>(
+    "/output/object",
+    [&latest_msg](const DetectedObjects::ConstSharedPtr msg) { latest_msg = *msg; });
+
+  DetectedObjects main_objects;
+  main_objects.header.frame_id = "base_link";
+  main_objects.objects.push_back(
+    make_cylinder_object(0.0, 4.0, 0.6, 2.0, ObjectClassification::PEDESTRIAN));
+
+  DetectedObjects sub_objects;
+  sub_objects.header.frame_id = "base_link";
+  sub_objects.objects.push_back(make_polygon_object(
+    0.5, 1.0, 0.5,
+    {
+      geometry_msgs::build<geometry_msgs::msg::Point32>().x(1.5).y(1.2).z(0.0),
+      geometry_msgs::build<geometry_msgs::msg::Point32>().x(1.5).y(-1.2).z(0.0),
+      geometry_msgs::build<geometry_msgs::msg::Point32>().x(-0.5).y(-1.2).z(0.0),
+      geometry_msgs::build<geometry_msgs::msg::Point32>().x(-0.5).y(1.2).z(0.0),
+    },
+    ObjectClassification::PEDESTRIAN));
+
+  test_manager->test_pub_msg<DetectedObjects>(test_target_node, "input/main_object", main_objects);
+  test_manager->test_pub_msg<DetectedObjects>(test_target_node, "input/sub_object", sub_objects);
+
+  ASSERT_EQ(latest_msg.objects.size(), 1U);
+  EXPECT_EQ(latest_msg.objects.front().shape.type, Shape::CYLINDER);
+  EXPECT_GT(latest_msg.objects.front().shape.dimensions.x, 4.6);
+  EXPECT_NEAR(
+    latest_msg.objects.front().shape.dimensions.x, latest_msg.objects.front().shape.dimensions.y,
+    1e-3);
+
+  rclcpp::shutdown();
+}
+
+TEST(ObjectFusionMergerNodeTest, testUnionCanBeEnclosedWithMainPolygon)
+{
+  rclcpp::init(0, nullptr);
+
+  auto test_manager = generate_test_manager();
+  auto test_target_node = generate_node();
+  auto tf_node = create_static_tf_broadcaster_node("map", "base_link");
+
+  DetectedObjects latest_msg;
+  test_manager->set_subscriber<DetectedObjects>(
+    "/output/object",
+    [&latest_msg](const DetectedObjects::ConstSharedPtr msg) { latest_msg = *msg; });
+
+  DetectedObjects main_objects;
+  main_objects.header.frame_id = "base_link";
+  main_objects.objects.push_back(make_polygon_object(
+    0.0, 4.0, 0.6,
+    {
+      geometry_msgs::build<geometry_msgs::msg::Point32>().x(1.0).y(1.0).z(0.0),
+      geometry_msgs::build<geometry_msgs::msg::Point32>().x(1.0).y(-1.0).z(0.0),
+      geometry_msgs::build<geometry_msgs::msg::Point32>().x(-1.0).y(-1.0).z(0.0),
+      geometry_msgs::build<geometry_msgs::msg::Point32>().x(-1.0).y(1.0).z(0.0),
+    },
+    ObjectClassification::CAR));
+
+  DetectedObjects sub_objects;
+  sub_objects.header.frame_id = "base_link";
+  sub_objects.objects.push_back(make_polygon_object(
+    0.6, 1.0, 0.5,
+    {
+      geometry_msgs::build<geometry_msgs::msg::Point32>().x(1.6).y(1.0).z(0.0),
+      geometry_msgs::build<geometry_msgs::msg::Point32>().x(1.6).y(-1.0).z(0.0),
+      geometry_msgs::build<geometry_msgs::msg::Point32>().x(-0.6).y(-1.0).z(0.0),
+      geometry_msgs::build<geometry_msgs::msg::Point32>().x(-0.6).y(1.0).z(0.0),
+    },
+    ObjectClassification::CAR));
+
+  test_manager->test_pub_msg<DetectedObjects>(test_target_node, "input/main_object", main_objects);
+  test_manager->test_pub_msg<DetectedObjects>(test_target_node, "input/sub_object", sub_objects);
+
+  ASSERT_EQ(latest_msg.objects.size(), 1U);
+  EXPECT_EQ(latest_msg.objects.front().shape.type, Shape::POLYGON);
+  EXPECT_GT(latest_msg.objects.front().shape.footprint.points.size(), 3U);
+  EXPECT_GT(max_abs_footprint_x(latest_msg.objects.front()), 2.1);
+  EXPECT_GT(max_abs_footprint_y(latest_msg.objects.front()), 0.9);
+
+  rclcpp::shutdown();
+}

--- a/perception/autoware_object_merger/test/test_object_fusion_merger_node.cpp
+++ b/perception/autoware_object_merger/test/test_object_fusion_merger_node.cpp
@@ -145,9 +145,13 @@ TEST(ObjectFusionMergerNodeTest, testMatchedObjectsAreFused)
   auto tf_node = create_static_tf_broadcaster_node("map", "base_link");
 
   DetectedObjects latest_msg;
+  DetectedObjects unmatched_sub_msg;
   test_manager->set_subscriber<DetectedObjects>(
-    "/output/object",
+    "/output/objects",
     [&latest_msg](const DetectedObjects::ConstSharedPtr msg) { latest_msg = *msg; });
+  test_manager->set_subscriber<DetectedObjects>(
+    "/output/other_objects",
+    [&unmatched_sub_msg](const DetectedObjects::ConstSharedPtr msg) { unmatched_sub_msg = *msg; });
 
   DetectedObjects main_objects;
   main_objects.header.frame_id = "base_link";
@@ -161,6 +165,7 @@ TEST(ObjectFusionMergerNodeTest, testMatchedObjectsAreFused)
   test_manager->test_pub_msg<DetectedObjects>(test_target_node, "input/sub_object", sub_objects);
 
   ASSERT_EQ(latest_msg.objects.size(), 1U);
+  EXPECT_TRUE(unmatched_sub_msg.objects.empty());
   EXPECT_NEAR(
     latest_msg.objects.front().kinematics.pose_with_covariance.pose.position.x, 0.0, 1e-3);
   EXPECT_NEAR(latest_msg.objects.front().shape.dimensions.x, 5.0, 1e-3);
@@ -180,9 +185,13 @@ TEST(ObjectFusionMergerNodeTest, testUnmatchedMainIsKeptAndUnmatchedSubIsDiscard
   auto tf_node = create_static_tf_broadcaster_node("map", "base_link");
 
   DetectedObjects latest_msg;
+  DetectedObjects unmatched_sub_msg;
   test_manager->set_subscriber<DetectedObjects>(
-    "/output/object",
+    "/output/objects",
     [&latest_msg](const DetectedObjects::ConstSharedPtr msg) { latest_msg = *msg; });
+  test_manager->set_subscriber<DetectedObjects>(
+    "/output/other_objects",
+    [&unmatched_sub_msg](const DetectedObjects::ConstSharedPtr msg) { unmatched_sub_msg = *msg; });
 
   DetectedObjects main_objects;
   main_objects.header.frame_id = "base_link";
@@ -202,6 +211,12 @@ TEST(ObjectFusionMergerNodeTest, testUnmatchedMainIsKeptAndUnmatchedSubIsDiscard
   EXPECT_NEAR(latest_msg.objects.at(1).kinematics.pose_with_covariance.pose.position.x, 10.0, 1e-3);
   ASSERT_EQ(latest_msg.objects.at(1).classification.size(), 1U);
   EXPECT_EQ(latest_msg.objects.at(1).classification.front().label, ObjectClassification::TRUCK);
+  ASSERT_EQ(unmatched_sub_msg.objects.size(), 1U);
+  EXPECT_NEAR(
+    unmatched_sub_msg.objects.front().kinematics.pose_with_covariance.pose.position.x, 20.0, 1e-3);
+  ASSERT_EQ(unmatched_sub_msg.objects.front().classification.size(), 1U);
+  EXPECT_EQ(
+    unmatched_sub_msg.objects.front().classification.front().label, ObjectClassification::BUS);
 
   rclcpp::shutdown();
 }
@@ -216,7 +231,7 @@ TEST(ObjectFusionMergerNodeTest, testUnionCanBeEnclosedWithMainBoundingBox)
 
   DetectedObjects latest_msg;
   test_manager->set_subscriber<DetectedObjects>(
-    "/output/object",
+    "/output/objects",
     [&latest_msg](const DetectedObjects::ConstSharedPtr msg) { latest_msg = *msg; });
 
   DetectedObjects main_objects;
@@ -256,7 +271,7 @@ TEST(ObjectFusionMergerNodeTest, testUnionCanBeEnclosedWithMainCylinder)
 
   DetectedObjects latest_msg;
   test_manager->set_subscriber<DetectedObjects>(
-    "/output/object",
+    "/output/objects",
     [&latest_msg](const DetectedObjects::ConstSharedPtr msg) { latest_msg = *msg; });
 
   DetectedObjects main_objects;
@@ -299,7 +314,7 @@ TEST(ObjectFusionMergerNodeTest, testUnionCanBeEnclosedWithMainPolygon)
 
   DetectedObjects latest_msg;
   test_manager->set_subscriber<DetectedObjects>(
-    "/output/object",
+    "/output/objects",
     [&latest_msg](const DetectedObjects::ConstSharedPtr msg) { latest_msg = *msg; });
 
   DetectedObjects main_objects;

--- a/perception/autoware_object_merger/test/test_object_fusion_merger_node.cpp
+++ b/perception/autoware_object_merger/test/test_object_fusion_merger_node.cpp
@@ -167,8 +167,8 @@ TEST(ObjectFusionMergerNodeTest, testMatchedObjectsAreFused)
   ASSERT_EQ(latest_msg.objects.size(), 1U);
   EXPECT_TRUE(unmatched_sub_msg.objects.empty());
   EXPECT_NEAR(
-    latest_msg.objects.front().kinematics.pose_with_covariance.pose.position.x, 0.0, 1e-3);
-  EXPECT_NEAR(latest_msg.objects.front().shape.dimensions.x, 5.0, 1e-3);
+    latest_msg.objects.front().kinematics.pose_with_covariance.pose.position.x, 0.25, 1e-3);
+  EXPECT_NEAR(latest_msg.objects.front().shape.dimensions.x, 4.5, 1e-3);
   EXPECT_NEAR(latest_msg.objects.front().existence_probability, 0.6, 1e-3);
   ASSERT_EQ(latest_msg.objects.front().classification.size(), 1U);
   EXPECT_EQ(latest_msg.objects.front().classification.front().label, ObjectClassification::CAR);
@@ -207,7 +207,8 @@ TEST(ObjectFusionMergerNodeTest, testUnmatchedMainIsKeptAndUnmatchedSubIsDiscard
   test_manager->test_pub_msg<DetectedObjects>(test_target_node, "input/sub_object", sub_objects);
 
   ASSERT_EQ(latest_msg.objects.size(), 2U);
-  EXPECT_NEAR(latest_msg.objects.at(0).shape.dimensions.x, 5.0, 1e-3);
+  EXPECT_NEAR(latest_msg.objects.at(0).kinematics.pose_with_covariance.pose.position.x, 0.25, 1e-3);
+  EXPECT_NEAR(latest_msg.objects.at(0).shape.dimensions.x, 4.5, 1e-3);
   EXPECT_NEAR(latest_msg.objects.at(1).kinematics.pose_with_covariance.pose.position.x, 10.0, 1e-3);
   ASSERT_EQ(latest_msg.objects.at(1).classification.size(), 1U);
   EXPECT_EQ(latest_msg.objects.at(1).classification.front().label, ObjectClassification::TRUCK);
@@ -255,8 +256,9 @@ TEST(ObjectFusionMergerNodeTest, testUnionCanBeEnclosedWithMainBoundingBox)
 
   ASSERT_EQ(latest_msg.objects.size(), 1U);
   EXPECT_EQ(latest_msg.objects.front().shape.type, Shape::BOUNDING_BOX);
-  EXPECT_GT(latest_msg.objects.front().shape.dimensions.x, 6.5);
-  EXPECT_GT(latest_msg.objects.front().shape.dimensions.y, 2.9);
+  EXPECT_NEAR(latest_msg.objects.front().kinematics.pose_with_covariance.pose.position.x, 1.0, 1e-3);
+  EXPECT_NEAR(latest_msg.objects.front().shape.dimensions.x, 7.0, 1e-3);
+  EXPECT_NEAR(latest_msg.objects.front().shape.dimensions.y, 3.0, 1e-3);
 
   rclcpp::shutdown();
 }


### PR DESCRIPTION
## What

[TIER IV INTERNAL LINK](https://tier4.atlassian.net/browse/RDDR-100?focusedCommentId=306301)

This pull request introduces a new node, `object_fusion_merger`, to the `autoware_object_merger` package, which performs fusion of detected object streams by associating and expanding object shapes based on matches between main and sub streams.

**New Node: Object Fusion Merger**

* Added the `ObjectFusionMergerNode` implementation (`object_fusion_merger_node.cpp`, `object_fusion_merger_node.hpp`) that associates main and sub detected-object streams, expands shapes for matched pairs, and publishes fused and unmatched objects.
* Added configuration (`object_fusion_merger.param.yaml`), launch file (`object_fusion_merger.launch.xml`), documentation (`object_fusion_merger.md`), and build/test setup for the new node. [[1]](diffhunk://#diff-014cb3865f85249fedb2a151ba3fcadc0f5b3866645c38b23b2543ed6949cd4eR1-R4) [[2]](diffhunk://#diff-6a3e7a9fa080bf2c11d4985736cc240731f3414ea243cbb882490ba87e3916f0R1-R16) [[3]](diffhunk://#diff-fb128e071da7fef34b0ec23b93bbdcd1f686ac0efea0b44df16cc793c110359fR1-R105) [[4]](diffhunk://#diff-71a44a08434864435ea07c11c4781195e78d5eb2399fc4625e8bb0322345ad4aR17-R25) [[5]](diffhunk://#diff-71a44a08434864435ea07c11c4781195e78d5eb2399fc4625e8bb0322345ad4aR40-R59) [[6]](diffhunk://#diff-f1d8491b50b11e313e72803843152f5105924eceef4a749a373e9f4fe02542f5R20-R23)

**Update: Label Based Euclidean Cluster**

* Updated label mapping and allowed `ANIMAL` and `UNKNOWN` as well.
* Added a parameter called `shape_policy` that enables to choose whether `0: ALL_POLYGON` or `1: LABEL_DEPEND`.

### Sample Result

- Yellow: 3D ML Detector (Centerpoint)
- Green: Label-based Cluster (PTv3-tiny + Cluster)
- Pink: Fusion Output (ObjectFusionMerger)
- White: Unmatched  Output (ObjectFusionMerger)

https://github.com/user-attachments/assets/ababf38d-43b3-46cb-84f1-b9cbc9c47a7a

