### PR TITLE
fix: imu scale estimation covariance limit for stability

### DIFF
--- a/perception/autoware_ptv3/README.md
+++ b/perception/autoware_ptv3/README.md
@@ -20,17 +20,17 @@ Autoware installs it automatically in its setup script. If needed, the user can 
 
 ### Output
 
-| Name                                   | Type                                                | Description                                             |
-| -------------------------------------- | --------------------------------------------------- | ------------------------------------------------------- |
-| `~/output/pointcloud/segmentation`     | `sensor_msgs::msg::PointCloud2`                     | XYZ cloud with class ID and probability fields.         |
-| `~/output/pointcloud/visualization`    | `sensor_msgs::msg::PointCloud2`                     | XYZ cloud with RGB field.                               |
-| `~/output/pointcloud/filtered`         | `sensor_msgs::msg::PointCloud2`                     | Filtered cloud in the requested `filter.output_format`. |
-| `debug/cyclic_time_ms`                 | `autoware_internal_debug_msgs::msg::Float64Stamped` | Cyclic time (ms).                                       |
-| `debug/pipeline_latency_ms`            | `autoware_internal_debug_msgs::msg::Float64Stamped` | Pipeline latency time (ms).                             |
-| `debug/processing_time/preprocess_ms`  | `autoware_internal_debug_msgs::msg::Float64Stamped` | Preprocess (ms).                                        |
-| `debug/processing_time/inference_ms`   | `autoware_internal_debug_msgs::msg::Float64Stamped` | Inference time (ms).                                    |
-| `debug/processing_time/postprocess_ms` | `autoware_internal_debug_msgs::msg::Float64Stamped` | Postprocess time (ms).                                  |
-| `debug/processing_time/total_ms`       | `autoware_internal_debug_msgs::msg::Float64Stamped` | Total processing time (ms).                             |
+| Name                                   | Type                                                | Description                                                                                                                             |
+| -------------------------------------- | --------------------------------------------------- | --------------------------------------------------------------------------------------------------------------------------------------- |
+| `~/output/pointcloud/segmentation`     | `sensor_msgs::msg::PointCloud2`                     | XYZ cloud with class ID and probability fields. When `filter_segmentation` is true, points matching the configured filter are excluded. |
+| `~/output/pointcloud/visualization`    | `sensor_msgs::msg::PointCloud2`                     | XYZ cloud with RGB field.                                                                                                               |
+| `~/output/pointcloud/filtered`         | `sensor_msgs::msg::PointCloud2`                     | Filtered cloud in the requested `filter.output_format`.                                                                                 |
+| `debug/cyclic_time_ms`                 | `autoware_internal_debug_msgs::msg::Float64Stamped` | Cyclic time (ms).                                                                                                                       |
+| `debug/pipeline_latency_ms`            | `autoware_internal_debug_msgs::msg::Float64Stamped` | Pipeline latency time (ms).                                                                                                             |
+| `debug/processing_time/preprocess_ms`  | `autoware_internal_debug_msgs::msg::Float64Stamped` | Preprocess (ms).                                                                                                                        |
+| `debug/processing_time/inference_ms`   | `autoware_internal_debug_msgs::msg::Float64Stamped` | Inference time (ms).                                                                                                                    |
+| `debug/processing_time/postprocess_ms` | `autoware_internal_debug_msgs::msg::Float64Stamped` | Postprocess time (ms).                                                                                                                  |
+| `debug/processing_time/total_ms`       | `autoware_internal_debug_msgs::msg::Float64Stamped` | Total processing time (ms).                                                                                                             |
 
 ## Parameters
 
@@ -73,6 +73,10 @@ supports:
 
 The filtered output cloud format is controlled by `filter.output_format`. When it is set to an
 empty string, the filtered output preserves the same format as the input cloud.
+
+When `filter_segmentation` is `true`, `~/output/pointcloud/segmentation` keeps the same
+segmentation fields (`x`, `y`, `z`, `class_id`, `probability`) but excludes points matching the
+configured `filter.classes` and `filter.class_probability_threshold`.
 
 ## Trained Models
 

--- a/perception/autoware_ptv3/config/ptv3.param.yaml
+++ b/perception/autoware_ptv3/config/ptv3.param.yaml
@@ -18,3 +18,4 @@
         "manmade"
       ]
       output_format: ""
+    filter_segmentation: false

