### PR TITLE
feat(behavior_path_side_shift_module): add improved side shift module feature

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_planner/include/autoware/behavior_path_planner/behavior_path_planner_node.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner/include/autoware/behavior_path_planner/behavior_path_planner_node.hpp
@@ -152,7 +152,6 @@ private:
   void onMap(const LaneletMapBin::ConstSharedPtr map_msg);
   void onRoute(const LaneletRoute::ConstSharedPtr route_msg);
   void onOperationMode(const OperationModeState::ConstSharedPtr msg);
-  void onLateralOffset(const LateralOffset::ConstSharedPtr msg);
   void on_external_velocity_limiter(
     const autoware_internal_planning_msgs::msg::VelocityLimit::ConstSharedPtr msg);
 

--- a/planning/behavior_path_planner/autoware_behavior_path_planner/include/autoware/behavior_path_planner/behavior_path_planner_node.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner/include/autoware/behavior_path_planner/behavior_path_planner_node.hpp
@@ -69,7 +69,6 @@ using nav_msgs::msg::OccupancyGrid;
 using nav_msgs::msg::Odometry;
 using rcl_interfaces::msg::SetParametersResult;
 using tier4_planning_msgs::msg::AvoidanceDebugMsgArray;
-using tier4_planning_msgs::msg::LateralOffset;
 using tier4_planning_msgs::msg::RerouteAvailability;
 using visualization_msgs::msg::Marker;
 using visualization_msgs::msg::MarkerArray;
@@ -108,8 +107,6 @@ private:
     this, "~/input/costmap"};
   autoware_utils::InterProcessPollingSubscriber<TrafficLightGroupArray> traffic_signals_subscriber_{
     this, "~/input/traffic_signals"};
-  autoware_utils::InterProcessPollingSubscriber<LateralOffset> lateral_offset_subscriber_{
-    this, "~/input/lateral_offset"};
   autoware_utils::InterProcessPollingSubscriber<OperationModeState> operation_mode_subscriber_{
     this, "/system/operation_mode/state", rclcpp::QoS{1}.transient_local()};
   autoware_utils::InterProcessPollingSubscriber<autoware_internal_planning_msgs::msg::VelocityLimit>

--- a/planning/behavior_path_planner/autoware_behavior_path_planner/src/behavior_path_planner_node.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner/src/behavior_path_planner_node.cpp
@@ -228,13 +228,6 @@ void BehaviorPathPlannerNode::takeData()
       onTrafficSignals(msg);
     }
   }
-  // lateral_offset
-  {
-    const auto msg = lateral_offset_subscriber_.take_data();
-    if (msg) {
-      onLateralOffset(msg);
-    }
-  }
   // operation_mode
   {
     const auto msg = operation_mode_subscriber_.take_data();
@@ -755,24 +748,6 @@ void BehaviorPathPlannerNode::onTrafficSignals(const TrafficLightGroupArray::Con
     traffic_signal.signal = signal;
     planner_data_->traffic_light_id_map[signal.traffic_light_group_id] = traffic_signal;
   }
-}
-
-void BehaviorPathPlannerNode::onLateralOffset(const LateralOffset::ConstSharedPtr msg)
-{
-  if (!planner_data_->lateral_offset) {
-    planner_data_->lateral_offset = msg;
-    return;
-  }
-
-  const auto & new_offset = msg->lateral_offset;
-  const auto & old_offset = planner_data_->lateral_offset->lateral_offset;
-
-  // offset is not changed.
-  if (std::abs(old_offset - new_offset) < 1e-4) {
-    return;
-  }
-
-  planner_data_->lateral_offset = msg;
 }
 
 SetParametersResult BehaviorPathPlannerNode::onSetParam(

--- a/planning/behavior_path_planner/autoware_behavior_path_planner/src/planner_manager.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner/src/planner_manager.cpp
@@ -152,6 +152,8 @@ BehaviorModuleOutput PlannerManager::run(const std::shared_ptr<PlannerData> & da
     RCLCPP_WARN_THROTTLE(
       logger_, clock_, 5000,
       "Ego is out of route, no module is running. Skip running scene modules.");
+    data->scene_module_names_approved.clear();
+    data->scene_module_names_candidate.clear();
     generateCombinedDrivableArea(result_output, data);
     return result_output;
   }
@@ -185,6 +187,17 @@ BehaviorModuleOutput PlannerManager::run(const std::shared_ptr<PlannerData> & da
     m->publishRTCStatus();
     m->publish_planning_factors();
   });
+
+  data->scene_module_names_approved.clear();
+  data->scene_module_names_candidate.clear();
+  for (const auto & slot : planner_manager_slots_) {
+    for (const auto & m : slot.approved_modules()) {
+      data->scene_module_names_approved.push_back(m->name());
+    }
+    for (const auto & m : slot.candidate_modules()) {
+      data->scene_module_names_candidate.push_back(m->name());
+    }
+  }
 
   generateCombinedDrivableArea(result_output.valid_output, data);
   return result_output.valid_output;

--- a/planning/behavior_path_planner/autoware_behavior_path_planner/src/test_utils.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner/src/test_utils.cpp
@@ -18,8 +18,6 @@
 #include <autoware/planning_test_manager/autoware_planning_test_manager.hpp>
 #include <autoware_test_utils/autoware_test_utils.hpp>
 
-#include <tier4_planning_msgs/msg/lateral_offset.hpp>
-
 #include <memory>
 #include <string>
 #include <vector>
@@ -108,8 +106,5 @@ void publishMandatoryTopics(
   test_manager->publishInput(
     test_target_node, "system/operation_mode/state",
     autoware_adapi_v1_msgs::msg::OperationModeState{});
-  test_manager->publishInput(
-    test_target_node, "behavior_path_planner/input/lateral_offset",
-    tier4_planning_msgs::msg::LateralOffset{});
 }
 }  // namespace autoware::behavior_path_planner

--- a/planning/behavior_path_planner/autoware_behavior_path_planner_common/include/autoware/behavior_path_planner_common/data_manager.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner_common/include/autoware/behavior_path_planner_common/data_manager.hpp
@@ -39,7 +39,6 @@
 #include <geometry_msgs/msg/pose_stamped.hpp>
 #include <nav_msgs/msg/occupancy_grid.hpp>
 #include <nav_msgs/msg/odometry.hpp>
-#include <tier4_planning_msgs/msg/lateral_offset.hpp>
 
 #include <limits>
 #include <map>
@@ -63,7 +62,6 @@ using geometry_msgs::msg::AccelWithCovarianceStamped;
 using geometry_msgs::msg::PoseStamped;
 using nav_msgs::msg::OccupancyGrid;
 using nav_msgs::msg::Odometry;
-using tier4_planning_msgs::msg::LateralOffset;
 using PlanResult = PathWithLaneId::SharedPtr;
 using autoware_internal_planning_msgs::msg::VelocityLimit;
 using lanelet::TrafficLight;
@@ -165,7 +163,6 @@ struct PlannerData
   PredictedObjects::ConstSharedPtr dynamic_object{};
   OccupancyGrid::ConstSharedPtr occupancy_grid{};
   OccupancyGrid::ConstSharedPtr costmap{};
-  LateralOffset::ConstSharedPtr lateral_offset{};
   OperationModeState::ConstSharedPtr operation_mode{};
   PathWithLaneId::SharedPtr prev_output_path{std::make_shared<PathWithLaneId>()};
   std::optional<PoseWithUuidStamped> prev_modified_goal{};
@@ -180,7 +177,6 @@ struct PlannerData
   mutable std::vector<geometry_msgs::msg::Pose> drivable_area_expansion_prev_path_poses{};
   mutable std::vector<double> drivable_area_expansion_prev_curvatures{};
   mutable TurnSignalDecider turn_signal_decider;
