### PR TITLE
feat(processing_time_checker): add e2e metric topics

### DIFF
--- a/planning/autoware_diffusion_planner/include/autoware/diffusion_planner/diffusion_planner_node.hpp
+++ b/planning/autoware_diffusion_planner/include/autoware/diffusion_planner/diffusion_planner_node.hpp
@@ -25,11 +25,13 @@
 #include <autoware_utils/ros/update_param.hpp>
 #include <autoware_utils/system/time_keeper.hpp>
 #include <autoware_utils_diagnostics/diagnostics_interface.hpp>
+#include <autoware_utils_system/stop_watch.hpp>
 #include <autoware_vehicle_info_utils/vehicle_info_utils.hpp>
 #include <rclcpp/rclcpp.hpp>
 #include <rclcpp/subscription.hpp>
 #include <rclcpp/timer.hpp>
 
+#include <autoware_internal_debug_msgs/msg/float64_stamped.hpp>
 #include <autoware_internal_planning_msgs/msg/candidate_trajectories.hpp>
 #include <autoware_map_msgs/msg/lanelet_map_bin.hpp>
 #include <autoware_perception_msgs/msg/predicted_objects.hpp>
@@ -181,6 +183,8 @@ private:
   rclcpp::TimerBase::SharedPtr timer_;
   rclcpp::Publisher<autoware_utils::ProcessingTimeDetail>::SharedPtr
     debug_processing_time_detail_pub_;
+  rclcpp::Publisher<autoware_internal_debug_msgs::msg::Float64Stamped>::SharedPtr
+    debug_processing_time_pub_{nullptr};
   rclcpp::Publisher<Trajectory>::SharedPtr pub_trajectory_{nullptr};
   rclcpp::Publisher<CandidateTrajectories>::SharedPtr pub_trajectories_{nullptr};
   rclcpp::Publisher<PredictedObjects>::SharedPtr pub_objects_{nullptr};
@@ -214,6 +218,8 @@ private:
 
   std::unique_ptr<DiagnosticsInterface> diagnostics_inference_;
   std::shared_ptr<const lanelet::LaneletMap> lanelet_map_ptr_{nullptr};
+
+  std::unique_ptr<autoware_utils_system::StopWatch<std::chrono::milliseconds>> stop_watch_ptr_;
 
   std::unique_ptr<autoware::planning_factor_interface::PlanningFactorInterface>
     planning_factor_interface_;

--- a/planning/autoware_diffusion_planner/src/diffusion_planner_node.cpp
+++ b/planning/autoware_diffusion_planner/src/diffusion_planner_node.cpp
@@ -52,6 +52,9 @@ DiffusionPlanner::DiffusionPlanner(const rclcpp::NodeOptions & options)
     "~/output/debug/traffic_signal", 1);
   debug_processing_time_detail_pub_ = this->create_publisher<autoware_utils::ProcessingTimeDetail>(
     "~/debug/processing_time_detail_ms", 1);
+  debug_processing_time_pub_ =
+    this->create_publisher<autoware_internal_debug_msgs::msg::Float64Stamped>(
+      "~/debug/processing_time_ms", 1);
   time_keeper_ = std::make_shared<autoware_utils::TimeKeeper>(debug_processing_time_detail_pub_);
 
   set_up_params();
@@ -272,6 +275,8 @@ void DiffusionPlanner::on_timer()
 {
   // Timer callback function
   autoware_utils_debug::ScopedTimeTrack st(__func__, *time_keeper_);
+  stop_watch_ptr_ = std::make_unique<autoware_utils_system::StopWatch<std::chrono::milliseconds>>();
+  stop_watch_ptr_->tic("processing_time");
 
   diagnostics_inference_->clear();
 
@@ -393,6 +398,12 @@ void DiffusionPlanner::on_timer()
 
   // Publish diagnostics
   diagnostics_inference_->publish(frame_time);
+
+  // Publish processing time
+  autoware_internal_debug_msgs::msg::Float64Stamped processing_time_msg;
+  processing_time_msg.stamp = get_clock()->now();
+  processing_time_msg.data = stop_watch_ptr_->toc("processing_time", true);
+  debug_processing_time_pub_->publish(processing_time_msg);
 }
 
 void DiffusionPlanner::publish_planning_factor(const Trajectory & trajectory)