--- a/perception/autoware_ptv3/include/autoware/ptv3/postprocess/postprocess_kernel.hpp
+++ b/perception/autoware_ptv3/include/autoware/ptv3/postprocess/postprocess_kernel.hpp
@@ -41,6 +41,10 @@ public:
     const float * input_features, const std::int64_t * pred_labels, const float * pred_probs,
     std::uint8_t * output_points, std::size_t num_classes, std::size_t num_points);
 
+  std::size_t createFilteredSegmentationPointcloud(
+    const float * input_features, const std::int64_t * pred_labels, const float * pred_probs,
+    std::uint8_t * output_points, std::size_t num_classes, std::size_t num_points);
+
   std::size_t createFilteredPointcloud(
     const void * compact_input_points, CloudFormat input_format, CloudFormat output_format,
     const float * pred_probs, void * output_points, std::size_t num_classes,

--- a/perception/autoware_ptv3/include/autoware/ptv3/ptv3_config.hpp
+++ b/perception/autoware_ptv3/include/autoware/ptv3/ptv3_config.hpp
@@ -36,7 +36,8 @@ public:
     const std::vector<std::int64_t> & voxels_num, const std::vector<float> & point_cloud_range,
     const std::vector<float> & voxel_size, const std::vector<std::string> & class_names,
     const std::vector<std::int64_t> & palette, const float filter_class_probability_threshold,
-    const std::vector<std::string> & filter_classes, const std::string & filter_output_format)
+    const std::vector<std::string> & filter_classes, const std::string & filter_output_format,
+    const bool filter_segmentation)
   {
     plugins_path_ = plugins_path;
 
@@ -91,6 +92,7 @@ public:
     filter_class_probability_threshold_ = filter_class_probability_threshold;
     filter_class_indices_ = make_filter_class_indices(class_names_, filter_classes);
     filter_output_format_ = filter_output_format;
+    filter_segmentation_ = filter_segmentation;
   }
 
   static std::vector<std::uint32_t> make_filter_class_indices(
@@ -155,6 +157,7 @@ public:
   float filter_class_probability_threshold_{};
   std::vector<std::uint32_t> filter_class_indices_;
   std::string filter_output_format_;
+  bool filter_segmentation_{};
 
   // Common network parameters
   std::int64_t cloud_capacity_{};

--- a/perception/autoware_ptv3/lib/postprocess/postprocess_kernel.cu
+++ b/perception/autoware_ptv3/lib/postprocess/postprocess_kernel.cu
@@ -62,6 +62,42 @@ __global__ void createSegmentationPointcloudKernel(
   output_points[idx].probability = pred_probs[idx * num_classes + label];
 }
 
+__global__ void createFilteredSegmentationPointcloudKernel(
+  const float4 * input_features, const std::int64_t * labels, const float * pred_probs,
+  const std::uint32_t * filter_class_indices, std::size_t num_filter_classes,
+  float filter_class_probability_threshold, std::size_t num_classes,
+  std::uint32_t * output_num_points, OutputSegmentationPointType * output_points,
+  std::size_t num_points)
+{
+  const auto idx = static_cast<std::uint32_t>(blockIdx.x * blockDim.x + threadIdx.x);
+  if (idx >= num_points) {
+    return;
+  }
+
+  bool keep_point = true;
+  const float * point_probs = &pred_probs[num_classes * idx];
+  for (std::size_t i = 0; i < num_filter_classes; ++i) {
+    const auto class_idx = filter_class_indices[i];
+    if (point_probs[class_idx] >= filter_class_probability_threshold) {
+      keep_point = false;
+      break;
+    }
+  }
+
+  if (!keep_point) {
+    return;
+  }
+
+  const auto output_idx = atomicAdd(output_num_points, 1U);
+  const auto input_point = input_features[idx];
+  const auto label = labels[idx];
+  output_points[output_idx].x = input_point.x;
+  output_points[output_idx].y = input_point.y;
+  output_points[output_idx].z = input_point.z;
+  output_points[output_idx].class_id = static_cast<std::uint8_t>(label);
+  output_points[output_idx].probability = point_probs[label];
+}
+
 template <typename OutputPointT>
 __device__ void set_point_from_input(
   OutputPointT & output_point, const CloudPointTypeXYZI & input_point);
@@ -235,6 +271,28 @@ void PostprocessCuda::createSegmentationPointcloud(
     reinterpret_cast<OutputSegmentationPointType *>(output_points), num_classes, num_points);
 
   CHECK_CUDA_ERROR(cudaStreamSynchronize(stream_));
+}
+
+std::size_t PostprocessCuda::createFilteredSegmentationPointcloud(
+  const float * input_features, const std::int64_t * pred_labels, const float * pred_probs,
+  std::uint8_t * output_points, std::size_t num_classes, std::size_t num_points)
+{
+  cudaMemsetAsync(filtered_mask_d_.get(), 0, sizeof(std::uint32_t), stream_);
+
+  const auto num_blocks = divup(num_points, config_.threads_per_block_);
+  createFilteredSegmentationPointcloudKernel<<<
+    num_blocks, config_.threads_per_block_, 0, stream_>>>(
+    reinterpret_cast<const float4 *>(input_features), pred_labels, pred_probs,
+    filter_class_indices_d_.get(), config_.filter_class_indices_.size(),
+    config_.filter_class_probability_threshold_, num_classes, filtered_mask_d_.get(),
+    reinterpret_cast<OutputSegmentationPointType *>(output_points), num_points);
+
+  std::uint32_t num_filtered_points = 0;
+  cudaMemcpyAsync(
+    &num_filtered_points, filtered_mask_d_.get(), sizeof(std::uint32_t), cudaMemcpyDeviceToHost,
+    stream_);
+  CHECK_CUDA_ERROR(cudaStreamSynchronize(stream_));
+  return num_filtered_points;
 }
 
 std::size_t PostprocessCuda::createFilteredPointcloud(

--- a/perception/autoware_ptv3/lib/ptv3_trt.cpp
+++ b/perception/autoware_ptv3/lib/ptv3_trt.cpp
@@ -404,13 +404,18 @@ bool PTv3TRT::postProcess(
 {
   // Segmentation pointcloud
   if (should_publish_segmented_pointcloud) {
-    post_ptr_->createSegmentationPointcloud(
-      feat_d_.get(), pred_labels_d_.get(), pred_probs_d_.get(),
-      segmented_points_msg_ptr_->data.get(), config_.class_names_.size(), num_voxels_);
-    CHECK_CUDA_ERROR(cudaStreamSynchronize(stream_));
+    const auto num_segmented_points =
+      config_.filter_segmentation_
+        ? post_ptr_->createFilteredSegmentationPointcloud(
+            feat_d_.get(), pred_labels_d_.get(), pred_probs_d_.get(),
+            segmented_points_msg_ptr_->data.get(), config_.class_names_.size(), num_voxels_)
+        : (post_ptr_->createSegmentationPointcloud(
+             feat_d_.get(), pred_labels_d_.get(), pred_probs_d_.get(),
+             segmented_points_msg_ptr_->data.get(), config_.class_names_.size(), num_voxels_),
+           num_voxels_);
 
     segmented_points_msg_ptr_->header = header;
-    segmented_points_msg_ptr_->width = num_voxels_;
+    segmented_points_msg_ptr_->width = num_segmented_points;
     publish_segmented_pointcloud_(std::move(segmented_points_msg_ptr_));
     segmented_points_msg_ptr_ = nullptr;
   }

--- a/perception/autoware_ptv3/schema/ptv3.schema.json
+++ b/perception/autoware_ptv3/schema/ptv3.schema.json
@@ -62,6 +62,11 @@
         },
         "filter": {
           "$ref": "#/definitions/filter"
+        },
+        "filter_segmentation": {
+          "type": "boolean",
+          "description": "When true, the segmentation output drops points matching the configured filter classes and threshold.",
+          "default": false
         }
       },
       "required": [
@@ -70,7 +75,8 @@
         "cloud_capacity",
         "onnx_path",
         "engine_path",
-        "filter"
+        "filter",
+        "filter_segmentation"
       ],
       "additionalProperties": false
     }

