### PR TITLE
feat(trajectory_modifier): add parameterized safety buffer around obstacle footprint

### DIFF
--- a/planning/autoware_minimum_rule_based_planner/config/minimum_rule_based_planner.param.yaml
+++ b/planning/autoware_minimum_rule_based_planner/config/minimum_rule_based_planner.param.yaml
@@ -49,6 +49,7 @@
         max_velocity_th: 1.0     # maximum velocity threshold for target object [m/s]
         stopped_velocity_th: 0.25 # velocity threshold for target object to be considered as stopped [m/s]
         max_lateral_velocity_th: 1.0 # [m/s] max lateral velocity (w.r.t ego traj) to consider for obstacle stop
+        safety_buffer: 0.0 # [m] safety buffer to expand object shape
 
       rss_params:
         enable: true

--- a/planning/autoware_minimum_rule_based_planner/param/minimum_rule_based_planner_parameters.yaml
+++ b/planning/autoware_minimum_rule_based_planner/param/minimum_rule_based_planner_parameters.yaml
@@ -159,6 +159,10 @@ minimum_rule_based_planner:
         type: double
         default_value: 1.0
         description: maximum lateral velocity threshold for target object [m/s]
+      safety_buffer:
+        type: double
+        default_value: 0.0
+        description: safety buffer to expand object shape [m]
     rss_params:
       enable:
         type: bool

--- a/planning/autoware_minimum_rule_based_planner/plugins/obstacle_stop.cpp
+++ b/planning/autoware_minimum_rule_based_planner/plugins/obstacle_stop.cpp
@@ -52,7 +52,8 @@ void ObstacleStop::on_initialize(const MinimumRuleBasedPlannerParams & params)
 
   object_filter_ = std::make_unique<trajectory_modifier::utils::obstacle_stop::ObjectFilter>(
     params_.objects.object_types, params_.objects.max_velocity_th,
-    params_.objects.stopped_velocity_th, params_.objects.max_lateral_velocity_th);
+    params_.objects.stopped_velocity_th, params_.objects.max_lateral_velocity_th,
+    params_.objects.safety_buffer);
 
   pub_clustered_pointcloud_ =
     get_node_ptr()->create_publisher<PointCloud2>("~/obstacle_stop/debug/cluster_points", 1);

--- a/planning/autoware_minimum_rule_based_planner/plugins/obstacle_stop.hpp
+++ b/planning/autoware_minimum_rule_based_planner/plugins/obstacle_stop.hpp
@@ -59,7 +59,8 @@ public:
     {
       const auto & p = params_.objects;
       object_filter_->set_params(
-        p.object_types, p.max_velocity_th, p.stopped_velocity_th, p.max_lateral_velocity_th);
+        p.object_types, p.max_velocity_th, p.stopped_velocity_th, p.max_lateral_velocity_th,
+        p.safety_buffer);
     }
 
     {

--- a/planning/autoware_minimum_rule_based_planner/schema/minimum_rule_based_planner.schema.json
+++ b/planning/autoware_minimum_rule_based_planner/schema/minimum_rule_based_planner.schema.json
@@ -253,6 +253,12 @@
                   "description": "Max lateral velocity threshold [m/s]",
                   "default": 1.0,
                   "minimum": 0.0
+                },
+                "safety_buffer": {
+                  "type": "number",
+                  "description": "Safety buffer to expand object shape [m]",
+                  "default": 0.0,
+                  "minimum": 0.0
                 }
               },
               "required": [],

--- a/planning/autoware_trajectory_modifier/config/trajectory_modifier.param.yaml
+++ b/planning/autoware_trajectory_modifier/config/trajectory_modifier.param.yaml
@@ -42,6 +42,7 @@
         max_velocity_th: 5.0      # maximum velocity threshold for target object [m/s]
         stopped_velocity_th: 0.25 # [m/s]
         max_lateral_velocity_th: 1.0 # [m/s] max lateral velocity (w.r.t ego traj) to consider for obstacle stop
