### PR TITLE
feat(trajectory_modifier): improve obstacle stop to better handle crossing objects

### DIFF
--- a/planning/autoware_minimum_rule_based_planner/config/minimum_rule_based_planner.param.yaml
+++ b/planning/autoware_minimum_rule_based_planner/config/minimum_rule_based_planner.param.yaml
@@ -48,6 +48,7 @@
         object_types: ["car", "truck", "bus", "trailer", "motorcycle", "bicycle", "pedestrian", "unknown"] # object types to consider for obstacle stop
         max_velocity_th: 1.0     # maximum velocity threshold for target object [m/s]
         stopped_velocity_th: 0.25 # velocity threshold for target object to be considered as stopped [m/s]
+        max_lateral_velocity_th: 1.0 # [m/s] max lateral velocity (w.r.t ego traj) to consider for obstacle stop
 
       rss_params:
         enable: true

--- a/planning/autoware_minimum_rule_based_planner/param/minimum_rule_based_planner_parameters.yaml
+++ b/planning/autoware_minimum_rule_based_planner/param/minimum_rule_based_planner_parameters.yaml
@@ -155,6 +155,10 @@ minimum_rule_based_planner:
         type: double
         default_value: 0.25
         description: velocity threshold for target object to be considered as stopped [m/s]
+      max_lateral_velocity_th:
+        type: double
+        default_value: 1.0
+        description: maximum lateral velocity threshold for target object [m/s]
     rss_params:
       enable:
         type: bool

--- a/planning/autoware_minimum_rule_based_planner/plugins/obstacle_stop.cpp
+++ b/planning/autoware_minimum_rule_based_planner/plugins/obstacle_stop.cpp
@@ -52,7 +52,7 @@ void ObstacleStop::on_initialize(const MinimumRuleBasedPlannerParams & params)
 
   object_filter_ = std::make_unique<trajectory_modifier::utils::obstacle_stop::ObjectFilter>(
     params_.objects.object_types, params_.objects.max_velocity_th,
-    params_.objects.stopped_velocity_th);
+    params_.objects.stopped_velocity_th, params_.objects.max_lateral_velocity_th);
 
   pub_clustered_pointcloud_ =
     get_node_ptr()->create_publisher<PointCloud2>("~/obstacle_stop/debug/cluster_points", 1);

--- a/planning/autoware_minimum_rule_based_planner/plugins/obstacle_stop.cpp
+++ b/planning/autoware_minimum_rule_based_planner/plugins/obstacle_stop.cpp
@@ -161,12 +161,11 @@ std::optional<CollisionPoint> ObstacleStop::check_predicted_objects(
   autoware_perception_msgs::msg::PredictedObject colliding_object;
   auto collision_point = std::invoke([&]() -> std::optional<CollisionPoint> {
     if (!params_.rss_params.enable) {
-      return get_nearest_object_collision(
-        traj_points, predicted_objects, colliding_object);
+      return get_nearest_object_collision(traj_points, predicted_objects, colliding_object);
     }
     return get_nearest_object_collision(
-      traj_points, vehicle_info_, predicted_objects,
-      object_decel_map_, params_.rss_params.ego_decel, params_.rss_params.reaction_time,
+      traj_points, vehicle_info_, predicted_objects, object_decel_map_,
+      params_.rss_params.ego_decel, params_.rss_params.reaction_time,
       params_.rss_params.safety_margin, params_.objects.stopped_velocity_th,
       params_.rss_params.lookahead_horizon, colliding_object);
   });

--- a/planning/autoware_minimum_rule_based_planner/plugins/obstacle_stop.cpp
+++ b/planning/autoware_minimum_rule_based_planner/plugins/obstacle_stop.cpp
@@ -51,7 +51,8 @@ void ObstacleStop::on_initialize(const MinimumRuleBasedPlannerParams & params)
       params_.pointcloud.clustering.max_size);
 
   object_filter_ = std::make_unique<trajectory_modifier::utils::obstacle_stop::ObjectFilter>(
-    params_.objects.object_types, params_.objects.max_velocity_th);
+    params_.objects.object_types, params_.objects.max_velocity_th,
+    params_.objects.stopped_velocity_th);
 
   pub_clustered_pointcloud_ =
     get_node_ptr()->create_publisher<PointCloud2>("~/obstacle_stop/debug/cluster_points", 1);
@@ -153,19 +154,21 @@ std::optional<CollisionPoint> ObstacleStop::check_predicted_objects(
   auto predicted_objects = *data_->predicted_objects_ptr;
 
   object_filter_->filter_objects(predicted_objects);
+  object_filter_->filter_by_target_area(
+    predicted_objects, traj_points, debug_data_.trajectory_shape.polygon,
+    debug_data_.target_polygons);
 
   autoware_perception_msgs::msg::PredictedObject colliding_object;
   auto collision_point = std::invoke([&]() -> std::optional<CollisionPoint> {
     if (!params_.rss_params.enable) {
       return get_nearest_object_collision(
-        traj_points, debug_data_.trajectory_shape, predicted_objects, debug_data_.target_polygons,
-        colliding_object);
+        traj_points, predicted_objects, colliding_object);
     }
     return get_nearest_object_collision(
-      traj_points, debug_data_.trajectory_shape, vehicle_info_, predicted_objects,
+      traj_points, vehicle_info_, predicted_objects,
       object_decel_map_, params_.rss_params.ego_decel, params_.rss_params.reaction_time,
       params_.rss_params.safety_margin, params_.objects.stopped_velocity_th,
-      params_.rss_params.lookahead_horizon, debug_data_.target_polygons, colliding_object);
+      params_.rss_params.lookahead_horizon, colliding_object);
   });
   if (collision_point) debug_data_.colliding_object = colliding_object;
   return collision_point;

--- a/planning/autoware_minimum_rule_based_planner/plugins/obstacle_stop.hpp
+++ b/planning/autoware_minimum_rule_based_planner/plugins/obstacle_stop.hpp
@@ -58,7 +58,7 @@ public:
 
     {
       const auto & p = params_.objects;
-      object_filter_->set_params(p.object_types, p.max_velocity_th);
+      object_filter_->set_params(p.object_types, p.max_velocity_th, p.stopped_velocity_th);
     }
 
     {

--- a/planning/autoware_minimum_rule_based_planner/plugins/obstacle_stop.hpp
+++ b/planning/autoware_minimum_rule_based_planner/plugins/obstacle_stop.hpp
@@ -58,7 +58,8 @@ public:
 
     {
       const auto & p = params_.objects;
-      object_filter_->set_params(p.object_types, p.max_velocity_th, p.stopped_velocity_th);
+      object_filter_->set_params(
+        p.object_types, p.max_velocity_th, p.stopped_velocity_th, p.max_lateral_velocity_th);
     }
 
     {

--- a/planning/autoware_minimum_rule_based_planner/schema/minimum_rule_based_planner.schema.json
+++ b/planning/autoware_minimum_rule_based_planner/schema/minimum_rule_based_planner.schema.json
@@ -247,6 +247,12 @@
                   "description": "Velocity threshold for target object to be considered as stopped [m/s]",
                   "default": 0.25,
                   "minimum": 0.0
+                },
+                "max_lateral_velocity_th": {
+                  "type": "number",
+                  "description": "Max lateral velocity threshold [m/s]",
+                  "default": 1.0,
+                  "minimum": 0.0
                 }
               },
               "required": [],

