### PR TITLE
refactor(traffic_light_filter): separate plugin and logic implementation

### DIFF
--- a/planning/autoware_trajectory_validator/CMakeLists.txt
+++ b/planning/autoware_trajectory_validator/CMakeLists.txt
@@ -39,6 +39,7 @@ ament_auto_add_library(autoware_trajectory_validator_plugins SHARED
   src/filters/safety/vehicle_constraint_filter.cpp
   src/filters/safety/collision_check_filter/collision_check_filter.cpp
   src/filters/traffic_rule/traffic_light_filter.cpp
+  src/filters/traffic_rule/traffic_light_compliance_checker.cpp
 )
 
 target_link_libraries(autoware_trajectory_validator_plugins

--- a/planning/autoware_trajectory_validator/include/autoware/trajectory_validator/filters/traffic_rule/traffic_light_compliance_checker.hpp
+++ b/planning/autoware_trajectory_validator/include/autoware/trajectory_validator/filters/traffic_rule/traffic_light_compliance_checker.hpp
@@ -1,0 +1,128 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef AUTOWARE__TRAJECTORY_VALIDATOR__FILTERS__TRAFFIC_RULE__TRAFFIC_LIGHT_COMPLIANCE_CHECKER_HPP_
+#define AUTOWARE__TRAJECTORY_VALIDATOR__FILTERS__TRAFFIC_RULE__TRAFFIC_LIGHT_COMPLIANCE_CHECKER_HPP_
+
+#include <autoware/vehicle_info_utils/vehicle_info.hpp>
+#include <tl_expected/expected.hpp>
+
+#include <autoware_perception_msgs/msg/traffic_light_group_array.hpp>
+#include <autoware_planning_msgs/msg/lanelet_route.hpp>
+#include <autoware_planning_msgs/msg/trajectory_point.hpp>
+
+#include <lanelet2_core/LaneletMap.h>
+#include <lanelet2_core/geometry/LineString.h>
+
+#include <optional>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace autoware::trajectory_validator::traffic_light_filter
+{
+
+/// @brief input data for traffic light compliance check
+struct Inputs
+{
+  std::vector<autoware_planning_msgs::msg::TrajectoryPoint> trajectory;
+  lanelet::LaneletMapPtr map;
+  autoware_planning_msgs::msg::LaneletRoute route;
+  autoware_perception_msgs::msg::TrafficLightGroupArray signals;
+  double current_velocity;
+  double current_acceleration;
+};
+
+/// @brief type of traffic light violation
+enum class ViolationType { RED_LIGHT, AMBER_LIGHT };
+
+/// @brief violation detail
+struct Violation
+{
+  ViolationType type;
+  lanelet::BasicLineString2d stop_line;
+};
+
+/// @brief result of compliance check
+struct ComplianceResult
+{
+  std::vector<Violation> violations;
+};
+
+/// @brief parameters for traffic light compliance check
+struct Parameters
+{
+  double deceleration_limit;
+  double jerk_limit;
+  double delay_response_time;
+  double crossing_time_limit;
+  bool treat_amber_light_as_red_light;
+  double stop_overshoot_margin;
+  struct CheckedTrajectoryLength
+  {
+    double deceleration_limit;
+    double jerk_limit;
+  } checked_trajectory_length;
+};
+
+/// @brief class to check if a trajectory complies with traffic lights
+class TrafficLightComplianceChecker
+{
+public:
+  /**
+   * @brief constructor
+   * @param parameters parameters for compliance check
+   * @param vehicle_info vehicle information
+   */
+  TrafficLightComplianceChecker(
+    const Parameters & parameters, const vehicle_info_utils::VehicleInfo & vehicle_info);
+
+  /**
+   * @brief check if the trajectory complies with traffic lights
+   * @param input input data for compliance check
+   * @return result of compliance check, or error message if check fails
+   */
+  [[nodiscard]] tl::expected<ComplianceResult, std::string> check(const Inputs & input) const;
+
+  /**
+   * @brief update parameters
+   * @param parameters new parameters
+   */
+  void update_parameters(const Parameters & parameters);
+
+private:
+  /// @brief return the red and amber stop lines related to the given traffic light groups
+  [[nodiscard]] std::pair<
+    std::vector<lanelet::BasicLineString2d>, std::vector<lanelet::BasicLineString2d>>
+  get_stop_lines(
+    const lanelet::LaneletMap & lanelet_map,
+    const autoware_planning_msgs::msg::LaneletRoute & route,
+    const autoware_perception_msgs::msg::TrafficLightGroupArray & traffic_lights) const;
+
+  /// @brief return true if there is a stop point and it is within margin distance of the stop line
+  [[nodiscard]] bool is_stop_point_within_margin_from_stop_line(
+    const std::optional<lanelet::BasicPoint2d> & stop_point,
+    const lanelet::BasicLineString2d & stop_line) const;
+
+  /// @brief return true if ego can safely pass an amber traffic light
+  [[nodiscard]] bool can_pass_amber_light(
+    const double distance_to_stop_line, const double current_velocity,
+    const double current_acceleration, const double time_to_cross_stop_line) const;
+
+  Parameters params_;
+  vehicle_info_utils::VehicleInfo vehicle_info_;
+};
+
+}  // namespace autoware::trajectory_validator::traffic_light_filter
+#endif  // AUTOWARE__TRAJECTORY_VALIDATOR__FILTERS__TRAFFIC_RULE__TRAFFIC_LIGHT_COMPLIANCE_CHECKER_HPP_

--- a/planning/autoware_trajectory_validator/include/autoware/trajectory_validator/filters/traffic_rule/traffic_light_filter.hpp
+++ b/planning/autoware_trajectory_validator/include/autoware/trajectory_validator/filters/traffic_rule/traffic_light_filter.hpp
@@ -15,14 +15,15 @@
 #ifndef AUTOWARE__TRAJECTORY_VALIDATOR__FILTERS__TRAFFIC_RULE__TRAFFIC_LIGHT_FILTER_HPP_
 #define AUTOWARE__TRAJECTORY_VALIDATOR__FILTERS__TRAFFIC_RULE__TRAFFIC_LIGHT_FILTER_HPP_
 
+#include "autoware/trajectory_validator/filters/traffic_rule/traffic_light_compliance_checker.hpp"
 #include "autoware/trajectory_validator/validator_interface.hpp"
 
 #include <autoware_planning_msgs/msg/lanelet_route.hpp>
 
 #include <lanelet2_core/Forward.h>
 
+#include <memory>
 #include <string>
-#include <utility>
 #include <vector>
 
 namespace autoware::trajectory_validator::plugin::traffic_rule
@@ -36,25 +37,10 @@ public:
 
   void update_parameters(const validator::Params & params) final;
 
-  /// @brief return true if ego can safely pass an amber traffic light
-  /// @note made public for testing purposes
-  [[nodiscard]] bool can_pass_amber_light(
-    const double distance_to_stop_line, const double current_velocity,
-    const double current_acceleration, const double time_to_cross_stop_line) const;
+  void set_vehicle_info(const VehicleInfo & vehicle_info) final;
 
 private:
-  /// @brief return the red and amber stop lines related to the given traffic light groups
-  [[nodiscard]] std::pair<
-    std::vector<lanelet::BasicLineString2d>, std::vector<lanelet::BasicLineString2d>>
-  get_stop_lines(
-    const lanelet::LaneletMap & lanelet_map,
-    const autoware_planning_msgs::msg::LaneletRoute & route,
-    const autoware_perception_msgs::msg::TrafficLightGroupArray & traffic_lights) const;
-  /// @brief return true if there is a stop point and it is within margin distance of the stop line
-  [[nodiscard]] bool is_stop_point_within_margin_from_stop_line(
-    const std::optional<lanelet::BasicPoint2d> & stop_p,
-    const lanelet::BasicLineString2d & stop_line) const;
-
+  std::unique_ptr<traffic_light_filter::TrafficLightComplianceChecker> checker_;
   validator::Params::TrafficLight params_;
 };
 