-
   void init_parameters(rclcpp::Node & node)
   {
     parameters.traffic_light_signal_timeout =

--- a/planning/behavior_path_planner/autoware_behavior_path_planner_common/include/autoware/behavior_path_planner_common/data_manager.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner_common/include/autoware/behavior_path_planner_common/data_manager.hpp
@@ -173,6 +173,8 @@ struct PlannerData
   autoware::behavior_path_planner::drivable_area_expansion::DrivableAreaExpansionParameters
     drivable_area_expansion_parameters{};
   VelocityLimit::ConstSharedPtr external_limit_max_velocity{};
+  std::vector<std::string> scene_module_names_approved{};
+  std::vector<std::string> scene_module_names_candidate{};
 
   mutable std::vector<geometry_msgs::msg::Pose> drivable_area_expansion_prev_path_poses{};
   mutable std::vector<double> drivable_area_expansion_prev_curvatures{};

--- a/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/CMakeLists.txt
+++ b/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/CMakeLists.txt
@@ -9,6 +9,7 @@ ament_auto_add_library(${PROJECT_NAME} SHARED
   src/scene.cpp
   src/utils.cpp
   src/manager.cpp
+  src/validation.cpp
 )
 
 if(BUILD_TESTING)

--- a/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/README.md
+++ b/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/README.md
@@ -16,14 +16,34 @@ Please be aware that `requested_lateral_offset_` is continuously updated with th
 
 Offsets use the same sign convention as `tier4_planning_msgs/msg/LateralOffset` (**positive = left** of the reference path, **negative = right**).
 
-| Interface    | Message / service                                               | Role                                                                                                                                                                                |
-| ------------ | --------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| Subscription | `~/input/lateral_offset` (`tier4_planning_msgs/LateralOffset`)  | Stream of requested lateral offset [m].                                                                                                                                             |
-| Service      | `~/set_lateral_offset` (`tier4_planning_msgs/SetLateralOffset`) | Request a new offset with a response: `EXPLICIT_LATERAL_OFFSET_AMOUNT` sets `shift_value` [m] directly; `DIRECTION` uses `LEFT` / `RIGHT` / `RESET` with step size from parameters. |
-| Publisher    | `~/output/lateral_offset` (`tier4_planning_msgs/LateralOffset`) | Reports the **current** inserted lateral offset [m] for feedback.                                                                                                                   |
+| Interface    | Message / service                                               | Role                                                                                                                                                                                               |
+| ------------ | --------------------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Subscription | `~/input/lateral_offset` (`tier4_planning_msgs/LateralOffset`)  | Stream of requested lateral offset [m].                                                                                                                                                            |
+| Service      | `~/set_lateral_offset` (`tier4_planning_msgs/SetLateralOffset`) | Request a new offset with a response: `EXPLICIT_LATERAL_OFFSET_AMOUNT` sets `shift_value` [m] directly; `LATERAL_OFFSET_DIRECTION` uses `LEFT` / `RIGHT` / `RESET` with step size from parameters. |
+| Publisher    | `~/output/lateral_offset` (`tier4_planning_msgs/LateralOffset`) | Reports the **current** inserted lateral offset [m] for feedback.                                                                                                                                  |
 
 The same validation (magnitude limits, minimum gap versus the previous offset, and so on) applies whether the request arrives on the topic or through the service.
 It is recommended to use services so that the user can understand whether the request is accepted or not.
+
+### `~/set_lateral_offset` response `status.code` values
+
+The service fills `autoware_common_msgs/ResponseStatus` (`success`, `code`, `message`). The numeric `code` is either a constant from `tier4_planning_msgs/srv/SetLateralOffset` (service-specific) or from `autoware_common_msgs/msg/ResponseStatus` (shared infrastructure).
+
+| `code` value | Constant                    | Typical `success` | Meaning                                                                                                                                                                                                                  |
+| -----------: | --------------------------- | :---------------: | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
+|            0 | `SUCCESS`                   |      `true`       | Request accepted; lateral offset updated as requested.                                                                                                                                                                   |
+|        10000 | `ERROR_UNKNOWN`             |      `false`      | Unspecified error.                                                                                                                                                                                                       |
+|        10001 | `ERROR_INVALID_MODE`        |      `false`      | `shift_mode` is not a supported value.                                                                                                                                                                                   |
+|        10002 | `ERROR_INVALID_DIRECTION`   |      `false`      | In `LATERAL_OFFSET_DIRECTION` mode, `shift_direction_value` is not `RESET`, `LEFT`, or `RIGHT`.                                                                                                                          |
+|        10003 | `ERROR_EXCEEDED_LIMIT`      |      `false`      | The path is shifted **already at limit** (configured by parameters) and your request is trying to go even further.                                                                                                       |
+|        10004 | `ERROR_SHIFT_GAP_TOO_SMALL` |      `false`      | Change versus the current offset is smaller than `min_shift_gap` (treated as no meaningful update).                                                                                                                      |
+|        10005 | `ERROR_MODULES_CONFLICTING` |      `false`      | Cannot perform side shift because modules that cannot be run together with the side_shift module is active in the `behavior_path_planner`                                                                                |
+|        20000 | `WARN_UNKNOWN`              |      `false`      | Unspecified warning.                                                                                                                                                                                                     |
+|        20001 | `WARN_EXCEEDED_LIMIT`       |      `true`       | You request reached the limit (configured by parameters) and side_shift module tries to shift the path to the possible maximum. If you try shift even further next, then the service will return `ERROR_EXCEEDED_LIMIT`. |
+|        50001 | `SERVICE_UNREADY`           |      `false`      | `behavior_path_planner` is not ready; request ignored.                                                                                                                                                                   |
+|        50004 | `PARAMETER_ERROR`           |      `false`      | Invalid side-shift node parameters were detected (e.g. non-positive `unit_shift_amount` when using direction steps).                                                                                                     |
+
+`success` is set to `true` only when `code` is `SUCCESS` (0) or `WARN_EXCEEDED_LIMIT` (20001); in those cases the requested offset (possibly clamped) is applied. For all other rows, the previous requested offset is left unchanged.
 
 ## Statuses of the Side Shift
 

--- a/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/README.md
+++ b/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/README.md
@@ -31,7 +31,8 @@ The service fills `autoware_common_msgs/ResponseStatus` (`success`, `code`, `mes
 
 | `code` value | Constant                    | Typical `success` | Meaning                                                                                                                                                                                                                  |
 | -----------: | --------------------------- | :---------------: | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-|            0 | `SUCCESS`                   |      `true`       | Request accepted; lateral offset updated as requested.                                                                                                                                                                   |
+|            0 | `UNKNOWN`                   |      `false`      | No specific result (e.g. zero-initialized `code`; this node always sets `code` explicitly on return).                                                                                                                    |
+|            1 | `SUCCESS`                   |      `true`       | Request accepted; lateral offset updated as requested.                                                                                                                                                                   |
 |        10000 | `ERROR_UNKNOWN`             |      `false`      | Unspecified error.                                                                                                                                                                                                       |
 |        10001 | `ERROR_INVALID_MODE`        |      `false`      | `shift_mode` is not a supported value.                                                                                                                                                                                   |
 |        10002 | `ERROR_INVALID_DIRECTION`   |      `false`      | In `LATERAL_OFFSET_DIRECTION` mode, `shift_direction_value` is not `RESET`, `LEFT`, or `RIGHT`.                                                                                                                          |
@@ -43,7 +44,7 @@ The service fills `autoware_common_msgs/ResponseStatus` (`success`, `code`, `mes
 |        50001 | `SERVICE_UNREADY`           |      `false`      | `behavior_path_planner` is not ready; request ignored.                                                                                                                                                                   |
 |        50004 | `PARAMETER_ERROR`           |      `false`      | Invalid side-shift node parameters were detected (e.g. non-positive `unit_shift_amount` when using direction steps).                                                                                                     |
 
-`success` is set to `true` only when `code` is `SUCCESS` (0) or `WARN_EXCEEDED_LIMIT` (20001); in those cases the requested offset (possibly clamped) is applied. For all other rows, the previous requested offset is left unchanged.
+`success` is set to `true` only when `code` is `SUCCESS` (1) or `WARN_EXCEEDED_LIMIT` (20001); in those cases the requested offset (possibly clamped) is applied. For all other rows, the previous requested offset is left unchanged.
 
 ## Statuses of the Side Shift
 

--- a/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/README.md
+++ b/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/README.md
@@ -4,13 +4,26 @@
 
 ## Overview of the Side Shift Module Process
 
-1. Receive the required lateral offset input.
+1. Receive the required lateral offset from the topic and/or the `~/set_lateral_offset` service.
 2. Update the `requested_lateral_offset_` under the following conditions:
    a. Verify if the last update time has elapsed.
    b. Ensure the required lateral offset value is different from the previous one.
 3. Insert the shift points into the path if the side shift module's status is not in the SHIFTING status.
 
 Please be aware that `requested_lateral_offset_` is continuously updated with the latest values and is not queued.
+
+## Lateral offset inputs and outputs
+
+Offsets use the same sign convention as `tier4_planning_msgs/msg/LateralOffset` (**positive = left** of the reference path, **negative = right**).
+
+| Interface    | Message / service                                               | Role                                                                                                                                                                                |
+| ------------ | --------------------------------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| Subscription | `~/input/lateral_offset` (`tier4_planning_msgs/LateralOffset`)  | Stream of requested lateral offset [m].                                                                                                                                             |
+| Service      | `~/set_lateral_offset` (`tier4_planning_msgs/SetLateralOffset`) | Request a new offset with a response: `EXPLICIT_LATERAL_OFFSET_AMOUNT` sets `shift_value` [m] directly; `DIRECTION` uses `LEFT` / `RIGHT` / `RESET` with step size from parameters. |
+| Publisher    | `~/output/lateral_offset` (`tier4_planning_msgs/LateralOffset`) | Reports the **current** inserted lateral offset [m] for feedback.                                                                                                                   |
+
+The same validation (magnitude limits, minimum gap versus the previous offset, and so on) applies whether the request arrives on the topic or through the service.
+It is recommended to use services so that the user can understand whether the request is accepted or not.
 
 ## Statuses of the Side Shift
 

--- a/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/README.md
+++ b/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/README.md
@@ -25,26 +25,28 @@ Offsets use the same sign convention as `tier4_planning_msgs/msg/LateralOffset` 
 The same validation (magnitude limits, minimum gap versus the previous offset, and so on) applies whether the request arrives on the topic or through the service.
 It is recommended to use services so that the user can understand whether the request is accepted or not.
 
-### `~/set_lateral_offset` response `status.code` values
+### `~/set_lateral_offset` response: `response_code` values
 
-The service fills `autoware_common_msgs/ResponseStatus` (`success`, `code`, `message`). The numeric `code` is either a constant from `tier4_planning_msgs/srv/SetLateralOffset` (service-specific) or from `autoware_common_msgs/msg/ResponseStatus` (shared infrastructure).
+`response_code` is the primary outcome field. It uses the lateral-shift constants from `tier4_planning_msgs/srv/SetLateralOffset`, and may also use **`SERVICE_UNREADY`** and **`PARAMETER_ERROR`** from `autoware_common_msgs/msg/ResponseStatus.msg` with the **same numeric values** as `ResponseStatus.code`.
 
-| `code` value | Constant                    | Typical `success` | Meaning                                                                                                                                                                                                                  |
-| -----------: | --------------------------- | :---------------: | ------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------ |
-|            0 | `UNKNOWN`                   |      `false`      | No specific result (e.g. zero-initialized `code`; this node always sets `code` explicitly on return).                                                                                                                    |
-|            1 | `SUCCESS`                   |      `true`       | Request accepted; lateral offset updated as requested.                                                                                                                                                                   |
-|        10000 | `ERROR_UNKNOWN`             |      `false`      | Unspecified error.                                                                                                                                                                                                       |
-|        10001 | `ERROR_INVALID_MODE`        |      `false`      | `shift_mode` is not a supported value.                                                                                                                                                                                   |
-|        10002 | `ERROR_INVALID_DIRECTION`   |      `false`      | In `LATERAL_OFFSET_DIRECTION` mode, `shift_direction_value` is not `RESET`, `LEFT`, or `RIGHT`.                                                                                                                          |
-|        10003 | `ERROR_EXCEEDED_LIMIT`      |      `false`      | The path is shifted **already at limit** (configured by parameters) and your request is trying to go even further.                                                                                                       |
-|        10004 | `ERROR_SHIFT_GAP_TOO_SMALL` |      `false`      | Change versus the current offset is smaller than `min_shift_gap` (treated as no meaningful update).                                                                                                                      |
-|        10005 | `ERROR_MODULES_CONFLICTING` |      `false`      | Cannot perform side shift because modules that cannot be run together with the side_shift module is active in the `behavior_path_planner`                                                                                |
-|        20000 | `WARN_UNKNOWN`              |      `false`      | Unspecified warning.                                                                                                                                                                                                     |
-|        20001 | `WARN_EXCEEDED_LIMIT`       |      `true`       | You request reached the limit (configured by parameters) and side_shift module tries to shift the path to the possible maximum. If you try shift even further next, then the service will return `ERROR_EXCEEDED_LIMIT`. |
-|        50001 | `SERVICE_UNREADY`           |      `false`      | `behavior_path_planner` is not ready; request ignored.                                                                                                                                                                   |
-|        50004 | `PARAMETER_ERROR`           |      `false`      | Invalid side-shift node parameters were detected (e.g. non-positive `unit_shift_amount` when using direction steps).                                                                                                     |
+| Value | Constant                    | Typical `success` | Meaning                                                                                                    |
+| ----: | --------------------------- | :---------------: | ---------------------------------------------------------------------------------------------------------- |
+|     0 | `UNKNOWN`                   |      `false`      | No result assigned (for example default-initialized; this implementation sets `response_code` explicitly). |
+|     1 | `SUCCESS`                   |      `true`       | The request was accepted and the lateral offset was updated.                                               |
+| 10000 | `ERROR_UNKNOWN`             |      `false`      | An unspecified error occurred.                                                                             |
+| 10001 | `ERROR_INVALID_MODE`        |      `false`      | `shift_mode` is not supported.                                                                             |
+| 10002 | `ERROR_INVALID_DIRECTION`   |      `false`      | In `LATERAL_OFFSET_DIRECTION` mode, `shift_direction_value` is not `RESET`, `LEFT`, or `RIGHT`.            |
+| 10003 | `ERROR_EXCEEDED_LIMIT`      |      `false`      | The offset is already at the configured limit and the request would exceed it.                             |
+| 10004 | `ERROR_SHIFT_GAP_TOO_SMALL` |      `false`      | The requested change is smaller than `min_shift_gap`.                                                      |
+| 10005 | `ERROR_MODULES_CONFLICTING` |      `false`      | Other active modules in `behavior_path_planner` conflict with this operation.                              |
+| 20000 | `WARN_UNKNOWN`              |      `false`      | An unspecified warning occurred.                                                                           |
+| 20001 | `WARN_EXCEEDED_LIMIT`       |      `true`       | The request hit the limit; the offset was clamped to the maximum allowed value.                            |
 
-`success` is set to `true` only when `code` is `SUCCESS` (1) or `WARN_EXCEEDED_LIMIT` (20001); in those cases the requested offset (possibly clamped) is applied. For all other rows, the previous requested offset is left unchanged.
+In addition, `status.success` is `true` only when `response_code` is `SUCCESS` (1) or `WARN_EXCEEDED_LIMIT` (20001); only then is the requested offset (possibly clamped) applied. Otherwise the previous requested offset is unchanged.
+
+### `~/set_lateral_offset` response: `status` (`autoware_common_msgs/ResponseStatus`)
+
+`status.message` summarizes the outcome using `response_code`. **`status.code` is never set to SetLateralOffset-specific values** (such as `SUCCESS` or `ERROR_EXCEEDED_LIMIT`); those appear only in `response_code`. When the failure is infrastructure or configuration, `status.code` is `SERVICE_UNREADY` or `PARAMETER_ERROR` (and matches `response_code`). For all other outcomes that use only SetLateralOffset constants, `status.code` is **`UNKNOWN`** (50000) from `ResponseStatus.msg`.
 
 ## Statuses of the Side Shift
 

--- a/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/config/side_shift.param.yaml
+++ b/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/config/side_shift.param.yaml
@@ -7,4 +7,7 @@
       min_shifting_distance: 5.0
       min_shifting_speed: 5.56
       shift_request_time_limit: 1.0
+      max_shift_magnitude: 1.0
+      min_shift_gap: 0.001
+      unit_shift_amount: 0.1
       publish_debug_marker: false

--- a/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/config/side_shift.param.yaml
+++ b/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/config/side_shift.param.yaml
@@ -7,9 +7,9 @@
       min_shifting_distance: 5.0
       min_shifting_speed: 5.56
       shift_request_time_limit: 1.0
+      drivable_area_check_mode: 1 # 0 = No check, 1 = Only current lane, 2 = Adjacent lanes included
+      min_drivable_area_margin: 0.3
       max_shift_magnitude: 1.0
       min_shift_gap: 0.001
       unit_shift_amount: 0.1
-      drivable_area_check_mode: 1
-      min_drivable_area_margin: 0.3
       publish_debug_marker: false

--- a/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/config/side_shift.param.yaml
+++ b/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/config/side_shift.param.yaml
@@ -10,6 +10,6 @@
       max_shift_magnitude: 1.0
       min_shift_gap: 0.001
       unit_shift_amount: 0.1
-      drivable_area_check_mode: 2
+      drivable_area_check_mode: 1
       min_drivable_area_margin: 0.3
       publish_debug_marker: false

--- a/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/config/side_shift.param.yaml
+++ b/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/config/side_shift.param.yaml
@@ -8,7 +8,7 @@
       min_shifting_speed: 5.56
       shift_request_time_limit: 1.0
       drivable_area_check_mode: 1 # 0 = No check, 1 = Only current lane, 2 = Adjacent lanes included
-      min_drivable_area_margin: 0.3
+      min_margin_from_lanelet_border: 0.3
       max_shift_magnitude: 1.0
       min_shift_gap: 0.001
       unit_shift_amount: 0.1

--- a/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/config/side_shift.param.yaml
+++ b/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/config/side_shift.param.yaml
@@ -10,4 +10,6 @@
       max_shift_magnitude: 1.0
       min_shift_gap: 0.001
       unit_shift_amount: 0.1
+      drivable_area_check_mode: 2
+      min_drivable_area_margin: 0.3
       publish_debug_marker: false

--- a/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/include/autoware/behavior_path_side_shift_module/data_structs.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/include/autoware/behavior_path_side_shift_module/data_structs.hpp
@@ -19,6 +19,7 @@
 
 #include <tier4_planning_msgs/msg/lateral_offset.hpp>
 
+#include <atomic>
 #include <memory>
 #include <string>
 #include <vector>
@@ -40,6 +41,9 @@ struct SideShiftParameters
   double drivable_area_width;
   double drivable_area_height;
   double shift_request_time_limit;
+  double max_shift_magnitude;
+  double min_shift_gap;
+  double unit_shift_amount;
   bool publish_debug_marker;
 };
 
@@ -48,6 +52,26 @@ struct SideShiftDebugData
   std::shared_ptr<PathShifter> path_shifter{};
   ShiftLineArray shift_lines{};
   double current_request{0.0};
+};
+
+/**
+ * @brief Shared state for the inserted (actually applied) lateral offset [m].
+ *        The manager owns this and passes it to the scene; the scene updates it
+ *        whenever inserted_lateral_offset_ changes; the manager reads it periodically to publish.
+ */
+struct InsertedLateralOffsetState
+{
+  std::atomic<double> value{0.0};
+};
+
+/**
+ * @brief Shared state for the requested lateral offset [m] coming from external commands.
+ *        The manager owns this and passes it to the scene; the manager updates it when a new
+ *        lateral offset command is received; the scene reads it in updateData().
+ */
+struct RequestedLateralOffsetState
+{
+  std::atomic<double> value{0.0};
 };
 
 }  // namespace autoware::behavior_path_planner

--- a/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/include/autoware/behavior_path_side_shift_module/data_structs.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/include/autoware/behavior_path_side_shift_module/data_structs.hpp
@@ -30,6 +30,12 @@ using tier4_planning_msgs::msg::LateralOffset;
 
 enum class SideShiftStatus { STOP = 0, BEFORE_SHIFT, SHIFTING, AFTER_SHIFT };
 
+enum class DrivableAreaCheckMode {
+  DISABLED = 0,       // No boundary check; shift by exact requested amount
+  CURRENT_LANE = 1,   // Clamp to current lane boundaries
+  ADJACENT_LANES = 2  // Extend limit into same-direction neighbor lanes
+};
+
 struct SideShiftParameters
 {
   double time_to_start_shifting;
@@ -44,6 +50,8 @@ struct SideShiftParameters
   double max_shift_magnitude;
   double min_shift_gap;
   double unit_shift_amount;
+  DrivableAreaCheckMode drivable_area_check_mode;
+  double min_drivable_area_margin;
   bool publish_debug_marker;
 };
 

--- a/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/include/autoware/behavior_path_side_shift_module/data_structs.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/include/autoware/behavior_path_side_shift_module/data_structs.hpp
@@ -47,11 +47,11 @@ struct SideShiftParameters
   double drivable_area_width;
   double drivable_area_height;
   double shift_request_time_limit;
+  DrivableAreaCheckMode drivable_area_check_mode;
+  double min_margin_from_lanelet_border;
   double max_shift_magnitude;
   double min_shift_gap;
   double unit_shift_amount;
-  DrivableAreaCheckMode drivable_area_check_mode;
-  double min_drivable_area_margin;
   bool publish_debug_marker;
 };
 

--- a/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/include/autoware/behavior_path_side_shift_module/manager.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/include/autoware/behavior_path_side_shift_module/manager.hpp
@@ -57,11 +57,15 @@ private:
 
   void onLateralOffset(const tier4_planning_msgs::msg::LateralOffset::ConstSharedPtr msg);
 
+  void publishInsertedLateralOffsetTimerCallback();
+
   std::shared_ptr<SideShiftParameters> parameters_;
   std::shared_ptr<InsertedLateralOffsetState> inserted_lateral_offset_state_;
   std::shared_ptr<RequestedLateralOffsetState> requested_lateral_offset_state_;
   rclcpp::Service<tier4_planning_msgs::srv::SetLateralOffset>::SharedPtr set_lateral_offset_srv_;
+  rclcpp::Publisher<tier4_planning_msgs::msg::LateralOffset>::SharedPtr lateral_offset_publisher_;
   rclcpp::Subscription<tier4_planning_msgs::msg::LateralOffset>::SharedPtr lateral_offset_sub_;
+  rclcpp::TimerBase::SharedPtr lateral_offset_publish_timer_;
 };
 
 }  // namespace autoware::behavior_path_planner