+        safety_buffer: 0.0 # [m] safety buffer to expand object shape
 
       pointcloud:
         height_buffer: 0.5  # height buffer to add above ego height [m]

--- a/planning/autoware_trajectory_modifier/include/autoware/trajectory_modifier/trajectory_modifier_utils/obstacle_stop_utils.hpp
+++ b/planning/autoware_trajectory_modifier/include/autoware/trajectory_modifier/trajectory_modifier_utils/obstacle_stop_utils.hpp
@@ -248,13 +248,16 @@ struct ObjectFilter
    * @param max_velocity_th Remove objects with longitudinal twist.x above this [m/s].
    * @param stopped_velocity_th Used when filtering by target area for "moving" vs stopped.
    * @param max_lateral_velocity_th Lateral speed threshold for the exiting-object heuristic [m/s].
+   * @param safety_buffer Safety buffer to expand object shape [m].
    */
   ObjectFilter(
     const std::vector<std::string> & object_type_strings, const double max_velocity_th,
-    const double stopped_velocity_th, const double max_lateral_velocity_th)
+    const double stopped_velocity_th, const double max_lateral_velocity_th,
+    const double safety_buffer)
   : max_velocity_th_(max_velocity_th),
     stopped_velocity_th_(stopped_velocity_th),
-    max_lateral_velocity_th_(max_lateral_velocity_th)
+    max_lateral_velocity_th_(max_lateral_velocity_th),
+    safety_buffer_(safety_buffer)
   {
     for (const auto & object_type_string : object_type_strings) {
       if (string_to_object_type.count(object_type_string) == 0) continue;
@@ -301,7 +304,8 @@ struct ObjectFilter
    */
   void set_params(
     const std::vector<std::string> & object_type_strings, const double max_velocity_th,
-    const double stopped_velocity_th, const double max_lateral_velocity_th)
+    const double stopped_velocity_th, const double max_lateral_velocity_th,
+    const double safety_buffer)
   {
     object_types_.clear();
     for (const auto & object_type_string : object_type_strings) {
@@ -311,6 +315,7 @@ struct ObjectFilter
     max_velocity_th_ = max_velocity_th;
     stopped_velocity_th_ = stopped_velocity_th;
     max_lateral_velocity_th_ = max_lateral_velocity_th;
+    safety_buffer_ = safety_buffer;
   }
 
 private:
@@ -318,6 +323,7 @@ private:
   double max_velocity_th_;
   double stopped_velocity_th_;
   double max_lateral_velocity_th_;
+  double safety_buffer_;
 };
 
 /// PCL-based downsampling, cropping, clustering, and object masking for obstacle point clouds.

--- a/planning/autoware_trajectory_modifier/param/trajectory_modifier_parameter_struct.yaml
+++ b/planning/autoware_trajectory_modifier/param/trajectory_modifier_parameter_struct.yaml
@@ -201,7 +201,13 @@ trajectory_modifier_params:
         validation:
           bounds<>: [0.0, 10.0]
         read_only: false
-
+      safety_buffer:
+        type: double
+        default_value: 0.0
+        description: Safety buffer to expand object shape [m]
+        validation:
+          bounds<>: [0.0, 10.0]
+        read_only: false
     pointcloud:
       height_buffer:
         type: double

--- a/planning/autoware_trajectory_modifier/schema/trajectory_modifier.schema.json
+++ b/planning/autoware_trajectory_modifier/schema/trajectory_modifier.schema.json
@@ -199,6 +199,12 @@
                   "description": "Maximum lateral velocity threshold for target object to be considered for obstacle stop [m/s]",
                   "default": 1.0,
                   "minimum": 0.0
+                },
+                "safety_buffer": {
+                  "type": "number",
+                  "description": "Safety buffer to expand object shape [m]",
+                  "default": 0.0,
+                  "minimum": 0.0
                 }
               },
               "required": [],