--- a/planning/autoware_trajectory_validator/src/filters/traffic_rule/traffic_light_compliance_checker.cpp
+++ b/planning/autoware_trajectory_validator/src/filters/traffic_rule/traffic_light_compliance_checker.cpp
@@ -1,0 +1,259 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/trajectory_validator/filters/traffic_rule/traffic_light_compliance_checker.hpp"
+
+#include <autoware/interpolation/linear_interpolation.hpp>
+#include <autoware/motion_utils/distance/distance.hpp>
+#include <autoware/traffic_light_utils/traffic_light_utils.hpp>
+#include <rclcpp/duration.hpp>
+
+#include <boost/geometry.hpp>
+
+#include <lanelet2_core/geometry/Lanelet.h>
+#include <lanelet2_core/geometry/Point.h>
+#include <lanelet2_core/primitives/BasicRegulatoryElements.h>
+
+#include <algorithm>
+#include <memory>
+#include <string>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+namespace
+{
+/// @brief get stop lines where ego need to stop, and their corresponding signals from the given
+/// traffic light groups
+std::vector<std::pair<lanelet::BasicLineString2d, autoware_perception_msgs::msg::TrafficLightGroup>>
+collect_stop_lines(
+  const lanelet::LaneletMap & lanelet_map, const autoware_planning_msgs::msg::LaneletRoute & route,
+  const std::vector<autoware_perception_msgs::msg::TrafficLightGroup> & traffic_light_groups)
+{
+  std::vector<
+    std::pair<lanelet::BasicLineString2d, autoware_perception_msgs::msg::TrafficLightGroup>>
+    stop_lines;
+  std::unordered_map<lanelet::Id, lanelet::Id> route_lanelet_id_per_traffic_light_id;
+  for (const auto & segment : route.segments) {
+    for (const auto & tl : lanelet_map.laneletLayer.get(segment.preferred_primitive.id)
+                             .regulatoryElementsAs<lanelet::TrafficLight>()) {
+      route_lanelet_id_per_traffic_light_id.emplace(tl->id(), segment.preferred_primitive.id);
+    }
+  }
+
+  for (const auto & signal : traffic_light_groups) {
+    const auto hit = route_lanelet_id_per_traffic_light_id.find(signal.traffic_light_group_id);
+    if (hit == route_lanelet_id_per_traffic_light_id.end()) {
+      continue;
+    }
+    const auto traffic_light_it =
+      lanelet_map.regulatoryElementLayer.find(signal.traffic_light_group_id);
+    if (traffic_light_it == lanelet_map.regulatoryElementLayer.end()) {
+      continue;
+    }
+
+    if (!autoware::traffic_light_utils::isTrafficSignalStop(
+          lanelet_map.laneletLayer.get(hit->second), signal)) {
+      continue;
+    }
+
+    const auto traffic_light =
+      std::dynamic_pointer_cast<const lanelet::TrafficLight>(*traffic_light_it);
+    if (!traffic_light || !traffic_light->stopLine().has_value()) {
+      continue;
+    }
+    stop_lines.emplace_back(
+      lanelet::utils::to2D(traffic_light->stopLine()->basicLineString()), signal);
+  }
+  return stop_lines;
+}
+}  // namespace
+
+namespace autoware::trajectory_validator::traffic_light_filter
+{
+
+TrafficLightComplianceChecker::TrafficLightComplianceChecker(
+  const Parameters & parameters, const vehicle_info_utils::VehicleInfo & vehicle_info)
+: params_(parameters), vehicle_info_(vehicle_info)
+{
+}
+
+void TrafficLightComplianceChecker::update_parameters(const Parameters & parameters)
+{
+  params_ = parameters;
+}
+
+tl::expected<ComplianceResult, std::string> TrafficLightComplianceChecker::check(
+  const Inputs & input) const
+{
+  std::vector<autoware_planning_msgs::msg::TrajectoryPoint> trajectory;
+  lanelet::BasicLineString2d trajectory_ls;
+  const auto distance_for_ego_to_stop = autoware::motion_utils::calculate_stop_distance(
+    input.current_velocity, input.current_acceleration,
+    params_.checked_trajectory_length.deceleration_limit,
+    params_.checked_trajectory_length.jerk_limit, params_.delay_response_time);
+  const auto max_trajectory_length = distance_for_ego_to_stop.value_or(0.0);
+  auto length = 0.0;
+  bool is_stopping_trajectory = false;
+  for (const auto & p : input.trajectory) {
+    // skip points behind ego
+    if (rclcpp::Duration(p.time_from_start).seconds() < 0.0) {
+      continue;
+    }
+    const lanelet::BasicPoint2d lanelet_p(p.pose.position.x, p.pose.position.y);
+    if (!trajectory_ls.empty()) {
+      length += lanelet::geometry::distance2d(trajectory_ls.back(), lanelet_p);
+    }
+
+    trajectory.push_back(p);
+    trajectory_ls.emplace_back(lanelet_p);
+
+    // skip points beyond the first stop, or skip once we reach the maximum length
+    is_stopping_trajectory = p.longitudinal_velocity_mps <= 0.0;
+    if (is_stopping_trajectory || length > max_trajectory_length) {
+      break;
+    }
+  }
+
+  if (trajectory_ls.size() < 2) {
+    return ComplianceResult{};  // allow empty or stopped trajectories as they do not cross traffic
+                                // lights
+  }
+
+  if (vehicle_info_.max_longitudinal_offset_m > 0.0) {
+    // extend the trajectory linestring by the vehicle's longitudinal offset
+    const lanelet::BasicSegment2d last_segment(
+      trajectory_ls[trajectory_ls.size() - 2], trajectory_ls.back());
+    const auto last_vector = last_segment.second - last_segment.first;
+    const auto last_length = boost::geometry::length(last_segment);
+    if (last_length > 0.0) {
+      const auto ratio = (last_length + vehicle_info_.max_longitudinal_offset_m) / last_length;
+      lanelet::BasicPoint2d front_vehicle_point = last_segment.first + last_vector * ratio;
+      trajectory_ls.emplace_back(front_vehicle_point);
+    }
+  }
+  std::optional<lanelet::BasicPoint2d> stop_point;
+  if (is_stopping_trajectory) {
+    stop_point = trajectory_ls.back();
+  }
+
+  const auto [red_stop_lines, amber_stop_lines] =
+    get_stop_lines(*input.map, input.route, input.signals);
+
+  ComplianceResult result;
+
+  // Check for red light crossings
+  for (const auto & red_stop_line : red_stop_lines) {
+    if (boost::geometry::intersects(trajectory_ls, red_stop_line)) {
+      if (is_stop_point_within_margin_from_stop_line(stop_point, red_stop_line)) {
+        continue;
+      }
+      result.violations.push_back({ViolationType::RED_LIGHT, red_stop_line});
+    }
+  }
+
+  // Check for amber light crossings
+  for (const auto & amber_stop_line : amber_stop_lines) {
+    auto distance_to_stop_line = 0.0;
+    std::optional<double> amber_stop_line_crossing_time;
+    for (size_t i = 0; i + 1 < trajectory.size(); ++i) {
+      lanelet::BasicPoints2d intersection_points;
+      const lanelet::BasicLineString2d segment{trajectory_ls[i], trajectory_ls[i + 1]};
+      const auto segment_length = static_cast<double>(boost::geometry::length(segment));
+      boost::geometry::intersection(segment, amber_stop_line, intersection_points);
+      if (!intersection_points.empty()) {
+        const auto distance_to_intersection =
+          boost::geometry::distance(segment.front(), intersection_points.front());
+        distance_to_stop_line += distance_to_intersection;
+        const auto ratio = distance_to_intersection / segment_length;
+        amber_stop_line_crossing_time = autoware::interpolation::lerp(
+          rclcpp::Duration(trajectory[i].time_from_start).seconds(),
+          rclcpp::Duration(trajectory[i + 1].time_from_start).seconds(), ratio);
+        break;
+      }
+      distance_to_stop_line += segment_length;
+    }
+
+    const auto current_velocity = trajectory.front().longitudinal_velocity_mps;
+    const auto current_acceleration = trajectory.front().acceleration_mps2;
+    if (amber_stop_line_crossing_time) {
+      if (is_stop_point_within_margin_from_stop_line(stop_point, amber_stop_line)) {
+        continue;
+      }
+      if (!can_pass_amber_light(
+            distance_to_stop_line, current_velocity, current_acceleration,
+            *amber_stop_line_crossing_time)) {
+        result.violations.push_back({ViolationType::AMBER_LIGHT, amber_stop_line});
+      }
+    }
+  }
+
+  return result;
+}
+
+std::pair<std::vector<lanelet::BasicLineString2d>, std::vector<lanelet::BasicLineString2d>>
+TrafficLightComplianceChecker::get_stop_lines(
+  const lanelet::LaneletMap & lanelet_map, const autoware_planning_msgs::msg::LaneletRoute & route,
+  const autoware_perception_msgs::msg::TrafficLightGroupArray & traffic_lights) const
+{
+  std::vector<lanelet::BasicLineString2d> red_stop_lines;
+  std::vector<lanelet::BasicLineString2d> amber_stop_lines;
+  for (const auto & [stop_line, signal] :
+       collect_stop_lines(lanelet_map, route, traffic_lights.traffic_light_groups)) {
+    if (autoware::traffic_light_utils::hasTrafficLightCircleColor(
+          signal.elements, autoware_perception_msgs::msg::TrafficLightElement::RED)) {
+      red_stop_lines.push_back(stop_line);
+    }
+    if (autoware::traffic_light_utils::hasTrafficLightCircleColor(
+          signal.elements, autoware_perception_msgs::msg::TrafficLightElement::AMBER)) {
+      amber_stop_lines.push_back(stop_line);
+    }
+  }
+  if (params_.treat_amber_light_as_red_light) {
+    red_stop_lines.insert(red_stop_lines.end(), amber_stop_lines.begin(), amber_stop_lines.end());
+    amber_stop_lines.clear();
+  }
+  return {red_stop_lines, amber_stop_lines};
+}
+
+bool TrafficLightComplianceChecker::is_stop_point_within_margin_from_stop_line(
+  const std::optional<lanelet::BasicPoint2d> & stop_point,
+  const lanelet::BasicLineString2d & stop_line) const
+{
+  if (stop_point.has_value()) {
+    if (boost::geometry::distance(*stop_point, stop_line) <= params_.stop_overshoot_margin) {
+      return true;
+    }
+  }
+  return false;
+}
+
+bool TrafficLightComplianceChecker::can_pass_amber_light(
+  const double distance_to_stop_line, const double current_velocity,
+  const double current_acceleration, const double time_to_cross_stop_line) const
+{
+  const double decel_limit = params_.deceleration_limit;
+  const double jerk_limit = params_.jerk_limit;
+  const double delay_response_time = params_.delay_response_time;
+  const auto distance_for_ego_to_stop = autoware::motion_utils::calculate_stop_distance(
+    current_velocity, current_acceleration, decel_limit, jerk_limit, delay_response_time);
+
+  const bool can_stop =
+    distance_for_ego_to_stop.has_value() && *distance_for_ego_to_stop <= distance_to_stop_line;
+  const bool can_pass_in_time = time_to_cross_stop_line <= params_.crossing_time_limit;
+  const bool can_pass = !can_stop && can_pass_in_time;
+  return can_pass;
+}
+
+}  // namespace autoware::trajectory_validator::traffic_light_filter

