### PR TITLE
fix(compare_map_segmentation): ignore Werror=array-bounds (#12316)

### DIFF
--- a/perception/autoware_compare_map_segmentation/src/voxel_based_approximate_compare_map_filter/node.cpp
+++ b/perception/autoware_compare_map_segmentation/src/voxel_based_approximate_compare_map_filter/node.cpp
@@ -70,8 +70,13 @@ bool VoxelBasedApproximateDynamicMapLoader::is_close_to_map(
     map_cell_voxel_grid = current_voxel_grid_array_.at(map_grid_index)->map_cell_voxel_grid;
   }
 
-  const int index = map_cell_voxel_grid.getCentroidIndexAt(
-    map_cell_voxel_grid.getGridCoordinates(point.x, point.y, point.z));
+  const Eigen::Vector3i grid_coordinates =
+    map_cell_voxel_grid.getGridCoordinates(point.x, point.y, point.z);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Warray-bounds"
+  const int index = map_cell_voxel_grid.getCentroidIndexAt(grid_coordinates);
+#pragma GCC diagnostic pop
+
   return (index != -1);
 }
 


### PR DESCRIPTION
## Description

> [!NOTE]
> **Jazzy migration**

* cherry-pick  https://github.com/autowarefoundation/autoware_universe/pull/12316

### Original Description

> Compilation fails in jazzy.


### Related Jazzy migration PRs 

- https://github.com/tier4/autoware_tools/pull/50
- https://github.com/tier4/autoware_universe/pull/2930
- https://github.com/tier4/autoware_universe/pull/2929
- https://github.com/tier4/autoware_universe/pull/2928