--- a/planning/autoware_trajectory_modifier/src/trajectory_modifier_plugins/obstacle_stop.cpp
+++ b/planning/autoware_trajectory_modifier/src/trajectory_modifier_plugins/obstacle_stop.cpp
@@ -87,7 +87,8 @@ void ObstacleStop::on_initialize(const TrajectoryModifierParams & params)
   {
     const auto & p = params_.objects;
     object_filter_ = std::make_unique<utils::obstacle_stop::ObjectFilter>(
-      p.object_types, p.max_velocity_th, p.stopped_velocity_th, p.max_lateral_velocity_th);
+      p.object_types, p.max_velocity_th, p.stopped_velocity_th, p.max_lateral_velocity_th,
+      p.safety_buffer);
   }
 
   {
@@ -133,7 +134,8 @@ void ObstacleStop::update_params(const TrajectoryModifierParams & params)
   {
     const auto & p = params_.objects;
     object_filter_->set_params(
-      p.object_types, p.max_velocity_th, p.stopped_velocity_th, p.max_lateral_velocity_th);
+      p.object_types, p.max_velocity_th, p.stopped_velocity_th, p.max_lateral_velocity_th,
+      p.safety_buffer);
   }
 
   {

--- a/planning/autoware_trajectory_modifier/src/trajectory_modifier_utils/obstacle_stop_utils.cpp
+++ b/planning/autoware_trajectory_modifier/src/trajectory_modifier_utils/obstacle_stop_utils.cpp
@@ -481,6 +481,11 @@ void ObjectFilter::filter_by_target_area(
     return t_to_obj - time_buffer;
   };
 
+  auto get_object_polygon = [&](const auto & pose, const auto & shape) {
+    const auto polygon = autoware_utils::to_polygon2d(pose, shape);
+    return autoware_utils::expand_polygon(polygon, safety_buffer_);
+  };
+
   auto is_exiting = [&](const auto & object) -> bool {
     const auto & object_pose = object.kinematics.initial_pose_with_covariance.pose;
     const auto obj_rot = Eigen::Rotation2Dd(tf2::getYaw(object_pose.orientation));
@@ -499,7 +504,7 @@ void ObjectFilter::filter_by_target_area(
     if (object.kinematics.predicted_paths.empty()) return true;
     const auto t_to_obj_current_pos = time_to_obj_current_pos(object_pose, nearest_seg);
     const auto obj_pred_pose = get_predicted_obj_pose_at_time(object, t_to_obj_current_pos);
-    const auto obj_pred_polygon = autoware_utils::to_polygon2d(obj_pred_pose, object.shape);
+    const auto obj_pred_polygon = get_object_polygon(obj_pred_pose, object.shape);
     return boost::geometry::disjoint(obj_pred_polygon, target_area);
   };
 
@@ -508,7 +513,7 @@ void ObjectFilter::filter_by_target_area(
       objects.objects.begin(), objects.objects.end(),
       [&](const auto & object) {
         const auto object_pose = object.kinematics.initial_pose_with_covariance.pose;
-        const auto object_polygon = autoware_utils::to_polygon2d(object_pose, object.shape);
+        const auto object_polygon = get_object_polygon(object_pose, object.shape);
         if (boost::geometry::disjoint(object_polygon, target_area)) return true;
         if (is_exiting(object)) return true;
         target_polygons.emplace_back(object_polygon);


### PR DESCRIPTION
diffusion planner sometimes generates trajectories that navigate very close to obstacles, resulting in dangerous situations.
In addition to having lateral margin for generating ego trajectory footprints, its also useful to have an option to expand obstacles footprint to account for perception jitter.

This PR adds parameterized safety buffer for expanding obstacle footprint when checking for overlap.

requires https://github.com/tier4/autoware_launch.x2/pull/2257