--- a/planning/autoware_trajectory_validator/src/filters/traffic_rule/traffic_light_filter.cpp
+++ b/planning/autoware_trajectory_validator/src/filters/traffic_rule/traffic_light_filter.cpp
@@ -14,77 +14,15 @@
 
 #include "autoware/trajectory_validator/filters/traffic_rule/traffic_light_filter.hpp"
 
-#include <autoware/interpolation/linear_interpolation.hpp>
-#include <autoware/motion_utils/distance/distance.hpp>
-#include <autoware/traffic_light_utils/traffic_light_utils.hpp>
-#include <rclcpp/logger.hpp>
 #include <rclcpp/logging.hpp>
-#include <tl_expected/expected.hpp>
 
-#include <boost/geometry.hpp>
-#include <boost/geometry/algorithms/for_each.hpp>
-
-#include <lanelet2_core/LaneletMap.h>
-#include <lanelet2_core/geometry/Lanelet.h>
-#include <lanelet2_core/geometry/Point.h>
-#include <lanelet2_core/primitives/BasicRegulatoryElements.h>
-#include <lanelet2_core/primitives/LineString.h>
-
-#include <algorithm>
-#include <ctime>
 #include <memory>
 #include <string>
-#include <unordered_map>
 #include <utility>
 #include <vector>
 
 namespace
 {
-/// @brief get stop lines where ego need to stop, and their corresponding signals from the given
-/// traffic light groups
-std::vector<std::pair<lanelet::BasicLineString2d, autoware_perception_msgs::msg::TrafficLightGroup>>
-collect_stop_lines(
-  const lanelet::LaneletMap & lanelet_map, const autoware_planning_msgs::msg::LaneletRoute & route,
-  const std::vector<autoware_perception_msgs::msg::TrafficLightGroup> & traffic_light_groups)
-{
-  std::vector<
-    std::pair<lanelet::BasicLineString2d, autoware_perception_msgs::msg::TrafficLightGroup>>
-    stop_lines;
-  std::unordered_map<lanelet::Id, lanelet::Id> route_lanelet_id_per_traffic_light_id;
-  for (const auto & segment : route.segments) {
-    for (const auto & tl : lanelet_map.laneletLayer.get(segment.preferred_primitive.id)
-                             .regulatoryElementsAs<lanelet::TrafficLight>()) {
-      route_lanelet_id_per_traffic_light_id.emplace(tl->id(), segment.preferred_primitive.id);
-    }
-  }
-
-  for (const auto & signal : traffic_light_groups) {
-    const auto hit = route_lanelet_id_per_traffic_light_id.find(signal.traffic_light_group_id);
-    if (hit == route_lanelet_id_per_traffic_light_id.end()) {
-      continue;
-    }
-    const auto traffic_light_it =
-      lanelet_map.regulatoryElementLayer.find(signal.traffic_light_group_id);
-    if (traffic_light_it == lanelet_map.regulatoryElementLayer.end()) {
-      continue;
-    }
-
-    if (!autoware::traffic_light_utils::isTrafficSignalStop(
-          lanelet_map.laneletLayer.get(hit->second), signal)) {
-      continue;
-    }
-
-    const auto traffic_light =
-      std::dynamic_pointer_cast<const lanelet::TrafficLight>(*traffic_light_it);
-    if (!traffic_light || !traffic_light->stopLine().has_value()) {
-      continue;
-    }
-    stop_lines.emplace_back(
-      lanelet::utils::to2D(traffic_light->stopLine()->basicLineString()), signal);
-  }
-  return stop_lines;
-}
-
 std::optional<std::string> is_invalid_input(
   const autoware::trajectory_validator::FilterContext & context,
   const std::shared_ptr<autoware::vehicle_info_utils::VehicleInfo> & vehicle_info)
@@ -105,7 +43,27 @@ std::optional<std::string> is_invalid_input(
     return "Traffic light signals are not available in the context.";
   }
 
+  if (!context.odometry || !context.acceleration) {
+    return "Odometry or acceleration is not available in the context.";
+  }
+
   return std::nullopt;
+}
+
+autoware::trajectory_validator::traffic_light_filter::Parameters to_checker_params(
+  const validator::Params::TrafficLight & params)
+{
+  autoware::trajectory_validator::traffic_light_filter::Parameters p;
+  p.deceleration_limit = params.deceleration_limit;
+  p.jerk_limit = params.jerk_limit;
+  p.delay_response_time = params.delay_response_time;
+  p.crossing_time_limit = params.crossing_time_limit;
+  p.treat_amber_light_as_red_light = params.treat_amber_light_as_red_light;
+  p.stop_overshoot_margin = params.stop_overshoot_margin;
+  p.checked_trajectory_length.deceleration_limit =
+    params.checked_trajectory_length.deceleration_limit;
+  p.checked_trajectory_length.jerk_limit = params.checked_trajectory_length.jerk_limit;
+  return p;
 }
 }  // namespace
 