--- a/planning/autoware_trajectory_modifier/config/trajectory_modifier.param.yaml
+++ b/planning/autoware_trajectory_modifier/config/trajectory_modifier.param.yaml
@@ -26,7 +26,7 @@
       maximum_stopping_decel: 4.0 # [m/s^2]
       stopping_jerk: 3.0 # [m/s^3]
       lateral_margin: 0.0     # lateral margin on top of ego width from trajectory to consider for obstacle stop [m]
-      duplicate_check_threshold: 1.0 # threshold to check if the stop point is already in the trajectory [m]
+      duplicate_check_threshold: 0.5 # threshold to check if the stop point is already in the trajectory [m]
       arrived_distance_threshold: 0.5 # threshold to check if the ego vehicle has arrived at the stop point [m]
 
       obstacle_tracking:

--- a/planning/autoware_trajectory_modifier/config/trajectory_modifier.param.yaml
+++ b/planning/autoware_trajectory_modifier/config/trajectory_modifier.param.yaml
@@ -41,6 +41,7 @@
         object_types: ["car", "truck", "bus", "trailer", "motorcycle", "bicycle", "pedestrian"] # object types to consider for obstacle stop
         max_velocity_th: 5.0      # maximum velocity threshold for target object [m/s]
         stopped_velocity_th: 0.25 # [m/s]
+        max_lateral_velocity_th: 1.0 # [m/s] max lateral velocity (w.r.t ego traj) to consider for obstacle stop
 
       pointcloud:
         height_buffer: 0.5  # height buffer to add above ego height [m]

--- a/planning/autoware_trajectory_modifier/include/autoware/trajectory_modifier/trajectory_modifier_utils/obstacle_stop_utils.hpp
+++ b/planning/autoware_trajectory_modifier/include/autoware/trajectory_modifier/trajectory_modifier_utils/obstacle_stop_utils.hpp
@@ -151,22 +151,23 @@ std::optional<CollisionPoint> get_nearest_pcd_collision(
   const PointCloud::Ptr & pointcloud, std::vector<geometry_msgs::msg::Point> & target_pcd_points);
 
 std::optional<CollisionPoint> get_nearest_object_collision(
-  const TrajectoryPoints & trajectory_points, const TrajectoryShape & trajectory_shape,
-  const PredictedObjects & objects, MultiPolygon2d & target_polygons,
+  const TrajectoryPoints & trajectory_points, const PredictedObjects & target_objects,
   PredictedObject & colliding_object);
 
 using ObjectDecelMap = std::unordered_map<ObjectType, double>;
 std::optional<CollisionPoint> get_nearest_object_collision(
-  const TrajectoryPoints & trajectory_points, const TrajectoryShape & trajectory_shape,
-  const autoware::vehicle_info_utils::VehicleInfo & vehicle_info, const PredictedObjects & objects,
-  const ObjectDecelMap & object_decel_map, const double ego_decel, const double reaction_time,
-  const double safety_margin, const double stopped_vel_th, const double lookahead_horizon,
-  MultiPolygon2d & target_polygons, PredictedObject & colliding_object);
+  const TrajectoryPoints & trajectory_points,
+  const autoware::vehicle_info_utils::VehicleInfo & vehicle_info,
+  const PredictedObjects & target_objects, const ObjectDecelMap & object_decel_map,
+  const double ego_decel, const double reaction_time, const double safety_margin,
+  const double stopped_vel_th, const double lookahead_horizon, PredictedObject & colliding_object);
 
 struct ObjectFilter
 {
-  ObjectFilter(const std::vector<std::string> & object_type_strings, const double max_velocity_th)
-  : max_velocity_th_(max_velocity_th)
+  ObjectFilter(
+    const std::vector<std::string> & object_type_strings, const double max_velocity_th,
+    const double stopped_velocity_th)
+  : max_velocity_th_(max_velocity_th), stopped_velocity_th_(stopped_velocity_th)
   {
     for (const auto & object_type_string : object_type_strings) {
       if (string_to_object_type.count(object_type_string) == 0) continue;
@@ -190,8 +191,13 @@ struct ObjectFilter
       objects.objects.end());
   }
 
+  void filter_by_target_area(
+    PredictedObjects & objects, const TrajectoryPoints & trajectory_points,
+    const MultiPolygon2d & target_area, MultiPolygon2d & target_polygons);
+
   void set_params(
-    const std::vector<std::string> & object_type_strings, const double max_velocity_th)
+    const std::vector<std::string> & object_type_strings, const double max_velocity_th,
+    const double stopped_velocity_th)
   {
     object_types_.clear();
     for (const auto & object_type_string : object_type_strings) {
@@ -199,11 +205,13 @@ struct ObjectFilter
       object_types_.emplace(string_to_object_type.at(object_type_string));
     }
     max_velocity_th_ = max_velocity_th;
+    stopped_velocity_th_ = stopped_velocity_th;
   }
 
 private:
   std::unordered_set<ObjectType> object_types_;
   double max_velocity_th_;
+  double stopped_velocity_th_;
 };
 
 struct PointCloudFilter

--- a/planning/autoware_trajectory_modifier/include/autoware/trajectory_modifier/trajectory_modifier_utils/obstacle_stop_utils.hpp
+++ b/planning/autoware_trajectory_modifier/include/autoware/trajectory_modifier/trajectory_modifier_utils/obstacle_stop_utils.hpp
@@ -166,8 +166,10 @@ struct ObjectFilter
 {
   ObjectFilter(
     const std::vector<std::string> & object_type_strings, const double max_velocity_th,
-    const double stopped_velocity_th)
-  : max_velocity_th_(max_velocity_th), stopped_velocity_th_(stopped_velocity_th)
+    const double stopped_velocity_th, const double max_lateral_velocity_th)
+  : max_velocity_th_(max_velocity_th),
+    stopped_velocity_th_(stopped_velocity_th),
+    max_lateral_velocity_th_(max_lateral_velocity_th)
   {
     for (const auto & object_type_string : object_type_strings) {
       if (string_to_object_type.count(object_type_string) == 0) continue;
@@ -197,7 +199,7 @@ struct ObjectFilter
 
   void set_params(
     const std::vector<std::string> & object_type_strings, const double max_velocity_th,
-    const double stopped_velocity_th)
+    const double stopped_velocity_th, const double max_lateral_velocity_th)
   {
     object_types_.clear();
     for (const auto & object_type_string : object_type_strings) {
@@ -206,12 +208,14 @@ struct ObjectFilter
     }
     max_velocity_th_ = max_velocity_th;
     stopped_velocity_th_ = stopped_velocity_th;
+    max_lateral_velocity_th_ = max_lateral_velocity_th;
   }
 
 private:
   std::unordered_set<ObjectType> object_types_;
   double max_velocity_th_;
   double stopped_velocity_th_;
+  double max_lateral_velocity_th_;
 };
 
 struct PointCloudFilter

--- a/planning/autoware_trajectory_modifier/include/autoware/trajectory_modifier/trajectory_modifier_utils/obstacle_stop_utils.hpp
+++ b/planning/autoware_trajectory_modifier/include/autoware/trajectory_modifier/trajectory_modifier_utils/obstacle_stop_utils.hpp
@@ -91,11 +91,22 @@ struct CollisionPoint
   rclcpp::Time start_time;
   bool is_active{false};
 
