### PR TITLE
fix(boundary_departure_checker): link pybind11 properly (#12155)

### DIFF
--- a/common/autoware_boundary_departure_checker/CMakeLists.txt
+++ b/common/autoware_boundary_departure_checker/CMakeLists.txt
@@ -35,7 +35,10 @@ target_link_libraries(boundary_departure_checker
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   ament_lint_auto_find_test_dependencies()
-  find_package(autoware_pyplot REQUIRED)
+  find_package(python_cmake_module REQUIRED)
+  find_package(Python3 REQUIRED COMPONENTS Interpreter Development)
+  find_package(pybind11_vendor REQUIRED)
+  find_package(pybind11 REQUIRED)
   option(EXPORT_TEST_PLOT_FIGURE "Enable plotting in tests" OFF)
   file(GLOB_RECURSE TEST_SOURCES test/*.cpp)
   ament_add_gtest(test_${PROJECT_NAME}
@@ -45,6 +48,8 @@ if(BUILD_TESTING)
     boundary_departure_checker_utils
     boundary_departure_checker
     uncrossable_boundary_departure_checker
+    Python3::Python
+    pybind11::embed
   )
   target_include_directories(test_${PROJECT_NAME} PRIVATE
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/src>

--- a/common/autoware_boundary_departure_checker/package.xml
+++ b/common/autoware_boundary_departure_checker/package.xml
@@ -22,7 +22,6 @@
   <depend>autoware_map_msgs</depend>
   <depend>autoware_motion_utils</depend>
   <depend>autoware_planning_msgs</depend>
-  <depend>autoware_pyplot</depend>
   <depend>autoware_trajectory</depend>
   <depend>autoware_universe_utils</depend>
   <depend>autoware_utils_debug</depend>
@@ -49,6 +48,7 @@
   <test_depend>ament_cmake_ros</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>autoware_lint_common</test_depend>
+  <test_depend>autoware_pyplot</test_depend>
   <test_depend>autoware_test_utils</test_depend>
 
   <export>


### PR DESCRIPTION
## Description

> [!NOTE]
> **Jazzy migration**

* cherry-pick  https://github.com/autowarefoundation/autoware_universe/pull/12155

### Original Description
> It compiles fine for humble but for jazzy it needs explicit linking like similar packages that use pyplot in the autoware workspace.

> Compilation errors (on jazzy) before this PR:
[gist.github.com/xmfcx/ea033facd6f4ab610f81f5c0ee02fad7](https://gist.github.com/xmfcx/ea033facd6f4ab610f81f5c0ee02fad7)

### Related Jazzy migration PRs 

- https://github.com/tier4/autoware_tools/pull/50
- https://github.com/tier4/autoware_universe/pull/2930
- https://github.com/tier4/autoware_universe/pull/2929
- https://github.com/tier4/autoware_universe/pull/2928