@@ -119,43 +77,16 @@ TrafficLightFilter::TrafficLightFilter() : ValidatorInterface("traffic_light_fil
 void TrafficLightFilter::update_parameters(const validator::Params & params)
 {
   params_ = params.traffic_light;
+  if (checker_) {
+    checker_->update_parameters(to_checker_params(params_));
+  }
 }
 
-std::pair<std::vector<lanelet::BasicLineString2d>, std::vector<lanelet::BasicLineString2d>>
-TrafficLightFilter::get_stop_lines(
-  const lanelet::LaneletMap & lanelet_map, const autoware_planning_msgs::msg::LaneletRoute & route,
-  const autoware_perception_msgs::msg::TrafficLightGroupArray & traffic_lights) const
+void TrafficLightFilter::set_vehicle_info(const VehicleInfo & vehicle_info)
 {
-  std::vector<lanelet::BasicLineString2d> red_stop_lines;
-  std::vector<lanelet::BasicLineString2d> amber_stop_lines;
-  for (const auto & [stop_line, signal] :
-       collect_stop_lines(lanelet_map, route, traffic_lights.traffic_light_groups)) {
-    if (traffic_light_utils::hasTrafficLightCircleColor(
-          signal.elements, tier4_perception_msgs::msg::TrafficLightElement::RED)) {
-      red_stop_lines.push_back(stop_line);
-    }
-    if (traffic_light_utils::hasTrafficLightCircleColor(
-          signal.elements, tier4_perception_msgs::msg::TrafficLightElement::AMBER)) {
-      amber_stop_lines.push_back(stop_line);
-    }
-  }
-  if (params_.treat_amber_light_as_red_light) {
-    red_stop_lines.insert(red_stop_lines.end(), amber_stop_lines.begin(), amber_stop_lines.end());
-    amber_stop_lines.clear();
-  }
-  return {red_stop_lines, amber_stop_lines};
-}
-
-bool TrafficLightFilter::is_stop_point_within_margin_from_stop_line(
-  const std::optional<lanelet::BasicPoint2d> & stop_p,
-  const lanelet::BasicLineString2d & stop_line) const
-{
-  if (stop_p.has_value()) {
-    if (boost::geometry::distance(*stop_p, stop_line) <= params_.stop_overshoot_margin) {
-      return true;
-    }
-  }
-  return false;
+  ValidatorInterface::set_vehicle_info(vehicle_info);
+  checker_ = std::make_unique<traffic_light_filter::TrafficLightComplianceChecker>(
+    to_checker_params(params_), vehicle_info);
 }
 
 TrafficLightFilter::result_t TrafficLightFilter::is_feasible(
@@ -164,145 +95,53 @@ TrafficLightFilter::result_t TrafficLightFilter::is_feasible(
   if (const auto has_invalid_input = is_invalid_input(context, vehicle_info_ptr_)) {
     return tl::make_unexpected(*has_invalid_input);
   }
-  TrajectoryPoints trajectory;
-  lanelet::BasicLineString2d trajectory_ls;
-  constexpr auto delay_response_time = 0.0;
-  const auto distance_for_ego_to_stop = motion_utils::calculate_stop_distance(
-    context.odometry->twist.twist.linear.x, context.acceleration->accel.accel.linear.x,
-    params_.checked_trajectory_length.deceleration_limit,
-    params_.checked_trajectory_length.jerk_limit, delay_response_time);
-  const auto max_trajectory_length = distance_for_ego_to_stop.value_or(0.0);
-  auto length = 0.0;
-  bool is_stopping_trajectory = false;
-  for (const auto & p : traj_points) {
-    // skip points behind ego
-    if (rclcpp::Duration(p.time_from_start).seconds() < 0.0) {
-      continue;
-    }
-    const lanelet::BasicPoint2d lanelet_p(p.pose.position.x, p.pose.position.y);
-    if (!trajectory_ls.empty()) {
-      length += lanelet::geometry::distance2d(trajectory_ls.back(), lanelet_p);
-    }
 
-    trajectory.push_back(p);
-    trajectory_ls.emplace_back(lanelet_p);
-
-    // skip points beyond the first stop, or skip once we reach the maximum length
-    is_stopping_trajectory = p.longitudinal_velocity_mps <= 0.0;
-    if (is_stopping_trajectory || length > max_trajectory_length) {
-      break;
-    }
+  if (!checker_) {
+    return tl::make_unexpected("Compliance checker is not initialized.");
   }
 
-  if (trajectory_ls.size() < 2) {
-    return {};  // allow empty or stopped trajectories as they do not cross traffic lights
+  const traffic_light_filter::Inputs inputs{
+    traj_points,
+    context.lanelet_map,
+    *context.route,
+    *context.traffic_light_signals,
+    context.odometry->twist.twist.linear.x,
+    context.acceleration->accel.accel.linear.x};
+
+  const auto result = checker_->check(inputs);
+  if (!result) {
+    return tl::make_unexpected(result.error());
   }
 
-  if (vehicle_info_ptr_->max_longitudinal_offset_m > 0.0) {
-    // extend the trajectory linestring by the vehicle's longitudinal offset
-    const lanelet::BasicSegment2d last_segment(
-      trajectory_ls[trajectory_ls.size() - 2], trajectory_ls.back());
-    const auto last_vector = last_segment.second - last_segment.first;
-    const auto last_length = boost::geometry::length(last_segment);
-    if (last_length > 0.0) {
-      const auto ratio = (last_length + vehicle_info_ptr_->max_longitudinal_offset_m) / last_length;
-      lanelet::BasicPoint2d front_vehicle_point = last_segment.first + last_vector * ratio;
-      trajectory_ls.emplace_back(front_vehicle_point);
-    }
-  }
-  std::optional<lanelet::BasicPoint2d> stop_point;
-  if (is_stopping_trajectory) {
-    stop_point = trajectory_ls.back();
-  }
-
-  const auto [red_stop_lines, amber_stop_lines] =
-    get_stop_lines(*context.lanelet_map, *context.route, *context.traffic_light_signals);
-
-  bool is_feasible = true;
-  std::vector<MetricReport> metrics;
-
-  // Check for red light crossings
   bool is_crossing_red = false;
-  for (const auto & red_stop_line : red_stop_lines) {
-    if (boost::geometry::intersects(trajectory_ls, red_stop_line)) {
-      if (is_stop_point_within_margin_from_stop_line(stop_point, red_stop_line)) {
-        continue;
-      }
-      is_crossing_red = true;  // Reject trajectory (cross red light)
-      break;
+  bool is_crossing_amber = false;
+
+  for (const auto & violation : result->violations) {
+    if (violation.type == traffic_light_filter::ViolationType::RED_LIGHT) {
+      is_crossing_red = true;
+    } else if (violation.type == traffic_light_filter::ViolationType::AMBER_LIGHT) {
+      is_crossing_amber = true;
     }
   }
+
+  std::vector<MetricReport> metrics;
   metrics.push_back(autoware_trajectory_validator::build<MetricReport>()
                       .validator_name(get_name())
                       .validator_category(category())
                       .metric_name("check_crossing_red_light")
                       .metric_value(0.0)
                       .level(is_crossing_red ? MetricReport::ERROR : MetricReport::OK));
-  is_feasible = is_feasible && !is_crossing_red;
 
-  // Check for amber light crossings
-  bool is_crossing_amber = false;
-  for (const auto & amber_stop_line : amber_stop_lines) {
-    auto distance_to_stop_line = 0.0;
-    std::optional<double> amber_stop_line_crossing_time;
-    for (size_t i = 0; i + 1 < trajectory.size(); ++i) {
-      lanelet::BasicPoints2d intersection_points;
-      const lanelet::BasicLineString2d segment{trajectory_ls[i], trajectory_ls[i + 1]};
-      const auto segment_length = static_cast<double>(boost::geometry::length(segment));
-      boost::geometry::intersection(segment, amber_stop_line, intersection_points);
-      if (!intersection_points.empty()) {
-        const auto distance_to_intersection =
-          boost::geometry::distance(segment.front(), intersection_points.front());
-        distance_to_stop_line += distance_to_intersection;
-        const auto ratio = distance_to_intersection / segment_length;
-        amber_stop_line_crossing_time = interpolation::lerp(
-          rclcpp::Duration(trajectory[i].time_from_start).seconds(),
-          rclcpp::Duration(trajectory[i + 1].time_from_start).seconds(), ratio);
-        break;
-      }
-      distance_to_stop_line += segment_length;
-    }
-
-    const auto current_velocity = trajectory.front().longitudinal_velocity_mps;
-    const auto current_acceleration = trajectory.front().acceleration_mps2;
-    if (amber_stop_line_crossing_time) {
-      if (is_stop_point_within_margin_from_stop_line(stop_point, amber_stop_line)) {
-        continue;
-      }
-      if (!can_pass_amber_light(
-            distance_to_stop_line, current_velocity, current_acceleration,
-            *amber_stop_line_crossing_time)) {
-        is_crossing_amber = true;  // Reject trajectory (cross amber light)
-        break;
-      }
-    }
-  }
   metrics.push_back(autoware_trajectory_validator::build<MetricReport>()
                       .validator_name(get_name())
                       .validator_category(category())
                       .metric_name("check_crossing_amber_light")
                       .metric_value(0.0)
                       .level(is_crossing_amber ? MetricReport::ERROR : MetricReport::OK));
-  is_feasible = is_feasible && !is_crossing_amber;
+
+  const bool is_feasible = !is_crossing_red && !is_crossing_amber;
 
   return ValidationResult{is_feasible, std::move(metrics)};
-}
-
-bool TrafficLightFilter::can_pass_amber_light(
-  const double distance_to_stop_line, const double current_velocity,
-  const double current_acceleration, const double time_to_cross_stop_line) const
-{
-  const double decel_limit = params_.deceleration_limit;
-  const double jerk_limit = params_.jerk_limit;
-  const double delay_response_time = params_.delay_response_time;
-  const auto distance_for_ego_to_stop = motion_utils::calculate_stop_distance(
-    current_velocity, current_acceleration, decel_limit, jerk_limit, delay_response_time);
-
-  const bool can_stop =
-    distance_for_ego_to_stop.has_value() && *distance_for_ego_to_stop <= distance_to_stop_line;
-  const bool can_pass_in_time = time_to_cross_stop_line <= params_.crossing_time_limit;
-  const bool can_pass = !can_stop && can_pass_in_time;
-  return can_pass;
 }
 }  // namespace autoware::trajectory_validator::plugin::traffic_rule
 


### PR DESCRIPTION
Refactor the `traffic_light_filter` plugin (in `autoware_trajectory_validator`) to clearly separate the plugin logic (implementation of the plugin interface, preparation of the inputs/outputs), from the core filtering logic.