+  /**
+   * @brief Construct a collision sample from a point and its arc length along the reference path.
+   * @param point Collision position in map frame.
+   * @param arc_length Signed arc length from the start of the trajectory to the collision point.
+   */
   CollisionPoint(const geometry_msgs::msg::Point & point, const double arc_length)
   : point(point), arc_length(arc_length)
   {
   }
 
+  /**
+   * @brief Copy a collision point and attach timing / activation state (e.g. for hysteresis).
+   * @param collision_point Source geometry and arc length.
+   * @param start_time Time associated with this collision state.
+   * @param active Whether this collision is currently considered active.
+   */
   CollisionPoint(
     const CollisionPoint & collision_point, const rclcpp::Time & start_time, const bool active)
   : point(collision_point.point),
@@ -133,28 +144,94 @@ struct DebugData
   std::optional<PredictedObject> colliding_object;
 };
 
+/**
+ * @brief Trim the trajectory after the first zero-velocity point and remove overlapping duplicate
+ * points.
+ * @param[in,out] trajectory_points Trajectory to shorten and deduplicate in place.
+ */
 void trim_trajectory_and_remove_duplicates(TrajectoryPoints & trajectory_points);
 
+/**
+ * @brief Build a 2D swept footprint of the ego vehicle along the portion of the path used for
+ * obstacle detection.
+ * @details The detection length combines stopping-distance logic (speed, deceleration, jerk,
+ * margins) with the path ahead of the ego. The polygon is the union of vehicle footprints
+ * sampled along that segment; the returned bounding box encloses that multi-polygon.
+ * @param trajectory_points Full reference trajectory.
+ * @param ego_pose Current ego pose on the trajectory.
+ * @param vehicle_info Vehicle geometry for the footprint polygon.
+ * @param ego_vel Current longitudinal speed [m/s].
+ * @param ego_accel Current longitudinal acceleration [m/s^2].
+ * @param decel Magnitude of comfortable deceleration used for stopping distance [m/s^2].
+ * @param jerk Longitudinal jerk limit used for stopping distance [m/s^3].
+ * @param stop_margin Extra longitudinal margin added to the detection range [m].
+ * @param lateral_margin Lateral expansion of the footprint [m].
+ * @param longitudinal_margin Longitudinal expansion of the footprint [m].
+ * @return Swept shape, its axis-aligned bounding box, total trajectory length, and forward arc
+ * length from the ego.
+ */
 TrajectoryShape get_trajectory_shape(
   const TrajectoryPoints & trajectory_points, const geometry_msgs::msg::Pose & ego_pose,
   const autoware::vehicle_info_utils::VehicleInfo & vehicle_info, const double ego_vel,
   const double ego_accel, const double decel, const double jerk, const double stop_margin,
   const double lateral_margin = 0.0, const double longitudinal_margin = 0.0);
 
-void filter_objects_by_type(
-  PredictedObjects & objects, const std::vector<std::string> & object_type_strings);
-
-void filter_objects_by_velocity(PredictedObjects & objects, const double max_velocity);
-
+/**
+ * @brief Find the closest point-cloud obstacle inside the trajectory swept area.
+ * @details Points inside `trajectory_shape.polygon` are considered; the collision is the one with
+ * minimum arc length along `trajectory_points`. All inlier points are appended to
+ * `target_pcd_points` for visualization or debugging.
+ * @param trajectory_points Reference path for arc-length queries.
+ * @param trajectory_shape Swept ego region from get_trajectory_shape().
+ * @param pointcloud Input points in the same frame as the trajectory.
+ * @param[out] target_pcd_points Points that fell inside the trajectory polygon.
+ * @return Nearest collision by arc length, or nullopt if the cloud is empty or none intersect.
+ */
 std::optional<CollisionPoint> get_nearest_pcd_collision(
   const TrajectoryPoints & trajectory_points, const TrajectoryShape & trajectory_shape,
   const PointCloud::Ptr & pointcloud, std::vector<geometry_msgs::msg::Point> & target_pcd_points);
 
+/**
+ * @brief Find the nearest obstacle along the path using each object's footprint polygon at the
+ * current time.
+ * @details For every target object, polygon vertices are projected onto arc length along the
+ * trajectory; the minimum over all vertices and objects defines the collision point.
+ * @param trajectory_points Reference path.
+ * @param target_objects Predicted objects to test (typically already filtered).
+ * @param[out] colliding_object Object that yielded the minimum arc-length collision.
+ * @return Collision point and arc length, or nullopt if inputs are invalid or no objects.
+ */
 std::optional<CollisionPoint> get_nearest_object_collision(
   const TrajectoryPoints & trajectory_points, const PredictedObjects & target_objects,
   PredictedObject & colliding_object);
 
 using ObjectDecelMap = std::unordered_map<ObjectType, double>;
+
+/**
+ * @brief Find the nearest predicted object that is not longitudinally safe relative to the ego
+ * path within a time horizon.
+ * @details For each trajectory point up to `lookahead_horizon`, an RSS check is applied to the
+ * ego's and the object's predicted states to determine if the object is longitudinally safe
+ * relative to the ego path. If the object is not longitudinally safe, the object is considered to
+ * be a collision candidate. If the object's lon. velocity along ego path is below `stopped_vel_th`,
+ * the object is considered to be a collision candidate. The object with the smallest arc length
+ * along `trajectory_points` is returned as the collision point.
+ * @param trajectory_points Reference path; arc lengths and ego motion are read from these points.
+ * @param vehicle_info Used for the ego front longitudinal offset when comparing gap to safe
+ * distance.
+ * @param target_objects Predicted objects to evaluate (already filtered).
+ * @param object_decel_map Braking magnitude [m/s^2] per object type for the object stopping term in
+ * the safe-distance model.
+ * @param ego_decel Magnitude of ego deceleration [m/s^2] for the ego stopping term.
+ * @param reaction_time system reaction time [s] to respond to detected collision.
+ * @param safety_margin Extra longitudinal buffer [m] added to the computed safe distance.
+ * @param stopped_vel_th Objects with longitudinal speed along the path below this [m/s] are
+ * considered static.
+ * @param lookahead_horizon Maximum `time_from_start` along the trajectory [s] to propagate objects
+ * and ego states.
+ * @param[out] colliding_object Object with the smallest arc-length collision among unsafe cases.
+ * @return Collision geometry and arc length, or nullopt if inputs are invalid or objects are safe
+ */
 std::optional<CollisionPoint> get_nearest_object_collision(
   const TrajectoryPoints & trajectory_points,
   const autoware::vehicle_info_utils::VehicleInfo & vehicle_info,
@@ -162,8 +239,16 @@ std::optional<CollisionPoint> get_nearest_object_collision(
   const double ego_decel, const double reaction_time, const double safety_margin,
   const double stopped_vel_th, const double lookahead_horizon, PredictedObject & colliding_object);
 
+/// Filters predicted objects by semantic type, speed, and spatial relationship to the trajectory.
 struct ObjectFilter
 {
+  /**
+   * @brief Construct a filter from allowed type names and speed thresholds.
+   * @param object_type_strings Allowed object classes (see string_to_object_type).
+   * @param max_velocity_th Remove objects with longitudinal twist.x above this [m/s].
+   * @param stopped_velocity_th Used when filtering by target area for "moving" vs stopped.
+   * @param max_lateral_velocity_th Lateral speed threshold for the exiting-object heuristic [m/s].
+   */
   ObjectFilter(
     const std::vector<std::string> & object_type_strings, const double max_velocity_th,
     const double stopped_velocity_th, const double max_lateral_velocity_th)
@@ -177,6 +262,10 @@ struct ObjectFilter
     }
   }
 