--- a/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/include/autoware/behavior_path_side_shift_module/manager.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/include/autoware/behavior_path_side_shift_module/manager.hpp
@@ -16,9 +16,13 @@
 #define AUTOWARE__BEHAVIOR_PATH_SIDE_SHIFT_MODULE__MANAGER_HPP_
 
 #include "autoware/behavior_path_planner_common/interface/scene_module_manager_interface.hpp"
+#include "autoware/behavior_path_side_shift_module/data_structs.hpp"
 #include "autoware/behavior_path_side_shift_module/scene.hpp"
 
 #include <rclcpp/rclcpp.hpp>
+
+#include <tier4_planning_msgs/msg/lateral_offset.hpp>
+#include <tier4_planning_msgs/srv/set_lateral_offset.hpp>
 
 #include <memory>
 #include <string>
@@ -27,6 +31,7 @@
 
 namespace autoware::behavior_path_planner
 {
+using SetLateralOffset = tier4_planning_msgs::srv::SetLateralOffset;
 
 class SideShiftModuleManager : public SceneModuleManagerInterface
 {
@@ -39,13 +44,24 @@ public:
   {
     return std::make_unique<SideShiftModule>(
       name_, *node_, parameters_, rtc_interface_ptr_map_,
-      objects_of_interest_marker_interface_ptr_map_, planning_factor_interface_);
+      objects_of_interest_marker_interface_ptr_map_, planning_factor_interface_,
+      inserted_lateral_offset_state_, requested_lateral_offset_state_);
   }
 
   void updateModuleParams(const std::vector<rclcpp::Parameter> & parameters) override;
 
 private:
+  void onSetLateralOffset(
+    const tier4_planning_msgs::srv::SetLateralOffset::Request::SharedPtr request,
+    tier4_planning_msgs::srv::SetLateralOffset::Response::SharedPtr response);
+
+  void onLateralOffset(const tier4_planning_msgs::msg::LateralOffset::ConstSharedPtr msg);
+
   std::shared_ptr<SideShiftParameters> parameters_;
+  std::shared_ptr<InsertedLateralOffsetState> inserted_lateral_offset_state_;
+  std::shared_ptr<RequestedLateralOffsetState> requested_lateral_offset_state_;
+  rclcpp::Service<tier4_planning_msgs::srv::SetLateralOffset>::SharedPtr set_lateral_offset_srv_;
+  rclcpp::Subscription<tier4_planning_msgs::msg::LateralOffset>::SharedPtr lateral_offset_sub_;
 };
 
 }  // namespace autoware::behavior_path_planner

--- a/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/include/autoware/behavior_path_side_shift_module/manager.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/include/autoware/behavior_path_side_shift_module/manager.hpp
@@ -59,6 +59,14 @@ private:
 
   void publishInsertedLateralOffsetTimerCallback();
 
+  /**
+   * @brief Locate a SideShiftModule instance via the framework's observers_ list, falling back
+   * to idle_module_ptr_ when no module is currently active. The returned pointer is non-owning
+   * and only valid for the duration of the calling stack frame.
+   * @return raw pointer to a SideShiftModule, or nullptr if neither is reachable.
+   */
+  SideShiftModule * findActiveOrIdleSideShiftModule() const;
+
   std::shared_ptr<SideShiftParameters> parameters_;
   std::shared_ptr<InsertedLateralOffsetState> inserted_lateral_offset_state_;
   std::shared_ptr<RequestedLateralOffsetState> requested_lateral_offset_state_;

--- a/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/include/autoware/behavior_path_side_shift_module/scene.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/include/autoware/behavior_path_side_shift_module/scene.hpp
@@ -24,6 +24,7 @@
 #include <autoware_internal_planning_msgs/msg/path_with_lane_id.hpp>
 
 #include <memory>
+#include <optional>
 #include <string>
 #include <unordered_map>
 #include <utility>
@@ -122,6 +123,7 @@ private:
   mutable rclcpp::Time last_requested_shift_change_time_{clock_->now()};
 
   rclcpp::Time latest_lateral_offset_stamp_;
+  std::optional<rclcpp::Time> conflicting_approved_module_since_{std::nullopt};
 
   /** Shared state updated by this scene and read by the manager for publishing. */
   std::shared_ptr<InsertedLateralOffsetState> inserted_lateral_offset_state_;

--- a/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/include/autoware/behavior_path_side_shift_module/scene.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/include/autoware/behavior_path_side_shift_module/scene.hpp
@@ -22,7 +22,6 @@
 #include <rclcpp/rclcpp.hpp>
 
 #include <autoware_internal_planning_msgs/msg/path_with_lane_id.hpp>
-#include <tier4_planning_msgs/msg/lateral_offset.hpp>
 
 #include <memory>
 #include <string>
@@ -35,7 +34,6 @@ namespace autoware::behavior_path_planner
 using autoware_internal_planning_msgs::msg::PathWithLaneId;
 using geometry_msgs::msg::Pose;
 using nav_msgs::msg::OccupancyGrid;
-using tier4_planning_msgs::msg::LateralOffset;
 
 class SideShiftModule : public SceneModuleInterface
 {
@@ -46,7 +44,9 @@ public:
     const std::unordered_map<std::string, std::shared_ptr<RTCInterface>> & rtc_interface_ptr_map,
     std::unordered_map<std::string, std::shared_ptr<ObjectsOfInterestMarkerInterface>> &
       objects_of_interest_marker_interface_ptr_map,
-    const std::shared_ptr<PlanningFactorInterface> planning_factor_interface);
+    const std::shared_ptr<PlanningFactorInterface> planning_factor_interface,
+    const std::shared_ptr<InsertedLateralOffsetState> & inserted_lateral_offset_state = nullptr,
+    const std::shared_ptr<RequestedLateralOffsetState> & requested_lateral_offset_state = nullptr);
 
   bool isExecutionRequested() const override;
   bool isExecutionReady() const override;
@@ -122,6 +122,12 @@ private:
   mutable rclcpp::Time last_requested_shift_change_time_{clock_->now()};
 
   rclcpp::Time latest_lateral_offset_stamp_;
+
+  /** Shared state updated by this scene and read by the manager for publishing. */
+  std::shared_ptr<InsertedLateralOffsetState> inserted_lateral_offset_state_;
+
+  /** Shared state updated by the manager and read by this scene. */
+  std::shared_ptr<RequestedLateralOffsetState> requested_lateral_offset_state_;
 
   // debug
   mutable SideShiftDebugData debug_data_;

--- a/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/include/autoware/behavior_path_side_shift_module/scene.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/include/autoware/behavior_path_side_shift_module/scene.hpp
@@ -72,6 +72,14 @@ public:
   {
   }
 
+  /**
+   * @brief Compute the lateral offset limits derived from the current lanelet boundaries.
+   * @return {right_limit, left_limit} pair in metres, or std::nullopt when the limits cannot
+   * be evaluated (no planner data, empty reference path, or no lanelet found along the planned
+   * shift segment).
+   */
+  std::optional<std::pair<double, double>> calcOffsetLimitsFromLanelets() const;
+
 private:
   bool canTransitSuccessState() override;
 
@@ -87,8 +95,6 @@ private:
   void replaceShiftLine();
 
   double calcMaxLateralOffset(const double requested_offset) const;
-
-  std::pair<double, double> calcOffsetLimitsFromLanelets(const double requested_offset) const;
 
   // const methods
   void publishPath(const PathWithLaneId & path) const;

--- a/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/include/autoware/behavior_path_side_shift_module/scene.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/include/autoware/behavior_path_side_shift_module/scene.hpp
@@ -86,6 +86,10 @@ private:
 
   void replaceShiftLine();
 
+  double calcMaxLateralOffset(const double requested_offset) const;
+
+  std::pair<double, double> calcOffsetLimitsFromLanelets() const;
+
   // const methods
   void publishPath(const PathWithLaneId & path) const;
 

--- a/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/include/autoware/behavior_path_side_shift_module/scene.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/include/autoware/behavior_path_side_shift_module/scene.hpp
@@ -88,7 +88,7 @@ private:
 
   double calcMaxLateralOffset(const double requested_offset) const;
 
-  std::pair<double, double> calcOffsetLimitsFromLanelets() const;
+  std::pair<double, double> calcOffsetLimitsFromLanelets(const double requested_offset) const;
 
   // const methods
   void publishPath(const PathWithLaneId & path) const;

--- a/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/include/autoware/behavior_path_side_shift_module/utils.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/include/autoware/behavior_path_side_shift_module/utils.hpp
@@ -22,8 +22,12 @@
 #include <geometry_msgs/msg/pose.hpp>
 #include <geometry_msgs/msg/transform_stamped.hpp>
 
+#include <memory>
+
 namespace autoware::behavior_path_planner
 {
+struct PlannerData;
+
 using autoware_internal_planning_msgs::msg::PathWithLaneId;
 using geometry_msgs::msg::Point;
 using geometry_msgs::msg::Pose;
@@ -47,6 +51,16 @@ void setOrientation(PathWithLaneId * path);
  */
 double getClosestShiftLength(
   const ShiftedPath & shifted_path, const geometry_msgs::msg::Point ego_point);
+
+/**
+ * @brief True if any approved module name contains "lane_change" or "avoidance".
+ */
+bool hasConflictingApprovedModules(const PlannerData & data);
+
+/**
+ * @brief True if any approved/candidate module name contains "lane_change" or "avoidance".
+ */
+bool hasConflictingSceneModules(const PlannerData & data);
 
 }  // namespace autoware::behavior_path_planner
 

--- a/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/include/autoware/behavior_path_side_shift_module/validation.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/include/autoware/behavior_path_side_shift_module/validation.hpp
@@ -33,7 +33,7 @@ using SetLateralOffset = tier4_planning_msgs::srv::SetLateralOffset;
 /**
  * @brief Validation for SetLateralOffset service request.
  * @param request SetLateralOffset service request (uses Request::EXPLICIT_LATERAL_OFFSET_AMOUNT,
- *        Request::DIRECTION,
+ *        Request::LATERAL_OFFSET_DIRECTION,
  *        Request::RESET, Request::LEFT, Request::RIGHT from the message)
  * @param current_inserted_lateral_offset Current inserted lateral offset [m]
  * @param parameters Parameters used for the side shift module

--- a/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/include/autoware/behavior_path_side_shift_module/validation.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/include/autoware/behavior_path_side_shift_module/validation.hpp
@@ -18,7 +18,6 @@
 #include "autoware/behavior_path_side_shift_module/data_structs.hpp"
 #include "autoware/behavior_path_side_shift_module/manager.hpp"
 
-#include <tier4_planning_msgs/srv/detail/set_lateral_offset__struct.hpp>
 #include <tier4_planning_msgs/srv/set_lateral_offset.hpp>
 
 #include <cstdint>
@@ -81,7 +80,6 @@ std::pair<uint16_t, double> validateShiftRight(
  * @return const char* status message
  */
 const char * getStatusMessage(uint16_t status_code);
-
 }  // namespace autoware::behavior_path_planner
 
 #endif  // AUTOWARE__BEHAVIOR_PATH_SIDE_SHIFT_MODULE__VALIDATION_HPP_

--- a/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/include/autoware/behavior_path_side_shift_module/validation.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/include/autoware/behavior_path_side_shift_module/validation.hpp
@@ -1,0 +1,86 @@
+// Copyright 2023 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef AUTOWARE__BEHAVIOR_PATH_SIDE_SHIFT_MODULE__VALIDATION_HPP_
+#define AUTOWARE__BEHAVIOR_PATH_SIDE_SHIFT_MODULE__VALIDATION_HPP_
+
+#include "autoware/behavior_path_side_shift_module/data_structs.hpp"
+#include "autoware/behavior_path_side_shift_module/manager.hpp"
+
+#include <tier4_planning_msgs/srv/detail/set_lateral_offset__struct.hpp>
+#include <tier4_planning_msgs/srv/set_lateral_offset.hpp>
+
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <utility>
+
+namespace autoware::behavior_path_planner
+{
+using SetLateralOffset = tier4_planning_msgs::srv::SetLateralOffset;
+
+/**
+ * @brief Validation for SetLateralOffset service request.
+ * @param request SetLateralOffset service request (uses Request::RAW_VALUE, Request::DIRECTION,
+ *        Request::RESET, Request::LEFT, Request::RIGHT from the message)
+ * @param current_inserted_lateral_offset Current inserted lateral offset [m]
+ * @param parameters Parameters used for the side shift module
+ * @return Computed lateral offset in meters, and its status_code reflecting the validation results
+ */
+std::pair<uint16_t, double> validateAndComputeLateralOffset(
+  const SetLateralOffset::Request & request, const double current_inserted_lateral_offset,
+  const std::shared_ptr<SideShiftParameters> & parameters);
+
+/**
+ * @brief Validation of the lateral offset when its value (in meters) is directly sent
+ * @param lateral_offset The lateral offset sent from the user
+ * @param current_inserted_lateral_offset Current inserted lateral offset [m]
+ * @param parameters Parameters used for the side shift module
+ * @return Computed lateral offset in meters, and its status_code reflecting the validation results
+ */
+std::pair<uint16_t, double> validateRawValue(
+  const double lateral_offset, const double current_inserted_lateral_offset,
+  const std::shared_ptr<SideShiftParameters> & parameters);
+
+/**
+ * @brief Validation of the lateral offset when LEFT command is sent
+ * @param current_inserted_lateral_offset Current inserted lateral offset [m]
+ * @param parameters Parameters used for the side shift module
+ * @return Computed lateral offset in meters, and its status_code reflecting the validation results
+ */
+std::pair<uint16_t, double> validateShiftLeft(
+  const double current_inserted_lateral_offset,
+  const std::shared_ptr<SideShiftParameters> & parameters);
+
+/**
+ * @brief Validation of the lateral offset when RIGHT command is sent
+ * @param current_inserted_lateral_offset Current inserted lateral offset [m]
+ * @param parameters Parameters used for the side shift module
+ * @return Computed lateral offset in meters, and its status_code reflecting the validation results
+ */
+std::pair<uint16_t, double> validateShiftRight(
+  const double current_inserted_lateral_offset,
+  const std::shared_ptr<SideShiftParameters> & parameters);
+
+/**
+ * @brief Get the status message identical to te status code
+ *
+ * @param status_code
+ * @return const char* status message
+ */
+const char * getStatusMessage(uint16_t status_code);
+
+}  // namespace autoware::behavior_path_planner
+
+#endif  // AUTOWARE__BEHAVIOR_PATH_SIDE_SHIFT_MODULE__VALIDATION_HPP_