--- a/perception/autoware_ptv3/src/ptv3_node.cpp
+++ b/perception/autoware_ptv3/src/ptv3_node.cpp
@@ -53,12 +53,13 @@ PTv3Node::PTv3Node(const rclcpp::NodeOptions & options) : Node("ptv3", options)
   // Head parameters
   auto class_names = this->declare_parameter<std::vector<std::string>>("class_names", descriptor);
   const auto palette = this->declare_parameter<std::vector<std::int64_t>>("palette", descriptor);
-  const auto filter_class_probability_threshold =
-    this->declare_parameter<float>("filter.class_probability_threshold", descriptor);
+  const auto filter_class_probability_threshold = static_cast<float>(
+    this->declare_parameter<double>("filter.class_probability_threshold", descriptor));
   const auto filter_classes =
     this->declare_parameter<std::vector<std::string>>("filter.classes", descriptor);
   const auto filter_output_format =
     this->declare_parameter<std::string>("filter.output_format", descriptor);
+  const auto filter_segmentation = this->declare_parameter<bool>("filter_segmentation", descriptor);
 
   if (point_cloud_range.size() != 6) {
     throw std::runtime_error("The size of point_cloud_range != 6");
@@ -69,7 +70,7 @@ PTv3Node::PTv3Node(const rclcpp::NodeOptions & options) : Node("ptv3", options)
 
   PTv3Config config(
     plugins_path, cloud_capacity, voxels_num, point_cloud_range, voxel_size, class_names, palette,
-    filter_class_probability_threshold, filter_classes, filter_output_format);
+    filter_class_probability_threshold, filter_classes, filter_output_format, filter_segmentation);
 
   auto trt_config =
     tensorrt_common::TrtCommonConfig(onnx_path, trt_precision, engine_path, 1ULL << 33U);