+  /**
+   * @brief Remove objects that are too fast or whose class is not in the configured allow-list.
+   * @param[in,out] objects Predicted objects message updated in place.
+   */
   void filter_objects(PredictedObjects & objects)
   {
     objects.objects.erase(
@@ -193,10 +282,23 @@ struct ObjectFilter
       objects.objects.end());
   }
 
+  /**
+   * @brief Keep only objects that intersect the target region, dropping those leaving laterally.
+   * @details Objects disjoint from `target_area` are removed. Moving objects that are judged to be
+   * exiting the corridor (using lateral velocity and a short prediction horizon) are also removed.
+   * Polygons of retained objects are accumulated in `target_polygons`.
+   * @param[in,out] objects Predicted objects to filter in place.
+   * @param trajectory_points Reference path for time and geometry queries.
+   * @param target_area Multi-polygon region of interest (e.g. expanded path).
+   * @param[out] target_polygons Footprints of objects that remain after filtering.
+   */
   void filter_by_target_area(
     PredictedObjects & objects, const TrajectoryPoints & trajectory_points,
     const MultiPolygon2d & target_area, MultiPolygon2d & target_polygons);
 
+  /**
+   * @brief Update allow-listed types and velocity thresholds without reconstructing the filter.
+   */
   void set_params(
     const std::vector<std::string> & object_type_strings, const double max_velocity_th,
     const double stopped_velocity_th, const double max_lateral_velocity_th)
@@ -218,8 +320,12 @@ private:
   double max_lateral_velocity_th_;
 };
 
+/// PCL-based downsampling, cropping, clustering, and object masking for obstacle point clouds.
 struct PointCloudFilter
 {
+  /**
+   * @brief Configure voxel grid and euclidean clustering parameters used by subsequent filters.
+   */
   PointCloudFilter(
     double voxel_size_x, double voxel_size_y, double voxel_size_z, int voxel_min_size,
     double cluster_tolerance, int cluster_min_size, int cluster_max_size)
@@ -233,6 +339,9 @@ struct PointCloudFilter
     convex_hull_.setDimension(2);
   };
 
+  /**
+   * @brief Update voxel and clustering parameters at runtime.
+   */
   void set_params(
     double voxel_size_x, double voxel_size_y, double voxel_size_z, int voxel_min_size,
     double cluster_tolerance, int cluster_min_size, int cluster_max_size)
@@ -244,11 +353,27 @@ struct PointCloudFilter
     ec_.setMaxClusterSize(cluster_max_size);
   }
 
+  /**
+   * @brief Crop the cloud to an axis-aligned box, then apply voxel grid downsampling.
+   * @param[in,out] pointcloud Cloud updated in place; empty if nothing remains.
+   * @param min_x,max_x,min_y,max_y,min_z,max_z Crop box bounds in the cloud frame.
+   */
   void filter_pointcloud(
     PointCloud::Ptr & pointcloud, const double min_x, const double max_x, const double min_y,
     const double max_y, const double min_z, const double max_z);
+  /**
+   * @brief Cluster the cloud and output 2D convex hull vertices of clusters above a height cutoff.
+   * @param input Downsampled or cropped cloud.
+   * @param[out] output Hull vertices of qualifying clusters (typically for footprint tests).
+   * @param min_height A cluster is kept only if at least one point has z >= this value [m].
+   */
   void cluster_pointcloud(
     const PointCloud::Ptr & input, PointCloud::Ptr & output, const double min_height);
+  /**
+   * @brief Remove points that lie inside predicted object footprints (expanded by a small margin).
+   * @param[in,out] pointcloud Cloud to strip in place.
+   * @param objects Predicted obstacles whose shapes define removal regions.
+   */
   void filter_pointcloud_by_object(PointCloud::Ptr & pointcloud, const PredictedObjects & objects);
 
 private:
@@ -259,8 +384,18 @@ private:
   pcl::ConvexHull<pcl::PointXYZ> convex_hull_;
 };
 
+/// Temporal association of obstacle detections (objects and points) with hysteresis.
 struct ObstacleTracker
 {
+  /**
+   * @brief Construct with time buffers and association thresholds.
+   * @param on_time_buffer Seconds a track must be seen before it is considered active.
+   * @param off_time_buffer Seconds without observation before an active track may be removed.
+   * @param object_distance_th Max 2D distance to match a new detection to an existing object track.
+   * @param object_yaw_th Max yaw difference to match object detections [rad].
+   * @param pcd_distance_th Max 2D distance to match a point to an existing point track.
+   * @param grace_period Seconds to keep inactive tracks before deletion.
+   */
   ObstacleTracker(
     const double on_time_buffer, const double off_time_buffer, const double object_distance_th,
     const double object_yaw_th, const double pcd_distance_th, const double grace_period)
@@ -273,6 +408,9 @@ struct ObstacleTracker
   {
   }
 
+  /**
+   * @brief Update association and timing parameters.
+   */
   void set_params(
     const double on_time_buffer, const double off_time_buffer, const double object_distance_th,
     const double object_yaw_th, const double pcd_distance_th, const double grace_period)
@@ -291,6 +429,7 @@ struct ObstacleTracker
    * based on the on_time_buffer and off_time_buffer.
    * @param objects Input predicted objects after filtering
    * @param persistent_objects Output persistent objects
+   * @param now Current stamp used for track aging and activation timing
    */
   void update_objects(
     const PredictedObjects & objects, PredictedObjects & persistent_objects,
@@ -302,6 +441,7 @@ struct ObstacleTracker
    * based on the on_time_buffer and off_time_buffer.
    * @param points Input pointcloud
    * @param persistent_points Output persistent points
+   * @param now Current stamp used for track aging and activation timing
    */
   void update_points(
     const PointCloud::Ptr & points, PointCloud::Ptr & persistent_points, const rclcpp::Time & now);

--- a/planning/autoware_trajectory_modifier/param/trajectory_modifier_parameter_struct.yaml
+++ b/planning/autoware_trajectory_modifier/param/trajectory_modifier_parameter_struct.yaml
@@ -194,6 +194,13 @@ trajectory_modifier_params:
         validation:
           bounds<>: [0.0, 10.0]
         read_only: false
+      max_lateral_velocity_th:
+        type: double
+        default_value: 1.0
+        description: Maximum lateral velocity threshold for target object to be considered for obstacle stop [m/s]
+        validation:
+          bounds<>: [0.0, 10.0]
+        read_only: false
 
     pointcloud:
       height_buffer:

--- a/planning/autoware_trajectory_modifier/param/trajectory_modifier_parameter_struct.yaml
+++ b/planning/autoware_trajectory_modifier/param/trajectory_modifier_parameter_struct.yaml
@@ -3,8 +3,8 @@ trajectory_modifier_params:
     type: string_array
     default_value:
       [
-        "autoware::trajectory_modifier::plugin::ObstacleStop",
-        "autoware::trajectory_modifier::plugin::StopPointFixer",
+        autoware::trajectory_modifier::plugin::ObstacleStop,
+        autoware::trajectory_modifier::plugin::StopPointFixer,
       ]
     description: List of plugin names to load
     read_only: false

--- a/planning/autoware_trajectory_modifier/param/trajectory_modifier_parameter_struct.yaml
+++ b/planning/autoware_trajectory_modifier/param/trajectory_modifier_parameter_struct.yaml
@@ -117,7 +117,7 @@ trajectory_modifier_params:
       read_only: false
     duplicate_check_threshold:
       type: double
-      default_value: 1.0
+      default_value: 0.5
       description: Threshold to check if the stop point is already in the trajectory [m]
       validation:
         bounds<>: [0.0, 10.0]

--- a/planning/autoware_trajectory_modifier/schema/trajectory_modifier.schema.json
+++ b/planning/autoware_trajectory_modifier/schema/trajectory_modifier.schema.json
@@ -193,6 +193,12 @@
                   "description": "Velocity threshold for target object to be considered as stopped [m/s]",
                   "default": 0.25,
                   "minimum": 0.0
+                },
+                "max_lateral_velocity_th": {
+                  "type": "number",
+                  "description": "Maximum lateral velocity threshold for target object to be considered for obstacle stop [m/s]",
+                  "default": 1.0,
+                  "minimum": 0.0
                 }
               },
               "required": [],

