### PR TITLE
refactor(trajectory_validator): emit per-prediction-type worst metrics for PET/DRAC/RSS 

### DIFF
--- a/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/collision_check_filter.cpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/collision_check_filter.cpp
@@ -1302,6 +1302,17 @@ std::optional<double> combine_per_type_drac(
   return overall;
 }
 
+std::map<std::string, DracParams> isolate_drac_param_map(
+  const std::map<std::string, DracParams> & drac_param_map, const std::string & target_type)
+{
+  auto isolated = drac_param_map;
+  auto & at = isolated.at(DEFAULT_PARAM_KEY).assessment_trajectories;
+  at.map_based = at.map_based && target_type == "map_based_predicted_path";
+  at.constant_curvature = at.constant_curvature && target_type == "constant_curvature_path";
+  at.diffusion_based = at.diffusion_based && target_type == "diffusion_based_trajectory";
+  return isolated;
+}
+
 DracAssessment assess_drac(
   const TrajectoryPoints & traj_points, const FilterContext & context,
   const std::map<std::string, DracParams> & drac_param_map, VehicleInfo & vehicle_info,
@@ -1428,12 +1439,8 @@ Result assess(
     // Per-type DRAC: isolate assessment_trajectories to one type per call, because
     // assess_drac's stop condition aggregates findings across all enabled types.
     for (const auto * type : kCanonicalTypes) {
-      auto type_isolated_map = drac_param_map;
-      auto & at = type_isolated_map.at(DEFAULT_PARAM_KEY).assessment_trajectories;
-      const std::string t{type};
-      at.map_based = at.map_based && t == "map_based_predicted_path";
-      at.constant_curvature = at.constant_curvature && t == "constant_curvature_path";
-      at.diffusion_based = at.diffusion_based && t == "diffusion_based_trajectory";
+      const auto type_isolated_map = isolate_drac_param_map(drac_param_map, type);
+      const auto & at = type_isolated_map.at(DEFAULT_PARAM_KEY).assessment_trajectories;
       if (!at.map_based && !at.constant_curvature && !at.diffusion_based) {
         result.drac_by_type[type] = std::optional<double>{0.0};
         continue;

--- a/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/collision_check_filter.cpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/collision_check_filter.cpp
@@ -1306,8 +1306,7 @@ DracAssessment assess_drac(
   const TrajectoryPoints & traj_points, const FilterContext & context,
   const std::map<std::string, DracParams> & drac_param_map, VehicleInfo & vehicle_info,
   const std::vector<TrajectoryData> & object_trajectories,
-  const validator::Params::CollisionCheck::GlobalSetting & global_setting,
-  const std::string & target_type)
+  const validator::Params::CollisionCheck::GlobalSetting & global_setting)
 {
   const auto drac_params_default = drac_param_map.at(DEFAULT_PARAM_KEY);
 
@@ -1343,9 +1342,9 @@ DracAssessment assess_drac(
         continue;
       }
 
-      if (
-        object_trajectory.getObjectIdentification().trajectory_type.find(target_type) ==
-        std::string::npos) {
+      if (!is_target_trajectory_type(
+            ObjectTrajectoryGenerationOptions{drac_params_default},
+            object_trajectory.getObjectIdentification().trajectory_type)) {
         continue;
       }
       // todo: prepare parameter
@@ -1425,21 +1424,20 @@ Result assess(
   if (drac_params_default.enable_assessment) {
     constexpr std::array<const char *, 3> kCanonicalTypes = {
       "map_based_predicted_path", "constant_curvature_path", "diffusion_based_trajectory"};
-    const auto & at = drac_params_default.assessment_trajectories;
-    const auto type_enabled = [&](const std::string & t) {
-      if (t == "map_based_predicted_path") return at.map_based;
-      if (t == "constant_curvature_path") return at.constant_curvature;
-      if (t == "diffusion_based_trajectory") return at.diffusion_based;
-      return false;
-    };
     for (const auto * type : kCanonicalTypes) {
-      if (!type_enabled(type)) {
+      auto type_isolated_map = drac_param_map;
+      auto & at = type_isolated_map.at(DEFAULT_PARAM_KEY).assessment_trajectories;
+      const std::string t{type};
+      at.map_based = at.map_based && t == "map_based_predicted_path";
+      at.constant_curvature = at.constant_curvature && t == "constant_curvature_path";
+      at.diffusion_based = at.diffusion_based && t == "diffusion_based_trajectory";
+      if (!at.map_based && !at.constant_curvature && !at.diffusion_based) {
         result.drac_by_type[type] = std::optional<double>{0.0};
         continue;
       }
       const auto sub = assess_drac(
-        traj_points, context, drac_param_map, vehicle_info, nominal_speed_object_trajectories,
-        global_setting, type);
+        traj_points, context, type_isolated_map, vehicle_info, nominal_speed_object_trajectories,
+        global_setting);
       result.drac_by_type[type] = sub.drac;
       for (auto & f : sub.findings) result.drac_findings.push_back(std::move(f));
     }

--- a/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/collision_check_filter.cpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/collision_check_filter.cpp
@@ -1961,7 +1961,6 @@ void process_rss_violations(
     rss_worst.metric_level()));
 }
 
-
 CollisionCheckFilter::result_t CollisionCheckFilter::is_feasible(
   const TrajectoryPoints & traj_points, const FilterContext & context)
 {

--- a/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/collision_check_filter.cpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/collision_check_filter.cpp
@@ -1432,7 +1432,12 @@ Result assess(
       nominal_speed_object_trajectories);
   }
 
-  if (drac_params_default.enable_assessment) {
+
+  if (!drac_params_default.enable_assessment) {
+    DracAssessment drac_assessment{0.0, {}};  // dummy
+    result.drac_findings = drac_assessment.findings;
+    result.drac = drac_assessment.drac;
+  } else {
     constexpr std::array<const char *, 3> kCanonicalTypes = {
       "map_based_predicted_path", "constant_curvature_path", "diffusion_based_trajectory"};
     // Per-type DRAC: isolate assessment_trajectories to one type per call, because

--- a/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/collision_check_filter.cpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/collision_check_filter.cpp
@@ -1050,6 +1050,7 @@ struct Result
   std::vector<Finding> planned_speed_findings;
   std::optional<double> drac{0.0};
   std::vector<Finding> drac_findings;  // Last evaluated PET findings during DRAC search.
+  std::map<std::string, std::optional<double>> drac_by_type;
 };
 
 struct ObjectTrajectoryGenerationOptions
@@ -1290,6 +1291,33 @@ std::vector<Finding> assess_planned_speed_collision_timing(
   return findings;
 }
 
+std::optional<std::map<std::string, DracParams>> isolate_drac_params_to_type(
+  const std::map<std::string, DracParams> & drac_param_map, const std::string & type)
+{
+  auto isolated = drac_param_map.at(DEFAULT_PARAM_KEY);
+  auto & at = isolated.assessment_trajectories;
+  at.map_based = at.map_based && type == "map_based_predicted_path";
+  at.constant_curvature = at.constant_curvature && type == "constant_curvature_path";
+  at.diffusion_based = at.diffusion_based && type == "diffusion_based_trajectory";
+  if (!at.map_based && !at.constant_curvature && !at.diffusion_based) {
+    return std::nullopt;
+  }
+  auto isolated_map = drac_param_map;
+  isolated_map[DEFAULT_PARAM_KEY] = isolated;
+  return isolated_map;
+}
+
+std::optional<double> combine_per_type_drac(
+  const std::map<std::string, std::optional<double>> & per_type)
+{
+  std::optional<double> overall{0.0};
+  for (const auto & [_, opt] : per_type) {
+    if (!opt.has_value()) return std::nullopt;
+    overall = std::max(overall.value(), opt.value());
+  }
+  return overall;
+}
+
 DracAssessment assess_drac(
   const TrajectoryPoints & traj_points, const FilterContext & context,
   const std::map<std::string, DracParams> & drac_param_map, VehicleInfo & vehicle_info,
@@ -1409,16 +1437,22 @@ Result assess(
       nominal_speed_object_trajectories);
   }
 
-  if (!drac_params_default.enable_assessment) {
-    DracAssessment drac_assessment{0.0, {}};  // dummy
-    result.drac_findings = drac_assessment.findings;
-    result.drac = drac_assessment.drac;
-  } else {
-    const auto drac_assessment = assess_drac(
-      traj_points, context, drac_param_map, vehicle_info, nominal_speed_object_trajectories,
-      global_setting);
-    result.drac_findings = drac_assessment.findings;
-    result.drac = drac_assessment.drac;
+  if (drac_params_default.enable_assessment) {
+    constexpr std::array<const char *, 3> kCanonicalTypes = {
+      "map_based_predicted_path", "constant_curvature_path", "diffusion_based_trajectory"};
+    for (const auto * type : kCanonicalTypes) {
+      const auto isolated = isolate_drac_params_to_type(drac_param_map, type);
+      if (!isolated.has_value()) {
+        result.drac_by_type[type] = std::optional<double>{0.0};
+        continue;
+      }
+      const auto sub = assess_drac(
+        traj_points, context, *isolated, vehicle_info, nominal_speed_object_trajectories,
+        global_setting);
+      result.drac_by_type[type] = sub.drac;
+      for (auto & f : sub.findings) result.drac_findings.push_back(std::move(f));
+    }
+    result.drac = combine_per_type_drac(result.drac_by_type);
   }
   return result;
 }
@@ -1754,12 +1788,9 @@ std::map<std::string, DracWorst> compute_drac_worst(
 {
   std::map<std::string, DracWorst> worst;
   for (const auto * type : kAggregatedTrajectoryTypes) {
-    worst[type] = DracWorst{};
-  }
-  for (const auto & f : result.drac_findings) {
-    const auto type = canonical_trajectory_type(f.object_identification.trajectory_type);
-    if (type.empty()) continue;
-    worst[type].drac = result.drac;
+    const auto it = result.drac_by_type.find(type);
+    worst[type] =
+      DracWorst{it != result.drac_by_type.end() ? it->second : std::optional<double>{0.0}};
   }
   return worst;
 }

--- a/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/collision_check_filter.cpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/collision_check_filter.cpp
@@ -1421,9 +1421,12 @@ Result assess(
       nominal_speed_object_trajectories);
   }
 
+
   if (drac_params_default.enable_assessment) {
     constexpr std::array<const char *, 3> kCanonicalTypes = {
       "map_based_predicted_path", "constant_curvature_path", "diffusion_based_trajectory"};
+    // Per-type DRAC: isolate assessment_trajectories to one type per call, because
+    // assess_drac's stop condition aggregates findings across all enabled types.
     for (const auto * type : kCanonicalTypes) {
       auto type_isolated_map = drac_param_map;
       auto & at = type_isolated_map.at(DEFAULT_PARAM_KEY).assessment_trajectories;

--- a/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/collision_check_filter.cpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/collision_check_filter.cpp
@@ -1932,7 +1932,7 @@ void process_rss_violations(
 {
   const auto rss_params_default = rss_param_map.at(DEFAULT_PARAM_KEY);
 
-   if (!rss_params_default.enable_assessment) {
+  if (!rss_params_default.enable_assessment) {
     return;
   }
 

--- a/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/collision_check_filter.cpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/collision_check_filter.cpp
@@ -1432,7 +1432,6 @@ Result assess(
       nominal_speed_object_trajectories);
   }
 
-
   if (!drac_params_default.enable_assessment) {
     DracAssessment drac_assessment{0.0, {}};  // dummy
     result.drac_findings = drac_assessment.findings;

--- a/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/collision_check_filter.cpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/collision_check_filter.cpp
@@ -1874,10 +1874,16 @@ void process_drac_findings(
     current_time, collision_timing_result.drac_findings,
     [](const auto & finding) { return finding.object_identification.trajectory_id_string(); });
 
+  const bool is_warn =
+    collision_timing_result.drac == std::nullopt ||
+    collision_timing_result.drac.value() >= -drac_params_default.warn_threshold.ego_acceleration;
   const bool is_error =
     collision_timing_result.drac == std::nullopt ||
     collision_timing_result.drac.value() >= -drac_params_default.error_threshold.ego_acceleration;
-
+  if (!is_warn) {
+    return;
+  }
+  
   std::string log_messages{};
   std::string marker_messages{};
   const uint8_t metric_level = is_error ? MetricReport::ERROR : MetricReport::WARN;
@@ -1929,7 +1935,7 @@ void process_rss_violations(
    if (!rss_params_default.enable_assessment) {
     return;
   }
-  
+
   rss_continuous_times.update(current_time, rss_result.violations, [](const auto & violation) {
     return violation.object.object_id_string();
   });

--- a/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/collision_check_filter.cpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/collision_check_filter.cpp
@@ -1926,15 +1926,10 @@ void process_rss_violations(
 {
   const auto rss_params_default = rss_param_map.at(DEFAULT_PARAM_KEY);
 
-  if (!rss_params_default.enable_assessment) {
-    const RssWorst w{};
-    artifacts.metrics.push_back(make_metric_report(
-      validator_name, validator_category, "check_RSS", w.metric_value(), w.metric_level()));
+   if (!rss_params_default.enable_assessment) {
     return;
   }
-
-  const auto rss_result = rss_deceleration::assess(
-    traj_points, context, rss_param_map, global_setting.time_resolution, vehicle_info);
+  
   rss_continuous_times.update(current_time, rss_result.violations, [](const auto & violation) {
     return violation.object.object_id_string();
   });

--- a/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/collision_check_filter.cpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/collision_check_filter.cpp
@@ -1291,22 +1291,6 @@ std::vector<Finding> assess_planned_speed_collision_timing(
   return findings;
 }
 
-std::optional<std::map<std::string, DracParams>> isolate_drac_params_to_type(
-  const std::map<std::string, DracParams> & drac_param_map, const std::string & type)
-{
-  auto isolated = drac_param_map.at(DEFAULT_PARAM_KEY);
-  auto & at = isolated.assessment_trajectories;
-  at.map_based = at.map_based && type == "map_based_predicted_path";
-  at.constant_curvature = at.constant_curvature && type == "constant_curvature_path";
-  at.diffusion_based = at.diffusion_based && type == "diffusion_based_trajectory";
-  if (!at.map_based && !at.constant_curvature && !at.diffusion_based) {
-    return std::nullopt;
-  }
-  auto isolated_map = drac_param_map;
-  isolated_map[DEFAULT_PARAM_KEY] = isolated;
-  return isolated_map;
-}
-
 std::optional<double> combine_per_type_drac(
   const std::map<std::string, std::optional<double>> & per_type)
 {
@@ -1322,7 +1306,8 @@ DracAssessment assess_drac(
   const TrajectoryPoints & traj_points, const FilterContext & context,
   const std::map<std::string, DracParams> & drac_param_map, VehicleInfo & vehicle_info,
   const std::vector<TrajectoryData> & object_trajectories,
-  const validator::Params::CollisionCheck::GlobalSetting & global_setting)
+  const validator::Params::CollisionCheck::GlobalSetting & global_setting,
+  const std::string & target_type)
 {
   const auto drac_params_default = drac_param_map.at(DEFAULT_PARAM_KEY);
 
@@ -1358,9 +1343,9 @@ DracAssessment assess_drac(
         continue;
       }
 
-      if (!is_target_trajectory_type(
-            ObjectTrajectoryGenerationOptions{drac_params_default},
-            object_trajectory.getObjectIdentification().trajectory_type)) {
+      if (
+        object_trajectory.getObjectIdentification().trajectory_type.find(target_type) ==
+        std::string::npos) {
         continue;
       }
       // todo: prepare parameter
@@ -1440,15 +1425,21 @@ Result assess(
   if (drac_params_default.enable_assessment) {
     constexpr std::array<const char *, 3> kCanonicalTypes = {
       "map_based_predicted_path", "constant_curvature_path", "diffusion_based_trajectory"};
+    const auto & at = drac_params_default.assessment_trajectories;
+    const auto type_enabled = [&](const std::string & t) {
+      if (t == "map_based_predicted_path") return at.map_based;
+      if (t == "constant_curvature_path") return at.constant_curvature;
+      if (t == "diffusion_based_trajectory") return at.diffusion_based;
+      return false;
+    };
     for (const auto * type : kCanonicalTypes) {
-      const auto isolated = isolate_drac_params_to_type(drac_param_map, type);
-      if (!isolated.has_value()) {
+      if (!type_enabled(type)) {
         result.drac_by_type[type] = std::optional<double>{0.0};
         continue;
       }
       const auto sub = assess_drac(
-        traj_points, context, *isolated, vehicle_info, nominal_speed_object_trajectories,
-        global_setting);
+        traj_points, context, drac_param_map, vehicle_info, nominal_speed_object_trajectories,
+        global_setting, type);
       result.drac_by_type[type] = sub.drac;
       for (auto & f : sub.findings) result.drac_findings.push_back(std::move(f));
     }
@@ -1458,6 +1449,124 @@ Result assess(
 }
 
 }  // namespace collision_timing_assessment
+
+namespace metric
+{
+
+constexpr std::array<const char *, 3> kAggregatedTrajectoryTypes = {
+  "map_based_predicted_path",
+  "constant_curvature_path",
+  "diffusion_based_trajectory",
+};
+
+std::string canonical_trajectory_type(const std::string & raw)
+{
+  for (const auto * type : kAggregatedTrajectoryTypes) {
+    if (raw.find(type) != std::string::npos) {
+      return type;
+    }
+  }
+  return {};
+}
+
+MetricReport make_metric_report(
+  const std::string & validator_name, const std::string & validator_category,
+  const std::string & metric_name, double value, uint8_t level)
+{
+  return autoware_trajectory_validator::build<MetricReport>()
+    .validator_name(validator_name)
+    .validator_category(validator_category)
+    .metric_name(metric_name)
+    .metric_value(value)
+    .level(level);
+}
+
+struct PetWorst
+{
+  double pet{std::numeric_limits<double>::infinity()};
+  bool has_finding{false};
+
+  double metric_value() const
+  {
+    return has_finding ? pet : std::numeric_limits<double>::infinity();
+  }
+
+  uint8_t metric_level(const PetCollisionParams & params) const
+  {
+    if (!has_finding) return MetricReport::OK;
+    const bool is_error = pet <= params.error_threshold.ego_first_passing_time_gap &&
+                          pet >= -params.error_threshold.object_first_passing_time_gap;
+    return is_error ? MetricReport::ERROR : MetricReport::WARN;
+  }
+};
+
+struct DracWorst
+{
+  std::optional<double> drac{0.0};
+
+  double metric_value() const
+  {
+    return drac.has_value() ? drac.value() : std::numeric_limits<double>::max();
+  }
+
+  uint8_t metric_level(const DracParams & params) const
+  {
+    if (!drac.has_value()) return MetricReport::ERROR;
+    const double v = drac.value();
+    if (v <= 0.0) return MetricReport::OK;
+    if (v >= -params.error_threshold.ego_acceleration) return MetricReport::ERROR;
+    if (v >= -params.warn_threshold.ego_acceleration) return MetricReport::WARN;
+    return MetricReport::OK;
+  }
+};
+
+struct RssWorst
+{
+  double required_deceleration{0.0};
+  bool has_violation{false};
+
+  double metric_value() const { return required_deceleration; }
+
+  uint8_t metric_level() const { return has_violation ? MetricReport::ERROR : MetricReport::OK; }
+};
+
+std::map<std::string, PetWorst> compute_pet_worst(
+  const std::vector<collision_timing_assessment::Finding> & findings)
+{
+  std::map<std::string, PetWorst> worst;
+  for (const auto & f : findings) {
+    const auto type = canonical_trajectory_type(f.object_identification.trajectory_type);
+    if (type.empty()) continue;
+    auto & w = worst[type];
+    if (!w.has_finding || std::abs(f.pet) < std::abs(w.pet)) {
+      w.pet = f.pet;
+      w.has_finding = true;
+    }
+  }
+  return worst;
+}
+
+std::map<std::string, DracWorst> compute_drac_worst(
+  const collision_timing_assessment::Result & result)
+{
+  std::map<std::string, DracWorst> worst;
+  for (const auto * type : kAggregatedTrajectoryTypes) {
+    const auto it = result.drac_by_type.find(type);
+    worst[type] =
+      DracWorst{it != result.drac_by_type.end() ? it->second : std::optional<double>{0.0}};
+  }
+  return worst;
+}
+
+RssWorst compute_rss_worst(const rss_deceleration::Result & rss_result)
+{
+  return RssWorst{
+    rss_result.worst_assessment.has_value() ? rss_result.worst_assessment->required_deceleration
+                                            : 0.0,
+    rss_result.has_violation};
+}
+
+}  // namespace metric
 
 void CollisionCheckFilter::update_parameters(const validator::Params & params)
 {
@@ -1690,119 +1799,6 @@ void add_collision_planning_factor(
   planning_factors.factors.push_back(std::move(factor));
 }
 
-constexpr std::array<const char *, 3> kAggregatedTrajectoryTypes = {
-  "map_based_predicted_path",
-  "constant_curvature_path",
-  "diffusion_based_trajectory",
-};
-
-std::string canonical_trajectory_type(const std::string & raw)
-{
-  for (const auto * type : kAggregatedTrajectoryTypes) {
-    if (raw.find(type) != std::string::npos) {
-      return type;
-    }
-  }
-  return {};
-}
-
-MetricReport make_metric_report(
-  const std::string & validator_name, const std::string & validator_category,
-  const std::string & metric_name, double value, uint8_t level)
-{
-  return autoware_trajectory_validator::build<MetricReport>()
-    .validator_name(validator_name)
-    .validator_category(validator_category)
-    .metric_name(metric_name)
-    .metric_value(value)
-    .level(level);
-}
-
-struct PetWorst
-{
-  double pet{std::numeric_limits<double>::infinity()};
-  bool has_finding{false};
-
-  double metric_value() const
-  {
-    return has_finding ? pet : std::numeric_limits<double>::infinity();
-  }
-
-  uint8_t metric_level(const PetCollisionParams & params) const
-  {
-    if (!has_finding) return MetricReport::OK;
-    const bool is_error = pet <= params.error_threshold.ego_first_passing_time_gap &&
-                          pet >= -params.error_threshold.object_first_passing_time_gap;
-    return is_error ? MetricReport::ERROR : MetricReport::WARN;
-  }
-};
-
-struct DracWorst
-{
-  std::optional<double> drac{0.0};
-
-  double metric_value() const
-  {
-    return drac.has_value() ? drac.value() : std::numeric_limits<double>::max();
-  }
-
-  uint8_t metric_level(const DracParams & params) const
-  {
-    if (!drac.has_value()) return MetricReport::ERROR;
-    const double v = drac.value();
-    if (v <= 0.0) return MetricReport::OK;
-    if (v >= -params.error_threshold.ego_acceleration) return MetricReport::ERROR;
-    if (v >= -params.warn_threshold.ego_acceleration) return MetricReport::WARN;
-    return MetricReport::OK;
-  }
-};
-
-struct RssWorst
-{
-  double required_deceleration{0.0};
-  bool has_violation{false};
-
-  double metric_value() const { return required_deceleration; }
-
-  uint8_t metric_level() const { return has_violation ? MetricReport::ERROR : MetricReport::OK; }
-};
-
-std::map<std::string, PetWorst> compute_pet_worst(
-  const std::vector<collision_timing_assessment::Finding> & findings)
-{
-  std::map<std::string, PetWorst> worst;
-  for (const auto & f : findings) {
-    const auto type = canonical_trajectory_type(f.object_identification.trajectory_type);
-    if (type.empty()) continue;
-    auto & w = worst[type];
-    if (!w.has_finding || std::abs(f.pet) < std::abs(w.pet)) {
-      w.pet = f.pet;
-      w.has_finding = true;
-    }
-  }
-  return worst;
-}
-
-std::map<std::string, DracWorst> compute_drac_worst(
-  const collision_timing_assessment::Result & result)
-{
-  std::map<std::string, DracWorst> worst;
-  for (const auto * type : kAggregatedTrajectoryTypes) {
-    const auto it = result.drac_by_type.find(type);
-    worst[type] =
-      DracWorst{it != result.drac_by_type.end() ? it->second : std::optional<double>{0.0}};
-  }
-  return worst;
-}
-
-RssWorst compute_rss_worst(const rss_deceleration::Result & rss_result)
-{
-  return RssWorst{
-    rss_result.worst_assessment.has_value() ? rss_result.worst_assessment->required_deceleration
-                                            : 0.0,
-    rss_result.has_violation};
-}
-
 void process_pet_findings(
   const std::string & validator_name, const std::string & validator_category,
   const std::map<std::string, PetCollisionParams> & pet_collision_param_map,
@@ -1846,11 +1842,11 @@ void process_pet_findings(
     }
   }
 
-  const auto pet_worst = compute_pet_worst(findings);
-  for (const auto * type : kAggregatedTrajectoryTypes) {
+  const auto pet_worst = metric::compute_pet_worst(findings);
+  for (const auto * type : metric::kAggregatedTrajectoryTypes) {
     const auto it = pet_worst.find(type);
-    const PetWorst w = it != pet_worst.end() ? it->second : PetWorst{};
-    artifacts.metrics.push_back(make_metric_report(
+    const auto w = it != pet_worst.end() ? it->second : metric::PetWorst{};
+    artifacts.metrics.push_back(metric::make_metric_report(
       validator_name, validator_category, fmt::format("check_PET_{}", type), w.metric_value(),
       w.metric_level(pet_collision_params_default)));
   }
@@ -1874,6 +1870,14 @@ void process_drac_findings(
     current_time, collision_timing_result.drac_findings,
     [](const auto & finding) { return finding.object_identification.trajectory_id_string(); });
 
+  const auto drac_worst = metric::compute_drac_worst(collision_timing_result);
+  for (const auto * type : metric::kAggregatedTrajectoryTypes) {
+    const auto & w = drac_worst.at(type);
+    artifacts.metrics.push_back(metric::make_metric_report(
+      validator_name, validator_category, fmt::format("check_DRAC_{}", type), w.metric_value(),
+      w.metric_level(drac_params_default)));
+  }
+
   const bool is_warn =
     collision_timing_result.drac == std::nullopt ||
     collision_timing_result.drac.value() >= -drac_params_default.warn_threshold.ego_acceleration;
@@ -1883,7 +1887,7 @@ void process_drac_findings(
   if (!is_warn) {
     return;
   }
-  
+
   std::string log_messages{};
   std::string marker_messages{};
   const uint8_t metric_level = is_error ? MetricReport::ERROR : MetricReport::WARN;
@@ -1912,14 +1916,6 @@ void process_drac_findings(
 
   artifacts.error_msg += marker_messages;
   log_collision_messages(metric_level, log_messages);
-
-  const auto drac_worst = compute_drac_worst(collision_timing_result);
-  for (const auto * type : kAggregatedTrajectoryTypes) {
-    const auto & w = drac_worst.at(type);
-    artifacts.metrics.push_back(make_metric_report(
-      validator_name, validator_category, fmt::format("check_DRAC_{}", type), w.metric_value(),
-      w.metric_level(drac_params_default)));
-  }
 }
 
 void process_rss_violations(
@@ -1936,6 +1932,8 @@ void process_rss_violations(
     return;
   }
 
+  const auto rss_result = rss_deceleration::assess(
+    traj_points, context, rss_param_map, global_setting.time_resolution, vehicle_info);
   rss_continuous_times.update(current_time, rss_result.violations, [](const auto & violation) {
     return violation.object.object_id_string();
   });
@@ -1957,11 +1955,12 @@ void process_rss_violations(
   artifacts.error_msg += marker_messages;
   log_collision_messages(MetricReport::ERROR, log_messages);
 
-  const auto rss_worst = compute_rss_worst(rss_result);
-  artifacts.metrics.push_back(make_metric_report(
+  const auto rss_worst = metric::compute_rss_worst(rss_result);
+  artifacts.metrics.push_back(metric::make_metric_report(
     validator_name, validator_category, "check_RSS", rss_worst.metric_value(),
     rss_worst.metric_level()));
 }
+
 
 CollisionCheckFilter::result_t CollisionCheckFilter::is_feasible(
   const TrajectoryPoints & traj_points, const FilterContext & context)

--- a/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/collision_check_filter.cpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/collision_check_filter.cpp
@@ -1432,7 +1432,6 @@ Result assess(
       nominal_speed_object_trajectories);
   }
 
-
   if (drac_params_default.enable_assessment) {
     constexpr std::array<const char *, 3> kCanonicalTypes = {
       "map_based_predicted_path", "constant_curvature_path", "diffusion_based_trajectory"};

--- a/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/collision_check_filter.cpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/collision_check_filter.cpp
@@ -1687,56 +1687,96 @@ MetricReport make_metric_report(
 struct PetWorst
 {
   double pet{std::numeric_limits<double>::infinity()};
-  uint8_t level{MetricReport::OK};
+  bool has_finding{false};
 };
 
-std::map<std::string, PetWorst> compute_pet_worst_by_type(
-  const std::vector<collision_timing_assessment::Finding> & findings,
-  const PetCollisionParams & params)
+struct DracWorst
+{
+  std::optional<double> drac{0.0};
+};
+
+struct RssWorst
+{
+  double required_deceleration{0.0};
+  bool has_violation{false};
+};
+
+std::map<std::string, PetWorst> compute_pet_worst(
+  const std::vector<collision_timing_assessment::Finding> & findings)
 {
   std::map<std::string, PetWorst> worst;
   for (const auto & f : findings) {
     const auto type = canonical_trajectory_type(f.object_identification.trajectory_type);
     if (type.empty()) continue;
-    const bool is_error = f.pet <= params.error_threshold.ego_first_passing_time_gap &&
-                          f.pet >= -params.error_threshold.object_first_passing_time_gap;
     auto & w = worst[type];
-    if (std::abs(f.pet) < std::abs(w.pet)) {
+    if (!w.has_finding || std::abs(f.pet) < std::abs(w.pet)) {
       w.pet = f.pet;
-      w.level = is_error ? MetricReport::ERROR : MetricReport::WARN;
+      w.has_finding = true;
     }
   }
   return worst;
 }
 
-std::map<std::string, std::optional<double>> compute_drac_worst_by_type(
+std::map<std::string, DracWorst> compute_drac_worst(
   const collision_timing_assessment::Result & result)
 {
-  std::map<std::string, std::optional<double>> worst;
+  std::map<std::string, DracWorst> worst;
   for (const auto * type : kAggregatedTrajectoryTypes) {
-    worst[type] = std::optional<double>{0.0};
+    worst[type] = DracWorst{};
   }
   for (const auto & f : result.drac_findings) {
     const auto type = canonical_trajectory_type(f.object_identification.trajectory_type);
     if (type.empty()) continue;
-    worst[type] = result.drac;
+    worst[type].drac = result.drac;
   }
   return worst;
 }
 
-double drac_metric_value(const std::optional<double> & drac_opt)
+RssWorst compute_rss_worst(const rss_deceleration::Result & rss_result)
 {
-  return drac_opt.has_value() ? drac_opt.value() : std::numeric_limits<double>::max();
+  return RssWorst{
+    rss_result.worst_assessment.has_value()
+      ? rss_result.worst_assessment->required_deceleration
+      : 0.0,
+    rss_result.has_violation};
 }
 
-uint8_t drac_metric_level(const std::optional<double> & drac_opt, const DracParams & params)
+double pet_metric_value(const PetWorst & w)
 {
-  if (!drac_opt.has_value()) return MetricReport::ERROR;
-  const double v = drac_opt.value();
+  return w.has_finding ? w.pet : std::numeric_limits<double>::infinity();
+}
+
+uint8_t pet_metric_level(const PetWorst & w, const PetCollisionParams & params)
+{
+  if (!w.has_finding) return MetricReport::OK;
+  const bool is_error = w.pet <= params.error_threshold.ego_first_passing_time_gap &&
+                        w.pet >= -params.error_threshold.object_first_passing_time_gap;
+  return is_error ? MetricReport::ERROR : MetricReport::WARN;
+}
+
+double drac_metric_value(const DracWorst & w)
+{
+  return w.drac.has_value() ? w.drac.value() : std::numeric_limits<double>::max();
+}
+
+uint8_t drac_metric_level(const DracWorst & w, const DracParams & params)
+{
+  if (!w.drac.has_value()) return MetricReport::ERROR;
+  const double v = w.drac.value();
   if (v <= 0.0) return MetricReport::OK;
   if (v >= -params.error_threshold.ego_acceleration) return MetricReport::ERROR;
   if (v >= -params.warn_threshold.ego_acceleration) return MetricReport::WARN;
   return MetricReport::OK;
+}
+
+double rss_metric_value(const RssWorst & w)
+{
+  return w.required_deceleration;
+}
+
+uint8_t rss_metric_level(const RssWorst & w)
+{
+  return w.has_violation ? MetricReport::ERROR : MetricReport::OK;
 }
 
 void process_pet_findings(
@@ -1754,12 +1794,13 @@ void process_pet_findings(
     return finding.object_identification.trajectory_id_string();
   });
 
-  const auto pet_worst = compute_pet_worst_by_type(findings, pet_collision_params_default);
+  const auto pet_worst = compute_pet_worst(findings);
   for (const auto * type : kAggregatedTrajectoryTypes) {
     const auto it = pet_worst.find(type);
     const PetWorst w = it != pet_worst.end() ? it->second : PetWorst{};
     artifacts.metrics.push_back(make_metric_report(
-      validator_name, validator_category, fmt::format("check_PET_{}", type), w.pet, w.level));
+      validator_name, validator_category, fmt::format("check_PET_{}", type),
+      pet_metric_value(w), pet_metric_level(w, pet_collision_params_default)));
   }
 
   std::string log_messages{};
@@ -1809,12 +1850,12 @@ void process_drac_findings(
     current_time, collision_timing_result.drac_findings,
     [](const auto & finding) { return finding.object_identification.trajectory_id_string(); });
 
-  const auto drac_worst = compute_drac_worst_by_type(collision_timing_result);
+  const auto drac_worst = compute_drac_worst(collision_timing_result);
   for (const auto * type : kAggregatedTrajectoryTypes) {
-    const auto & drac_opt = drac_worst.at(type);
+    const auto & w = drac_worst.at(type);
     artifacts.metrics.push_back(make_metric_report(
       validator_name, validator_category, fmt::format("check_DRAC_{}", type),
-      drac_metric_value(drac_opt), drac_metric_level(drac_opt, drac_params_default)));
+      drac_metric_value(w), drac_metric_level(w, drac_params_default)));
   }
 
   const bool is_warn =
@@ -1868,8 +1909,9 @@ void process_rss_violations(
   const auto rss_params_default = rss_param_map.at(DEFAULT_PARAM_KEY);
 
   if (!rss_params_default.enable_assessment) {
-    artifacts.metrics.push_back(
-      make_metric_report(validator_name, validator_category, "check_RSS", 0.0, MetricReport::OK));
+    const RssWorst w{};
+    artifacts.metrics.push_back(make_metric_report(
+      validator_name, validator_category, "check_RSS", rss_metric_value(w), rss_metric_level(w)));
     return;
   }
 
@@ -1879,11 +1921,10 @@ void process_rss_violations(
     return violation.object.object_id_string();
   });
 
+  const auto rss_worst = compute_rss_worst(rss_result);
   artifacts.metrics.push_back(make_metric_report(
-    validator_name, validator_category, "check_RSS",
-    rss_result.worst_assessment.has_value() ? rss_result.worst_assessment->required_deceleration
-                                            : 0.0,
-    rss_result.has_violation ? MetricReport::ERROR : MetricReport::OK));
+    validator_name, validator_category, "check_RSS", rss_metric_value(rss_worst),
+    rss_metric_level(rss_worst)));
 
   std::string log_messages{};
   std::string marker_messages{};

--- a/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/collision_check_filter.cpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/collision_check_filter.cpp
@@ -1730,10 +1730,7 @@ struct RssWorst
 
   double metric_value() const { return required_deceleration; }
 
-  uint8_t metric_level() const
-  {
-    return has_violation ? MetricReport::ERROR : MetricReport::OK;
-  }
+  uint8_t metric_level() const { return has_violation ? MetricReport::ERROR : MetricReport::OK; }
 };
 
 std::map<std::string, PetWorst> compute_pet_worst(
@@ -1770,9 +1767,8 @@ std::map<std::string, DracWorst> compute_drac_worst(
 RssWorst compute_rss_worst(const rss_deceleration::Result & rss_result)
 {
   return RssWorst{
-    rss_result.worst_assessment.has_value()
-      ? rss_result.worst_assessment->required_deceleration
-      : 0.0,
+    rss_result.worst_assessment.has_value() ? rss_result.worst_assessment->required_deceleration
+                                            : 0.0,
     rss_result.has_violation};
 }
 

--- a/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/collision_check_filter.cpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/collision_check_filter.cpp
@@ -1688,17 +1688,52 @@ struct PetWorst
 {
   double pet{std::numeric_limits<double>::infinity()};
   bool has_finding{false};
+
+  double metric_value() const
+  {
+    return has_finding ? pet : std::numeric_limits<double>::infinity();
+  }
+
+  uint8_t metric_level(const PetCollisionParams & params) const
+  {
+    if (!has_finding) return MetricReport::OK;
+    const bool is_error = pet <= params.error_threshold.ego_first_passing_time_gap &&
+                          pet >= -params.error_threshold.object_first_passing_time_gap;
+    return is_error ? MetricReport::ERROR : MetricReport::WARN;
+  }
 };
 
 struct DracWorst
 {
   std::optional<double> drac{0.0};
+
+  double metric_value() const
+  {
+    return drac.has_value() ? drac.value() : std::numeric_limits<double>::max();
+  }
+
+  uint8_t metric_level(const DracParams & params) const
+  {
+    if (!drac.has_value()) return MetricReport::ERROR;
+    const double v = drac.value();
+    if (v <= 0.0) return MetricReport::OK;
+    if (v >= -params.error_threshold.ego_acceleration) return MetricReport::ERROR;
+    if (v >= -params.warn_threshold.ego_acceleration) return MetricReport::WARN;
+    return MetricReport::OK;
+  }
 };
 
 struct RssWorst
 {
   double required_deceleration{0.0};
   bool has_violation{false};
+
+  double metric_value() const { return required_deceleration; }
+
+  uint8_t metric_level() const
+  {
+    return has_violation ? MetricReport::ERROR : MetricReport::OK;
+  }
 };
 
 std::map<std::string, PetWorst> compute_pet_worst(
@@ -1741,44 +1776,6 @@ RssWorst compute_rss_worst(const rss_deceleration::Result & rss_result)
     rss_result.has_violation};
 }
 
-double pet_metric_value(const PetWorst & w)
-{
-  return w.has_finding ? w.pet : std::numeric_limits<double>::infinity();
-}
-
-uint8_t pet_metric_level(const PetWorst & w, const PetCollisionParams & params)
-{
-  if (!w.has_finding) return MetricReport::OK;
-  const bool is_error = w.pet <= params.error_threshold.ego_first_passing_time_gap &&
-                        w.pet >= -params.error_threshold.object_first_passing_time_gap;
-  return is_error ? MetricReport::ERROR : MetricReport::WARN;
-}
-
-double drac_metric_value(const DracWorst & w)
-{
-  return w.drac.has_value() ? w.drac.value() : std::numeric_limits<double>::max();
-}
-
-uint8_t drac_metric_level(const DracWorst & w, const DracParams & params)
-{
-  if (!w.drac.has_value()) return MetricReport::ERROR;
-  const double v = w.drac.value();
-  if (v <= 0.0) return MetricReport::OK;
-  if (v >= -params.error_threshold.ego_acceleration) return MetricReport::ERROR;
-  if (v >= -params.warn_threshold.ego_acceleration) return MetricReport::WARN;
-  return MetricReport::OK;
-}
-
-double rss_metric_value(const RssWorst & w)
-{
-  return w.required_deceleration;
-}
-
-uint8_t rss_metric_level(const RssWorst & w)
-{
-  return w.has_violation ? MetricReport::ERROR : MetricReport::OK;
-}
-
 void process_pet_findings(
   const std::string & validator_name, const std::string & validator_category,
   const std::map<std::string, PetCollisionParams> & pet_collision_param_map,
@@ -1793,15 +1790,6 @@ void process_pet_findings(
   pet_continuous_times.update(current_time, findings, [](const auto & finding) {
     return finding.object_identification.trajectory_id_string();
   });
-
-  const auto pet_worst = compute_pet_worst(findings);
-  for (const auto * type : kAggregatedTrajectoryTypes) {
-    const auto it = pet_worst.find(type);
-    const PetWorst w = it != pet_worst.end() ? it->second : PetWorst{};
-    artifacts.metrics.push_back(make_metric_report(
-      validator_name, validator_category, fmt::format("check_PET_{}", type),
-      pet_metric_value(w), pet_metric_level(w, pet_collision_params_default)));
-  }
 
   std::string log_messages{};
   std::string marker_messages{};
@@ -1831,6 +1819,15 @@ void process_pet_findings(
     }
   }
 
+  const auto pet_worst = compute_pet_worst(findings);
+  for (const auto * type : kAggregatedTrajectoryTypes) {
+    const auto it = pet_worst.find(type);
+    const PetWorst w = it != pet_worst.end() ? it->second : PetWorst{};
+    artifacts.metrics.push_back(make_metric_report(
+      validator_name, validator_category, fmt::format("check_PET_{}", type), w.metric_value(),
+      w.metric_level(pet_collision_params_default)));
+  }
+
   artifacts.error_msg += marker_messages;
   log_collision_messages(log_level, log_messages);
 }
@@ -1850,23 +1847,9 @@ void process_drac_findings(
     current_time, collision_timing_result.drac_findings,
     [](const auto & finding) { return finding.object_identification.trajectory_id_string(); });
 
-  const auto drac_worst = compute_drac_worst(collision_timing_result);
-  for (const auto * type : kAggregatedTrajectoryTypes) {
-    const auto & w = drac_worst.at(type);
-    artifacts.metrics.push_back(make_metric_report(
-      validator_name, validator_category, fmt::format("check_DRAC_{}", type),
-      drac_metric_value(w), drac_metric_level(w, drac_params_default)));
-  }
-
-  const bool is_warn =
-    collision_timing_result.drac == std::nullopt ||
-    collision_timing_result.drac.value() >= -drac_params_default.warn_threshold.ego_acceleration;
   const bool is_error =
     collision_timing_result.drac == std::nullopt ||
     collision_timing_result.drac.value() >= -drac_params_default.error_threshold.ego_acceleration;
-  if (!is_warn) {
-    return;
-  }
 
   std::string log_messages{};
   std::string marker_messages{};
@@ -1896,6 +1879,14 @@ void process_drac_findings(
 
   artifacts.error_msg += marker_messages;
   log_collision_messages(metric_level, log_messages);
+
+  const auto drac_worst = compute_drac_worst(collision_timing_result);
+  for (const auto * type : kAggregatedTrajectoryTypes) {
+    const auto & w = drac_worst.at(type);
+    artifacts.metrics.push_back(make_metric_report(
+      validator_name, validator_category, fmt::format("check_DRAC_{}", type), w.metric_value(),
+      w.metric_level(drac_params_default)));
+  }
 }
 
 void process_rss_violations(
@@ -1911,7 +1902,7 @@ void process_rss_violations(
   if (!rss_params_default.enable_assessment) {
     const RssWorst w{};
     artifacts.metrics.push_back(make_metric_report(
-      validator_name, validator_category, "check_RSS", rss_metric_value(w), rss_metric_level(w)));
+      validator_name, validator_category, "check_RSS", w.metric_value(), w.metric_level()));
     return;
   }
 
@@ -1920,11 +1911,6 @@ void process_rss_violations(
   rss_continuous_times.update(current_time, rss_result.violations, [](const auto & violation) {
     return violation.object.object_id_string();
   });
-
-  const auto rss_worst = compute_rss_worst(rss_result);
-  artifacts.metrics.push_back(make_metric_report(
-    validator_name, validator_category, "check_RSS", rss_metric_value(rss_worst),
-    rss_metric_level(rss_worst)));
 
   std::string log_messages{};
   std::string marker_messages{};
@@ -1942,6 +1928,11 @@ void process_rss_violations(
 
   artifacts.error_msg += marker_messages;
   log_collision_messages(MetricReport::ERROR, log_messages);
+
+  const auto rss_worst = compute_rss_worst(rss_result);
+  artifacts.metrics.push_back(make_metric_report(
+    validator_name, validator_category, "check_RSS", rss_worst.metric_value(),
+    rss_worst.metric_level()));
 }
 
 CollisionCheckFilter::result_t CollisionCheckFilter::is_feasible(

--- a/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/collision_check_filter.cpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/collision_check_filter.cpp
@@ -1656,6 +1656,89 @@ void add_collision_planning_factor(
   planning_factors.factors.push_back(std::move(factor));
 }
 
+constexpr std::array<const char *, 3> kAggregatedTrajectoryTypes = {
+  "map_based_predicted_path",
+  "constant_curvature_path",
+  "diffusion_based_trajectory",
+};
+
+std::string canonical_trajectory_type(const std::string & raw)
+{
+  for (const auto * type : kAggregatedTrajectoryTypes) {
+    if (raw.find(type) != std::string::npos) {
+      return type;
+    }
+  }
+  return {};
+}
+
+MetricReport make_metric_report(
+  const std::string & validator_name, const std::string & validator_category,
+  const std::string & metric_name, double value, uint8_t level)
+{
+  return autoware_trajectory_validator::build<MetricReport>()
+    .validator_name(validator_name)
+    .validator_category(validator_category)
+    .metric_name(metric_name)
+    .metric_value(value)
+    .level(level);
+}
+
+struct PetWorst
+{
+  double pet{std::numeric_limits<double>::infinity()};
+  uint8_t level{MetricReport::OK};
+};
+
+std::map<std::string, PetWorst> compute_pet_worst_by_type(
+  const std::vector<collision_timing_assessment::Finding> & findings,
+  const PetCollisionParams & params)
+{
+  std::map<std::string, PetWorst> worst;
+  for (const auto & f : findings) {
+    const auto type = canonical_trajectory_type(f.object_identification.trajectory_type);
+    if (type.empty()) continue;
+    const bool is_error = f.pet <= params.error_threshold.ego_first_passing_time_gap &&
+                          f.pet >= -params.error_threshold.object_first_passing_time_gap;
+    auto & w = worst[type];
+    if (std::abs(f.pet) < std::abs(w.pet)) {
+      w.pet = f.pet;
+      w.level = is_error ? MetricReport::ERROR : MetricReport::WARN;
+    }
+  }
+  return worst;
+}
+
+std::map<std::string, std::optional<double>> compute_drac_worst_by_type(
+  const collision_timing_assessment::Result & result)
+{
+  std::map<std::string, std::optional<double>> worst;
+  for (const auto * type : kAggregatedTrajectoryTypes) {
+    worst[type] = std::optional<double>{0.0};
+  }
+  for (const auto & f : result.drac_findings) {
+    const auto type = canonical_trajectory_type(f.object_identification.trajectory_type);
+    if (type.empty()) continue;
+    worst[type] = result.drac;
+  }
+  return worst;
+}
+
+double drac_metric_value(const std::optional<double> & drac_opt)
+{
+  return drac_opt.has_value() ? drac_opt.value() : std::numeric_limits<double>::max();
+}
+
+uint8_t drac_metric_level(const std::optional<double> & drac_opt, const DracParams & params)
+{
+  if (!drac_opt.has_value()) return MetricReport::ERROR;
+  const double v = drac_opt.value();
+  if (v <= 0.0) return MetricReport::OK;
+  if (v >= -params.error_threshold.ego_acceleration) return MetricReport::ERROR;
+  if (v >= -params.warn_threshold.ego_acceleration) return MetricReport::WARN;
+  return MetricReport::OK;
+}
+
 void process_pet_findings(
   const std::string & validator_name, const std::string & validator_category,
   const std::map<std::string, PetCollisionParams> & pet_collision_param_map,
@@ -1671,6 +1754,14 @@ void process_pet_findings(
     return finding.object_identification.trajectory_id_string();
   });
 
+  const auto pet_worst = compute_pet_worst_by_type(findings, pet_collision_params_default);
+  for (const auto * type : kAggregatedTrajectoryTypes) {
+    const auto it = pet_worst.find(type);
+    const PetWorst w = it != pet_worst.end() ? it->second : PetWorst{};
+    artifacts.metrics.push_back(make_metric_report(
+      validator_name, validator_category, fmt::format("check_PET_{}", type), w.pet, w.level));
+  }
+
   std::string log_messages{};
   std::string marker_messages{};
   uint8_t log_level = MetricReport::WARN;
@@ -1679,28 +1770,10 @@ void process_pet_findings(
     const bool is_error =
       finding.pet <= pet_collision_params_default.error_threshold.ego_first_passing_time_gap &&
       finding.pet >= -pet_collision_params_default.error_threshold.object_first_passing_time_gap;
-    const uint8_t metric_level = is_error ? MetricReport::ERROR : MetricReport::WARN;
     if (is_error) {
       artifacts.is_feasible = false;
       log_level = MetricReport::ERROR;
     }
-
-    artifacts.metrics.push_back(
-      autoware_trajectory_validator::build<MetricReport>()
-        .validator_name(validator_name)
-        .validator_category(validator_category)
-        .metric_name(
-          fmt::format("check_PET_{}_{}", obj_id.trajectory_id_string(), obj_id.classification))
-        .metric_value(finding.pet)
-        .level(metric_level));
-    artifacts.metrics.push_back(
-      autoware_trajectory_validator::build<MetricReport>()
-        .validator_name(validator_name)
-        .validator_category(validator_category)
-        .metric_name(
-          fmt::format("check_TTC_{}_{}", obj_id.trajectory_id_string(), obj_id.classification))
-        .metric_value(finding.ttc)
-        .level(metric_level));
 
     const auto finding_msg = fmt::format(
       "PET collision, classification: {}, ID: {}, PET: {}, TTC: {}, duration: {}, stamp: {}.{};",
@@ -1736,6 +1809,14 @@ void process_drac_findings(
     current_time, collision_timing_result.drac_findings,
     [](const auto & finding) { return finding.object_identification.trajectory_id_string(); });
 
+  const auto drac_worst = compute_drac_worst_by_type(collision_timing_result);
+  for (const auto * type : kAggregatedTrajectoryTypes) {
+    const auto & drac_opt = drac_worst.at(type);
+    artifacts.metrics.push_back(make_metric_report(
+      validator_name, validator_category, fmt::format("check_DRAC_{}", type),
+      drac_metric_value(drac_opt), drac_metric_level(drac_opt, drac_params_default)));
+  }
+
   const bool is_warn =
     collision_timing_result.drac == std::nullopt ||
     collision_timing_result.drac.value() >= -drac_params_default.warn_threshold.ego_acceleration;
@@ -1754,15 +1835,6 @@ void process_drac_findings(
     if (is_error) {
       artifacts.is_feasible = false;
     }
-
-    artifacts.metrics.push_back(autoware_trajectory_validator::build<MetricReport>()
-                                  .validator_name(validator_name)
-                                  .validator_category(validator_category)
-                                  .metric_name(fmt::format(
-                                    "check_DRAC_{}_{}_{}", obj_id.trajectory_id_string(),
-                                    obj_id.classification, obj_id.trajectory_type))
-                                  .metric_value(collision_timing_result.drac.value_or(0.0))
-                                  .level(metric_level));
 
     const auto finding_msg = fmt::format(
       "DRAC collision, ID: {}, PET: {}, TTC: {}, DRAC: {}, stamp: {}.{};",
@@ -1796,6 +1868,8 @@ void process_rss_violations(
   const auto rss_params_default = rss_param_map.at(DEFAULT_PARAM_KEY);
 
   if (!rss_params_default.enable_assessment) {
+    artifacts.metrics.push_back(
+      make_metric_report(validator_name, validator_category, "check_RSS", 0.0, MetricReport::OK));
     return;
   }
 
@@ -1805,19 +1879,17 @@ void process_rss_violations(
     return violation.object.object_id_string();
   });
 
+  artifacts.metrics.push_back(make_metric_report(
+    validator_name, validator_category, "check_RSS",
+    rss_result.worst_assessment.has_value() ? rss_result.worst_assessment->required_deceleration
+                                            : 0.0,
+    rss_result.has_violation ? MetricReport::ERROR : MetricReport::OK));
+
   std::string log_messages{};
   std::string marker_messages{};
   for (const auto & violation : rss_result.violations) {
     const auto object_id = violation.object.object_id_string();
     artifacts.is_feasible = false;
-    artifacts.metrics.push_back(
-      autoware_trajectory_validator::build<MetricReport>()
-        .validator_name(validator_name)
-        .validator_category(validator_category)
-        .metric_name(fmt::format("check_RSS_{}_{}", violation.object.classification, object_id))
-        .metric_value(violation.required_deceleration)
-        .level(MetricReport::ERROR));
-
     const auto finding_msg = fmt::format(
       "RSS collision, classification: {}, ID: {}, duration: {}, required deceleration: {}, "
       "stamp: {}.{};",


### PR DESCRIPTION
## Summary

Replaced the per-finding `MetricReport` output of `CollisionCheckFilter` in `autoware_trajectory_validator` (which embedded UUIDs and class names into dynamic metric_names) with **a fixed set of 7 worst-aggregated metrics per cycle (PET × 3 + DRAC × 3 + RSS × 1)**.

### Problem with the previous output

```yaml
# Before
metric_name: 'check_PET_1f89f2488d74888b3571752df9e81445_diffusion_based_trajectory acc: 0.000000_CAR'
metric_name: 'check_TTC_1f89f2488d74888b3571752df9e81445_diffusion_based_trajectory acc: 0.000000_CAR'
metric_name: 'check_DRAC_<uuid>_<class>_<trajectory_type>'
metric_name: 'check_RSS_<class>_<object_id>'
```

- UUID / classification / acceleration were dynamically embedded in `metric_name`, so the metrics **were not picked up by Evaluator/Grafana time series** (filtered out by the UUID-exclusion regex; series did not stay continuous because `metric_name` varied per cycle).
- The same `metric_name` was pushed multiple times within a single cycle, causing first-write-wins / last-write-wins issues in the Evaluator aggregation.

### After the change

```yaml
# After: a fixed 7 metrics per ValidationReport
metric_name: check_PET_map_based_predicted_path
metric_name: check_PET_constant_curvature_path
metric_name: check_PET_diffusion_based_trajectory
metric_name: check_DRAC_map_based_predicted_path
metric_name: check_DRAC_constant_curvature_path
metric_name: check_DRAC_diffusion_based_trajectory
metric_name: check_RSS
```

Even when no detection occurs, the following values are emitted:

| Worst struct | Default value | Default `metric_value()` | Default `metric_level()` |
| --- | --- | --- | --- |
| `PetWorst{}` | `pet=+inf, has_finding=false` | `+inf` | `OK` |
| `DracWorst{}` | `drac=optional<double>{0.0}` | `0.0` | `OK` |
| `RssWorst{}` | `required_deceleration=0.0, has_violation=false` | `0.0` | `OK` |

## Main implementation changes

### 1. New `metric` namespace (presentation layer)
- Added `metric_value()` / `metric_level(params)` member functions to the `PetWorst` / `DracWorst` / `RssWorst` structs
- Added `compute_pet_worst(findings)` / `compute_drac_worst(result)` / `compute_rss_worst(rss_result)` worst-aggregation helpers
- Added `make_metric_report(...)` to centralize the `MetricReport` builder boilerplate

### 2. PET worst (per-type)
`compute_pet_worst` groups `planned_speed_findings` by `trajectory_type` and selects the finding with the smallest `|pet|` for each type.

### 3. DRAC worst (per-type)
`assess_drac` is invoked **three times independently**, each call with a `drac_param_map` whose `assessment_trajectories` is isolated to a single trajectory_type. This preserves `assess_drac`'s original stop condition ("all enabled types' findings empty") while still producing per-type DRAC values.

### 4. RSS worst
`compute_rss_worst` wraps `worst_assessment.required_deceleration`. The level (OK / ERROR) is determined solely by `has_violation`.


## Test

- Verified that the metric output matches the target format by replaying a recorded ROSBAG against a standalone `trajectory_validator_node` and diffing the captured `validation_reports` against the expected reference.