--- a/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/include/autoware/behavior_path_side_shift_module/validation.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/include/autoware/behavior_path_side_shift_module/validation.hpp
@@ -32,7 +32,8 @@ using SetLateralOffset = tier4_planning_msgs::srv::SetLateralOffset;
 
 /**
  * @brief Validation for SetLateralOffset service request.
- * @param request SetLateralOffset service request (uses Request::RAW_VALUE, Request::DIRECTION,
+ * @param request SetLateralOffset service request (uses Request::EXPLICIT_LATERAL_OFFSET_AMOUNT,
+ *        Request::DIRECTION,
  *        Request::RESET, Request::LEFT, Request::RIGHT from the message)
  * @param current_inserted_lateral_offset Current inserted lateral offset [m]
  * @param parameters Parameters used for the side shift module

--- a/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/include/autoware/behavior_path_side_shift_module/validation.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/include/autoware/behavior_path_side_shift_module/validation.hpp
@@ -37,7 +37,7 @@ using SetLateralOffset = tier4_planning_msgs::srv::SetLateralOffset;
  *        Request::RESET, Request::LEFT, Request::RIGHT from the message)
  * @param current_inserted_lateral_offset Current inserted lateral offset [m]
  * @param parameters Parameters used for the side shift module
- * @return Computed lateral offset in meters, and its status_code reflecting the validation results
+ * @return Pair of (value for SetLateralOffset::Response::response_code, lateral offset [m])
  */
 std::pair<uint16_t, double> validateAndComputeLateralOffset(
   const SetLateralOffset::Request & request, const double current_inserted_lateral_offset,

--- a/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/include/autoware/behavior_path_side_shift_module/validation.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/include/autoware/behavior_path_side_shift_module/validation.hpp
@@ -22,7 +22,6 @@
 
 #include <cstdint>
 #include <memory>
-#include <optional>
 #include <utility>
 
 namespace autoware::behavior_path_planner
@@ -31,47 +30,35 @@ using SetLateralOffset = tier4_planning_msgs::srv::SetLateralOffset;
 
 /**
  * @brief Validation for SetLateralOffset service request.
+ *
  * @param request SetLateralOffset service request (uses Request::EXPLICIT_LATERAL_OFFSET_AMOUNT,
  *        Request::LATERAL_OFFSET_DIRECTION,
  *        Request::RESET, Request::LEFT, Request::RIGHT from the message)
  * @param current_inserted_lateral_offset Current inserted lateral offset [m]
- * @param parameters Parameters used for the side shift module
+ * @param parameters Parameters used for the side shift module (only `unit_shift_amount` and
+ *        `min_shift_gap` are read here; `max_shift_magnitude` is encoded into `lanelet_limits`
+ *        by the caller)
+ * @param lanelet_limits Pair of {right_limit, left_limit} [m] that the request is clamped
+ *        into. The caller (the manager) is expected to pass a meaningful range
  * @return Pair of (value for SetLateralOffset::Response::response_code, lateral offset [m])
  */
 std::pair<uint16_t, double> validateAndComputeLateralOffset(
   const SetLateralOffset::Request & request, const double current_inserted_lateral_offset,
-  const std::shared_ptr<SideShiftParameters> & parameters);
+  const std::shared_ptr<SideShiftParameters> & parameters,
+  const std::pair<double, double> & lanelet_limits);
 
 /**
  * @brief Validation of the lateral offset when its value (in meters) is directly sent
  * @param lateral_offset The lateral offset sent from the user
  * @param current_inserted_lateral_offset Current inserted lateral offset [m]
- * @param parameters Parameters used for the side shift module
+ * @param left_limit Left limit of the lateral offset [m]
+ * @param right_limit Right limit of the lateral offset [m]
+ * @param min_shift_gap Minimum shift gap [m]
  * @return Computed lateral offset in meters, and its status_code reflecting the validation results
  */
 std::pair<uint16_t, double> validateRawValue(
   const double lateral_offset, const double current_inserted_lateral_offset,
-  const std::shared_ptr<SideShiftParameters> & parameters);
-
-/**
- * @brief Validation of the lateral offset when LEFT command is sent
- * @param current_inserted_lateral_offset Current inserted lateral offset [m]
- * @param parameters Parameters used for the side shift module
- * @return Computed lateral offset in meters, and its status_code reflecting the validation results
- */
-std::pair<uint16_t, double> validateShiftLeft(
-  const double current_inserted_lateral_offset,
-  const std::shared_ptr<SideShiftParameters> & parameters);
-
-/**
- * @brief Validation of the lateral offset when RIGHT command is sent
- * @param current_inserted_lateral_offset Current inserted lateral offset [m]
- * @param parameters Parameters used for the side shift module
- * @return Computed lateral offset in meters, and its status_code reflecting the validation results
- */
-std::pair<uint16_t, double> validateShiftRight(
-  const double current_inserted_lateral_offset,
-  const std::shared_ptr<SideShiftParameters> & parameters);
+  const double left_limit, const double right_limit, const double min_shift_gap);
 
 /**
  * @brief Get the status message identical to te status code

--- a/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/package.xml
+++ b/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/package.xml
@@ -20,6 +20,7 @@
 
   <depend>autoware_behavior_path_planner</depend>
   <depend>autoware_behavior_path_planner_common</depend>
+  <depend>autoware_common_msgs</depend>
   <depend>autoware_motion_utils</depend>
   <depend>autoware_planning_msgs</depend>
   <depend>autoware_utils</depend>

--- a/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/src/manager.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/src/manager.cpp
@@ -14,6 +14,7 @@
 
 #include "autoware/behavior_path_side_shift_module/manager.hpp"
 
+#include "autoware/behavior_path_side_shift_module/utils.hpp"
 #include "autoware/behavior_path_side_shift_module/validation.hpp"
 #include "autoware_utils/ros/update_param.hpp"
 
@@ -80,6 +81,16 @@ void SideShiftModuleManager::onSetLateralOffset(
 {
   if (!planner_data_ || !planner_data_->route_handler->isHandlerReady()) {
     response->response_code = autoware_common_msgs::msg::ResponseStatus::SERVICE_UNREADY;
+    response->status.success = false;
+    response->status.code = response->response_code;
+    response->status.message = getStatusMessage(response->response_code);
+    return;
+  }
+
+  // Reject all lateral offset service requests while lane change or avoidance modules are
+  // approved or candidate (see PlannerData scene module name lists).
+  if (hasConflictingSceneModules(*planner_data_)) {
+    response->response_code = SetLateralOffset::Response::ERROR_MODULES_CONFLICTING;
     response->status.success = false;
     response->status.code = response->response_code;
     response->status.message = getStatusMessage(response->response_code);

--- a/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/src/manager.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/src/manager.cpp
@@ -79,24 +79,35 @@ void SideShiftModuleManager::onSetLateralOffset(
   SetLateralOffset::Response::SharedPtr response)
 {
   if (!planner_data_ || !planner_data_->route_handler->isHandlerReady()) {
+    response->response_code = autoware_common_msgs::msg::ResponseStatus::SERVICE_UNREADY;
     response->status.success = false;
-    response->status.code = autoware_common_msgs::msg::ResponseStatus::SERVICE_UNREADY;
-    response->status.message = getStatusMessage(response->status.code);
+    response->status.code = response->response_code;
+    response->status.message = getStatusMessage(response->response_code);
     return;
   }
 
   const double current_inserted =
     inserted_lateral_offset_state_ ? inserted_lateral_offset_state_->value.load() : 0.0;
 
-  const auto [status_code, lateral_offset] =
+  const auto [shift_request_result, lateral_offset] =
     validateAndComputeLateralOffset(*request, current_inserted, parameters_);
+
+  if (shift_request_result == autoware_common_msgs::msg::ResponseStatus::PARAMETER_ERROR) {
+    response->response_code = autoware_common_msgs::msg::ResponseStatus::PARAMETER_ERROR;
+    response->status.success = false;
+    response->status.code = response->response_code;
+    response->status.message = getStatusMessage(response->response_code);
+    return;
+  }
+
+  response->response_code = shift_request_result;
 
   // WARN_EXCEEDED_LIMIT will be treated as success since the shift itself will be performed
   response->status.success =
-    (status_code == SetLateralOffset::Response::SUCCESS ||
-     status_code == SetLateralOffset::Response::WARN_EXCEEDED_LIMIT);
-  response->status.code = status_code;
-  response->status.message = getStatusMessage(status_code);
+    (shift_request_result == SetLateralOffset::Response::SUCCESS ||
+     shift_request_result == SetLateralOffset::Response::WARN_EXCEEDED_LIMIT);
+  response->status.code = autoware_common_msgs::msg::ResponseStatus::UNKNOWN;
+  response->status.message = getStatusMessage(response->response_code);
 
   if (response->status.success) {
     requested_lateral_offset_state_->value.store(lateral_offset);

--- a/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/src/manager.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/src/manager.cpp
@@ -61,9 +61,17 @@ void SideShiftModuleManager::init(rclcpp::Node * node)
                               &SideShiftModuleManager::onSetLateralOffset, this,
                               std::placeholders::_1, std::placeholders::_2));
 
+  lateral_offset_publisher_ =
+    node->create_publisher<tier4_planning_msgs::msg::LateralOffset>("~/output/lateral_offset", 1);
+
   lateral_offset_sub_ = node->create_subscription<tier4_planning_msgs::msg::LateralOffset>(
     "~/input/lateral_offset", rclcpp::QoS{1},
     std::bind(&SideShiftModuleManager::onLateralOffset, this, std::placeholders::_1));
+
+  const auto period = std::chrono::milliseconds(100);  // 10 Hz
+  lateral_offset_publish_timer_ = rclcpp::create_timer(
+    node_, node_->get_clock(), period,
+    std::bind(&SideShiftModuleManager::publishInsertedLateralOffsetTimerCallback, this));
 }
 
 void SideShiftModuleManager::onSetLateralOffset(
@@ -93,6 +101,14 @@ void SideShiftModuleManager::onSetLateralOffset(
   if (response->status.success) {
     requested_lateral_offset_state_->value.store(lateral_offset);
   }
+}
+
+void SideShiftModuleManager::publishInsertedLateralOffsetTimerCallback()
+{
+  tier4_planning_msgs::msg::LateralOffset msg;
+  msg.stamp = node_->now();
+  msg.lateral_offset = static_cast<float>(inserted_lateral_offset_state_->value.load());
+  lateral_offset_publisher_->publish(msg);
 }
 
 void SideShiftModuleManager::onLateralOffset(

--- a/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/src/manager.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/src/manager.cpp
@@ -14,10 +14,17 @@
 
 #include "autoware/behavior_path_side_shift_module/manager.hpp"
 
+#include "autoware/behavior_path_side_shift_module/validation.hpp"
 #include "autoware_utils/ros/update_param.hpp"
 
+#include <rclcpp/create_timer.hpp>
+#include <rclcpp/logging.hpp>
 #include <rclcpp/rclcpp.hpp>
 
+#include <autoware_common_msgs/msg/response_status.hpp>
+
+#include <algorithm>
+#include <chrono>
 #include <memory>
 #include <string>
 #include <vector>
@@ -40,9 +47,63 @@ void SideShiftModuleManager::init(rclcpp::Node * node)
   p.min_shifting_distance = node->declare_parameter<double>(ns + "min_shifting_distance");
   p.min_shifting_speed = node->declare_parameter<double>(ns + "min_shifting_speed");
   p.shift_request_time_limit = node->declare_parameter<double>(ns + "shift_request_time_limit");
+  p.max_shift_magnitude = node->declare_parameter<double>(ns + "max_shift_magnitude");
+  p.min_shift_gap = node->declare_parameter<double>(ns + "min_shift_gap");
+  p.unit_shift_amount = node->declare_parameter<double>(ns + "unit_shift_amount");
   p.publish_debug_marker = node->declare_parameter<bool>(ns + "publish_debug_marker");
 
   parameters_ = std::make_shared<SideShiftParameters>(p);
+  inserted_lateral_offset_state_ = std::make_shared<InsertedLateralOffsetState>();
+  requested_lateral_offset_state_ = std::make_shared<RequestedLateralOffsetState>();
+
+  set_lateral_offset_srv_ = node->create_service<SetLateralOffset>(
+    "~/set_lateral_offset", std::bind(
+                              &SideShiftModuleManager::onSetLateralOffset, this,
+                              std::placeholders::_1, std::placeholders::_2));
+
+  lateral_offset_sub_ = node->create_subscription<tier4_planning_msgs::msg::LateralOffset>(
+    "~/input/lateral_offset", rclcpp::QoS{1},
+    std::bind(&SideShiftModuleManager::onLateralOffset, this, std::placeholders::_1));
+}
+
+void SideShiftModuleManager::onSetLateralOffset(
+  const SetLateralOffset::Request::SharedPtr request,
+  SetLateralOffset::Response::SharedPtr response)
+{
+  if (!planner_data_ || !planner_data_->route_handler->isHandlerReady()) {
+    response->status.success = false;
+    response->status.code = autoware_common_msgs::msg::ResponseStatus::SERVICE_UNREADY;
+    response->status.message = getStatusMessage(response->status.code);
+    return;
+  }
+
+  const double current_inserted =
+    inserted_lateral_offset_state_ ? inserted_lateral_offset_state_->value.load() : 0.0;
+
+  const auto [status_code, lateral_offset] =
+    validateAndComputeLateralOffset(*request, current_inserted, parameters_);
+
+  // WARN_EXCEEDED_LIMIT will be treated as success since the shift itself will be performed
+  response->status.success =
+    (status_code == SetLateralOffset::Response::SUCCESS ||
+     status_code == SetLateralOffset::Response::WARN_EXCEEDED_LIMIT);
+  response->status.code = status_code;
+  response->status.message = getStatusMessage(status_code);
+
+  if (response->status.success) {
+    requested_lateral_offset_state_->value.store(lateral_offset);
+  }
+}
+
+void SideShiftModuleManager::onLateralOffset(
+  const tier4_planning_msgs::msg::LateralOffset::ConstSharedPtr msg)
+{
+  const auto new_offset = static_cast<double>(msg->lateral_offset);
+
+  const auto validation_result =
+    validateRawValue(new_offset, inserted_lateral_offset_state_->value.load(), parameters_);
+
+  requested_lateral_offset_state_->value.store(validation_result.second);
 }
 
 void SideShiftModuleManager::updateModuleParams(

--- a/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/src/manager.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/src/manager.cpp
@@ -27,7 +27,9 @@
 #include <algorithm>
 #include <chrono>
 #include <memory>
+#include <optional>
 #include <string>
+#include <utility>
 #include <vector>
 
 namespace autoware::behavior_path_planner
@@ -103,8 +105,29 @@ void SideShiftModuleManager::onSetLateralOffset(
   const double current_inserted =
     inserted_lateral_offset_state_ ? inserted_lateral_offset_state_->value.load() : 0.0;
 
+  // Resolve the lanelet-boundary limits and forward them to the validation
+  const auto lanelet_limits = [&]() -> std::optional<std::pair<double, double>> {
+    if (parameters_->drivable_area_check_mode == DrivableAreaCheckMode::DISABLED) {
+      const double m = parameters_->max_shift_magnitude;
+      return std::make_pair(-m, m);
+    }
+    auto * side_shift = findActiveOrIdleSideShiftModule();
+    if (!side_shift) {
+      return std::nullopt;
+    }
+    return side_shift->calcOffsetLimitsFromLanelets();
+  }();
+
+  if (!lanelet_limits) {
+    response->response_code = autoware_common_msgs::msg::ResponseStatus::SERVICE_UNREADY;
+    response->status.success = false;
+    response->status.code = response->response_code;
+    response->status.message = getStatusMessage(response->response_code);
+    return;
+  }
+
   const auto [shift_request_result, lateral_offset] =
-    validateAndComputeLateralOffset(*request, current_inserted, parameters_);
+    validateAndComputeLateralOffset(*request, current_inserted, parameters_, *lanelet_limits);
 
   if (shift_request_result == autoware_common_msgs::msg::ResponseStatus::PARAMETER_ERROR) {
     response->response_code = autoware_common_msgs::msg::ResponseStatus::PARAMETER_ERROR;
@@ -139,12 +162,61 @@ void SideShiftModuleManager::publishInsertedLateralOffsetTimerCallback()
 void SideShiftModuleManager::onLateralOffset(
   const tier4_planning_msgs::msg::LateralOffset::ConstSharedPtr msg)
 {
+  if (!planner_data_ || !planner_data_->route_handler->isHandlerReady()) {
+    return;
+  }
+
+  if (hasConflictingSceneModules(*planner_data_)) {
+    return;
+  }
+
+  const auto lanelet_limits = [&]() -> std::optional<std::pair<double, double>> {
+    if (parameters_->drivable_area_check_mode == DrivableAreaCheckMode::DISABLED) {
+      const double m = parameters_->max_shift_magnitude;
+      return std::make_pair(-m, m);
+    }
+    auto * side_shift = findActiveOrIdleSideShiftModule();
+    if (!side_shift) {
+      return std::nullopt;
+    }
+    return side_shift->calcOffsetLimitsFromLanelets();
+  }();
+
+  if (!lanelet_limits) {
+    return;
+  }
+
   const auto new_offset = static_cast<double>(msg->lateral_offset);
 
-  const auto validation_result =
-    validateRawValue(new_offset, inserted_lateral_offset_state_->value.load(), parameters_);
+  const auto validation_result = validateRawValue(
+    new_offset, inserted_lateral_offset_state_->value.load(), lanelet_limits->first,
+    lanelet_limits->second, parameters_->min_shift_gap);
+
+  if (validation_result.first == SetLateralOffset::Response::ERROR_EXCEEDED_LIMIT) {
+    return;
+  }
+
+  if (validation_result.first == SetLateralOffset::Response::ERROR_SHIFT_GAP_TOO_SMALL) {
+    return;
+  }
 
   requested_lateral_offset_state_->value.store(validation_result.second);
+}
+
+SideShiftModule * SideShiftModuleManager::findActiveOrIdleSideShiftModule() const
+{
+  for (const auto & observer : observers_) {
+    if (observer.expired()) {
+      continue;
+    }
+    if (auto ptr = std::dynamic_pointer_cast<SideShiftModule>(observer.lock())) {
+      return ptr.get();
+    }
+  }
+  if (idle_module_ptr_) {
+    return dynamic_cast<SideShiftModule *>(idle_module_ptr_.get());
+  }
+  return nullptr;
 }
 
 void SideShiftModuleManager::updateModuleParams(
@@ -157,8 +229,7 @@ void SideShiftModuleManager::updateModuleParams(
   const std::string ns = "side_shift.";
   int drivable_area_check_mode = static_cast<int>(p->drivable_area_check_mode);
   if (update_param<int>(parameters, ns + "drivable_area_check_mode", drivable_area_check_mode)) {
-    p->drivable_area_check_mode =
-      static_cast<DrivableAreaCheckMode>(drivable_area_check_mode);
+    p->drivable_area_check_mode = static_cast<DrivableAreaCheckMode>(drivable_area_check_mode);
   }
   update_param<double>(parameters, ns + "min_drivable_area_margin", p->min_drivable_area_margin);
   update_param<double>(

--- a/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/src/manager.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/src/manager.cpp
@@ -152,10 +152,23 @@ void SideShiftModuleManager::updateModuleParams(
 {
   using autoware_utils::update_param;
 
-  [[maybe_unused]] auto p = parameters_;
+  auto p = parameters_;
 
-  [[maybe_unused]] const std::string ns = "side_shift.";
-  // update_param<bool>(parameters, ns + ..., ...);
+  const std::string ns = "side_shift.";
+  int drivable_area_check_mode = static_cast<int>(p->drivable_area_check_mode);
+  if (update_param<int>(parameters, ns + "drivable_area_check_mode", drivable_area_check_mode)) {
+    p->drivable_area_check_mode =
+      static_cast<DrivableAreaCheckMode>(drivable_area_check_mode);
+  }
+  update_param<double>(parameters, ns + "min_drivable_area_margin", p->min_drivable_area_margin);
+  update_param<double>(
+    parameters, ns + "min_distance_to_start_shifting", p->min_distance_to_start_shifting);
+  update_param<double>(parameters, ns + "time_to_start_shifting", p->time_to_start_shifting);
+  update_param<double>(parameters, ns + "shifting_lateral_jerk", p->shifting_lateral_jerk);
+  update_param<double>(parameters, ns + "min_shifting_distance", p->min_shifting_distance);
+  update_param<double>(parameters, ns + "min_shifting_speed", p->min_shifting_speed);
+  update_param<double>(parameters, ns + "shift_request_time_limit", p->shift_request_time_limit);
+  update_param<bool>(parameters, ns + "publish_debug_marker", p->publish_debug_marker);
 
   std::for_each(observers_.begin(), observers_.end(), [&p](const auto & observer) {
     if (!observer.expired()) observer.lock()->updateModuleParams(p);

--- a/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/src/manager.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/src/manager.cpp
@@ -50,12 +50,13 @@ void SideShiftModuleManager::init(rclcpp::Node * node)
   p.min_shifting_distance = node->declare_parameter<double>(ns + "min_shifting_distance");
   p.min_shifting_speed = node->declare_parameter<double>(ns + "min_shifting_speed");
   p.shift_request_time_limit = node->declare_parameter<double>(ns + "shift_request_time_limit");
+  p.drivable_area_check_mode = static_cast<DrivableAreaCheckMode>(
+    node->declare_parameter<int>(ns + "drivable_area_check_mode"));
+  p.min_margin_from_lanelet_border =
+    node->declare_parameter<double>(ns + "min_margin_from_lanelet_border");
   p.max_shift_magnitude = node->declare_parameter<double>(ns + "max_shift_magnitude");
   p.min_shift_gap = node->declare_parameter<double>(ns + "min_shift_gap");
   p.unit_shift_amount = node->declare_parameter<double>(ns + "unit_shift_amount");
-  p.drivable_area_check_mode = static_cast<DrivableAreaCheckMode>(
-    node->declare_parameter<int>(ns + "drivable_area_check_mode"));
-  p.min_drivable_area_margin = node->declare_parameter<double>(ns + "min_drivable_area_margin");
   p.publish_debug_marker = node->declare_parameter<bool>(ns + "publish_debug_marker");
 
   parameters_ = std::make_shared<SideShiftParameters>(p);
@@ -231,7 +232,8 @@ void SideShiftModuleManager::updateModuleParams(
   if (update_param<int>(parameters, ns + "drivable_area_check_mode", drivable_area_check_mode)) {
     p->drivable_area_check_mode = static_cast<DrivableAreaCheckMode>(drivable_area_check_mode);
   }
-  update_param<double>(parameters, ns + "min_drivable_area_margin", p->min_drivable_area_margin);
+  update_param<double>(
+    parameters, ns + "min_margin_from_lanelet_border", p->min_margin_from_lanelet_border);
   update_param<double>(
     parameters, ns + "min_distance_to_start_shifting", p->min_distance_to_start_shifting);
   update_param<double>(parameters, ns + "time_to_start_shifting", p->time_to_start_shifting);

--- a/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/src/manager.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/src/manager.cpp
@@ -51,6 +51,9 @@ void SideShiftModuleManager::init(rclcpp::Node * node)
   p.max_shift_magnitude = node->declare_parameter<double>(ns + "max_shift_magnitude");
   p.min_shift_gap = node->declare_parameter<double>(ns + "min_shift_gap");
   p.unit_shift_amount = node->declare_parameter<double>(ns + "unit_shift_amount");
+  p.drivable_area_check_mode = static_cast<DrivableAreaCheckMode>(
+    node->declare_parameter<int>(ns + "drivable_area_check_mode"));
+  p.min_drivable_area_margin = node->declare_parameter<double>(ns + "min_drivable_area_margin");
   p.publish_debug_marker = node->declare_parameter<bool>(ns + "publish_debug_marker");
 
   parameters_ = std::make_shared<SideShiftParameters>(p);

--- a/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/src/scene.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/src/scene.cpp
@@ -74,6 +74,7 @@ void SideShiftModule::initVariables()
   if (inserted_lateral_offset_state_) {
     inserted_lateral_offset_state_->value.store(0.0);
   }
+  conflicting_approved_module_since_.reset();
 }
 
 void SideShiftModule::processOnEntry()
@@ -109,7 +110,10 @@ bool SideShiftModule::isExecutionRequested() const
 
 bool SideShiftModule::isExecutionReady() const
 {
-  return true;  // TODO(Horibe) is it ok to say "always safe"?
+  if (!planner_data_) {
+    return false;
+  }
+  return !hasConflictingApprovedModules(*planner_data_);
 }
 
 bool SideShiftModule::isReadyForNextRequest(
@@ -131,6 +135,20 @@ bool SideShiftModule::canTransitSuccessState()
   // Never return the FAILURE. When the desired offset is zero and the vehicle is in the original
   // drivable area,this module can stop the computation and return SUCCESS.
   constexpr double ZERO_THRESHOLD = 1.0e-4;
+  constexpr double force_shutdown_conflict_sec = 4.0;
+
+  if (conflicting_approved_module_since_) {
+    const double conflict_elapsed_sec =
+      (clock_->now() - conflicting_approved_module_since_.value()).seconds();
+    if (conflict_elapsed_sec >= force_shutdown_conflict_sec) {
+      RCLCPP_WARN_THROTTLE(
+        getLogger(), *clock_, 3000,
+        "Forcing side_shift to SUCCESS: lane_change/avoidance approved for >= %.1f s while "
+        "shift line could not be cleared (requested_lateral_offset=%.3f)",
+        force_shutdown_conflict_sec, requested_lateral_offset_);
+      return true;
+    }
+  }
 
   const auto isOffsetDiffAlmostZero = [this]() noexcept {
     const auto last_sp = path_shifter_.getLastShiftLine();
@@ -190,10 +208,21 @@ bool SideShiftModule::canTransitSuccessState()
 
 void SideShiftModule::updateData()
 {
+  constexpr double request_threshold = 1.0e-4;
+
+  if (planner_data_) {
+    if (hasConflictingApprovedModules(*planner_data_)) {
+      if (!conflicting_approved_module_since_) {
+        conflicting_approved_module_since_ = clock_->now();
+      }
+    } else {
+      conflicting_approved_module_since_.reset();
+    }
+  }
+
   const double requested = requested_lateral_offset_state_->value.load();
   // Only react when the requested value actually changes meaningfully.
-  constexpr double REQUEST_THRESHOLD = 1.0e-4;
-  if (std::fabs(requested - requested_lateral_offset_) > REQUEST_THRESHOLD) {
+  if (std::fabs(requested - requested_lateral_offset_) > request_threshold) {
     if (isReadyForNextRequest(parameters_->shift_request_time_limit)) {
       lateral_offset_change_request_ = true;
       requested_lateral_offset_ = requested;

--- a/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/src/scene.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/src/scene.cpp
@@ -43,9 +43,13 @@ SideShiftModule::SideShiftModule(
   const std::unordered_map<std::string, std::shared_ptr<RTCInterface>> & rtc_interface_ptr_map,
   std::unordered_map<std::string, std::shared_ptr<ObjectsOfInterestMarkerInterface>> &
     objects_of_interest_marker_interface_ptr_map,
-  const std::shared_ptr<PlanningFactorInterface> planning_factor_interface)
+  const std::shared_ptr<PlanningFactorInterface> planning_factor_interface,
+  const std::shared_ptr<InsertedLateralOffsetState> & inserted_lateral_offset_state,
+  const std::shared_ptr<RequestedLateralOffsetState> & requested_lateral_offset_state)
 : SceneModuleInterface{name, node, rtc_interface_ptr_map, objects_of_interest_marker_interface_ptr_map, planning_factor_interface},  // NOLINT
-  parameters_{parameters}
+  parameters_{parameters},
+  inserted_lateral_offset_state_{inserted_lateral_offset_state},
+  requested_lateral_offset_state_{requested_lateral_offset_state}
 {
 }
 
@@ -64,6 +68,12 @@ void SideShiftModule::initVariables()
   path_shifter_ = PathShifter{};
   resetPathCandidate();
   resetPathReference();
+  if (requested_lateral_offset_state_) {
+    requested_lateral_offset_state_->value.store(0.0);
+  }
+  if (inserted_lateral_offset_state_) {
+    inserted_lateral_offset_state_->value.store(0.0);
+  }
 }
 
 void SideShiftModule::processOnEntry()
@@ -180,13 +190,14 @@ bool SideShiftModule::canTransitSuccessState()
 
 void SideShiftModule::updateData()
 {
-  if (
-    planner_data_->lateral_offset != nullptr &&
-    planner_data_->lateral_offset->stamp != latest_lateral_offset_stamp_) {
+  const double requested = requested_lateral_offset_state_->value.load();
+  // Only react when the requested value actually changes meaningfully.
+  constexpr double REQUEST_THRESHOLD = 1.0e-4;
+  if (std::fabs(requested - requested_lateral_offset_) > REQUEST_THRESHOLD) {
     if (isReadyForNextRequest(parameters_->shift_request_time_limit)) {
       lateral_offset_change_request_ = true;
-      requested_lateral_offset_ = planner_data_->lateral_offset->lateral_offset;
-      latest_lateral_offset_stamp_ = planner_data_->lateral_offset->stamp;
+      requested_lateral_offset_ = requested;
+      latest_lateral_offset_stamp_ = clock_->now();
     }
   }
 
@@ -259,8 +270,7 @@ void SideShiftModule::replaceShiftLine()
   lateral_offset_change_request_ = false;
   inserted_lateral_offset_ = requested_lateral_offset_;
   inserted_shift_line_ = new_sl;
-
-  return;
+  inserted_lateral_offset_state_->value.store(inserted_lateral_offset_);
 }
 
 BehaviorModuleOutput SideShiftModule::plan()

--- a/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/src/scene.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/src/scene.cpp
@@ -276,9 +276,15 @@ BehaviorModuleOutput SideShiftModule::plan()
     RCLCPP_DEBUG(getLogger(), "change is not requested");
   }
 
-  // Refine path
+  // While SHIFTING, keep the entire shifted path fixed until AFTER_SHIFT.
   ShiftedPath shifted_path;
-  path_shifter_.generate(&shifted_path);
+  if (
+    shift_status_ == SideShiftStatus::SHIFTING && !lateral_offset_change_request_ &&
+    !prev_output_.path.points.empty()) {
+    shifted_path = prev_output_;
+  } else {
+    path_shifter_.generate(&shifted_path);
+  }
 
   if (shifted_path.path.points.empty()) {
     RCLCPP_ERROR(getLogger(), "Generated shift_path has no points");
@@ -323,9 +329,14 @@ CandidateOutput SideShiftModule::planCandidate() const
 
 BehaviorModuleOutput SideShiftModule::planWaitingApproval()
 {
-  // Refine path
   ShiftedPath shifted_path;
-  path_shifter_.generate(&shifted_path);
+  if (
+    shift_status_ == SideShiftStatus::SHIFTING && !lateral_offset_change_request_ &&
+    !prev_output_.path.points.empty()) {
+    shifted_path = prev_output_;
+  } else {
+    path_shifter_.generate(&shifted_path);
+  }
 
   // Reset orientation
   setOrientation(&shifted_path.path);

--- a/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/src/scene.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/src/scene.cpp
@@ -135,7 +135,7 @@ bool SideShiftModule::canTransitSuccessState()
   // Never return the FAILURE. When the desired offset is zero and the vehicle is in the original
   // drivable area,this module can stop the computation and return SUCCESS.
   constexpr double ZERO_THRESHOLD = 1.0e-4;
-  constexpr double force_shutdown_conflict_sec = 4.0;
+  constexpr double force_shutdown_conflict_sec = 3.0;
 
   if (conflicting_approved_module_since_) {
     const double conflict_elapsed_sec =

--- a/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/src/scene.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/src/scene.cpp
@@ -326,7 +326,9 @@ void SideShiftModule::replaceShiftLine()
 BehaviorModuleOutput SideShiftModule::plan()
 {
   // Replace shift line
-  if (lateral_offset_change_request_) {
+  if (
+    lateral_offset_change_request_ && ((shift_status_ == SideShiftStatus::BEFORE_SHIFT) ||
+                                       (shift_status_ == SideShiftStatus::AFTER_SHIFT))) {
     replaceShiftLine();
   } else if (shift_status_ == SideShiftStatus::SHIFTING) {
     RCLCPP_DEBUG(getLogger(), "ego is shifting");

--- a/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/src/scene.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/src/scene.cpp
@@ -292,7 +292,6 @@ void SideShiftModule::updateData()
         getLogger(), "SideShift: drivable area narrowed, clamping offset %.3f -> %.3f",
         requested_lateral_offset_, safe_offset);
       requested_lateral_offset_ = safe_offset;
-      inserted_lateral_offset_ = safe_offset;
       lateral_offset_change_request_ = true;
     }
   }
@@ -535,11 +534,10 @@ PathWithLaneId SideShiftModule::extendBackwardLength(const PathWithLaneId & orig
   return extended_path;
 }
 
-std::pair<double, double> SideShiftModule::calcOffsetLimitsFromLanelets(
-  const double requested_offset) const
+std::optional<std::pair<double, double>> SideShiftModule::calcOffsetLimitsFromLanelets() const
 {
   if (!planner_data_ || !planner_data_->route_handler || reference_path_.points.empty()) {
-    return {0.0, 0.0};
+    return std::nullopt;
   }
 
   const auto & route_handler = planner_data_->route_handler;
@@ -551,22 +549,13 @@ std::pair<double, double> SideShiftModule::calcOffsetLimitsFromLanelets(
   const auto ego_speed = std::abs(planner_data_->self_odometry->twist.twist.linear.x);
   const double dist_to_start = std::max(
     parameters_->min_distance_to_start_shifting, ego_speed * parameters_->time_to_start_shifting);
-  const double current_shift_length = getClosestShiftLength(prev_output_, getEgoPose().position);
-  const double shift_length = requested_offset - current_shift_length;
-  const double jerk_shifting_distance = autoware::motion_utils::calc_longitudinal_dist_from_jerk(
-    shift_length, parameters_->shifting_lateral_jerk,
-    std::max(ego_speed, parameters_->min_shifting_speed));
-  const double shifting_distance =
-    std::max(jerk_shifting_distance, parameters_->min_shifting_distance);
   const size_t start_idx = utils::getIdxByArclength(reference_path_, ego_idx, dist_to_start);
-  const size_t end_idx =
-    utils::getIdxByArclength(reference_path_, ego_idx, dist_to_start + shifting_distance);
 
   double safe_left = std::numeric_limits<double>::max();
   double safe_right = std::numeric_limits<double>::max();
   bool found = false;
 
-  for (size_t i = start_idx; i < reference_path_.points.size() && i <= end_idx; ++i) {
+  for (size_t i = start_idx; i < reference_path_.points.size(); ++i) {
     const auto & pose = reference_path_.points.at(i).point.pose;
     const lanelet::BasicPoint2d pt(pose.position.x, pose.position.y);
 
@@ -598,12 +587,12 @@ std::pair<double, double> SideShiftModule::calcOffsetLimitsFromLanelets(
   if (!found || !std::isfinite(safe_left) || !std::isfinite(safe_right)) {
     RCLCPP_WARN_THROTTLE(
       getLogger(), *clock_, 1000, "SideShift: no valid lanelet found for boundary check");
-    return {0.0, 0.0};
+    return std::nullopt;
   }
 
   const double left_limit = std::max(0.0, safe_left - vehicle_half_width - margin);
   const double right_limit = std::max(0.0, safe_right - vehicle_half_width - margin);
-  return {-right_limit, left_limit};
+  return std::make_pair(-right_limit, left_limit);
 }
 
 double SideShiftModule::calcMaxLateralOffset(const double requested_offset) const
@@ -612,8 +601,13 @@ double SideShiftModule::calcMaxLateralOffset(const double requested_offset) cons
     return requested_offset;
   }
 
-  const auto [right_limit, left_limit] = calcOffsetLimitsFromLanelets(requested_offset);
+  const auto limits = calcOffsetLimitsFromLanelets();
+  if (!limits) {
+    // unable to compute limits, restrict to zero
+    return 0.0;
+  }
 
+  const auto [right_limit, left_limit] = *limits;
   const double result = std::clamp(requested_offset, right_limit, left_limit);
 
   RCLCPP_DEBUG(

--- a/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/src/scene.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/src/scene.cpp
@@ -277,6 +277,25 @@ void SideShiftModule::updateData()
 
   const size_t nearest_idx = planner_data_->findEgoIndex(path_shifter_.getReferencePath().points);
   path_shifter_.removeBehindShiftLineAndSetBaseOffset(nearest_idx);
+
+  // Continuously clamp offsets against the current drivable boundary so the vehicle
+  // never departs when adjacent lanes disappear (e.g. at intersections, mode 2).
+  if (parameters_->drivable_area_check_mode != DrivableAreaCheckMode::DISABLED) {
+    const double safe_offset = calcMaxLateralOffset(requested_lateral_offset_);
+    // Detect narrowing: safe boundary has moved inward relative to what was planned.
+    const bool boundary_tightened =
+      (requested_lateral_offset_ > 0.0 && safe_offset < requested_lateral_offset_ - 1.0e-4) ||
+      (requested_lateral_offset_ < 0.0 && safe_offset > requested_lateral_offset_ + 1.0e-4);
+    if (boundary_tightened) {
+      RCLCPP_DEBUG(
+        getLogger(),
+        "SideShift: drivable area narrowed, clamping offset %.3f -> %.3f",
+        requested_lateral_offset_, safe_offset);
+      requested_lateral_offset_ = safe_offset;
+      inserted_lateral_offset_ = safe_offset;
+      lateral_offset_change_request_ = true;
+    }
+  }
 }
 
 void SideShiftModule::replaceShiftLine()
@@ -308,11 +327,9 @@ void SideShiftModule::replaceShiftLine()
 BehaviorModuleOutput SideShiftModule::plan()
 {
   // Replace shift line
-  if (
-    lateral_offset_change_request_ && ((shift_status_ == SideShiftStatus::BEFORE_SHIFT) ||
-                                       (shift_status_ == SideShiftStatus::AFTER_SHIFT))) {
+  if (lateral_offset_change_request_) {
     replaceShiftLine();
-  } else if (shift_status_ != SideShiftStatus::BEFORE_SHIFT) {
+  } else if (shift_status_ == SideShiftStatus::SHIFTING) {
     RCLCPP_DEBUG(getLogger(), "ego is shifting");
   } else {
     RCLCPP_DEBUG(getLogger(), "change is not requested");

--- a/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/src/scene.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/src/scene.cpp
@@ -30,6 +30,7 @@
 #include <memory>
 #include <string>
 #include <unordered_map>
+#include <utility>
 
 namespace autoware::behavior_path_planner
 {

--- a/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/src/scene.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/src/scene.cpp
@@ -400,26 +400,30 @@ ShiftLine SideShiftModule::calcShiftLine() const
 {
   const auto & p = parameters_;
   const auto ego_speed = std::abs(planner_data_->self_odometry->twist.twist.linear.x);
+  const double current_shift_length = getClosestShiftLength(prev_output_, getEgoPose().position);
+  const double final_shift_length = calcMaxLateralOffset(requested_lateral_offset_);
 
   const double dist_to_start =
     std::max(p->min_distance_to_start_shifting, ego_speed * p->time_to_start_shifting);
 
   const double dist_to_end = [&]() {
-    const double shift_length =
-      requested_lateral_offset_ - getClosestShiftLength(prev_output_, getEgoPose().position);
+    const double shift_length = final_shift_length - current_shift_length;
     const double jerk_shifting_distance = autoware::motion_utils::calc_longitudinal_dist_from_jerk(
       shift_length, p->shifting_lateral_jerk, std::max(ego_speed, p->min_shifting_speed));
     const double shifting_distance = std::max(jerk_shifting_distance, p->min_shifting_distance);
     const double dist_to_end = dist_to_start + shifting_distance;
     RCLCPP_DEBUG(
-      getLogger(), "min_distance_to_start_shifting = %f, dist_to_start = %f, dist_to_end = %f",
-      parameters_->min_distance_to_start_shifting, dist_to_start, dist_to_end);
+      getLogger(),
+      "SideShift: min_distance_to_start_shifting=%f, dist_to_start=%f, dist_to_end=%f, "
+      "current_shift=%f, final_shift=%f",
+      parameters_->min_distance_to_start_shifting, dist_to_start, dist_to_end,
+      current_shift_length, final_shift_length);
     return dist_to_end;
   }();
 
   const size_t nearest_idx = planner_data_->findEgoIndex(reference_path_.points);
   ShiftLine shift_line;
-  shift_line.end_shift_length = calcMaxLateralOffset(requested_lateral_offset_);
+  shift_line.end_shift_length = final_shift_length;
   shift_line.start_idx = utils::getIdxByArclength(reference_path_, nearest_idx, dist_to_start);
   shift_line.start = reference_path_.points.at(shift_line.start_idx).point.pose;
   shift_line.end_idx = utils::getIdxByArclength(reference_path_, nearest_idx, dist_to_end);
@@ -512,7 +516,8 @@ PathWithLaneId SideShiftModule::extendBackwardLength(const PathWithLaneId & orig
   return extended_path;
 }
 
-std::pair<double, double> SideShiftModule::calcOffsetLimitsFromLanelets() const
+std::pair<double, double> SideShiftModule::calcOffsetLimitsFromLanelets(
+  const double requested_offset) const
 {
   if (!planner_data_ || !planner_data_->route_handler || reference_path_.points.empty()) {
     return {0.0, 0.0};
@@ -524,14 +529,24 @@ std::pair<double, double> SideShiftModule::calcOffsetLimitsFromLanelets() const
   const double margin = parameters_->min_drivable_area_margin;
   const bool use_adjacent =
     (parameters_->drivable_area_check_mode == DrivableAreaCheckMode::ADJACENT_LANES);
-
   const auto ego_idx = planner_data_->findEgoIndex(reference_path_.points);
+  const auto ego_speed = std::abs(planner_data_->self_odometry->twist.twist.linear.x);
+  const double dist_to_start =
+    std::max(parameters_->min_distance_to_start_shifting, ego_speed * parameters_->time_to_start_shifting);
+  const double current_shift_length = getClosestShiftLength(prev_output_, getEgoPose().position);
+  const double shift_length = requested_offset - current_shift_length;
+  const double jerk_shifting_distance = autoware::motion_utils::calc_longitudinal_dist_from_jerk(
+    shift_length, parameters_->shifting_lateral_jerk, std::max(ego_speed, parameters_->min_shifting_speed));
+  const double shifting_distance = std::max(jerk_shifting_distance, parameters_->min_shifting_distance);
+  const size_t start_idx = utils::getIdxByArclength(reference_path_, ego_idx, dist_to_start);
+  const size_t end_idx =
+    utils::getIdxByArclength(reference_path_, ego_idx, dist_to_start + shifting_distance);
 
   double safe_left = std::numeric_limits<double>::max();
   double safe_right = std::numeric_limits<double>::max();
   bool found = false;
 
-  for (size_t i = ego_idx; i < reference_path_.points.size(); ++i) {
+  for (size_t i = start_idx; i < reference_path_.points.size() && i <= end_idx; ++i) {
     const auto & pose = reference_path_.points.at(i).point.pose;
     const lanelet::BasicPoint2d pt(pose.position.x, pose.position.y);
 
@@ -542,16 +557,14 @@ std::pair<double, double> SideShiftModule::calcOffsetLimitsFromLanelets() const
 
     const auto left_bound = [&]() -> lanelet::ConstLineString2d {
       if (use_adjacent) {
-        const auto adj = route_handler->getLeftLanelet(lane, true, false);
-        if (adj) return adj->leftBound2d();
+        return route_handler->getMostLeftLanelet(lane, true, false).leftBound2d();
       }
       return lane.leftBound2d();
     }();
 
     const auto right_bound = [&]() -> lanelet::ConstLineString2d {
       if (use_adjacent) {
-        const auto adj = route_handler->getRightLanelet(lane, true, false);
-        if (adj) return adj->rightBound2d();
+        return route_handler->getMostRightLanelet(lane, true, false).rightBound2d();
       }
       return lane.rightBound2d();
     }();
@@ -579,7 +592,7 @@ double SideShiftModule::calcMaxLateralOffset(const double requested_offset) cons
     return requested_offset;
   }
 
-  const auto [right_limit, left_limit] = calcOffsetLimitsFromLanelets();
+  const auto [right_limit, left_limit] = calcOffsetLimitsFromLanelets(requested_offset);
 
   const double result = (requested_offset > 0.0) ? std::min(requested_offset, left_limit)
                                                  : std::max(requested_offset, right_limit);

--- a/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/src/scene.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/src/scene.cpp
@@ -288,8 +288,7 @@ void SideShiftModule::updateData()
       (requested_lateral_offset_ < 0.0 && safe_offset > requested_lateral_offset_ + 1.0e-4);
     if (boundary_tightened) {
       RCLCPP_DEBUG(
-        getLogger(),
-        "SideShift: drivable area narrowed, clamping offset %.3f -> %.3f",
+        getLogger(), "SideShift: drivable area narrowed, clamping offset %.3f -> %.3f",
         requested_lateral_offset_, safe_offset);
       requested_lateral_offset_ = safe_offset;
       inserted_lateral_offset_ = safe_offset;
@@ -433,8 +432,8 @@ ShiftLine SideShiftModule::calcShiftLine() const
       getLogger(),
       "SideShift: min_distance_to_start_shifting=%f, dist_to_start=%f, dist_to_end=%f, "
       "current_shift=%f, final_shift=%f",
-      parameters_->min_distance_to_start_shifting, dist_to_start, dist_to_end,
-      current_shift_length, final_shift_length);
+      parameters_->min_distance_to_start_shifting, dist_to_start, dist_to_end, current_shift_length,
+      final_shift_length);
     return dist_to_end;
   }();
 
@@ -548,13 +547,15 @@ std::pair<double, double> SideShiftModule::calcOffsetLimitsFromLanelets(
     (parameters_->drivable_area_check_mode == DrivableAreaCheckMode::ADJACENT_LANES);
   const auto ego_idx = planner_data_->findEgoIndex(reference_path_.points);
   const auto ego_speed = std::abs(planner_data_->self_odometry->twist.twist.linear.x);
-  const double dist_to_start =
-    std::max(parameters_->min_distance_to_start_shifting, ego_speed * parameters_->time_to_start_shifting);
+  const double dist_to_start = std::max(
+    parameters_->min_distance_to_start_shifting, ego_speed * parameters_->time_to_start_shifting);
   const double current_shift_length = getClosestShiftLength(prev_output_, getEgoPose().position);
   const double shift_length = requested_offset - current_shift_length;
   const double jerk_shifting_distance = autoware::motion_utils::calc_longitudinal_dist_from_jerk(
-    shift_length, parameters_->shifting_lateral_jerk, std::max(ego_speed, parameters_->min_shifting_speed));
-  const double shifting_distance = std::max(jerk_shifting_distance, parameters_->min_shifting_distance);
+    shift_length, parameters_->shifting_lateral_jerk,
+    std::max(ego_speed, parameters_->min_shifting_speed));
+  const double shifting_distance =
+    std::max(jerk_shifting_distance, parameters_->min_shifting_distance);
   const size_t start_idx = utils::getIdxByArclength(reference_path_, ego_idx, dist_to_start);
   const size_t end_idx =
     utils::getIdxByArclength(reference_path_, ego_idx, dist_to_start + shifting_distance);
@@ -611,8 +612,7 @@ double SideShiftModule::calcMaxLateralOffset(const double requested_offset) cons
 
   const auto [right_limit, left_limit] = calcOffsetLimitsFromLanelets(requested_offset);
 
-  const double result = (requested_offset > 0.0) ? std::min(requested_offset, left_limit)
-                                                 : std::max(requested_offset, right_limit);
+  const double result = std::clamp(requested_offset, right_limit, left_limit);
 
   RCLCPP_DEBUG(
     getLogger(), "SideShift: req=%.2f left_limit=%.2f right_limit=%.2f result=%.2f mode=%d",

--- a/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/src/scene.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/src/scene.cpp
@@ -23,7 +23,10 @@
 #include <autoware/motion_utils/trajectory/path_shift.hpp>
 #include <autoware_lanelet2_extension/utility/utilities.hpp>
 
+#include <lanelet2_core/geometry/Lanelet.h>
+
 #include <algorithm>
+#include <limits>
 #include <memory>
 #include <string>
 #include <unordered_map>
@@ -416,7 +419,7 @@ ShiftLine SideShiftModule::calcShiftLine() const
 
   const size_t nearest_idx = planner_data_->findEgoIndex(reference_path_.points);
   ShiftLine shift_line;
-  shift_line.end_shift_length = requested_lateral_offset_;
+  shift_line.end_shift_length = calcMaxLateralOffset(requested_lateral_offset_);
   shift_line.start_idx = utils::getIdxByArclength(reference_path_, nearest_idx, dist_to_start);
   shift_line.start = reference_path_.points.at(shift_line.start_idx).point.pose;
   shift_line.end_idx = utils::getIdxByArclength(reference_path_, nearest_idx, dist_to_end);
@@ -507,6 +510,86 @@ PathWithLaneId SideShiftModule::extendBackwardLength(const PathWithLaneId & orig
   }
 
   return extended_path;
+}
+
+std::pair<double, double> SideShiftModule::calcOffsetLimitsFromLanelets() const
+{
+  if (!planner_data_ || !planner_data_->route_handler || reference_path_.points.empty()) {
+    return {0.0, 0.0};
+  }
+
+  const auto & route_handler = planner_data_->route_handler;
+  const auto & p = planner_data_->parameters;
+  const double vehicle_half_width = p.vehicle_width / 2.0;
+  const double margin = parameters_->min_drivable_area_margin;
+  const bool use_adjacent =
+    (parameters_->drivable_area_check_mode == DrivableAreaCheckMode::ADJACENT_LANES);
+
+  const auto ego_idx = planner_data_->findEgoIndex(reference_path_.points);
+
+  double safe_left = std::numeric_limits<double>::max();
+  double safe_right = std::numeric_limits<double>::max();
+  bool found = false;
+
+  for (size_t i = ego_idx; i < reference_path_.points.size(); ++i) {
+    const auto & pose = reference_path_.points.at(i).point.pose;
+    const lanelet::BasicPoint2d pt(pose.position.x, pose.position.y);
+
+    lanelet::ConstLanelet lane;
+    if (!route_handler->getClosestLaneletWithinRoute(pose, &lane)) {
+      continue;
+    }
+
+    const auto left_bound = [&]() -> lanelet::ConstLineString2d {
+      if (use_adjacent) {
+        const auto adj = route_handler->getLeftLanelet(lane, true, false);
+        if (adj) return adj->leftBound2d();
+      }
+      return lane.leftBound2d();
+    }();
+
+    const auto right_bound = [&]() -> lanelet::ConstLineString2d {
+      if (use_adjacent) {
+        const auto adj = route_handler->getRightLanelet(lane, true, false);
+        if (adj) return adj->rightBound2d();
+      }
+      return lane.rightBound2d();
+    }();
+
+    using lanelet::geometry::distance2d;
+    safe_left = std::min(safe_left, distance2d(left_bound, pt));
+    safe_right = std::min(safe_right, distance2d(right_bound, pt));
+    found = true;
+  }
+
+  if (!found || !std::isfinite(safe_left) || !std::isfinite(safe_right)) {
+    RCLCPP_WARN_THROTTLE(
+      getLogger(), *clock_, 1000, "SideShift: no valid lanelet found for boundary check");
+    return {0.0, 0.0};
+  }
+
+  const double left_limit = std::max(0.0, safe_left - vehicle_half_width - margin);
+  const double right_limit = std::max(0.0, safe_right - vehicle_half_width - margin);
+  return {-right_limit, left_limit};
+}
+
+double SideShiftModule::calcMaxLateralOffset(const double requested_offset) const
+{
+  if (parameters_->drivable_area_check_mode == DrivableAreaCheckMode::DISABLED) {
+    return requested_offset;
+  }
+
+  const auto [right_limit, left_limit] = calcOffsetLimitsFromLanelets();
+
+  const double result = (requested_offset > 0.0) ? std::min(requested_offset, left_limit)
+                                                 : std::max(requested_offset, right_limit);
+
+  RCLCPP_DEBUG(
+    getLogger(), "SideShift: req=%.2f left_limit=%.2f right_limit=%.2f result=%.2f mode=%d",
+    requested_offset, left_limit, right_limit, result,
+    static_cast<int>(parameters_->drivable_area_check_mode));
+
+  return result;
 }
 
 void SideShiftModule::setDebugMarkersVisualization() const

--- a/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/src/scene.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/src/scene.cpp
@@ -542,7 +542,7 @@ std::optional<std::pair<double, double>> SideShiftModule::calcOffsetLimitsFromLa
 
   const auto & route_handler = planner_data_->route_handler;
   const double vehicle_half_width = planner_data_->parameters.vehicle_width / 2.0;
-  const double margin = parameters_->min_drivable_area_margin;
+  const double margin = parameters_->min_margin_from_lanelet_border;
   const bool use_adjacent =
     (parameters_->drivable_area_check_mode == DrivableAreaCheckMode::ADJACENT_LANES);
   const auto ego_idx = planner_data_->findEgoIndex(reference_path_.points);

--- a/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/src/scene.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/src/scene.cpp
@@ -542,8 +542,7 @@ std::pair<double, double> SideShiftModule::calcOffsetLimitsFromLanelets(
   }
 
   const auto & route_handler = planner_data_->route_handler;
-  const auto & p = planner_data_->parameters;
-  const double vehicle_half_width = p.vehicle_width / 2.0;
+  const double vehicle_half_width = planner_data_->parameters.vehicle_width / 2.0;
   const double margin = parameters_->min_drivable_area_margin;
   const bool use_adjacent =
     (parameters_->drivable_area_check_mode == DrivableAreaCheckMode::ADJACENT_LANES);

--- a/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/src/utils.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/src/utils.cpp
@@ -14,16 +14,31 @@
 
 #include "autoware/behavior_path_side_shift_module/utils.hpp"
 
+#include "autoware/behavior_path_planner_common/data_manager.hpp"
 #include "autoware/behavior_path_planner_common/utils/utils.hpp"
 
 #include <rclcpp/rclcpp.hpp>
 
 #include <tf2/utils.h>
 
+#include <algorithm>
 #include <cmath>
+#include <string>
+#include <vector>
 
 namespace autoware::behavior_path_planner
 {
+namespace
+{
+bool hasConflictingNameIn(const std::vector<std::string> & names)
+{
+  return std::any_of(names.begin(), names.end(), [](const std::string & name) {
+    return name.find("lane_change") != std::string::npos ||
+           name.find("avoidance") != std::string::npos;
+  });
+}
+}  // namespace
+
 void setOrientation(PathWithLaneId * path)
 {
   // Reset orientation
@@ -57,6 +72,17 @@ double getClosestShiftLength(
   const auto closest =
     autoware::motion_utils::findNearestIndex(shifted_path.path.points, ego_point);
   return shifted_path.shift_length.at(closest);
+}
+
+bool hasConflictingApprovedModules(const PlannerData & data)
+{
+  return hasConflictingNameIn(data.scene_module_names_approved);
+}
+
+bool hasConflictingSceneModules(const PlannerData & data)
+{
+  return hasConflictingApprovedModules(data) ||
+         hasConflictingNameIn(data.scene_module_names_candidate);
 }
 
 }  // namespace autoware::behavior_path_planner

--- a/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/src/validation.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/src/validation.cpp
@@ -35,7 +35,7 @@ std::pair<uint16_t, double> validateAndComputeLateralOffset(
       static_cast<double>(request.shift_value), current_inserted_lateral_offset, parameters);
   }
 
-  if (request.shift_mode == SetLateralOffset::Request::DIRECTION) {
+  if (request.shift_mode == SetLateralOffset::Request::LATERAL_OFFSET_DIRECTION) {
     if (request.shift_direction_value == SetLateralOffset::Request::RESET) {
       return {SetLateralOffset::Response::SUCCESS, 0.0};
     }

--- a/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/src/validation.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/src/validation.cpp
@@ -116,6 +116,8 @@ std::pair<uint16_t, double> validateShiftRight(
 const char * getStatusMessage(uint16_t status_code)
 {
   switch (status_code) {
+    case SetLateralOffset::Response::UNKNOWN:
+      return "Unknown or uninitialized status";
     case SetLateralOffset::Response::SUCCESS:
       return "Updated successfully";
     case SetLateralOffset::Response::ERROR_UNKNOWN:

--- a/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/src/validation.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/src/validation.cpp
@@ -78,7 +78,8 @@ std::pair<uint16_t, double> validateShiftLeft(
   const double current_inserted_lateral_offset,
   const std::shared_ptr<SideShiftParameters> & parameters)
 {
-  if (current_inserted_lateral_offset >= parameters->max_shift_magnitude) {
+  constexpr double epsilon = 1.0e-4;
+  if (current_inserted_lateral_offset >= parameters->max_shift_magnitude - epsilon) {
     return {SetLateralOffset::Response::ERROR_EXCEEDED_LIMIT, parameters->max_shift_magnitude};
   }
 
@@ -98,7 +99,8 @@ std::pair<uint16_t, double> validateShiftRight(
   const double current_inserted_lateral_offset,
   const std::shared_ptr<SideShiftParameters> & parameters)
 {
-  if (current_inserted_lateral_offset <= -parameters->max_shift_magnitude) {
+  constexpr double epsilon = 1.0e-4;
+  if (current_inserted_lateral_offset <= -parameters->max_shift_magnitude + epsilon) {
     return {SetLateralOffset::Response::ERROR_EXCEEDED_LIMIT, -parameters->max_shift_magnitude};
   }
 

--- a/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/src/validation.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/src/validation.cpp
@@ -1,0 +1,146 @@
+// Copyright 2023 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/behavior_path_side_shift_module/validation.hpp"
+
+#include "autoware/behavior_path_side_shift_module/manager.hpp"
+
+#include <autoware_common_msgs/msg/response_status.hpp>
+
+#include <cmath>
+#include <memory>
+#include <utility>
+
+namespace autoware::behavior_path_planner
+{
+using ResponseStatus = autoware_common_msgs::msg::ResponseStatus;
+
+std::pair<uint16_t, double> validateAndComputeLateralOffset(
+  const SetLateralOffset::Request & request, const double current_inserted_lateral_offset,
+  const std::shared_ptr<SideShiftParameters> & parameters)
+{
+  if (request.shift_mode == SetLateralOffset::Request::RAW_VALUE) {
+    return validateRawValue(
+      static_cast<double>(request.shift_value), current_inserted_lateral_offset, parameters);
+  }
+
+  if (request.shift_mode == SetLateralOffset::Request::DIRECTION) {
+    if (request.shift_direction_value == SetLateralOffset::Request::RESET) {
+      return {SetLateralOffset::Response::SUCCESS, 0.0};
+    }
+
+    if (parameters->unit_shift_amount <= 0.0) {
+      return {ResponseStatus::PARAMETER_ERROR, 0.0};
+    }
+
+    if (request.shift_direction_value == SetLateralOffset::Request::LEFT) {
+      return validateShiftLeft(current_inserted_lateral_offset, parameters);
+    }
+
+    if (request.shift_direction_value == SetLateralOffset::Request::RIGHT) {
+      return validateShiftRight(current_inserted_lateral_offset, parameters);
+    }
+
+    return {SetLateralOffset::Response::ERROR_INVALID_DIRECTION, 0.0};
+  }
+
+  return {SetLateralOffset::Response::ERROR_INVALID_MODE, 0.0};
+}
+
+std::pair<uint16_t, double> validateRawValue(
+  const double lateral_offset, const double current_inserted_lateral_offset,
+  const std::shared_ptr<SideShiftParameters> & parameters)
+{
+  if (std::fabs(lateral_offset) > parameters->max_shift_magnitude) {
+    return {SetLateralOffset::Response::ERROR_EXCEEDED_LIMIT, current_inserted_lateral_offset};
+  }
+
+  if (std::fabs(lateral_offset - current_inserted_lateral_offset) < parameters->min_shift_gap) {
+    return {SetLateralOffset::Response::ERROR_SHIFT_GAP_TOO_SMALL, current_inserted_lateral_offset};
+  }
+
+  return {SetLateralOffset::Response::SUCCESS, lateral_offset};
+}
+
+std::pair<uint16_t, double> validateShiftLeft(
+  const double current_inserted_lateral_offset,
+  const std::shared_ptr<SideShiftParameters> & parameters)
+{
+  if (current_inserted_lateral_offset >= parameters->max_shift_magnitude) {
+    return {SetLateralOffset::Response::ERROR_EXCEEDED_LIMIT, parameters->max_shift_magnitude};
+  }
+
+  const double request_offset = current_inserted_lateral_offset + parameters->unit_shift_amount;
+  if (std::fabs(request_offset) >= parameters->max_shift_magnitude) {
+    return {SetLateralOffset::Response::WARN_EXCEEDED_LIMIT, parameters->max_shift_magnitude};
+  }
+
+  if (std::fabs(request_offset - current_inserted_lateral_offset) < parameters->min_shift_gap) {
+    return {SetLateralOffset::Response::ERROR_SHIFT_GAP_TOO_SMALL, current_inserted_lateral_offset};
+  }
+
+  return {SetLateralOffset::Response::SUCCESS, request_offset};
+}
+
+std::pair<uint16_t, double> validateShiftRight(
+  const double current_inserted_lateral_offset,
+  const std::shared_ptr<SideShiftParameters> & parameters)
+{
+  if (current_inserted_lateral_offset <= -parameters->max_shift_magnitude) {
+    return {SetLateralOffset::Response::ERROR_EXCEEDED_LIMIT, -parameters->max_shift_magnitude};
+  }
+
+  const double request_offset = current_inserted_lateral_offset - parameters->unit_shift_amount;
+  if (std::fabs(request_offset) >= parameters->max_shift_magnitude) {
+    return {SetLateralOffset::Response::WARN_EXCEEDED_LIMIT, -parameters->max_shift_magnitude};
+  }
+
+  if (std::fabs(request_offset - current_inserted_lateral_offset) < parameters->min_shift_gap) {
+    return {SetLateralOffset::Response::ERROR_SHIFT_GAP_TOO_SMALL, current_inserted_lateral_offset};
+  }
+
+  return {SetLateralOffset::Response::SUCCESS, request_offset};
+}
+
+const char * getStatusMessage(uint16_t status_code)
+{
+  switch (status_code) {
+    case SetLateralOffset::Response::SUCCESS:
+      return "Updated successfully";
+    case SetLateralOffset::Response::ERROR_UNKNOWN:
+      return "Unknown error occurred";
+    case SetLateralOffset::Response::ERROR_INVALID_MODE:
+      return "Invalid mode have been requested";
+    case SetLateralOffset::Response::ERROR_INVALID_DIRECTION:
+      return "Invalid direction have been requested";
+    case SetLateralOffset::Response::ERROR_EXCEEDED_LIMIT:
+      return "The vehicle cannot shift further than request";
+    case SetLateralOffset::Response::ERROR_SHIFT_GAP_TOO_SMALL:
+      return "The requested shift length differs too small from the current shift length";
+    case SetLateralOffset::Response::ERROR_MODULES_CONFLICTING:
+      return "Other modules are running in the behavior_path_planner";
+    case SetLateralOffset::Response::WARN_UNKNOWN:
+      return "Unknown warning occured";
+    case SetLateralOffset::Response::WARN_EXCEEDED_LIMIT:
+      return "The shift length reached limit. Shifted to the possible end.";
+    case ResponseStatus::SERVICE_UNREADY:
+      return "The side_shift module is not ready";
+    case ResponseStatus::PARAMETER_ERROR:
+      return "Invalid parameters defined in the side_shift module";
+    default:
+      return "Unknown status_code";
+  }
+}
+
+}  // namespace autoware::behavior_path_planner

--- a/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/src/validation.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/src/validation.cpp
@@ -136,12 +136,14 @@ const char * getStatusMessage(uint16_t status_code)
       return "Unknown warning occurred";
     case SetLateralOffset::Response::WARN_EXCEEDED_LIMIT:
       return "The shift length reached limit. Shifted to the possible end.";
+    case ResponseStatus::UNKNOWN:
+      return "Unknown response status";
     case ResponseStatus::SERVICE_UNREADY:
       return "The side_shift module is not ready";
     case ResponseStatus::PARAMETER_ERROR:
       return "Invalid parameters defined in the side_shift module";
     default:
-      return "Unknown status_code";
+      return "Unknown response_status";
   }
 }
 

--- a/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/src/validation.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/src/validation.cpp
@@ -131,7 +131,7 @@ const char * getStatusMessage(uint16_t status_code)
     case SetLateralOffset::Response::ERROR_MODULES_CONFLICTING:
       return "Other modules are running in the behavior_path_planner";
     case SetLateralOffset::Response::WARN_UNKNOWN:
-      return "Unknown warning occured";
+      return "Unknown warning occurred";
     case SetLateralOffset::Response::WARN_EXCEEDED_LIMIT:
       return "The shift length reached limit. Shifted to the possible end.";
     case ResponseStatus::SERVICE_UNREADY:

--- a/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/src/validation.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/src/validation.cpp
@@ -30,7 +30,7 @@ std::pair<uint16_t, double> validateAndComputeLateralOffset(
   const SetLateralOffset::Request & request, const double current_inserted_lateral_offset,
   const std::shared_ptr<SideShiftParameters> & parameters)
 {
-  if (request.shift_mode == SetLateralOffset::Request::RAW_VALUE) {
+  if (request.shift_mode == SetLateralOffset::Request::EXPLICIT_LATERAL_OFFSET_AMOUNT) {
     return validateRawValue(
       static_cast<double>(request.shift_value), current_inserted_lateral_offset, parameters);
   }

--- a/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/src/validation.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/src/validation.cpp
@@ -15,6 +15,7 @@
 #include "autoware/behavior_path_side_shift_module/validation.hpp"
 
 #include "autoware/behavior_path_side_shift_module/manager.hpp"
+#include "autoware/behavior_path_side_shift_module/utils.hpp"
 
 #include <autoware_common_msgs/msg/response_status.hpp>
 

--- a/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/src/validation.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_side_shift_module/src/validation.cpp
@@ -19,6 +19,7 @@
 
 #include <autoware_common_msgs/msg/response_status.hpp>
 
+#include <algorithm>
 #include <cmath>
 #include <memory>
 #include <utility>
@@ -29,91 +30,111 @@ using ResponseStatus = autoware_common_msgs::msg::ResponseStatus;
 
 std::pair<uint16_t, double> validateAndComputeLateralOffset(
   const SetLateralOffset::Request & request, const double current_inserted_lateral_offset,
-  const std::shared_ptr<SideShiftParameters> & parameters)
+  const std::shared_ptr<SideShiftParameters> & parameters,
+  const std::pair<double, double> & lanelet_limits)
 {
-  if (request.shift_mode == SetLateralOffset::Request::EXPLICIT_LATERAL_OFFSET_AMOUNT) {
-    return validateRawValue(
-      static_cast<double>(request.shift_value), current_inserted_lateral_offset, parameters);
+  constexpr double epsilon = 1.0e-4;
+
+  const double right_limit = std::max(lanelet_limits.first, -parameters->max_shift_magnitude);
+  const double left_limit = std::min(lanelet_limits.second, parameters->max_shift_magnitude);
+
+  // RESET is always permitted
+  if (
+    request.shift_mode == SetLateralOffset::Request::LATERAL_OFFSET_DIRECTION &&
+    request.shift_direction_value == SetLateralOffset::Request::RESET) {
+    return {SetLateralOffset::Response::SUCCESS, 0.0};
   }
 
-  if (request.shift_mode == SetLateralOffset::Request::LATERAL_OFFSET_DIRECTION) {
-    if (request.shift_direction_value == SetLateralOffset::Request::RESET) {
-      return {SetLateralOffset::Response::SUCCESS, 0.0};
-    }
+  // validate raw value first
+  if (request.shift_mode == SetLateralOffset::Request::EXPLICIT_LATERAL_OFFSET_AMOUNT) {
+    return validateRawValue(
+      request.shift_value, current_inserted_lateral_offset, left_limit, right_limit,
+      parameters->min_shift_gap);
+  }
 
-    if (parameters->unit_shift_amount <= 0.0) {
-      return {ResponseStatus::PARAMETER_ERROR, 0.0};
-    }
+  // check invalid mode is requested
+  if (request.shift_mode != SetLateralOffset::Request::LATERAL_OFFSET_DIRECTION) {
+    return {SetLateralOffset::Response::ERROR_INVALID_MODE, 0.0};
+  }
 
-    if (request.shift_direction_value == SetLateralOffset::Request::LEFT) {
-      return validateShiftLeft(current_inserted_lateral_offset, parameters);
-    }
-
-    if (request.shift_direction_value == SetLateralOffset::Request::RIGHT) {
-      return validateShiftRight(current_inserted_lateral_offset, parameters);
-    }
-
+  // The remaining validation is about direction values
+  if (
+    request.shift_direction_value != SetLateralOffset::Request::LEFT &&
+    request.shift_direction_value != SetLateralOffset::Request::RIGHT) {
     return {SetLateralOffset::Response::ERROR_INVALID_DIRECTION, 0.0};
   }
 
-  return {SetLateralOffset::Response::ERROR_INVALID_MODE, 0.0};
+  double requested_offset = current_inserted_lateral_offset;
+  if (request.shift_direction_value == SetLateralOffset::Request::LEFT) {
+    if (current_inserted_lateral_offset > left_limit - epsilon) {
+      return {SetLateralOffset::Response::ERROR_EXCEEDED_LIMIT, current_inserted_lateral_offset};
+    }
+
+    // If the vehicle is going left from right, return to zero first
+    requested_offset = (current_inserted_lateral_offset < 0 &&
+                        current_inserted_lateral_offset + parameters->unit_shift_amount > 0)
+                         ? 0.0
+                         : requested_offset + parameters->unit_shift_amount;
+
+    if (requested_offset > left_limit) {
+      requested_offset = left_limit;
+      return {SetLateralOffset::Response::WARN_EXCEEDED_LIMIT, requested_offset};
+    }
+  }
+
+  if (request.shift_direction_value == SetLateralOffset::Request::RIGHT) {
+    if (current_inserted_lateral_offset < right_limit + epsilon) {
+      return {SetLateralOffset::Response::ERROR_EXCEEDED_LIMIT, current_inserted_lateral_offset};
+    }
+
+    // If the vehicle is going right from left, return to zero first
+    requested_offset = (current_inserted_lateral_offset > 0 &&
+                        current_inserted_lateral_offset - parameters->unit_shift_amount < 0)
+                         ? 0.0
+                         : requested_offset - parameters->unit_shift_amount;
+
+    if (requested_offset < right_limit) {
+      requested_offset = right_limit;
+      return {SetLateralOffset::Response::WARN_EXCEEDED_LIMIT, requested_offset};
+    }
+  }
+
+  // This should only happen when the unit_shift_amount is smaller than the min_shift_gap
+  if (std::fabs(requested_offset - current_inserted_lateral_offset) < parameters->min_shift_gap) {
+    return {SetLateralOffset::Response::ERROR_SHIFT_GAP_TOO_SMALL, current_inserted_lateral_offset};
+  }
+
+  return {SetLateralOffset::Response::SUCCESS, requested_offset};
 }
 
 std::pair<uint16_t, double> validateRawValue(
   const double lateral_offset, const double current_inserted_lateral_offset,
-  const std::shared_ptr<SideShiftParameters> & parameters)
+  const double left_limit, const double right_limit, const double min_shift_gap)
 {
-  if (std::fabs(lateral_offset) > parameters->max_shift_magnitude) {
+  constexpr double epsilon = 1.0e-4;
+
+  // Check if the current inserted lateral offset is already at limit
+  if (lateral_offset < right_limit && current_inserted_lateral_offset < right_limit + epsilon) {
+    return {SetLateralOffset::Response::ERROR_EXCEEDED_LIMIT, current_inserted_lateral_offset};
+  }
+  if (lateral_offset > left_limit && current_inserted_lateral_offset > left_limit - epsilon) {
     return {SetLateralOffset::Response::ERROR_EXCEEDED_LIMIT, current_inserted_lateral_offset};
   }
 
-  if (std::fabs(lateral_offset - current_inserted_lateral_offset) < parameters->min_shift_gap) {
+  // Clamp the lateral offset to the limit if request is out of limit
+  if (lateral_offset < right_limit) {
+    return {SetLateralOffset::Response::WARN_EXCEEDED_LIMIT, right_limit};
+  }
+  if (lateral_offset > left_limit) {
+    return {SetLateralOffset::Response::WARN_EXCEEDED_LIMIT, left_limit};
+  }
+
+  // Check if the requested shift is too small
+  if (std::fabs(lateral_offset - current_inserted_lateral_offset) < min_shift_gap) {
     return {SetLateralOffset::Response::ERROR_SHIFT_GAP_TOO_SMALL, current_inserted_lateral_offset};
   }
 
   return {SetLateralOffset::Response::SUCCESS, lateral_offset};
-}
-
-std::pair<uint16_t, double> validateShiftLeft(
-  const double current_inserted_lateral_offset,
-  const std::shared_ptr<SideShiftParameters> & parameters)
-{
-  constexpr double epsilon = 1.0e-4;
-  if (current_inserted_lateral_offset >= parameters->max_shift_magnitude - epsilon) {
-    return {SetLateralOffset::Response::ERROR_EXCEEDED_LIMIT, parameters->max_shift_magnitude};
-  }
-
-  const double request_offset = current_inserted_lateral_offset + parameters->unit_shift_amount;
-  if (std::fabs(request_offset) >= parameters->max_shift_magnitude) {
-    return {SetLateralOffset::Response::WARN_EXCEEDED_LIMIT, parameters->max_shift_magnitude};
-  }
-
-  if (std::fabs(request_offset - current_inserted_lateral_offset) < parameters->min_shift_gap) {
-    return {SetLateralOffset::Response::ERROR_SHIFT_GAP_TOO_SMALL, current_inserted_lateral_offset};
-  }
-
-  return {SetLateralOffset::Response::SUCCESS, request_offset};
-}
-
-std::pair<uint16_t, double> validateShiftRight(
-  const double current_inserted_lateral_offset,
-  const std::shared_ptr<SideShiftParameters> & parameters)
-{
-  constexpr double epsilon = 1.0e-4;
-  if (current_inserted_lateral_offset <= -parameters->max_shift_magnitude + epsilon) {
-    return {SetLateralOffset::Response::ERROR_EXCEEDED_LIMIT, -parameters->max_shift_magnitude};
-  }
-
-  const double request_offset = current_inserted_lateral_offset - parameters->unit_shift_amount;
-  if (std::fabs(request_offset) >= parameters->max_shift_magnitude) {
-    return {SetLateralOffset::Response::WARN_EXCEEDED_LIMIT, -parameters->max_shift_magnitude};
-  }
-
-  if (std::fabs(request_offset - current_inserted_lateral_offset) < parameters->min_shift_gap) {
-    return {SetLateralOffset::Response::ERROR_SHIFT_GAP_TOO_SMALL, current_inserted_lateral_offset};
-  }
-
-  return {SetLateralOffset::Response::SUCCESS, request_offset};
 }
 
 const char * getStatusMessage(uint16_t status_code)


### PR DESCRIPTION
## Description

This PR adds new features to the `side_shift` module so that drivers/operators can use the side_shift module from external devices. **Read the functional specifications for further information.**

[<INTERNAL_LINK (Functional specifications)>](https://tier4.atlassian.net/wiki/x/ZZXHNAE)

## Related PRs

- (tier4_autoware_msgs) https://github.com/tier4/tier4_autoware_msgs/pull/220
- (autoware_launch) https://github.com/tier4/autoware_launch.x2/pull/2211

## To reviewers

Briefly I made these changes per package

- behavior_path_planner_common, behavior_path_planner
  - Removed the lateral_offset subscriber and moved it the side_shift module
  - Added `scene_module_names_approved` to planner_data so that the side_shift module can see what modules is running approved.
- behavior_path_side_shift_module
  - Add service server to get service inputs
  - Add prevention feature not deviate from the lanelet
  - Add feature to naturally disable the `side_shift` module when `lane_change` or `avoidance` will run 