--- a/sensing/autoware_imu_corrector/config/gyro_scale_estimator.param.yaml
+++ b/sensing/autoware_imu_corrector/config/gyro_scale_estimator.param.yaml
@@ -3,7 +3,7 @@
     estimate_scale_init: 1.0
     min_allowed_scale: 0.9
     max_allowed_scale: 1.1
-    threshold_to_estimate_scale: 0.1
+    threshold_to_estimate_scale: 0.05
     percentage_scale_rate_allow_correct: 0.04
     alpha: 0.99
     delay_gyro_ms: 170
@@ -28,7 +28,7 @@
       variance_p_angle: 5e-9
       measurement_noise_r_angle: 0.00005
       min_covariance_angle: 1e-11
-      decay_coefficient: 0.99999998
+      decay_coefficient: 0.9999999998
       samples_in_bounds_to_init: 250
       max_reinitialization_retries: 5
 

--- a/sensing/autoware_imu_corrector/schema/gyro_scale_estimator.schema.json
+++ b/sensing/autoware_imu_corrector/schema/gyro_scale_estimator.schema.json
@@ -24,7 +24,7 @@
         "threshold_to_estimate_scale": {
           "type": "number",
           "description": "Angular speed radians for scale estimation threshold.",
-          "default": 0.1
+          "default": 0.05
         },
         "percentage_scale_rate_allow_correct": {
           "type": "number",
@@ -147,7 +147,7 @@
             "decay_coefficient": {
               "type": "number",
               "description": "Decay coefficient for EKF.",
-              "default": 0.99999998
+              "default": 0.9999999998
             },
             "samples_in_bounds_to_init": {
               "type": "integer",

--- a/sensing/autoware_imu_corrector/src/gyro_bias_estimator.cpp
+++ b/sensing/autoware_imu_corrector/src/gyro_bias_estimator.cpp
@@ -278,6 +278,12 @@ void GyroBiasEstimator::callback_imu(const sensor_msgs::msg::Imu::ConstSharedPtr
     ekf_angle_.p_angle_(0, 0) = std::min(
       std::max(ekf_angle_.p_angle_(0, 0), ekf_angle_.min_covariance_angle_),
       ekf_angle_.max_variance_p_angle_);
+    ekf_angle_.p_angle_(0, 1) = std::min(
+      std::max(ekf_angle_.p_angle_(0, 1), -ekf_angle_.max_variance_p_angle_),
+      ekf_angle_.max_variance_p_angle_);
+    ekf_angle_.p_angle_(1, 0) = std::min(
+      std::max(ekf_angle_.p_angle_(1, 0), -ekf_angle_.max_variance_p_angle_),
+      ekf_angle_.max_variance_p_angle_);
     ekf_angle_.p_angle_(1, 1) = std::min(
       std::max(ekf_angle_.p_angle_(1, 1), ekf_angle_.min_covariance_angle_),
       ekf_angle_.max_variance_p_angle_);


### PR DESCRIPTION
Covariance limited to avoid scale estimation instability, tested on rosbag, but want to test on the vehicle.