--- a/planning/autoware_trajectory_modifier/schema/trajectory_modifier.schema.json
+++ b/planning/autoware_trajectory_modifier/schema/trajectory_modifier.schema.json
@@ -110,7 +110,7 @@
             "duplicate_check_threshold": {
               "type": "number",
               "description": "Threshold to check if the stop point is already in the trajectory [m]",
-              "default": 1.0,
+              "default": 0.5,
               "minimum": 0.0
             },
             "arrived_distance_threshold": {

--- a/planning/autoware_trajectory_modifier/src/trajectory_modifier_plugins/obstacle_stop.cpp
+++ b/planning/autoware_trajectory_modifier/src/trajectory_modifier_plugins/obstacle_stop.cpp
@@ -86,8 +86,8 @@ void ObstacleStop::on_initialize(const TrajectoryModifierParams & params)
 
   {
     const auto & p = params_.objects;
-    object_filter_ =
-      std::make_unique<utils::obstacle_stop::ObjectFilter>(p.object_types, p.max_velocity_th);
+    object_filter_ = std::make_unique<utils::obstacle_stop::ObjectFilter>(
+      p.object_types, p.max_velocity_th, p.stopped_velocity_th);
   }
 
   {
@@ -132,7 +132,7 @@ void ObstacleStop::update_params(const TrajectoryModifierParams & params)
 
   {
     const auto & p = params_.objects;
-    object_filter_->set_params(p.object_types, p.max_velocity_th);
+    object_filter_->set_params(p.object_types, p.max_velocity_th, p.stopped_velocity_th);
   }
 
   {
@@ -456,18 +456,19 @@ std::optional<CollisionPoint> ObstacleStop::check_predicted_objects(
   obstacle_tracker_->update_objects(
     debug_data_.filtered_objects, active_objects, get_clock()->now());
 
+  object_filter_->filter_by_target_area(
+    active_objects, traj_points, debug_data_.trajectory_shape.polygon, debug_data_.target_polygons);
+
   autoware_perception_msgs::msg::PredictedObject colliding_object;
   auto collision_point = std::invoke([&]() -> std::optional<CollisionPoint> {
     if (!params_.rss_params.enable) {
-      return get_nearest_object_collision(
-        traj_points, debug_data_.trajectory_shape, active_objects, debug_data_.target_polygons,
-        colliding_object);
+      return get_nearest_object_collision(traj_points, active_objects, colliding_object);
     }
     return get_nearest_object_collision(
-      traj_points, debug_data_.trajectory_shape, data_->vehicle_info, active_objects,
-      object_decel_map_, params_.rss_params.ego_decel, params_.rss_params.reaction_time,
+      traj_points, data_->vehicle_info, active_objects, object_decel_map_,
+      params_.rss_params.ego_decel, params_.rss_params.reaction_time,
       params_.rss_params.safety_margin, params_.objects.stopped_velocity_th,
-      params_.rss_params.lookahead_horizon, debug_data_.target_polygons, colliding_object);
+      params_.rss_params.lookahead_horizon, colliding_object);
   });
 
   if (collision_point) debug_data_.colliding_object = colliding_object;

--- a/planning/autoware_trajectory_modifier/src/trajectory_modifier_plugins/obstacle_stop.cpp
+++ b/planning/autoware_trajectory_modifier/src/trajectory_modifier_plugins/obstacle_stop.cpp
@@ -87,7 +87,7 @@ void ObstacleStop::on_initialize(const TrajectoryModifierParams & params)
   {
     const auto & p = params_.objects;
     object_filter_ = std::make_unique<utils::obstacle_stop::ObjectFilter>(
-      p.object_types, p.max_velocity_th, p.stopped_velocity_th);
+      p.object_types, p.max_velocity_th, p.stopped_velocity_th, p.max_lateral_velocity_th);
   }
 
   {
@@ -132,7 +132,8 @@ void ObstacleStop::update_params(const TrajectoryModifierParams & params)
 
   {
     const auto & p = params_.objects;
-    object_filter_->set_params(p.object_types, p.max_velocity_th, p.stopped_velocity_th);
+    object_filter_->set_params(
+      p.object_types, p.max_velocity_th, p.stopped_velocity_th, p.max_lateral_velocity_th);
   }
 
   {

--- a/planning/autoware_trajectory_modifier/src/trajectory_modifier_plugins/obstacle_stop.cpp
+++ b/planning/autoware_trajectory_modifier/src/trajectory_modifier_plugins/obstacle_stop.cpp
@@ -222,17 +222,14 @@ bool ObstacleStop::set_stop_point(TrajectoryPoints & traj_points)
   };
 
   constexpr double stop_velocity_threshold = 0.01;
-
-  if (params_.duplicate_check_threshold > std::numeric_limits<double>::epsilon()) {
-    auto checked_distance = 0.0;
-    for (size_t i = 1; i < traj_points.size(); ++i) {
-      const auto & curr = traj_points.at(i);
-      const auto & prev = traj_points.at(i - 1);
-      checked_distance += autoware_utils::calc_distance2d(curr.pose.position, prev.pose.position);
-      if (curr.longitudinal_velocity_mps > stop_velocity_threshold) continue;
-      if (checked_distance < target_stop_point_arc_length) {
-        return skip("Preceding stop point exists");
-      }
+  auto checked_distance = 0.0;
+  for (size_t i = 1; i < traj_points.size(); ++i) {
+    const auto & curr = traj_points.at(i);
+    const auto & prev = traj_points.at(i - 1);
+    checked_distance += autoware_utils::calc_distance2d(curr.pose.position, prev.pose.position);
+    if (checked_distance > target_stop_point_arc_length + params_.duplicate_check_threshold) break;
+    if (curr.longitudinal_velocity_mps < stop_velocity_threshold) {
+      return skip("Preceding (or duplicate) stop point exists");
     }
   }
 

--- a/planning/autoware_trajectory_modifier/src/trajectory_modifier_utils/obstacle_stop_utils.cpp
+++ b/planning/autoware_trajectory_modifier/src/trajectory_modifier_utils/obstacle_stop_utils.cpp
@@ -462,7 +462,6 @@ void ObjectFilter::filter_by_target_area(
   const MultiPolygon2d & target_area, MultiPolygon2d & target_polygons)
 {
   constexpr double time_buffer = 1.0;
-  constexpr double lat_vel_th = 1.0;
   auto is_exiting = [&](const auto & object) -> bool {
     const auto & object_pose = object.kinematics.initial_pose_with_covariance.pose;
     const auto nearest_seg =
@@ -474,7 +473,7 @@ void ObjectFilter::filter_by_target_area(
     const auto obj_vel = object.kinematics.initial_twist_with_covariance.twist.linear;
     const auto obj_vel_vector = (obj_rot * Eigen::Vector2d(obj_vel.x, obj_vel.y));
     const auto obj_lat_vel = obj_vel_vector.dot(traj_lat_dir);
-    if (std::abs(obj_lat_vel) < lat_vel_th) return false;
+    if (std::abs(obj_lat_vel) < max_lateral_velocity_th_) return false;
     if (object.kinematics.predicted_paths.empty()) return true;
     const auto time_to_obj_current_pos =
       rclcpp::Duration(trajectory_points.at(nearest_seg).time_from_start).seconds() - time_buffer;

--- a/planning/autoware_trajectory_modifier/src/trajectory_modifier_utils/obstacle_stop_utils.cpp
+++ b/planning/autoware_trajectory_modifier/src/trajectory_modifier_utils/obstacle_stop_utils.cpp
@@ -233,21 +233,17 @@ std::optional<CollisionPoint> get_nearest_pcd_collision(
 }
 
 std::optional<CollisionPoint> get_nearest_object_collision(
-  const TrajectoryPoints & trajectory_points, const TrajectoryShape & trajectory_shape,
-  const PredictedObjects & objects, MultiPolygon2d & target_polygons,
+  const TrajectoryPoints & trajectory_points, const PredictedObjects & target_objects,
   PredictedObject & colliding_object)
 {
-  if (objects.objects.empty() || trajectory_points.size() < 2) return std::nullopt;
+  if (target_objects.objects.empty() || trajectory_points.size() < 2) return std::nullopt;
 
   auto min_arc_length = std::numeric_limits<double>::max();
   geometry_msgs::msg::Point nearest_collision_point;
   bool found_collision = false;
-  for (const auto & object : objects.objects) {
+  for (const auto & object : target_objects.objects) {
     const auto object_pose = object.kinematics.initial_pose_with_covariance.pose;
     const auto object_polygon = autoware_utils::to_polygon2d(object_pose, object.shape);
-    if (boost::geometry::disjoint(object_polygon, trajectory_shape.polygon)) {
-      continue;
-    }
     found_collision = true;
     for (const auto & point : object_polygon.outer()) {
       geometry_msgs::msg::Point p = geometry_msgs::msg::Point().set__x(point.x()).set__y(point.y());
@@ -258,24 +254,27 @@ std::optional<CollisionPoint> get_nearest_object_collision(
         colliding_object = object;
       }
     }
-    target_polygons.emplace_back(object_polygon);
   }
 
   if (!found_collision) return std::nullopt;
   return CollisionPoint(nearest_collision_point, min_arc_length);
 }
 
+geometry_msgs::msg::Pose get_predicted_obj_pose_at_time(
+  const PredictedObject & object, const double t)
+{
+  if (object.kinematics.predicted_paths.empty())
+    return object.kinematics.initial_pose_with_covariance.pose;
+  const auto & pred_path = object.kinematics.predicted_paths.front();
+  size_t pred_pose_index = t / rclcpp::Duration(pred_path.time_step).seconds();
+  pred_pose_index = std::min(pred_pose_index, pred_path.path.size() - 1);
+  return pred_path.path.at(pred_pose_index);
+}
+
 ObjectState get_object_state_at_time(
   const TrajectoryPoints & trajectory_points, const PredictedObject & object, const double t)
 {
-  const auto predicted_obj_pose = std::invoke([&]() -> geometry_msgs::msg::Pose {
-    if (object.kinematics.predicted_paths.empty())
-      return object.kinematics.initial_pose_with_covariance.pose;
-    const auto & pred_path = object.kinematics.predicted_paths.front();
-    size_t pred_pose_index = t / rclcpp::Duration(pred_path.time_step).seconds();
-    pred_pose_index = std::min(pred_pose_index, pred_path.path.size() - 1);
-    return pred_path.path.at(pred_pose_index);
-  });
+  const auto predicted_obj_pose = get_predicted_obj_pose_at_time(object, t);
 
   const auto nearest_seg =
     motion_utils::findNearestSegmentIndex(trajectory_points, predicted_obj_pose.position);
@@ -283,10 +282,10 @@ ObjectState get_object_state_at_time(
   const auto p2 = trajectory_points.at(nearest_seg + 1).pose.position;
   auto lon_vel = std::invoke([&]() -> double {
     const auto traj_dir = Eigen::Vector2d(p2.x - p1.x, p2.y - p1.y).normalized();
-    const auto obj_yaw = tf2::getYaw(predicted_obj_pose.orientation);
-    const auto obj_dir = Eigen::Vector2d(std::cos(obj_yaw), std::sin(obj_yaw));
-    const auto obj_lon_vel = object.kinematics.initial_twist_with_covariance.twist.linear.x;
-    return std::max(0.0, obj_lon_vel * obj_dir.dot(traj_dir));
+    const Eigen::Rotation2Dd obj_rot(tf2::getYaw(predicted_obj_pose.orientation));
+    const auto obj_vel = object.kinematics.initial_twist_with_covariance.twist.linear;
+    const auto obj_vel_vector = obj_rot * Eigen::Vector2d(obj_vel.x, obj_vel.y);
+    return std::max(0.0, obj_vel_vector.dot(traj_dir));
   });
 
   const auto obj_polygon = autoware_utils::to_polygon2d(predicted_obj_pose, object.shape);
@@ -321,13 +320,13 @@ double get_safe_distance(
 }
 
 std::optional<CollisionPoint> get_nearest_object_collision(
-  const TrajectoryPoints & trajectory_points, const TrajectoryShape & trajectory_shape,
-  const autoware::vehicle_info_utils::VehicleInfo & vehicle_info, const PredictedObjects & objects,
-  const ObjectDecelMap & object_decel_map, const double ego_decel, const double reaction_time,
-  const double safety_margin, const double stopped_vel_th, const double lookahead_horizon,
-  MultiPolygon2d & target_polygons, PredictedObject & colliding_object)
+  const TrajectoryPoints & trajectory_points,
+  const autoware::vehicle_info_utils::VehicleInfo & vehicle_info,
+  const PredictedObjects & target_objects, const ObjectDecelMap & object_decel_map,
+  const double ego_decel, const double reaction_time, const double safety_margin,
+  const double stopped_vel_th, const double lookahead_horizon, PredictedObject & colliding_object)
 {
-  if (objects.objects.empty() || trajectory_points.size() < 2) return std::nullopt;
+  if (target_objects.objects.empty() || trajectory_points.size() < 2) return std::nullopt;
 
   const auto ego_front_offset = vehicle_info.max_longitudinal_offset_m;
 
@@ -345,17 +344,6 @@ std::optional<CollisionPoint> get_nearest_object_collision(
     const auto relative_arc_length = std::max(0.0, obj_arc_length - ego_front_arc_length);
     return relative_arc_length - safe_dist > 1e-3;
   };
-
-  PredictedObjects target_objects;
-  for (const auto & object : objects.objects) {
-    const auto object_pose = object.kinematics.initial_pose_with_covariance.pose;
-    const auto object_polygon = autoware_utils::to_polygon2d(object_pose, object.shape);
-    if (boost::geometry::disjoint(object_polygon, trajectory_shape.polygon)) {
-      continue;
-    }
-    target_objects.objects.push_back(object);
-    target_polygons.emplace_back(object_polygon);
-  }
 
   auto min_obj_arc_length = std::numeric_limits<double>::max();
   geometry_msgs::msg::Point nearest_collision_point;
@@ -467,6 +455,47 @@ void PointCloudFilter::filter_pointcloud_by_object(
         }),
       pointcloud->end());
   }
+}
+
+void ObjectFilter::filter_by_target_area(
+  PredictedObjects & objects, const TrajectoryPoints & trajectory_points,
+  const MultiPolygon2d & target_area, MultiPolygon2d & target_polygons)
+{
+  constexpr double time_buffer = 1.0;
+  constexpr double direction_th = 0.707;
+  auto is_exiting = [&](const auto & object) -> bool {
+    const auto & object_pose = object.kinematics.initial_pose_with_covariance.pose;
+    const auto nearest_seg =
+      motion_utils::findNearestSegmentIndex(trajectory_points, object_pose.position);
+    const auto p1 = trajectory_points.at(nearest_seg).pose.position;
+    const auto p2 = trajectory_points.at(nearest_seg + 1).pose.position;
+    const auto traj_dir = Eigen::Vector2d(p2.x - p1.x, p2.y - p1.y).normalized();
+    const auto obj_rot = Eigen::Rotation2Dd(tf2::getYaw(object_pose.orientation));
+    const auto obj_vel = object.kinematics.initial_twist_with_covariance.twist.linear;
+    const auto obj_vel_dir = (obj_rot * Eigen::Vector2d(obj_vel.x, obj_vel.y)).normalized();
+    if (obj_vel_dir.dot(traj_dir) > direction_th) return false;
+    if (object.kinematics.predicted_paths.empty()) return true;
+    const auto time_to_obj_current_pos =
+      rclcpp::Duration(trajectory_points.at(nearest_seg).time_from_start).seconds() - time_buffer;
+    const auto obj_pred_pose = get_predicted_obj_pose_at_time(object, time_to_obj_current_pos);
+    const auto obj_pred_polygon = autoware_utils::to_polygon2d(obj_pred_pose, object.shape);
+    return boost::geometry::disjoint(obj_pred_polygon, target_area);
+  };
+
+  objects.objects.erase(
+    std::remove_if(
+      objects.objects.begin(), objects.objects.end(),
+      [&](const auto & object) {
+        const auto object_pose = object.kinematics.initial_pose_with_covariance.pose;
+        const auto object_polygon = autoware_utils::to_polygon2d(object_pose, object.shape);
+        if (boost::geometry::disjoint(object_polygon, target_area)) return true;
+        const auto is_moving =
+          object.kinematics.initial_twist_with_covariance.twist.linear.x > stopped_velocity_th_;
+        if (is_moving && is_exiting(object)) return true;
+        target_polygons.emplace_back(object_polygon);
+        return false;
+      }),
+    objects.objects.end());
 }
 
 void ObstacleTracker::update_objects(

--- a/planning/autoware_trajectory_modifier/src/trajectory_modifier_utils/obstacle_stop_utils.cpp
+++ b/planning/autoware_trajectory_modifier/src/trajectory_modifier_utils/obstacle_stop_utils.cpp
@@ -38,11 +38,16 @@ void trim_trajectory_and_remove_duplicates(TrajectoryPoints & trajectory_points)
   if (trajectory_points.empty()) return;
   const auto zero_velocity_index =
     autoware::motion_utils::searchZeroVelocityIndex(trajectory_points);
-  if (zero_velocity_index && zero_velocity_index.value() < trajectory_points.size() - 1) {
+  const bool found_zero_vel =
+    zero_velocity_index && zero_velocity_index.value() < trajectory_points.size() - 1;
+  if (found_zero_vel) {
     trajectory_points.erase(
       trajectory_points.begin() + zero_velocity_index.value() + 1, trajectory_points.end());
   }
   trajectory_points = autoware::motion_utils::removeOverlapPoints(trajectory_points);
+  if (found_zero_vel)
+    trajectory_points.back().longitudinal_velocity_mps =
+      0.0;  // set zero velocity at the end of the trajectory
 }
 
 double get_detection_length(
@@ -266,7 +271,9 @@ geometry_msgs::msg::Pose get_predicted_obj_pose_at_time(
   if (object.kinematics.predicted_paths.empty())
     return object.kinematics.initial_pose_with_covariance.pose;
   const auto & pred_path = object.kinematics.predicted_paths.front();
-  size_t pred_pose_index = t / rclcpp::Duration(pred_path.time_step).seconds();
+  if (pred_path.path.empty()) return object.kinematics.initial_pose_with_covariance.pose;
+  const auto dt = std::max(rclcpp::Duration(pred_path.time_step).seconds(), 1e-3);
+  size_t pred_pose_index = (t + 1e-6) / dt;
   pred_pose_index = std::min(pred_pose_index, pred_path.path.size() - 1);
   return pred_path.path.at(pred_pose_index);
 }

--- a/planning/autoware_trajectory_modifier/src/trajectory_modifier_utils/obstacle_stop_utils.cpp
+++ b/planning/autoware_trajectory_modifier/src/trajectory_modifier_utils/obstacle_stop_utils.cpp
@@ -68,7 +68,7 @@ TrajectoryPoints extend_trajectory(
 
   const auto & last_p = trajectory_points.back();
   const auto yaw_last = tf2::getYaw(last_p.pose.orientation);
-  constexpr double lookback_distance = 1.0;  // [m]
+  constexpr double lookback_distance = 2.0;  // [m]
   const auto lookback_pose = motion_utils::calcLongitudinalOffsetPose(
     trajectory_points, trajectory_points.size() - 1, -1.0 * lookback_distance);
 
@@ -473,7 +473,7 @@ void ObjectFilter::filter_by_target_area(
     const auto obj_rot = Eigen::Rotation2Dd(tf2::getYaw(object_pose.orientation));
     const auto obj_vel = object.kinematics.initial_twist_with_covariance.twist.linear;
     const auto obj_vel_dir = (obj_rot * Eigen::Vector2d(obj_vel.x, obj_vel.y)).normalized();
-    if (obj_vel_dir.dot(traj_dir) > direction_th) return false;
+    if (std::abs(obj_vel_dir.dot(traj_dir)) > direction_th) return false;
     if (object.kinematics.predicted_paths.empty()) return true;
     const auto time_to_obj_current_pos =
       rclcpp::Duration(trajectory_points.at(nearest_seg).time_from_start).seconds() - time_buffer;

--- a/planning/autoware_trajectory_modifier/src/trajectory_modifier_utils/obstacle_stop_utils.cpp
+++ b/planning/autoware_trajectory_modifier/src/trajectory_modifier_utils/obstacle_stop_utils.cpp
@@ -469,22 +469,36 @@ void ObjectFilter::filter_by_target_area(
   const MultiPolygon2d & target_area, MultiPolygon2d & target_polygons)
 {
   constexpr double time_buffer = 1.0;
+  auto time_to_obj_current_pos =
+    [&](const auto & object_pose, const size_t nearest_seg_idx) -> double {
+    const auto t_to_nearest_seg =
+      rclcpp::Duration(trajectory_points.at(nearest_seg_idx).time_from_start).seconds();
+    if (nearest_seg_idx < trajectory_points.size() - 2) return t_to_nearest_seg - time_buffer;
+    const auto lon_offset_dist =
+      motion_utils::calcSignedArcLength(trajectory_points, nearest_seg_idx, object_pose.position);
+    const auto nearest_seg_vel = trajectory_points.at(nearest_seg_idx).longitudinal_velocity_mps;
+    const auto t_to_obj = t_to_nearest_seg + lon_offset_dist / nearest_seg_vel;
+    return t_to_obj - time_buffer;
+  };
+
   auto is_exiting = [&](const auto & object) -> bool {
     const auto & object_pose = object.kinematics.initial_pose_with_covariance.pose;
+    const auto obj_rot = Eigen::Rotation2Dd(tf2::getYaw(object_pose.orientation));
+    const auto obj_vel = object.kinematics.initial_twist_with_covariance.twist.linear;
+    const auto obj_vel_vector = (obj_rot * Eigen::Vector2d(obj_vel.x, obj_vel.y));
+    if (obj_vel_vector.norm() < stopped_velocity_th_) return false;  // object is stopped
     const auto nearest_seg =
       motion_utils::findNearestSegmentIndex(trajectory_points, object_pose.position);
     const auto p1 = trajectory_points.at(nearest_seg).pose.position;
     const auto p2 = trajectory_points.at(nearest_seg + 1).pose.position;
-    const auto traj_lat_dir = Eigen::Vector2d(p2.y - p1.y, p1.x - p2.x).normalized();
-    const auto obj_rot = Eigen::Rotation2Dd(tf2::getYaw(object_pose.orientation));
-    const auto obj_vel = object.kinematics.initial_twist_with_covariance.twist.linear;
-    const auto obj_vel_vector = (obj_rot * Eigen::Vector2d(obj_vel.x, obj_vel.y));
-    const auto obj_lat_vel = obj_vel_vector.dot(traj_lat_dir);
-    if (std::abs(obj_lat_vel) < max_lateral_velocity_th_) return false;
+    const auto traj_dir = Eigen::Vector2d(p2.x - p1.x, p2.y - p1.y).normalized();
+    const auto traj_lat_dir = Eigen::Vector2d(traj_dir.y(), -traj_dir.x());
+    const auto obj_lon_vel = std::abs(obj_vel_vector.dot(traj_dir));
+    const auto obj_lat_vel = std::abs(obj_vel_vector.dot(traj_lat_dir));
+    if (obj_lat_vel < max_lateral_velocity_th_ && obj_lat_vel < obj_lon_vel) return false;
     if (object.kinematics.predicted_paths.empty()) return true;
-    const auto time_to_obj_current_pos =
-      rclcpp::Duration(trajectory_points.at(nearest_seg).time_from_start).seconds() - time_buffer;
-    const auto obj_pred_pose = get_predicted_obj_pose_at_time(object, time_to_obj_current_pos);
+    const auto t_to_obj_current_pos = time_to_obj_current_pos(object_pose, nearest_seg);
+    const auto obj_pred_pose = get_predicted_obj_pose_at_time(object, t_to_obj_current_pos);
     const auto obj_pred_polygon = autoware_utils::to_polygon2d(obj_pred_pose, object.shape);
     return boost::geometry::disjoint(obj_pred_polygon, target_area);
   };
@@ -496,9 +510,7 @@ void ObjectFilter::filter_by_target_area(
         const auto object_pose = object.kinematics.initial_pose_with_covariance.pose;
         const auto object_polygon = autoware_utils::to_polygon2d(object_pose, object.shape);
         if (boost::geometry::disjoint(object_polygon, target_area)) return true;
-        const auto is_moving =
-          object.kinematics.initial_twist_with_covariance.twist.linear.x > stopped_velocity_th_;
-        if (is_moving && is_exiting(object)) return true;
+        if (is_exiting(object)) return true;
         target_polygons.emplace_back(object_polygon);
         return false;
       }),

--- a/planning/autoware_trajectory_modifier/src/trajectory_modifier_utils/obstacle_stop_utils.cpp
+++ b/planning/autoware_trajectory_modifier/src/trajectory_modifier_utils/obstacle_stop_utils.cpp
@@ -462,18 +462,19 @@ void ObjectFilter::filter_by_target_area(
   const MultiPolygon2d & target_area, MultiPolygon2d & target_polygons)
 {
   constexpr double time_buffer = 1.0;
-  constexpr double direction_th = 0.707;
+  constexpr double lat_vel_th = 1.0;
   auto is_exiting = [&](const auto & object) -> bool {
     const auto & object_pose = object.kinematics.initial_pose_with_covariance.pose;
     const auto nearest_seg =
       motion_utils::findNearestSegmentIndex(trajectory_points, object_pose.position);
     const auto p1 = trajectory_points.at(nearest_seg).pose.position;
     const auto p2 = trajectory_points.at(nearest_seg + 1).pose.position;
-    const auto traj_dir = Eigen::Vector2d(p2.x - p1.x, p2.y - p1.y).normalized();
+    const auto traj_lat_dir = Eigen::Vector2d(p2.y - p1.y, p1.x - p2.x).normalized();
     const auto obj_rot = Eigen::Rotation2Dd(tf2::getYaw(object_pose.orientation));
     const auto obj_vel = object.kinematics.initial_twist_with_covariance.twist.linear;
-    const auto obj_vel_dir = (obj_rot * Eigen::Vector2d(obj_vel.x, obj_vel.y)).normalized();
-    if (std::abs(obj_vel_dir.dot(traj_dir)) > direction_th) return false;
+    const auto obj_vel_vector = (obj_rot * Eigen::Vector2d(obj_vel.x, obj_vel.y));
+    const auto obj_lat_vel = obj_vel_vector.dot(traj_lat_dir);
+    if (std::abs(obj_lat_vel) < lat_vel_th) return false;
     if (object.kinematics.predicted_paths.empty()) return true;
     const auto time_to_obj_current_pos =
       rclcpp::Duration(trajectory_points.at(nearest_seg).time_from_start).seconds() - time_buffer;


### PR DESCRIPTION
This PR implement logic to properly ignore objects temporarily crossing ego intended trajectory:
- add function filter_by_target_area() to ObjectFilter struct
- filter out objects not overlaping with target area
- for remaining moving objects, check if objects lateral velocity (_w.r.t ego traj_) is above threshold
- filter out objects that are leaving target area before ego reaches relevant region

Additional changes:
- fix logic to check for duplicate stop point insertion


Tested using rosbag data ([cases](https://tier4.atlassian.net/wiki/spaces/CB/pages/5026349263/Modifier#Cases-to-Check%3A))

requires https://github.com/tier4/autoware_launch.x2/pull/2245