--- a/planning/autoware_minimum_rule_based_planner/package.xml
+++ b/planning/autoware_minimum_rule_based_planner/package.xml
@@ -17,6 +17,7 @@
 
   <build_depend>generate_parameter_library</build_depend>
 
+  <depend>autoware_internal_debug_msgs</depend>
   <depend>autoware_internal_planning_msgs</depend>
   <depend>autoware_lanelet2_extension</depend>
   <depend>autoware_map_msgs</depend>

--- a/planning/autoware_minimum_rule_based_planner/src/minimum_rule_based_planner.cpp
+++ b/planning/autoware_minimum_rule_based_planner/src/minimum_rule_based_planner.cpp
@@ -66,6 +66,9 @@ MinimumRuleBasedPlannerNode::MinimumRuleBasedPlannerNode(const rclcpp::NodeOptio
   debug_processing_time_detail_pub_ =
     this->create_publisher<autoware_utils_debug::ProcessingTimeDetail>(
       "~/debug/processing_time_detail_ms", 1);
+  debug_processing_time_pub_ =
+    this->create_publisher<autoware_internal_debug_msgs::msg::Float64Stamped>(
+      "~/debug/processing_time_ms", 1);
   time_keeper_ =
     std::make_shared<autoware_utils_debug::TimeKeeper>(debug_processing_time_detail_pub_);
 
@@ -223,6 +226,8 @@ void MinimumRuleBasedPlannerNode::set_modifier_data(
 void MinimumRuleBasedPlannerNode::on_timer()
 {
   autoware_utils_debug::ScopedTimeTrack st(__func__, *time_keeper_);
+  stop_watch_ptr_ = std::make_unique<autoware_utils_system::StopWatch<std::chrono::milliseconds>>();
+  stop_watch_ptr_->tic("processing_time");
 
   auto publish_debug_trajectory =
     [](const auto & publisher_map, const auto & plugin, const TrajectoryPoints & points) {
@@ -394,6 +399,12 @@ void MinimumRuleBasedPlannerNode::on_timer()
   if (params_.debug.enable_output_trajectory) {
     pub_debug_trajectory_->publish(smoothed_traj);
   }
+
+  // Publish processing time
+  autoware_internal_debug_msgs::msg::Float64Stamped processing_time_msg;
+  processing_time_msg.stamp = get_clock()->now();
+  processing_time_msg.data = stop_watch_ptr_->toc("processing_time", true);
+  debug_processing_time_pub_->publish(processing_time_msg);
 }
 
 MinimumRuleBasedPlannerNode::InputData MinimumRuleBasedPlannerNode::take_data()

--- a/planning/autoware_minimum_rule_based_planner/src/minimum_rule_based_planner.hpp
+++ b/planning/autoware_minimum_rule_based_planner/src/minimum_rule_based_planner.hpp
@@ -23,9 +23,12 @@
 #include <autoware_trajectory_modifier/trajectory_modifier_param.hpp>
 #include <autoware_utils/ros/polling_subscriber.hpp>
 #include <autoware_utils_debug/time_keeper.hpp>
+#include <autoware_utils_system/stop_watch.hpp>
 #include <autoware_utils_uuid/uuid_helper.hpp>
 #include <autoware_vehicle_info_utils/vehicle_info_utils.hpp>
 #include <rclcpp/rclcpp.hpp>
+
+#include <autoware_internal_debug_msgs/msg/float64_stamped.hpp>
 
 #include <map>
 #include <memory>
@@ -75,6 +78,9 @@ private:
   std::shared_ptr<autoware_utils_debug::TimeKeeper> time_keeper_;
   rclcpp::Publisher<autoware_utils_debug::ProcessingTimeDetail>::SharedPtr
     debug_processing_time_detail_pub_;
+  rclcpp::Publisher<autoware_internal_debug_msgs::msg::Float64Stamped>::SharedPtr
+    debug_processing_time_pub_;
+  std::unique_ptr<autoware_utils_system::StopWatch<std::chrono::milliseconds>> stop_watch_ptr_;
   minimum_rule_based_planner::Params params_;
   /** @} */
 

--- a/planning/autoware_trajectory_optimizer/include/autoware/trajectory_optimizer/trajectory_optimizer.hpp
+++ b/planning/autoware_trajectory_optimizer/include/autoware/trajectory_optimizer/trajectory_optimizer.hpp
@@ -24,6 +24,7 @@
 #include <rclcpp/rclcpp.hpp>
 #include <rclcpp/subscription.hpp>
 
+#include <autoware_internal_debug_msgs/msg/float64_stamped.hpp>
 #include <autoware_internal_planning_msgs/msg/candidate_trajectories.hpp>
 #include <autoware_planning_msgs/msg/trajectory.hpp>
 #include <geometry_msgs/msg/accel_with_covariance_stamped.hpp>
@@ -48,6 +49,7 @@ public:
 
 private:
   void on_traj(const CandidateTrajectories::ConstSharedPtr msg);
+  void publish_processing_time_ms(double processing_time_ms);
   void set_up_params();
   void initialize_optimizers();
   void load_plugin(const std::string & plugin_name);
@@ -78,9 +80,12 @@ private:
 
   Odometry::ConstSharedPtr current_odometry_ptr_;  // current odometry
   AccelWithCovarianceStamped::ConstSharedPtr current_acceleration_ptr_;
+  std::unique_ptr<autoware_utils_system::StopWatch<std::chrono::milliseconds>> stop_watch_ptr_;
 
   rclcpp::Publisher<autoware_utils::ProcessingTimeDetail>::SharedPtr
     debug_processing_time_detail_pub_;
+  rclcpp::Publisher<autoware_internal_debug_msgs::msg::Float64Stamped>::SharedPtr
+    debug_processing_time_pub_;
   mutable std::shared_ptr<autoware_utils::TimeKeeper> time_keeper_{nullptr};
 
   TrajectoryOptimizerParams params_;

--- a/planning/autoware_trajectory_optimizer/package.xml
+++ b/planning/autoware_trajectory_optimizer/package.xml
@@ -15,6 +15,7 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
+  <depend>autoware_internal_debug_msgs</depend>
   <depend>autoware_internal_planning_msgs</depend>
   <depend>autoware_motion_utils</depend>
   <depend>autoware_osqp_interface</depend>

--- a/planning/autoware_trajectory_optimizer/src/trajectory_optimizer.cpp
+++ b/planning/autoware_trajectory_optimizer/src/trajectory_optimizer.cpp
@@ -42,6 +42,8 @@ TrajectoryOptimizer::TrajectoryOptimizer(const rclcpp::NodeOptions & options)
 {
   debug_processing_time_detail_pub_ = create_publisher<autoware_utils_debug::ProcessingTimeDetail>(
     "~/debug/processing_time_detail_ms", 1);
+  debug_processing_time_pub_ = create_publisher<autoware_internal_debug_msgs::msg::Float64Stamped>(
+    "~/debug/processing_time_ms", 1);
   time_keeper_ =
     std::make_shared<autoware_utils_debug::TimeKeeper>(debug_processing_time_detail_pub_);
 
@@ -132,6 +134,14 @@ rcl_interfaces::msg::SetParametersResult TrajectoryOptimizer::on_parameter(
   return result;
 }
 
+void TrajectoryOptimizer::publish_processing_time_ms(const double processing_time_ms)
+{
+  autoware_internal_debug_msgs::msg::Float64Stamped msg;
+  msg.stamp = get_clock()->now();
+  msg.data = processing_time_ms;
+  debug_processing_time_pub_->publish(msg);
+}
+
 void TrajectoryOptimizer::set_up_params()
 {
   using autoware_utils_rclcpp::get_or_declare_parameter;
@@ -166,6 +176,8 @@ void TrajectoryOptimizer::set_up_params()
 void TrajectoryOptimizer::on_traj([[maybe_unused]] const CandidateTrajectories::ConstSharedPtr msg)
 {
   autoware_utils_debug::ScopedTimeTrack st(__func__, *time_keeper_);
+  stop_watch_ptr_ = std::make_unique<autoware_utils_system::StopWatch<std::chrono::milliseconds>>();
+  stop_watch_ptr_->tic("processing_time");
   initialize_optimizers();
 
   current_odometry_ptr_ = sub_current_odometry_.take_data();
@@ -173,6 +185,7 @@ void TrajectoryOptimizer::on_traj([[maybe_unused]] const CandidateTrajectories::
 
   if (!current_odometry_ptr_ || !current_acceleration_ptr_) {
     RCLCPP_WARN_THROTTLE(get_logger(), *get_clock(), 5000, "No odometry or acceleration data");
+    publish_processing_time_ms(stop_watch_ptr_->toc("processing_time", true));
     return;
   }
 
@@ -202,6 +215,7 @@ void TrajectoryOptimizer::on_traj([[maybe_unused]] const CandidateTrajectories::
   output_trajectory.points = output_trajectories.candidate_trajectories.front().points;
 
   trajectory_pub_->publish(output_trajectory);
+  publish_processing_time_ms(stop_watch_ptr_->toc("processing_time", true));
 }
 
 }  // namespace autoware::trajectory_optimizer

--- a/system/autoware_processing_time_checker/config/processing_time_checker.param.yaml
+++ b/system/autoware_processing_time_checker/config/processing_time_checker.param.yaml
@@ -53,3 +53,14 @@
       - /planning/scenario_planning/scenario_selector/debug/processing_time_ms
       - /planning/scenario_planning/velocity_smoother/debug/processing_time_ms
       - /simulation/shape_estimation/debug/processing_time_ms
+
+      # E2E metrics
+      - /planning/trajectory_generator/neural_network_based_planner/diffusion_planner_node/debug/processing_time_ms
+      - /planning/trajectory_generator/neural_network_based_planner/trajectory_modifier/debug/processing_time_ms
+      - /planning/trajectory_generator/neural_network_based_planner/trajectory_optimizer_node/debug/processing_time_ms
+      - /planning/trajectory_generator/minimum_rule_based_planner/minimum_rule_based_planner_node/debug/processing_time_ms
+      - /planning/trajectory_selector/trajectory_validator_node/debug/collision_check_filter/processing_time_ms
+      - /planning/trajectory_selector/trajectory_validator_node/debug/vehicle_constraint_filter/processing_time_ms
+      - /planning/trajectory_selector/trajectory_validator_node/debug/uncrossable_boundary_departure_filter/processing_time_ms
+      - /planning/trajectory_selector/trajectory_validator_node/debug/traffic_light_filter/processing_time_ms
+      - /planning/trajectory_selector/trajectory_validator_node/debug/processing_time_ms


### PR DESCRIPTION
# Description

- Published each `processing_time_ms` from `neural_network_based_planner`.
  - `diffusion_planner_node`
  - `trajectory_modifier`
  - `trajectory_optimzer_node`

- Add E2E Node processing_time to processing_time_checker.

## Added topic list to checker

- `/planning/trajectory_generator/neural_network_based_planner/diffusion_planner_node/debug/processing_time_ms`
- `/planning/trajectory_generator/neural_network_based_planner/trajectory_modifier/debug/processing_time_ms`
- `/planning/trajectory_generator/neural_network_based_planner/trajectory_optimizer_node/debug/processing_time_ms`
- `/planning/trajectory_generator/minimum_rule_based_planner/minimum_rule_based_planner_node/debug/processing_time_ms`
- `/planning/trajectory_selector/trajectory_validator_node/debug/collision_check_filter/processing_time_ms`
- `/planning/trajectory_selector/trajectory_validator_node/debug/vehicle_constraint_filter/processing_time_ms`
- `/planning/trajectory_selector/trajectory_validator_node/debug/uncrossable_boundary_departure_filter/processing_time_ms`
- `/planning/trajectory_selector/trajectory_validator_node/debug/traffic_light_filter/processing_time_ms`
- `/planning/trajectory_selector/trajectory_validator_node/debug/processing_time_ms`

# How to TEST

## Local test

```sh
$ ros2 topic echo /system/processing_time_checker/metrics
stamp:
  sec: 1777619493
  nanosec: 211969883
metric_array:
- name: processing_time/lane_departure_checker_node
  unit: millisecond
  value: '106.773000'
- name: processing_time/control_validator
  unit: millisecond
  value: '2.497000'
- name: processing_time/longitudinal
  unit: millisecond
  value: '1.009000'
- name: processing_time/lateral
  unit: millisecond
  value: '38.521000'
- name: processing_time/vehicle_constraint_filter
  unit: millisecond
  value: '0.260000'
- name: processing_time/traffic_light_filter
  unit: millisecond
  value: '0.065000'
- name: processing_time/uncrossable_boundary_departure_filter
  unit: millisecond
  value: '158.586000'
- name: processing_time/collision_check_filter
  unit: millisecond
  value: '0.049000'
- name: processing_time/planning_evaluator
  unit: millisecond
  value: '46.940000'
- name: processing_time/control_evaluator
  unit: millisecond
  value: '26.690000'
- name: processing_time/vehicle_cmd_gate
  unit: millisecond
  value: '1.038000'
- name: processing_time/map_based_prediction
  unit: millisecond
  value: '0.530000'
- name: processing_time/shape_estimation
  unit: millisecond
  value: '0.299000'
- name: processing_time/mission_planner
  unit: millisecond
  value: '16.227000'
- name: processing_time/multi_object_tracker
  unit: millisecond
  value: '0.490918'
- name: processing_time/route_selector
  unit: millisecond
  value: '18.405000'
- name: processing_time/trajectory_optimizer_node
  unit: millisecond
  value: '2.807000'
- name: processing_time/minimum_rule_based_planner_node
  unit: millisecond
  value: '216.015000'
- name: processing_time/diffusion_planner_node
  unit: millisecond
  value: '252.379000'
- name: processing_time/trajectory_modifier
  unit: millisecond
  value: '7.569000'
- name: processing_time/trajectory_validator_node
  unit: millisecond
  value: '159.715000'
---
```

## Evaluator test

[E2E processing time 確認用](https://evaluation.tier4.jp/evaluation/reports/5900685e-9583-5c46-ad97-52f3e176fdc2?project_id=x2_dev)

- Build and Engage check

https://github.com/user-attachments/assets/8fb42f23-f234-4dc8-8ad8-242706efd9fe

- [Archive Check](https://evaluation.tier4.jp/evaluation/reports/5900685e-9583-5c46-ad97-52f3e176fdc2/tests/c9ea775a-d0d1-597c-815f-6ca61e2b67d2/2902bd2b-3e16-5e79-9736-dcc368b7bbfc/6f160f9c-9e2e-50a6-920b-13fa5e4b255e?project_id=x2_dev)

  - <img width="1027" height="162" alt="image" src="https://github.com/user-attachments/assets/d14a29b9-c5ff-4627-b60f-0c3ef71c9e13" />
