### PR TITLE
chore: update pre-commit-hooks-ros

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,7 +42,7 @@ repos:
       - id: yamllint
 
   - repo: https://github.com/tier4/pre-commit-hooks-ros
-    rev: v0.10.0
+    rev: v0.10.1
     hooks:
       - id: flake8-ros
       - id: prettier-xacro

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -42,7 +42,7 @@ repos:
       - id: yamllint
 
   - repo: https://github.com/tier4/pre-commit-hooks-ros
-    rev: v0.10.1
+    rev: v0.10.2
     hooks:
       - id: flake8-ros
       - id: prettier-xacro


### PR DESCRIPTION
一部PRでpre-commit(Required)がpre-commit-hooks-rosのversion起因でPASSできないため更新します。
下記Slackスレを参照に修正するものです。
https://star4.slack.com/archives/C03QU7K50D8/p1771381623836089