### PR TITLE
feat: cherry pick temporal controller to v0.64 e2e

### DIFF
--- a/control/autoware_mpc_lateral_controller/include/autoware/mpc_lateral_controller/mpc.hpp
+++ b/control/autoware_mpc_lateral_controller/include/autoware/mpc_lateral_controller/mpc.hpp
@@ -28,10 +28,13 @@
 #include "autoware_planning_msgs/msg/trajectory.hpp"
 #include "autoware_vehicle_msgs/msg/steering_report.hpp"
 #include "geometry_msgs/msg/pose.hpp"
+#include "geometry_msgs/msg/pose_stamped.hpp"
 #include "nav_msgs/msg/odometry.hpp"
 
 #include <deque>
+#include <limits>
 #include <memory>
+#include <optional>
 #include <string>
 #include <utility>
 #include <vector>
@@ -45,6 +48,7 @@ using autoware_internal_debug_msgs::msg::Float32MultiArrayStamped;
 using autoware_planning_msgs::msg::Trajectory;
 using autoware_vehicle_msgs::msg::SteeringReport;
 using geometry_msgs::msg::Pose;
+using geometry_msgs::msg::PoseStamped;
 using nav_msgs::msg::Odometry;
 
 using Eigen::MatrixXd;
@@ -156,6 +160,14 @@ struct MPCData
   // Pose (position and orientation) of the nearest point in the trajectory.
   Pose nearest_pose{};
 
+  // Temporal tracking debug values.
+  double temporal_predicted_time{std::numeric_limits<double>::quiet_NaN()};
+  double temporal_observed_time{std::numeric_limits<double>::quiet_NaN()};
+  double temporal_fused_time{std::numeric_limits<double>::quiet_NaN()};
+  double temporal_window_min{std::numeric_limits<double>::quiet_NaN()};
+  double temporal_window_max{std::numeric_limits<double>::quiet_NaN()};
+  bool temporal_observation_used{false};
+
   // Current steering angle.
   double steer{};
 
@@ -226,9 +238,14 @@ private:
   double m_yaw_error_prev = 0.0;       // Previous heading error for derivative calculation.
 
   bool m_is_forward_shift = true;  // Flag indicating if the shift is in the forward direction.
+  std::optional<double> m_prev_nearest_time{};            // Stabilized nearest trajectory time.
+  std::optional<rclcpp::Time> m_prev_trajectory_stamp{};  // Last received trajectory stamp.
 
   rclcpp::Publisher<Trajectory>::SharedPtr m_debug_frenet_predicted_trajectory_pub;
   rclcpp::Publisher<Trajectory>::SharedPtr m_debug_resampled_reference_trajectory_pub;
+  rclcpp::Publisher<PoseStamped>::SharedPtr m_debug_nearest_pose_pub;
+  rclcpp::Publisher<Trajectory>::SharedPtr m_debug_nearest_segment_pub;
+  rclcpp::Publisher<Float32MultiArrayStamped>::SharedPtr m_debug_nearest_info_pub;
   /**
    * @brief Get variables for MPC calculation.
    * @param trajectory The reference trajectory.
@@ -392,6 +409,15 @@ private:
     const Odometry & current_kinematics) const;
 
   /**
+   * @brief Publish nearest-point debug information for RViz and log analysis.
+   * @param traj The current reference trajectory.
+   * @param self_pose The current ego pose.
+   * @param mpc_data The nearest-point related MPC data.
+   */
+  void publishNearestDebug(
+    const MPCTrajectory & traj, const Pose & self_pose, const MPCData & mpc_data) const;
+
+  /**
    * @brief calculate steering rate limit along with the target trajectory
    * @param reference_trajectory The reference trajectory.
    * @param current_velocity current velocity of ego.
@@ -436,6 +462,9 @@ public:
 
   bool m_use_delayed_initial_state =
     true;  // Flag to use x0_delayed as initial state for predicted trajectory
+
+  bool m_use_temporal_trajectory =
+    true;  // Flag to use temporal trajectory mode (true: use timestamps, false: spatial)
 
   bool m_publish_debug_trajectories = false;  // Flag to publish predicted trajectory and
                                               // resampled reference trajectory for debug purpose

--- a/control/autoware_mpc_lateral_controller/include/autoware/mpc_lateral_controller/mpc_utils.hpp
+++ b/control/autoware_mpc_lateral_controller/include/autoware/mpc_lateral_controller/mpc_utils.hpp
@@ -176,6 +176,21 @@ std::vector<double> calcTrajectoryCurvature(
   const bool use_short_segment_protection = false);
 
 /**
+ * @brief Calculate curvature for temporal trajectories by spatially resampling.
+ * Temporal trajectories have non-uniform spatial point distribution, which makes index-based
+ * curvature calculation unreliable. This function resamples the trajectory at equal spatial
+ * intervals, calculates curvature on the resampled points, then maps the result back to the
+ * original temporal trajectory points via arc-length interpolation.
+ * @param [in] curvature_smoothing_num_traj index distance for 3 points for curvature calculation
+ * @param [in] curvature_smoothing_num_ref_steer index distance for 3 points for smoothed curvature
+ * @param [in] resample_interval_dist spatial resampling interval [m]
+ * @param [inout] traj temporal trajectory whose k and smooth_k will be updated
+ */
+void calcTrajectoryCurvatureBySpatialResample(
+  const int curvature_smoothing_num_traj, const int curvature_smoothing_num_ref_steer,
+  const double resample_interval_dist, MPCTrajectory & traj);
+
+/**
  * @brief calculate nearest pose on MPCTrajectory with linear interpolation
  * @param [in] traj reference trajectory
  * @param [in] self_pose object pose

--- a/control/autoware_mpc_lateral_controller/include/autoware/mpc_lateral_controller/mpc_utils.hpp
+++ b/control/autoware_mpc_lateral_controller/include/autoware/mpc_lateral_controller/mpc_utils.hpp
@@ -28,6 +28,7 @@
 #include "tf2_geometry_msgs/tf2_geometry_msgs.hpp"
 
 #include <cmath>
+#include <limits>
 #include <string>
 #include <utility>
 #include <vector>
@@ -68,9 +69,12 @@ double calcLateralError(const Pose & ego_pose, const Pose & ref_pose);
 /**
  * @brief convert the given Trajectory msg to a MPCTrajectory object
  * @param [in] input trajectory to convert
+ * @param [in] use_temporal_trajectory if true, use time_from_start directly; if false, calculate
+ * from distance/velocity
  * @return resulting MPCTrajectory
  */
-MPCTrajectory convertToMPCTrajectory(const Trajectory & input);
+MPCTrajectory convertToMPCTrajectory(
+  const Trajectory & input, const bool use_temporal_trajectory = true);
 
 /**
  * @brief convert the given MPCTrajectory to a Trajectory msg
@@ -130,17 +134,23 @@ bool calcMPCTrajectoryTime(MPCTrajectory & traj);
  * @param [in] acc_lim limit on the acceleration
  * @param [in] tau constant to control the smoothing (high-value = very smooth)
  * @param [inout] traj MPCTrajectory for which to calculate the smoothed velocity
+ * @param [in] use_temporal_trajectory if true, preserve timestamps; if false, recalculate time from
+ * velocity
  */
 void dynamicSmoothingVelocity(
   const size_t start_seg_idx, const double start_vel, const double acc_lim, const double tau,
-  MPCTrajectory & traj);
+  MPCTrajectory & traj, const bool use_temporal_trajectory = true);
 
 /**
  * @brief calculate yaw angle in MPCTrajectory from xy vector
  * @param [inout] traj object trajectory
  * @param [in] shift is forward or not
+ * @param [in] use_input_yaw_for_short_segment if true, preserve input yaw for very short
+ * segments
  */
-void calcTrajectoryYawFromXY(MPCTrajectory & traj, const bool is_forward_shift);
+void calcTrajectoryYawFromXY(
+  MPCTrajectory & traj, const bool is_forward_shift,
+  const bool use_input_yaw_for_short_segment = false);
 
 /**
  * @brief Calculate path curvature by 3-points circle fitting with smoothing num (use nearest 3
@@ -152,7 +162,7 @@ void calcTrajectoryYawFromXY(MPCTrajectory & traj, const bool is_forward_shift);
  */
 void calcTrajectoryCurvature(
   const int curvature_smoothing_num_traj, const int curvature_smoothing_num_ref_steer,
-  MPCTrajectory & traj);
+  MPCTrajectory & traj, const bool use_short_segment_protection = false);
 
 /**
  * @brief Calculate path curvature by 3-points circle fitting with smoothing num (use nearest 3
@@ -162,7 +172,8 @@ void calcTrajectoryCurvature(
  * @return vector of curvatures at each point of the given trajectory
  */
 std::vector<double> calcTrajectoryCurvature(
-  const int curvature_smoothing_num, const MPCTrajectory & traj);
+  const int curvature_smoothing_num, const MPCTrajectory & traj,
+  const bool use_short_segment_protection = false);
 
 /**
  * @brief calculate nearest pose on MPCTrajectory with linear interpolation
@@ -175,7 +186,10 @@ std::vector<double> calcTrajectoryCurvature(
  */
 bool calcNearestPoseInterp(
   const MPCTrajectory & traj, const Pose & self_pose, Pose * nearest_pose, size_t * nearest_index,
-  double * nearest_time, const double max_dist, const double max_yaw);
+  double * nearest_time, const double max_dist, const double max_yaw,
+  const bool use_time_window = false,
+  const double min_time_window_sec = -std::numeric_limits<double>::infinity(),
+  const double max_time_window_sec = std::numeric_limits<double>::infinity());
 
 /**
  * @brief calculate distance to stopped point

--- a/control/autoware_mpc_lateral_controller/param/lateral_controller_defaults.param.yaml
+++ b/control/autoware_mpc_lateral_controller/param/lateral_controller_defaults.param.yaml
@@ -4,6 +4,8 @@
     traj_resample_dist: 0.1         # path resampling interval [m]
     use_steer_prediction: false     # flag for using steer prediction (do not use steer measurement)
     use_delayed_initial_state: true # flag to use x0_delayed as initial state for predicted trajectory
+    # NOTE: trajectory_reference_mode is now set at trajectory_follower_node level
+    # This default file is for MPC-specific parameters only
 
     # -- path smoothing --
     enable_path_smoothing: false   # flag for path smoothing

--- a/control/autoware_mpc_lateral_controller/src/mpc.cpp
+++ b/control/autoware_mpc_lateral_controller/src/mpc.cpp
@@ -321,11 +321,11 @@ void MPC::setReferenceTrajectory(
     mpc_traj_resampled = resampled;
   }
 
-    const auto is_forward_shift =
-      autoware::motion_utils::isDrivingForward(mpc_traj_resampled.toTrajectoryPoints());
+  const auto is_forward_shift =
+    autoware::motion_utils::isDrivingForward(mpc_traj_resampled.toTrajectoryPoints());
 
-    // if driving direction is unknown, use previous value
-    m_is_forward_shift = is_forward_shift ? is_forward_shift.value() : m_is_forward_shift;
+  // if driving direction is unknown, use previous value
+  m_is_forward_shift = is_forward_shift ? is_forward_shift.value() : m_is_forward_shift;
 
   // path smoothing
   MPCTrajectory mpc_traj_smoothed = mpc_traj_resampled;  // smooth filtered trajectory
@@ -362,9 +362,15 @@ void MPC::setReferenceTrajectory(
   MPCUtils::convertEulerAngleToMonotonic(mpc_traj_smoothed.yaw);
 
   // calculate curvature
-  MPCUtils::calcTrajectoryCurvature(
-    param.curvature_smoothing_num_traj, param.curvature_smoothing_num_ref_steer, mpc_traj_smoothed,
-    m_use_temporal_trajectory);
+  if (m_use_temporal_trajectory) {
+    MPCUtils::calcTrajectoryCurvatureBySpatialResample(
+      param.curvature_smoothing_num_traj, param.curvature_smoothing_num_ref_steer,
+      param.traj_resample_dist, mpc_traj_smoothed);
+  } else {
+    MPCUtils::calcTrajectoryCurvature(
+      param.curvature_smoothing_num_traj, param.curvature_smoothing_num_ref_steer,
+      mpc_traj_smoothed);
+  }
 
   // stop velocity at a terminal point
   mpc_traj_smoothed.vx.back() = 0.0;

--- a/control/autoware_mpc_lateral_controller/src/mpc.cpp
+++ b/control/autoware_mpc_lateral_controller/src/mpc.cpp
@@ -17,12 +17,14 @@
 #include "autoware/interpolation/linear_interpolation.hpp"
 #include "autoware/motion_utils/trajectory/trajectory.hpp"
 #include "autoware/mpc_lateral_controller/mpc_utils.hpp"
+#include "autoware_utils/geometry/geometry.hpp"
 #include "autoware_utils/math/unit_conversion.hpp"
 #include "rclcpp/rclcpp.hpp"
 
 #include <fmt/format.h>
 
 #include <algorithm>
+#include <cmath>
 #include <iostream>
 #include <limits>
 #include <string>
@@ -35,12 +37,80 @@ using autoware_utils::calc_distance2d;
 using autoware_utils::normalize_radian;
 using autoware_utils::rad2deg;
 
+namespace
+{
+double estimateLocalTimeStep(const MPCTrajectory & traj, const double target_time)
+{
+  if (traj.size() < 2) {
+    return 0.0;
+  }
+
+  if (target_time <= traj.relative_time.front()) {
+    return traj.relative_time.at(1) - traj.relative_time.front();
+  }
+  if (target_time >= traj.relative_time.back()) {
+    return traj.relative_time.back() - traj.relative_time.at(traj.size() - 2);
+  }
+
+  for (size_t i = 0; i < traj.size() - 1; ++i) {
+    if (target_time <= traj.relative_time.at(i + 1)) {
+      return traj.relative_time.at(i + 1) - traj.relative_time.at(i);
+    }
+  }
+
+  return traj.relative_time.back() - traj.relative_time.at(traj.size() - 2);
+}
+
+bool interpolateReferenceStateAtTime(
+  const MPCTrajectory & traj, const double target_time, Pose * pose, double * nearest_time,
+  size_t * nearest_index)
+{
+  if (!pose || !nearest_time || !nearest_index) {
+    return false;
+  }
+  if (traj.empty()) {
+    return false;
+  }
+
+  const std::vector<double> out_time{
+    std::clamp(target_time, traj.relative_time.front(), traj.relative_time.back())};
+  MPCTrajectory interpolated;
+  if (!MPCUtils::linearInterpMPCTrajectory(traj.relative_time, traj, out_time, interpolated)) {
+    return false;
+  }
+  if (interpolated.empty()) {
+    return false;
+  }
+
+  pose->position.x = interpolated.x.front();
+  pose->position.y = interpolated.y.front();
+  pose->position.z = interpolated.z.front();
+  pose->orientation = autoware_utils::create_quaternion_from_yaw(interpolated.yaw.front());
+  *nearest_time = interpolated.relative_time.front();
+
+  const auto upper =
+    std::lower_bound(traj.relative_time.begin(), traj.relative_time.end(), *nearest_time);
+  if (upper == traj.relative_time.end()) {
+    *nearest_index = traj.size() - 1;
+  } else {
+    *nearest_index = static_cast<size_t>(std::distance(traj.relative_time.begin(), upper));
+  }
+  return true;
+}
+}  // namespace
+
 MPC::MPC(rclcpp::Node & node)
 {
   m_debug_frenet_predicted_trajectory_pub = node.create_publisher<Trajectory>(
     "~/debug/predicted_trajectory_in_frenet_coordinate", rclcpp::QoS(1));
   m_debug_resampled_reference_trajectory_pub =
     node.create_publisher<Trajectory>("~/debug/resampled_reference_trajectory", rclcpp::QoS(1));
+  m_debug_nearest_pose_pub =
+    node.create_publisher<PoseStamped>("~/debug/nearest_pose", rclcpp::QoS(1));
+  m_debug_nearest_segment_pub =
+    node.create_publisher<Trajectory>("~/debug/nearest_segment", rclcpp::QoS(1));
+  m_debug_nearest_info_pub =
+    node.create_publisher<Float32MultiArrayStamped>("~/debug/nearest_info", rclcpp::QoS(1));
 }
 
 ResultWithReason MPC::calculateMPC(
@@ -54,10 +124,22 @@ ResultWithReason MPC::calculateMPC(
     applyVelocityDynamicsFilter(m_reference_trajectory, current_kinematics);
 
   // get the necessary data
-  const auto [get_data_result, mpc_data] =
+  const auto [get_data_result, mpc_data_raw] =
     getData(reference_trajectory, current_steer, current_kinematics);
   if (!get_data_result.result) {
     return ResultWithReason{false, fmt::format("getting MPC Data ({}).", get_data_result.reason)};
+  }
+
+  // For temporal mode, shift the internal MPC time origin to the ego-projected nearest point.
+  // This keeps planner-provided time intervals while making t=0 correspond to "current ego".
+  MPCTrajectory mpc_reference_trajectory = reference_trajectory;
+  MPCData mpc_data = mpc_data_raw;
+  if (m_use_temporal_trajectory) {
+    const double nearest_time_offset = mpc_data_raw.nearest_time;
+    for (auto & t : mpc_reference_trajectory.relative_time) {
+      t -= nearest_time_offset;
+    }
+    mpc_data.nearest_time = 0.0;
   }
 
   // calculate initial state of the error dynamics
@@ -65,7 +147,7 @@ ResultWithReason MPC::calculateMPC(
 
   // apply time delay compensation to the initial state
   const auto [success_delay, x0_delayed] =
-    updateStateForDelayCompensation(reference_trajectory, mpc_data.nearest_time, x0);
+    updateStateForDelayCompensation(mpc_reference_trajectory, mpc_data.nearest_time, x0);
   if (!success_delay) {
     return ResultWithReason{false, "delay compensation."};
   }
@@ -73,10 +155,10 @@ ResultWithReason MPC::calculateMPC(
   // resample reference trajectory with mpc sampling time
   const double mpc_start_time = mpc_data.nearest_time + m_param.input_delay;
   const double prediction_dt =
-    getPredictionDeltaTime(mpc_start_time, reference_trajectory, current_kinematics);
+    getPredictionDeltaTime(mpc_start_time, mpc_reference_trajectory, current_kinematics);
 
   const auto [resample_result, mpc_resampled_ref_trajectory] =
-    resampleMPCTrajectoryByTime(mpc_start_time, prediction_dt, reference_trajectory);
+    resampleMPCTrajectoryByTime(mpc_start_time, prediction_dt, mpc_reference_trajectory);
   if (!resample_result.result) {
     return ResultWithReason{
       false, fmt::format("trajectory resampling ({}).", resample_result.reason)};
@@ -141,7 +223,7 @@ ResultWithReason MPC::calculateMPC(
     lateral.steering_tire_angle = static_cast<float>(std::clamp(*it, -m_steer_lim, m_steer_lim));
     lateral.steering_tire_rotation_rate =
       (lateral.steering_tire_angle - ctrl_cmd_horizon.controls.back().steering_tire_angle) /
-      m_ctrl_period;
+      prediction_dt;
     ctrl_cmd_horizon.controls.push_back(lateral);
   }
 
@@ -192,6 +274,12 @@ Float32MultiArrayStamped MPC::generateDiagData(
   append_diag(iteration_num);             // [18] iteration number
   append_diag(runtime);                   // [19] runtime of the latest problem solved
   append_diag(objective_value);           // [20] objective value of the latest problem solved
+  append_diag(mpc_data.temporal_predicted_time);                // [21] temporal predicted time
+  append_diag(mpc_data.temporal_observed_time);                 // [22] temporal observed time
+  append_diag(mpc_data.temporal_fused_time);                    // [23] temporal fused time
+  append_diag(mpc_data.temporal_observation_used ? 1.0 : 0.0);  // [24] observation used
+  append_diag(mpc_data.temporal_window_min);                    // [25] temporal window min
+  append_diag(mpc_data.temporal_window_max);                    // [26] temporal window max
 
   return diagnostic;
 }
@@ -200,6 +288,13 @@ void MPC::setReferenceTrajectory(
   const Trajectory & trajectory_msg, const TrajectoryFilteringParam & param,
   const Odometry & current_kinematics)
 {
+  if (m_use_temporal_trajectory) {
+    const rclcpp::Time current_stamp(trajectory_msg.header.stamp);
+    m_prev_trajectory_stamp = current_stamp;
+  } else {
+    m_prev_trajectory_stamp.reset();
+  }
+
   const size_t nearest_seg_idx =
     autoware::motion_utils::findFirstNearestSegmentIndexWithSoftConstraints(
       trajectory_msg.points, current_kinematics.pose.pose, ego_nearest_dist_threshold,
@@ -207,21 +302,37 @@ void MPC::setReferenceTrajectory(
   const double ego_offset_to_segment = autoware::motion_utils::calcLongitudinalOffsetToSegment(
     trajectory_msg.points, nearest_seg_idx, current_kinematics.pose.pose.position);
 
-  const auto mpc_traj_raw = MPCUtils::convertToMPCTrajectory(trajectory_msg);
+  const auto mpc_traj_raw =
+    MPCUtils::convertToMPCTrajectory(trajectory_msg, m_use_temporal_trajectory);
 
   // resampling
-  const auto [success_resample, mpc_traj_resampled] = MPCUtils::resampleMPCTrajectoryByDistance(
-    mpc_traj_raw, param.traj_resample_dist, nearest_seg_idx, ego_offset_to_segment);
-  if (!success_resample) {
-    warn_throttle("[setReferenceTrajectory] spline error when resampling by distance");
-    return;
+  // Note: For temporal trajectories, skip distance-based resampling to preserve timestamps.
+  // Time-based resampling will be performed later in calculateMPC().
+  MPCTrajectory mpc_traj_resampled;
+  if (m_use_temporal_trajectory) {
+    mpc_traj_resampled = mpc_traj_raw;
+  } else {
+    const auto [success_resample, resampled] = MPCUtils::resampleMPCTrajectoryByDistance(
+      mpc_traj_raw, param.traj_resample_dist, nearest_seg_idx, ego_offset_to_segment);
+    if (!success_resample) {
+      warn_throttle("[setReferenceTrajectory] spline error when resampling by distance");
+      return;
+    }
+    mpc_traj_resampled = resampled;
   }
 
-  const auto is_forward_shift =
-    autoware::motion_utils::isDrivingForward(mpc_traj_resampled.toTrajectoryPoints());
+  if (m_use_temporal_trajectory) {
+    // Temporary policy for temporal mode: force forward direction.
+    // TODO(go-sakayori): Revisit with velocity-sign-based direction detection when reverse
+    // support is required in temporal mode.
+    m_is_forward_shift = true;
+  } else {
+    const auto is_forward_shift =
+      autoware::motion_utils::isDrivingForward(mpc_traj_resampled.toTrajectoryPoints());
 
-  // if driving direction is unknown, use previous value
-  m_is_forward_shift = is_forward_shift ? is_forward_shift.value() : m_is_forward_shift;
+    // if driving direction is unknown, use previous value
+    m_is_forward_shift = is_forward_shift ? is_forward_shift.value() : m_is_forward_shift;
+  }
 
   // path smoothing
   MPCTrajectory mpc_traj_smoothed = mpc_traj_resampled;  // smooth filtered trajectory
@@ -252,12 +363,15 @@ void MPC::setReferenceTrajectory(
   }
 
   // calculate yaw angle
-  MPCUtils::calcTrajectoryYawFromXY(mpc_traj_smoothed, m_is_forward_shift);
+  const bool use_input_yaw_for_short_segment = m_use_temporal_trajectory;
+  MPCUtils::calcTrajectoryYawFromXY(
+    mpc_traj_smoothed, m_is_forward_shift, use_input_yaw_for_short_segment);
   MPCUtils::convertEulerAngleToMonotonic(mpc_traj_smoothed.yaw);
 
   // calculate curvature
   MPCUtils::calcTrajectoryCurvature(
-    param.curvature_smoothing_num_traj, param.curvature_smoothing_num_ref_steer, mpc_traj_smoothed);
+    param.curvature_smoothing_num_traj, param.curvature_smoothing_num_ref_steer, mpc_traj_smoothed,
+    m_use_temporal_trajectory);
 
   // stop velocity at a terminal point
   mpc_traj_smoothed.vx.back() = 0.0;
@@ -292,10 +406,56 @@ std::pair<ResultWithReason, MPCData> MPC::getData(
   const auto current_pose = current_kinematics.pose.pose;
 
   MPCData data;
-  if (!MPCUtils::calcNearestPoseInterp(
-        traj, current_pose, &(data.nearest_pose), &(data.nearest_idx), &(data.nearest_time),
-        ego_nearest_dist_threshold, ego_nearest_yaw_threshold)) {
-    return {ResultWithReason{false, "error in calculating nearest pose"}, MPCData{}};
+  if (m_use_temporal_trajectory) {
+    const double traj_start_time = traj.relative_time.front();
+    const double traj_end_time = traj.relative_time.back();
+    const double prev_nearest_time =
+      m_prev_nearest_time.has_value()
+        ? std::clamp(*m_prev_nearest_time, traj_start_time, traj_end_time)
+        : traj_start_time;
+    const double predicted_time =
+      std::clamp(prev_nearest_time + m_ctrl_period, traj_start_time, traj_end_time);
+    const double local_dt =
+      std::max(estimateLocalTimeStep(traj, predicted_time), std::max(m_ctrl_period, 1.0e-3));
+    const double backward_window = std::max(local_dt, m_ctrl_period);
+    const double forward_window = std::max(3.0 * local_dt, m_ctrl_period);
+    data.temporal_predicted_time = predicted_time;
+    data.temporal_window_min = predicted_time - backward_window;
+    data.temporal_window_max = predicted_time + forward_window;
+
+    Pose observed_pose{};
+    size_t observed_index = 0;
+    double observed_time = predicted_time;
+    const bool observed = MPCUtils::calcNearestPoseInterp(
+      traj, current_pose, &observed_pose, &observed_index, &observed_time,
+      ego_nearest_dist_threshold, ego_nearest_yaw_threshold, true, predicted_time - backward_window,
+      predicted_time + forward_window);
+
+    double fused_time = predicted_time;
+    if (observed) {
+      data.temporal_observed_time = observed_time;
+      data.temporal_observation_used = true;
+      const double max_phase_correction = std::max(2.0 * local_dt, m_ctrl_period);
+      const double bounded_correction =
+        std::clamp(observed_time - predicted_time, -max_phase_correction, max_phase_correction);
+      constexpr double observation_gain = 0.5;
+      fused_time = std::clamp(
+        predicted_time + observation_gain * bounded_correction, traj_start_time, traj_end_time);
+    }
+    data.temporal_fused_time = fused_time;
+
+    if (!interpolateReferenceStateAtTime(
+          traj, fused_time, &(data.nearest_pose), &(data.nearest_time), &(data.nearest_idx))) {
+      return {ResultWithReason{false, "error in calculating temporal nearest pose"}, MPCData{}};
+    }
+    m_prev_nearest_time = data.nearest_time;
+  } else {
+    if (!MPCUtils::calcNearestPoseInterp(
+          traj, current_pose, &(data.nearest_pose), &(data.nearest_idx), &(data.nearest_time),
+          ego_nearest_dist_threshold, ego_nearest_yaw_threshold)) {
+      return {ResultWithReason{false, "error in calculating nearest pose"}, MPCData{}};
+    }
+    m_prev_nearest_time.reset();
   }
 
   // get data
@@ -307,14 +467,119 @@ std::pair<ResultWithReason, MPCData> MPC::getData(
   // get predicted steer
   data.predicted_steer = m_steering_predictor->calcSteerPrediction();
 
+  if (m_publish_debug_trajectories) {
+    publishNearestDebug(traj, current_pose, data);
+  }
+
   // check trajectory time length
-  const double max_prediction_time =
-    m_param.min_prediction_length / static_cast<double>(m_param.prediction_horizon - 1);
-  auto end_time = data.nearest_time + m_param.input_delay + m_ctrl_period + max_prediction_time;
+  const double required_prediction_time = [&]() {
+    if (m_use_temporal_trajectory) {
+      return m_param.prediction_dt * static_cast<double>(m_param.prediction_horizon - 1);
+    }
+    return m_param.min_prediction_length / static_cast<double>(m_param.prediction_horizon - 1);
+  }();
+  auto end_time =
+    data.nearest_time + m_param.input_delay + m_ctrl_period + required_prediction_time;
   if (end_time > traj.relative_time.back()) {
     return {ResultWithReason{false, "path is too short for prediction."}, MPCData{}};
   }
   return {ResultWithReason{true}, data};
+}
+
+void MPC::publishNearestDebug(
+  const MPCTrajectory & traj, const Pose & self_pose, const MPCData & mpc_data) const
+{
+  if (traj.empty()) {
+    return;
+  }
+
+  const auto now = m_clock->now();
+  const auto autoware_traj = MPCUtils::convertToAutowareTrajectory(traj);
+  if (autoware_traj.points.empty()) {
+    return;
+  }
+
+  const size_t nearest_idx = std::min(mpc_data.nearest_idx, traj.size() - 1);
+
+  PoseStamped nearest_pose_msg;
+  nearest_pose_msg.header.stamp = now;
+  nearest_pose_msg.header.frame_id = "map";
+  nearest_pose_msg.pose = mpc_data.nearest_pose;
+  m_debug_nearest_pose_pub->publish(nearest_pose_msg);
+
+  size_t prev_idx = nearest_idx;
+  size_t next_idx = nearest_idx;
+  if (traj.size() >= 2) {
+    if (nearest_idx == 0) {
+      prev_idx = 0;
+      next_idx = 1;
+    } else if (nearest_idx == traj.size() - 1) {
+      prev_idx = traj.size() - 2;
+      next_idx = traj.size() - 1;
+    } else {
+      const double signed_length = autoware::motion_utils::calcLongitudinalOffsetToSegment(
+        autoware_traj.points, nearest_idx, self_pose.position);
+      if (signed_length <= 0.0) {
+        prev_idx = nearest_idx - 1;
+        next_idx = nearest_idx;
+      } else {
+        prev_idx = nearest_idx;
+        next_idx = nearest_idx + 1;
+      }
+    }
+  }
+
+  Trajectory nearest_segment_msg;
+  nearest_segment_msg.header.stamp = now;
+  nearest_segment_msg.header.frame_id = "map";
+  nearest_segment_msg.points.push_back(autoware_traj.points.at(prev_idx));
+  if (nearest_idx != prev_idx && nearest_idx != next_idx) {
+    nearest_segment_msg.points.push_back(autoware_traj.points.at(nearest_idx));
+  }
+  if (next_idx != prev_idx) {
+    nearest_segment_msg.points.push_back(autoware_traj.points.at(next_idx));
+  }
+  m_debug_nearest_segment_pub->publish(nearest_segment_msg);
+
+  const double prev_t = traj.relative_time.at(prev_idx);
+  const double next_t = traj.relative_time.at(next_idx);
+  const double dt = next_t - prev_t;
+  const double ratio = (std::fabs(dt) < std::numeric_limits<double>::epsilon())
+                         ? 0.0
+                         : std::clamp((mpc_data.nearest_time - prev_t) / dt, 0.0, 1.0);
+
+  const double dx = self_pose.position.x - mpc_data.nearest_pose.position.x;
+  const double dy = self_pose.position.y - mpc_data.nearest_pose.position.y;
+  const double distance = std::hypot(dx, dy);
+  const double nearest_yaw = tf2::getYaw(mpc_data.nearest_pose.orientation);
+  const double longitudinal_error = std::cos(nearest_yaw) * dx + std::sin(nearest_yaw) * dy;
+
+  Float32MultiArrayStamped info_msg;
+  info_msg.stamp = now;
+  info_msg.data.reserve(15);
+  info_msg.data.push_back(static_cast<float>(nearest_idx));            // [0] nearest_idx
+  info_msg.data.push_back(static_cast<float>(mpc_data.nearest_time));  // [1] nearest_time [s]
+  info_msg.data.push_back(static_cast<float>(prev_idx));               // [2] prev_idx
+  info_msg.data.push_back(static_cast<float>(next_idx));               // [3] next_idx
+  info_msg.data.push_back(static_cast<float>(prev_t));                 // [4] prev_time [s]
+  info_msg.data.push_back(static_cast<float>(next_t));                 // [5] next_time [s]
+  info_msg.data.push_back(static_cast<float>(ratio));                  // [6] interpolation ratio
+  info_msg.data.push_back(static_cast<float>(distance));  // [7] ego-nearest distance [m]
+  info_msg.data.push_back(
+    static_cast<float>(longitudinal_error));  // [8] signed longitudinal error [m]
+  info_msg.data.push_back(
+    static_cast<float>(mpc_data.temporal_predicted_time));  // [9] temporal predicted time [s]
+  info_msg.data.push_back(
+    static_cast<float>(mpc_data.temporal_observed_time));  // [10] temporal observed time [s]
+  info_msg.data.push_back(
+    static_cast<float>(mpc_data.temporal_fused_time));  // [11] temporal fused time [s]
+  info_msg.data.push_back(
+    static_cast<float>(mpc_data.temporal_observation_used ? 1.0 : 0.0));  // [12] used
+  info_msg.data.push_back(
+    static_cast<float>(mpc_data.temporal_window_min));  // [13] temporal window min [s]
+  info_msg.data.push_back(
+    static_cast<float>(mpc_data.temporal_window_max));  // [14] temporal window max [s]
+  m_debug_nearest_info_pub->publish(info_msg);
 }
 
 std::pair<ResultWithReason, MPCTrajectory> MPC::resampleMPCTrajectoryByTime(
@@ -423,7 +688,7 @@ MPCTrajectory MPC::applyVelocityDynamicsFilter(
   MPCTrajectory output = input;
   MPCUtils::dynamicSmoothingVelocity(
     nearest_seg_idx, current_kinematics.twist.twist.linear.x, m_param.acceleration_limit,
-    m_param.velocity_time_constant, output);
+    m_param.velocity_time_constant, output, m_use_temporal_trajectory);
 
   auto last_point = output.back();
   last_point.relative_time += 100.0;  // extra time to prevent mpc calc failure due to short time
@@ -698,35 +963,60 @@ void MPC::addSteerWeightF(const double prediction_dt, MatrixXd & f) const
 double MPC::getPredictionDeltaTime(
   const double start_time, const MPCTrajectory & input, const Odometry & current_kinematics) const
 {
-  // Calculate the time min_prediction_length ahead from current_pose
-  const auto autoware_traj = MPCUtils::convertToAutowareTrajectory(input);
-  const size_t nearest_idx = autoware::motion_utils::findFirstNearestIndexWithSoftConstraints(
-    autoware_traj.points, current_kinematics.pose.pose, ego_nearest_dist_threshold,
-    ego_nearest_yaw_threshold);
-  double sum_dist = 0;
-  const double target_time = [&]() {
+  if (m_use_temporal_trajectory) {
+    // Temporal mode: use fixed prediction_dt from parameters
+    // Calculate the end time of the prediction horizon
+    const double horizon_end_time =
+      start_time + m_param.prediction_dt * static_cast<double>(m_param.prediction_horizon - 1);
+
+    // Check if the trajectory is long enough to cover the prediction horizon
     const double t_ext = 100.0;  // extra time to prevent mpc calculation failure due to short time
-    for (size_t i = nearest_idx + 1; i < input.relative_time.size(); i++) {
-      const double segment_dist = MPCUtils::calcDistance2d(input, i, i - 1);
-      sum_dist += segment_dist;
-      if (m_param.min_prediction_length < sum_dist) {
-        const double prev_sum_dist = sum_dist - segment_dist;
-        const double ratio = (m_param.min_prediction_length - prev_sum_dist) / segment_dist;
-        const double relative_time_at_i = i == input.relative_time.size() - 1
-                                            ? input.relative_time.at(i) - t_ext
-                                            : input.relative_time.at(i);
-        return input.relative_time.at(i - 1) +
-               (relative_time_at_i - input.relative_time.at(i - 1)) * ratio;
-      }
+    const double available_end_time = input.relative_time.back() - t_ext;
+
+    if (horizon_end_time > available_end_time) {
+      // If trajectory is too short, reduce dt to fit within available trajectory
+      const double available_time = available_end_time - start_time;
+      const double reduced_dt =
+        available_time / static_cast<double>(m_param.prediction_horizon - 1);
+      // Use reduced dt, but ensure it's not too small (at least 10% of nominal dt)
+      return std::max(reduced_dt, m_param.prediction_dt * 0.1);
     }
-    return input.relative_time.back() - t_ext;
-  }();
 
-  // Calculate delta time for min_prediction_length
-  const double dt =
-    (target_time - start_time) / static_cast<double>(m_param.prediction_horizon - 1);
+    // Trajectory is long enough, use nominal prediction_dt
+    return m_param.prediction_dt;
+  } else {
+    // Spatial mode (original implementation): calculate dt from distance
+    // Calculate the time min_prediction_length ahead from current_pose
+    const auto autoware_traj = MPCUtils::convertToAutowareTrajectory(input);
+    const size_t nearest_idx = autoware::motion_utils::findFirstNearestIndexWithSoftConstraints(
+      autoware_traj.points, current_kinematics.pose.pose, ego_nearest_dist_threshold,
+      ego_nearest_yaw_threshold);
+    double sum_dist = 0;
+    const double target_time = [&]() {
+      const double t_ext =
+        100.0;  // extra time to prevent mpc calculation failure due to short time
+      for (size_t i = nearest_idx + 1; i < input.relative_time.size(); i++) {
+        const double segment_dist = MPCUtils::calcDistance2d(input, i, i - 1);
+        sum_dist += segment_dist;
+        if (m_param.min_prediction_length < sum_dist) {
+          const double prev_sum_dist = sum_dist - segment_dist;
+          const double ratio = (m_param.min_prediction_length - prev_sum_dist) / segment_dist;
+          const double relative_time_at_i = i == input.relative_time.size() - 1
+                                              ? input.relative_time.at(i) - t_ext
+                                              : input.relative_time.at(i);
+          return input.relative_time.at(i - 1) +
+                 (relative_time_at_i - input.relative_time.at(i - 1)) * ratio;
+        }
+      }
+      return input.relative_time.back() - t_ext;
+    }();
 
-  return std::max(dt, m_param.prediction_dt);
+    // Calculate delta time for min_prediction_length
+    const double dt =
+      (target_time - start_time) / static_cast<double>(m_param.prediction_horizon - 1);
+
+    return std::max(dt, m_param.prediction_dt);
+  }
 }
 
 double MPC::calcDesiredSteeringRate(

--- a/control/autoware_mpc_lateral_controller/src/mpc.cpp
+++ b/control/autoware_mpc_lateral_controller/src/mpc.cpp
@@ -321,18 +321,11 @@ void MPC::setReferenceTrajectory(
     mpc_traj_resampled = resampled;
   }
 
-  if (m_use_temporal_trajectory) {
-    // Temporary policy for temporal mode: force forward direction.
-    // TODO(go-sakayori): Revisit with velocity-sign-based direction detection when reverse
-    // support is required in temporal mode.
-    m_is_forward_shift = true;
-  } else {
     const auto is_forward_shift =
       autoware::motion_utils::isDrivingForward(mpc_traj_resampled.toTrajectoryPoints());
 
     // if driving direction is unknown, use previous value
     m_is_forward_shift = is_forward_shift ? is_forward_shift.value() : m_is_forward_shift;
-  }
 
   // path smoothing
   MPCTrajectory mpc_traj_smoothed = mpc_traj_resampled;  // smooth filtered trajectory

--- a/control/autoware_mpc_lateral_controller/src/mpc_lateral_controller.cpp
+++ b/control/autoware_mpc_lateral_controller/src/mpc_lateral_controller.cpp
@@ -26,9 +26,11 @@
 #include <tf2/utils.hpp>
 
 #include <algorithm>
+#include <cmath>
 #include <deque>
 #include <limits>
 #include <memory>
+#include <stdexcept>
 #include <string>
 #include <utility>
 #include <vector>
@@ -144,6 +146,22 @@ MpcLateralController::MpcLateralController(
   m_mpc->ego_nearest_yaw_threshold = m_ego_nearest_yaw_threshold;
 
   m_mpc->m_use_delayed_initial_state = dp_bool("use_delayed_initial_state");
+
+  // trajectory_reference_mode is declared at controller_node level
+  // If not available, declare it with default value for standalone usage
+  const auto trajectory_reference_mode =
+    node.has_parameter("trajectory_reference_mode")
+      ? node.get_parameter("trajectory_reference_mode").as_string()
+      : node.declare_parameter<std::string>("trajectory_reference_mode", "spatial");
+
+  if (trajectory_reference_mode == "temporal") {
+    m_mpc->m_use_temporal_trajectory = true;
+  } else if (trajectory_reference_mode == "spatial") {
+    m_mpc->m_use_temporal_trajectory = false;
+  } else {
+    throw std::invalid_argument(
+      "Invalid trajectory_reference_mode. Expected \"spatial\" or \"temporal\".");
+  }
 
   m_mpc->m_publish_debug_trajectories = dp_bool("publish_debug_trajectories");
 
@@ -685,6 +703,7 @@ bool MpcLateralController::isTrajectoryShapeChanged() const
 
 bool MpcLateralController::isValidTrajectory(const Trajectory & traj) const
 {
+  double prev_time_from_start = -std::numeric_limits<double>::infinity();
   for (const auto & p : traj.points) {
     if (
       !isfinite(p.pose.position.x) || !isfinite(p.pose.position.y) ||
@@ -694,6 +713,14 @@ bool MpcLateralController::isValidTrajectory(const Trajectory & traj) const
       !isfinite(p.heading_rate_rps) || !isfinite(p.front_wheel_angle_rad) ||
       !isfinite(p.rear_wheel_angle_rad)) {
       return false;
+    }
+
+    if (m_mpc->m_use_temporal_trajectory) {
+      const double t = rclcpp::Duration(p.time_from_start).seconds();
+      if (!std::isfinite(t) || t <= prev_time_from_start) {
+        return false;
+      }
+      prev_time_from_start = t;
     }
   }
   return true;

--- a/control/autoware_mpc_lateral_controller/src/mpc_utils.cpp
+++ b/control/autoware_mpc_lateral_controller/src/mpc_utils.cpp
@@ -40,6 +40,28 @@ double calcLongitudinalOffset(
 
   return segment_vec.dot(target_vec) / segment_vec.norm();
 }
+
+bool isTemporalShortSegment(
+  const double ds, const double dt, const double vx, const bool use_short_segment_protection)
+{
+  if (!use_short_segment_protection) {
+    return ds < 1.0e-3;
+  }
+
+  constexpr double min_distance_threshold = 2.0e-2;
+  constexpr double stop_like_velocity_threshold = 1.0e-1;
+  constexpr double min_velocity_floor = 1.0e-1;
+  constexpr double expected_distance_ratio = 0.5;
+  constexpr double min_time_step = 1.0e-3;
+
+  if (ds < min_distance_threshold && std::fabs(vx) < stop_like_velocity_threshold) {
+    return true;
+  }
+
+  const double bounded_dt = std::max(dt, min_time_step);
+  const double expected_distance = std::max(std::fabs(vx), min_velocity_floor) * bounded_dt;
+  return ds < expected_distance_ratio * expected_distance;
+}
 }  // namespace
 
 namespace MPCUtils
@@ -191,7 +213,8 @@ bool linearInterpMPCTrajectory(
   return true;
 }
 
-void calcTrajectoryYawFromXY(MPCTrajectory & traj, const bool is_forward_shift)
+void calcTrajectoryYawFromXY(
+  MPCTrajectory & traj, const bool is_forward_shift, const bool use_input_yaw_for_short_segment)
 {
   if (traj.yaw.size() < 3) {  // at least 3 points are required to calculate yaw
     return;
@@ -201,30 +224,77 @@ void calcTrajectoryYawFromXY(MPCTrajectory & traj, const bool is_forward_shift)
     return;
   }
 
+  const auto input_yaw = traj.yaw;
+
   // interpolate yaw
   for (int i = 1; i < static_cast<int>(traj.yaw.size()) - 1; ++i) {
     const double dx = traj.x.at(i + 1) - traj.x.at(i - 1);
     const double dy = traj.y.at(i + 1) - traj.y.at(i - 1);
+    const auto curr_idx = static_cast<size_t>(i);
+    const double prev_dist = calcDistance2d(traj, curr_idx, curr_idx - 1);
+    const double next_dist = calcDistance2d(traj, curr_idx + 1, curr_idx);
+    const double prev_dt = traj.relative_time.at(curr_idx) - traj.relative_time.at(curr_idx - 1);
+    const double next_dt = traj.relative_time.at(curr_idx + 1) - traj.relative_time.at(curr_idx);
+    const double prev_vx = 0.5 * (traj.vx.at(curr_idx - 1) + traj.vx.at(curr_idx));
+    const double next_vx = 0.5 * (traj.vx.at(curr_idx) + traj.vx.at(curr_idx + 1));
+    if (
+      std::hypot(dx, dy) < 1.0e-3 ||
+      isTemporalShortSegment(prev_dist, prev_dt, prev_vx, use_input_yaw_for_short_segment) ||
+      isTemporalShortSegment(next_dist, next_dt, next_vx, use_input_yaw_for_short_segment)) {
+      traj.yaw.at(i) = use_input_yaw_for_short_segment ? input_yaw.at(i) : traj.yaw.at(i - 1);
+      continue;
+    }
     traj.yaw.at(i) = is_forward_shift ? std::atan2(dy, dx) : std::atan2(dy, dx) + M_PI;
   }
   if (traj.yaw.size() > 1) {
-    traj.yaw.at(0) = traj.yaw.at(1);
-    traj.yaw.back() = traj.yaw.at(traj.yaw.size() - 2);
+    const double dx0 = traj.x.at(1) - traj.x.at(0);
+    const double dy0 = traj.y.at(1) - traj.y.at(0);
+    const double ds0 = calcDistance2d(traj, 1, 0);
+    const double dt0 = traj.relative_time.at(1) - traj.relative_time.at(0);
+    const double vx0 = 0.5 * (traj.vx.at(0) + traj.vx.at(1));
+    if (
+      std::hypot(dx0, dy0) >= 1.0e-3 &&
+      !isTemporalShortSegment(ds0, dt0, vx0, use_input_yaw_for_short_segment)) {
+      traj.yaw.at(0) = is_forward_shift ? std::atan2(dy0, dx0) : std::atan2(dy0, dx0) + M_PI;
+    } else {
+      traj.yaw.at(0) = use_input_yaw_for_short_segment ? input_yaw.at(0) : traj.yaw.at(1);
+    }
+
+    const size_t last = traj.yaw.size() - 1;
+    const double dxn = traj.x.at(last) - traj.x.at(last - 1);
+    const double dyn = traj.y.at(last) - traj.y.at(last - 1);
+    const double dsn = calcDistance2d(traj, last, last - 1);
+    const double dtn = traj.relative_time.at(last) - traj.relative_time.at(last - 1);
+    const double vxn = 0.5 * (traj.vx.at(last - 1) + traj.vx.at(last));
+    if (
+      std::hypot(dxn, dyn) >= 1.0e-3 &&
+      !isTemporalShortSegment(dsn, dtn, vxn, use_input_yaw_for_short_segment)) {
+      traj.yaw.back() = is_forward_shift ? std::atan2(dyn, dxn) : std::atan2(dyn, dxn) + M_PI;
+    } else {
+      traj.yaw.back() =
+        use_input_yaw_for_short_segment ? input_yaw.at(last) : traj.yaw.at(last - 1);
+    }
   }
 }
 
 void calcTrajectoryCurvature(
   const int curvature_smoothing_num_traj, const int curvature_smoothing_num_ref_steer,
-  MPCTrajectory & traj)
+  MPCTrajectory & traj, const bool use_short_segment_protection)
 {
-  traj.k = calcTrajectoryCurvature(curvature_smoothing_num_traj, traj);
-  traj.smooth_k = calcTrajectoryCurvature(curvature_smoothing_num_ref_steer, traj);
+  traj.k =
+    calcTrajectoryCurvature(curvature_smoothing_num_traj, traj, use_short_segment_protection);
+  traj.smooth_k =
+    calcTrajectoryCurvature(curvature_smoothing_num_ref_steer, traj, use_short_segment_protection);
 }
 
 std::vector<double> calcTrajectoryCurvature(
-  const int curvature_smoothing_num, const MPCTrajectory & traj)
+  const int curvature_smoothing_num, const MPCTrajectory & traj,
+  const bool use_short_segment_protection)
 {
   std::vector<double> curvature_vec(traj.x.size());
+  if (traj.x.size() < 3) {
+    return curvature_vec;
+  }
 
   /* calculate curvature by circle fitting from three points */
   geometry_msgs::msg::Point p1, p2, p3;
@@ -235,6 +305,22 @@ std::vector<double> calcTrajectoryCurvature(
     const size_t curr_idx = i;
     const size_t prev_idx = curr_idx - L;
     const size_t next_idx = curr_idx + L;
+    const double dist_prev = calcDistance2d(traj, curr_idx, prev_idx);
+    const double dist_next = calcDistance2d(traj, next_idx, curr_idx);
+    const double dist_span = calcDistance2d(traj, next_idx, prev_idx);
+    const double dt_prev = traj.relative_time.at(curr_idx) - traj.relative_time.at(prev_idx);
+    const double dt_next = traj.relative_time.at(next_idx) - traj.relative_time.at(curr_idx);
+    const double dt_span = traj.relative_time.at(next_idx) - traj.relative_time.at(prev_idx);
+    const double vx_prev = 0.5 * (traj.vx.at(prev_idx) + traj.vx.at(curr_idx));
+    const double vx_next = 0.5 * (traj.vx.at(curr_idx) + traj.vx.at(next_idx));
+    const double vx_span = 0.5 * (traj.vx.at(prev_idx) + traj.vx.at(next_idx));
+    if (
+      isTemporalShortSegment(dist_prev, dt_prev, vx_prev, use_short_segment_protection) ||
+      isTemporalShortSegment(dist_next, dt_next, vx_next, use_short_segment_protection) ||
+      isTemporalShortSegment(dist_span, dt_span, vx_span, use_short_segment_protection)) {
+      curvature_vec.at(curr_idx) = curr_idx > 0 ? curvature_vec.at(curr_idx - 1) : 0.0;
+      continue;
+    }
     p1.x = traj.x.at(prev_idx);
     p2.x = traj.x.at(curr_idx);
     p3.x = traj.x.at(next_idx);
@@ -245,7 +331,7 @@ std::vector<double> calcTrajectoryCurvature(
       curvature_vec.at(curr_idx) = autoware_utils::calc_curvature(p1, p2, p3);
     } catch (...) {
       std::cerr << "[MPC] 2 points are too close to calculate curvature." << std::endl;
-      curvature_vec.at(curr_idx) = 0.0;
+      curvature_vec.at(curr_idx) = curr_idx > 0 ? curvature_vec.at(curr_idx - 1) : 0.0;
     }
   }
 
@@ -258,7 +344,7 @@ std::vector<double> calcTrajectoryCurvature(
   return curvature_vec;
 }
 
-MPCTrajectory convertToMPCTrajectory(const Trajectory & input)
+MPCTrajectory convertToMPCTrajectory(const Trajectory & input, const bool use_temporal_trajectory)
 {
   MPCTrajectory output;
   for (const TrajectoryPoint & p : input.points) {
@@ -268,10 +354,18 @@ MPCTrajectory convertToMPCTrajectory(const Trajectory & input)
     const double yaw = tf2::getYaw(p.pose.orientation);
     const double vx = p.longitudinal_velocity_mps;
     const double k = 0.0;
-    const double t = 0.0;
+
+    // Time handling: temporal (use timestamps) vs spatial (calculate from distance/velocity)
+    const double t = use_temporal_trajectory
+                       ? rclcpp::Duration(p.time_from_start).seconds()
+                       : 0.0;  // Will be recalculated by calcMPCTrajectoryTime()
     output.push_back(x, y, z, yaw, vx, k, k, t);
   }
-  calcMPCTrajectoryTime(output);
+
+  if (!use_temporal_trajectory) {
+    calcMPCTrajectoryTime(output);
+  }
+
   return output;
 }
 
@@ -316,7 +410,7 @@ bool calcMPCTrajectoryTime(MPCTrajectory & traj)
 
 void dynamicSmoothingVelocity(
   const size_t start_seg_idx, const double start_vel, const double acc_lim, const double tau,
-  MPCTrajectory & traj)
+  MPCTrajectory & traj, const bool use_temporal_trajectory)
 {
   double curr_v = start_vel;
   // set current velocity in both start and end point of the segment
@@ -327,19 +421,32 @@ void dynamicSmoothingVelocity(
 
   for (size_t i = start_seg_idx + 2; i < traj.size(); ++i) {
     const double ds = calcDistance2d(traj, i, i - 1);
-    const double dt = ds / std::max(std::fabs(curr_v), std::numeric_limits<double>::epsilon());
+    const double dt = [&]() {
+      if (use_temporal_trajectory) {
+        const double time_dt = traj.relative_time.at(i) - traj.relative_time.at(i - 1);
+        constexpr double min_time_dt = 1.0e-4;
+        return std::max(time_dt, min_time_dt);
+      }
+      return ds / std::max(std::fabs(curr_v), std::numeric_limits<double>::epsilon());
+    }();
     const double a = tau / std::max(tau + dt, std::numeric_limits<double>::epsilon());
     const double updated_v = a * curr_v + (1.0 - a) * traj.vx.at(i);
     const double dv = std::max(-acc_lim * dt, std::min(acc_lim * dt, updated_v - curr_v));
     curr_v = curr_v + dv;
     traj.vx.at(i) = curr_v;
   }
-  calcMPCTrajectoryTime(traj);
+
+  if (!use_temporal_trajectory) {
+    // Spatial mode: recalculate time after velocity changes
+    calcMPCTrajectoryTime(traj);
+  }
+  // Temporal mode keeps timestamps and updates velocity using time delta.
 }
 
 bool calcNearestPoseInterp(
   const MPCTrajectory & traj, const Pose & self_pose, Pose * nearest_pose, size_t * nearest_index,
-  double * nearest_time, const double max_dist, const double max_yaw)
+  double * nearest_time, const double max_dist, const double max_yaw, const bool use_time_window,
+  const double min_time_window_sec, const double max_time_window_sec)
 {
   if (traj.empty() || !nearest_pose || !nearest_index || !nearest_time) {
     return false;
@@ -355,6 +462,42 @@ bool calcNearestPoseInterp(
 
   *nearest_index = autoware::motion_utils::findFirstNearestIndexWithSoftConstraints(
     autoware_traj.points, self_pose, max_dist, max_yaw);
+  if (use_time_window) {
+    const double min_time_sec = std::min(min_time_window_sec, max_time_window_sec);
+    const double max_time_sec = std::max(min_time_window_sec, max_time_window_sec);
+    std::vector<size_t> candidates;
+    candidates.reserve(traj.size());
+    for (size_t i = 0; i < traj.size(); ++i) {
+      const double t = traj.relative_time.at(i);
+      if (min_time_sec <= t && t <= max_time_sec) {
+        candidates.push_back(i);
+      }
+    }
+    if (!candidates.empty()) {
+      const double self_yaw = tf2::getYaw(self_pose.orientation);
+      size_t best_relaxed_idx = candidates.front();
+      double best_relaxed_dist2 = std::numeric_limits<double>::max();
+      size_t best_strict_idx = candidates.front();
+      double best_strict_dist2 = std::numeric_limits<double>::max();
+      bool has_strict_candidate = false;
+      for (const auto idx : candidates) {
+        const double dx = traj.x.at(idx) - self_pose.position.x;
+        const double dy = traj.y.at(idx) - self_pose.position.y;
+        const double dist2 = dx * dx + dy * dy;
+        if (dist2 < best_relaxed_dist2) {
+          best_relaxed_dist2 = dist2;
+          best_relaxed_idx = idx;
+        }
+        const double yaw_error = std::fabs(normalize_radian(self_yaw - traj.yaw.at(idx)));
+        if (std::sqrt(dist2) <= max_dist && yaw_error <= max_yaw && dist2 < best_strict_dist2) {
+          best_strict_dist2 = dist2;
+          best_strict_idx = idx;
+          has_strict_candidate = true;
+        }
+      }
+      *nearest_index = has_strict_candidate ? best_strict_idx : best_relaxed_idx;
+    }
+  }
   const size_t traj_size = traj.size();
 
   if (traj.size() == 1) {

--- a/control/autoware_mpc_lateral_controller/src/mpc_utils.cpp
+++ b/control/autoware_mpc_lateral_controller/src/mpc_utils.cpp
@@ -287,6 +287,97 @@ void calcTrajectoryCurvature(
     calcTrajectoryCurvature(curvature_smoothing_num_ref_steer, traj, use_short_segment_protection);
 }
 
+void calcTrajectoryCurvatureBySpatialResample(
+  const int curvature_smoothing_num_traj, const int curvature_smoothing_num_ref_steer,
+  const double resample_interval_dist, MPCTrajectory & traj)
+{
+  if (traj.size() < 3) {
+    return;
+  }
+
+  // 1. Compute arc length of original temporal trajectory
+  std::vector<double> orig_arclength;
+  calcMPCTrajectoryArcLength(traj, orig_arclength);
+  const double total_length = orig_arclength.back();
+  if (total_length < 1e-6) {
+    return;
+  }
+
+  // 2. Remove spatially duplicate points (stopped vehicle).
+  //    Spline requires strictly increasing arc length.
+  constexpr double dedup_eps = 1e-3;
+  std::vector<double> unique_arclength;
+  std::vector<double> unique_x;
+  std::vector<double> unique_y;
+  unique_arclength.push_back(orig_arclength.front());
+  unique_x.push_back(traj.x.front());
+  unique_y.push_back(traj.y.front());
+  for (size_t i = 1; i < orig_arclength.size(); ++i) {
+    if (orig_arclength[i] - unique_arclength.back() > dedup_eps) {
+      unique_arclength.push_back(orig_arclength[i]);
+      unique_x.push_back(traj.x[i]);
+      unique_y.push_back(traj.y[i]);
+    }
+  }
+  if (unique_arclength.size() < 3) {
+    return;
+  }
+
+  // 3. Generate equally-spaced arc length points
+  std::vector<double> resampled_arclength;
+  for (double s = 0.0; s < total_length; s += resample_interval_dist) {
+    resampled_arclength.push_back(s);
+  }
+  if (resampled_arclength.back() < total_length - 1e-6) {
+    resampled_arclength.push_back(total_length);
+  }
+  if (resampled_arclength.size() < 3) {
+    return;
+  }
+
+  // 4. Spatially resample x, y using spline interpolation on deduplicated points
+  MPCTrajectory spatial_traj;
+  spatial_traj.x = autoware::interpolation::spline(unique_arclength, unique_x, resampled_arclength);
+  spatial_traj.y = autoware::interpolation::spline(unique_arclength, unique_y, resampled_arclength);
+  const auto n = resampled_arclength.size();
+  spatial_traj.z.resize(n, 0.0);
+  spatial_traj.yaw.resize(n, 0.0);
+  spatial_traj.vx.resize(n, 0.0);
+  spatial_traj.k.resize(n, 0.0);
+  spatial_traj.smooth_k.resize(n, 0.0);
+  spatial_traj.relative_time.resize(n, 0.0);
+
+  // 5. Calculate curvature on the spatially uniform trajectory
+  const auto k_spatial = calcTrajectoryCurvature(curvature_smoothing_num_traj, spatial_traj, false);
+  const auto smooth_k_spatial =
+    calcTrajectoryCurvature(curvature_smoothing_num_ref_steer, spatial_traj, false);
+
+  // 6. Map curvature back to original temporal trajectory.
+  //    Use lerp on unique (strictly increasing) arc lengths.
+  //    Duplicate-arclength points (stopped) get curvature = 0.
+  const auto k_at_unique =
+    autoware::interpolation::lerp(resampled_arclength, k_spatial, unique_arclength);
+  const auto smooth_k_at_unique =
+    autoware::interpolation::lerp(resampled_arclength, smooth_k_spatial, unique_arclength);
+
+  traj.k.assign(traj.size(), 0.0);
+  traj.smooth_k.assign(traj.size(), 0.0);
+  size_t unique_idx = 0;
+  for (size_t i = 0; i < traj.size(); ++i) {
+    // Find matching unique point
+    while (unique_idx + 1 < unique_arclength.size() &&
+           unique_arclength[unique_idx + 1] <= orig_arclength[i] + dedup_eps) {
+      ++unique_idx;
+    }
+    // Only assign curvature if this point has a unique spatial position
+    if (i == 0 || orig_arclength[i] - orig_arclength[i - 1] > dedup_eps) {
+      traj.k[i] = k_at_unique[unique_idx];
+      traj.smooth_k[i] = smooth_k_at_unique[unique_idx];
+    }
+    // else: remains 0.0 (stopped / duplicate point)
+  }
+}
+
 std::vector<double> calcTrajectoryCurvature(
   const int curvature_smoothing_num, const MPCTrajectory & traj,
   const bool use_short_segment_protection)

--- a/control/autoware_mpc_lateral_controller/test/test_mpc.cpp
+++ b/control/autoware_mpc_lateral_controller/test/test_mpc.cpp
@@ -160,7 +160,8 @@ protected:
     mpc.m_steer_rate_lim_map_by_velocity.emplace_back(0.0, steer_rate_lim);
     mpc.m_ctrl_period = ctrl_period;
     mpc.m_use_steer_prediction = use_steer_prediction;
-    // dummy trajectories below have no time_from_start; use spatial mode (temporal mode is covered in test_mpc_utils.cpp)
+    // dummy trajectories below have no time_from_start; use spatial mode (temporal mode is covered
+    // in test_mpc_utils.cpp)
     mpc.m_use_temporal_trajectory = false;
 
     mpc.initializeLowPassFilters(steering_lpf_cutoff_hz, error_deriv_lpf_cutoff_hz);

--- a/control/autoware_mpc_lateral_controller/test/test_mpc.cpp
+++ b/control/autoware_mpc_lateral_controller/test/test_mpc.cpp
@@ -160,6 +160,8 @@ protected:
     mpc.m_steer_rate_lim_map_by_velocity.emplace_back(0.0, steer_rate_lim);
     mpc.m_ctrl_period = ctrl_period;
     mpc.m_use_steer_prediction = use_steer_prediction;
+    // dummy trajectories below have no time_from_start; use spatial mode (temporal mode is covered in test_mpc_utils.cpp)
+    mpc.m_use_temporal_trajectory = false;
 
     mpc.initializeLowPassFilters(steering_lpf_cutoff_hz, error_deriv_lpf_cutoff_hz);
     mpc.initializeSteeringPredictor();

--- a/control/autoware_mpc_lateral_controller/test/test_mpc_utils.cpp
+++ b/control/autoware_mpc_lateral_controller/test/test_mpc_utils.cpp
@@ -15,10 +15,12 @@
 #include "autoware/mpc_lateral_controller/mpc_trajectory.hpp"
 #include "autoware/mpc_lateral_controller/mpc_utils.hpp"
 #include "gtest/gtest.h"
+#include "rclcpp/rclcpp.hpp"
 
 #include "autoware_planning_msgs/msg/trajectory.hpp"
 #include "autoware_planning_msgs/msg/trajectory_point.hpp"
 
+#include <cmath>
 #include <memory>
 #include <vector>
 
@@ -62,4 +64,104 @@ TEST(TestMPC, CalcStopDistance)
   EXPECT_EQ(MPCUtils::calcStopDistance(trajectory_msg, 6), 0.0);
   EXPECT_EQ(MPCUtils::calcStopDistance(trajectory_msg, 7), -1.0);
 }
+
+TEST(TestMPC, ConvertToMPCTrajectoryTemporalUsesTimeFromStart)
+{
+  Trajectory trajectory_msg;
+  auto p0 = makePoint(0.0, 0.0, 2.0f);
+  auto p1 = makePoint(1.0, 0.0, 2.0f);
+  auto p2 = makePoint(2.0, 0.0, 2.0f);
+  p0.time_from_start = rclcpp::Duration::from_seconds(0.0);
+  p1.time_from_start = rclcpp::Duration::from_seconds(0.3);
+  p2.time_from_start = rclcpp::Duration::from_seconds(0.8);
+  trajectory_msg.points = {p0, p1, p2};
+
+  const auto mpc_traj = MPCUtils::convertToMPCTrajectory(trajectory_msg, true);
+  ASSERT_EQ(mpc_traj.relative_time.size(), 3UL);
+  EXPECT_DOUBLE_EQ(mpc_traj.relative_time.at(0), 0.0);
+  EXPECT_DOUBLE_EQ(mpc_traj.relative_time.at(1), 0.3);
+  EXPECT_DOUBLE_EQ(mpc_traj.relative_time.at(2), 0.8);
+}
+
+TEST(TestMPC, CalcNearestPoseInterpUsesTimeWindowCandidates)
+{
+  using autoware::motion::control::mpc_lateral_controller::MPCTrajectory;
+  using geometry_msgs::msg::Pose;
+
+  MPCTrajectory traj;
+  traj.push_back(0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0);
+  traj.push_back(1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 1.0);
+  traj.push_back(2.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 2.0);
+  traj.push_back(3.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 3.0);
+
+  Pose self_pose{};
+  self_pose.position.x = 2.05;
+  self_pose.position.y = 0.0;
+  self_pose.orientation.w = 1.0;
+
+  Pose nearest_pose{};
+  size_t nearest_index = 0;
+  double nearest_time = 0.0;
+  constexpr double max_dist = 10.0;
+  constexpr double max_yaw = M_PI;
+  const bool ok = MPCUtils::calcNearestPoseInterp(
+    traj, self_pose, &nearest_pose, &nearest_index, &nearest_time, max_dist, max_yaw, true, 1.8,
+    2.2);
+
+  ASSERT_TRUE(ok);
+  EXPECT_GE(nearest_time, 1.8);
+  EXPECT_LE(nearest_time, 2.2);
+  EXPECT_NEAR(nearest_pose.position.x, 2.05, 1e-6);
+}
+
+TEST(TestMPC, CalcNearestPoseInterpFallsBackWhenTimeWindowHasNoCandidates)
+{
+  using autoware::motion::control::mpc_lateral_controller::MPCTrajectory;
+  using geometry_msgs::msg::Pose;
+
+  MPCTrajectory traj;
+  traj.push_back(0.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 0.0);
+  traj.push_back(1.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 1.0);
+  traj.push_back(2.0, 0.0, 0.0, 0.0, 1.0, 0.0, 0.0, 2.0);
+
+  Pose self_pose{};
+  self_pose.position.x = 0.2;
+  self_pose.position.y = 0.0;
+  self_pose.orientation.w = 1.0;
+
+  Pose nearest_pose{};
+  size_t nearest_index = 0;
+  double nearest_time = 0.0;
+  constexpr double max_dist = 10.0;
+  constexpr double max_yaw = M_PI;
+  const bool ok = MPCUtils::calcNearestPoseInterp(
+    traj, self_pose, &nearest_pose, &nearest_index, &nearest_time, max_dist, max_yaw, true, 10.0,
+    11.0);
+
+  ASSERT_TRUE(ok);
+  EXPECT_NEAR(nearest_pose.position.x, 0.2, 1e-6);
+  EXPECT_NEAR(nearest_time, 0.2, 1e-6);
+}
+
+TEST(TestMPC, TemporalYawAndCurvatureStayStableForShortSegments)
+{
+  using autoware::motion::control::mpc_lateral_controller::MPCTrajectory;
+
+  MPCTrajectory traj;
+  traj.push_back(0.0, 0.0, 0.0, 0.3, 0.0, 0.0, 0.0, 0.0);
+  traj.push_back(0.01, 0.0, 0.0, 0.3, 0.0, 0.0, 0.0, 0.1);
+  traj.push_back(0.02, 0.0, 0.0, 0.3, 0.0, 0.0, 0.0, 0.2);
+  traj.push_back(1.0, 0.0, 0.0, 0.3, 1.0, 0.0, 0.0, 0.3);
+
+  MPCUtils::calcTrajectoryYawFromXY(traj, true, true);
+  MPCUtils::calcTrajectoryCurvature(1, 1, traj, true);
+
+  EXPECT_NEAR(traj.yaw.at(0), 0.3, 1e-6);
+  EXPECT_NEAR(traj.yaw.at(1), 0.3, 1e-6);
+  EXPECT_NEAR(traj.yaw.at(2), 0.3, 1e-6);
+  EXPECT_NEAR(traj.k.at(0), 0.0, 1e-6);
+  EXPECT_NEAR(traj.k.at(1), 0.0, 1e-6);
+  EXPECT_NEAR(traj.k.at(2), 0.0, 1e-6);
+}
+
 }  // namespace

--- a/control/autoware_pid_longitudinal_controller/include/autoware/pid_longitudinal_controller/debug_values.hpp
+++ b/control/autoware_pid_longitudinal_controller/include/autoware/pid_longitudinal_controller/debug_values.hpp
@@ -64,6 +64,12 @@ public:
     PITCH_LPF_RAD = 34,
     PITCH_LPF_DEG = 35,
     SMOOTH_STOP_MODE = 36,
+    TEMPORAL_PREDICTED_TIME = 37,
+    TEMPORAL_OBSERVED_TIME = 38,
+    TEMPORAL_FUSED_TIME = 39,
+    TEMPORAL_OBSERVATION_USED = 40,
+    TEMPORAL_WINDOW_MIN = 41,
+    TEMPORAL_WINDOW_MAX = 42,
 
     SIZE  // this is the number of enum elements
   };

--- a/control/autoware_pid_longitudinal_controller/include/autoware/pid_longitudinal_controller/longitudinal_controller_utils.hpp
+++ b/control/autoware_pid_longitudinal_controller/include/autoware/pid_longitudinal_controller/longitudinal_controller_utils.hpp
@@ -19,6 +19,7 @@
 #include "autoware/interpolation/spherical_linear_interpolation.hpp"
 #include "autoware/motion_utils/trajectory/conversion.hpp"
 #include "autoware/motion_utils/trajectory/trajectory.hpp"
+#include "rclcpp/duration.hpp"
 
 #include <Eigen/Core>
 #include <Eigen/Geometry>
@@ -30,7 +31,9 @@
 
 #include <cmath>
 #include <limits>
+#include <optional>
 #include <utility>
+#include <vector>
 
 namespace autoware::motion::control::pid_longitudinal_controller
 {
@@ -46,7 +49,7 @@ using geometry_msgs::msg::Quaternion;
 /**
  * @brief check if trajectory is invalid or not
  */
-bool isValidTrajectory(const Trajectory & traj);
+bool isValidTrajectory(const Trajectory & traj, const bool use_temporal_trajectory = false);
 
 /**
  * @brief calculate distance to stopline from current vehicle position where velocity is 0
@@ -116,10 +119,48 @@ std::pair<TrajectoryPoint, size_t> lerpTrajectoryPoint(
       points.at(i).acceleration_mps2, points.at(i + 1).acceleration_mps2, interpolate_ratio);
     interpolated_point.heading_rate_rps = autoware::interpolation::lerp(
       points.at(i).heading_rate_rps, points.at(i + 1).heading_rate_rps, interpolate_ratio);
+    const double t0 = rclcpp::Duration(points.at(i).time_from_start).seconds();
+    const double t1 = rclcpp::Duration(points.at(i + 1).time_from_start).seconds();
+    const double interpolated_time = autoware::interpolation::lerp(t0, t1, interpolate_ratio);
+    interpolated_point.time_from_start = rclcpp::Duration::from_seconds(interpolated_time);
   }
 
   return std::make_pair(interpolated_point, seg_idx);
 }
+
+/**
+ * @brief apply linear interpolation to trajectory point at specified trajectory time
+ * @param [in] points trajectory points (time_from_start must be strictly increasing)
+ * @param [in] target_time target time_from_start [s]
+ * @return interpolated trajectory point and source segment index
+ */
+std::pair<TrajectoryPoint, size_t> lerpTrajectoryPointByTime(
+  const std::vector<TrajectoryPoint> & points, const double target_time);
+
+/**
+ * @brief estimate the trajectory time corresponding to the current pose within a bounded time
+ * window
+ * @param [in] points trajectory points (time_from_start must be strictly increasing)
+ * @param [in] pose current pose
+ * @param [in] max_dist nearest-search distance threshold
+ * @param [in] max_yaw nearest-search yaw threshold
+ * @param [in] min_time_window_sec lower bound of search window [s]
+ * @param [in] max_time_window_sec upper bound of search window [s]
+ * @return estimated trajectory time if a candidate exists in the window
+ */
+std::optional<double> estimateTrajectoryTimeFromPose(
+  const std::vector<TrajectoryPoint> & points, const Pose & pose, const double max_dist,
+  const double max_yaw, const double min_time_window_sec = -std::numeric_limits<double>::infinity(),
+  const double max_time_window_sec = std::numeric_limits<double>::infinity());
+
+/**
+ * @brief estimate a local time step around the target trajectory time
+ * @param [in] points trajectory points
+ * @param [in] target_time target trajectory time [s]
+ * @return local time step [s]
+ */
+double estimateLocalTrajectoryTimeStep(
+  const std::vector<TrajectoryPoint> & points, const double target_time);
 
 /**
  * @brief limit variable whose differential is within a certain value

--- a/control/autoware_pid_longitudinal_controller/include/autoware/pid_longitudinal_controller/pid_longitudinal_controller.hpp
+++ b/control/autoware_pid_longitudinal_controller/include/autoware/pid_longitudinal_controller/pid_longitudinal_controller.hpp
@@ -42,8 +42,10 @@
 #include "visualization_msgs/msg/marker.hpp"
 
 #include <deque>
+#include <limits>
 #include <memory>
 #include <optional>
+#include <stdexcept>
 #include <string>
 #include <utility>
 #include <vector>
@@ -93,6 +95,12 @@ private:
     double stop_dist{0.0};  // signed distance that is positive when car is before the stopline
     double slope_angle{0.0};
     double dt{0.0};
+    double temporal_predicted_time{std::numeric_limits<double>::quiet_NaN()};
+    double temporal_observed_time{std::numeric_limits<double>::quiet_NaN()};
+    double temporal_fused_time{std::numeric_limits<double>::quiet_NaN()};
+    double temporal_window_min{std::numeric_limits<double>::quiet_NaN()};
+    double temporal_window_max{std::numeric_limits<double>::quiet_NaN()};
+    bool temporal_observation_used{false};
   };
   rclcpp::node_interfaces::NodeParametersInterface::SharedPtr node_parameters_;
   rclcpp::Clock::SharedPtr clock_;
@@ -138,6 +146,9 @@ private:
 
   // delay compensation
   double m_delay_compensation_time;
+  bool m_use_temporal_trajectory{false};
+  std::optional<double> m_prev_nearest_time{std::nullopt};
+  std::optional<rclcpp::Time> m_prev_trajectory_stamp{std::nullopt};
 
   // enable flags
   bool m_enable_smooth_stop;

--- a/control/autoware_pid_longitudinal_controller/src/longitudinal_controller_utils.cpp
+++ b/control/autoware_pid_longitudinal_controller/src/longitudinal_controller_utils.cpp
@@ -15,6 +15,7 @@
 #include "autoware/pid_longitudinal_controller/longitudinal_controller_utils.hpp"
 
 #include "autoware_utils/geometry/geometry.hpp"
+#include "autoware_utils/math/normalization.hpp"
 
 #include <experimental/optional>  // NOLINT
 #include <tf2/LinearMath/Matrix3x3.hpp>
@@ -24,15 +25,23 @@
 
 #include <algorithm>
 #include <limits>
+#include <optional>
+#include <utility>
+#include <vector>
 #include <utility>
 
 namespace autoware::motion::control::pid_longitudinal_controller
 {
 namespace longitudinal_utils
 {
-
-bool isValidTrajectory(const Trajectory & traj)
+bool isValidTrajectory(const Trajectory & traj, const bool use_temporal_trajectory)
 {
+  // Check if trajectory is empty first
+  if (traj.points.empty()) {
+    return false;
+  }
+
+  double prev_t = -std::numeric_limits<double>::infinity();
   for (const auto & p : traj.points) {
     if (
       !isfinite(p.pose.position.x) || !isfinite(p.pose.position.y) ||
@@ -43,11 +52,14 @@ bool isValidTrajectory(const Trajectory & traj)
       !isfinite(p.heading_rate_rps)) {
       return false;
     }
-  }
 
-  // when trajectory is empty
-  if (traj.points.empty()) {
-    return false;
+    if (use_temporal_trajectory) {
+      const double t = rclcpp::Duration(p.time_from_start).seconds();
+      if (!std::isfinite(t) || t <= prev_t) {
+        return false;
+      }
+      prev_t = t;
+    }
   }
 
   return true;
@@ -184,6 +196,168 @@ geometry_msgs::msg::Pose findTrajectoryPoseAfterDistance(
     remain_dist -= dist;
   }
   return p;
+}
+
+std::pair<TrajectoryPoint, size_t> lerpTrajectoryPointByTime(
+  const std::vector<TrajectoryPoint> & points, const double target_time)
+{
+  if (points.empty()) {
+    return std::make_pair(TrajectoryPoint{}, 0);
+  }
+  if (points.size() == 1) {
+    return std::make_pair(points.front(), 0);
+  }
+
+  const double front_time = rclcpp::Duration(points.front().time_from_start).seconds();
+  if (target_time <= front_time) {
+    return std::make_pair(points.front(), 0);
+  }
+
+  const double back_time = rclcpp::Duration(points.back().time_from_start).seconds();
+  if (target_time >= back_time) {
+    return std::make_pair(points.back(), points.size() - 1);
+  }
+
+  for (size_t i = 0; i < points.size() - 1; ++i) {
+    const double t0 = rclcpp::Duration(points.at(i).time_from_start).seconds();
+    const double t1 = rclcpp::Duration(points.at(i + 1).time_from_start).seconds();
+    if (target_time > t1) {
+      continue;
+    }
+    const double ratio = std::clamp(
+      (target_time - t0) / std::max(t1 - t0, std::numeric_limits<double>::epsilon()), 0.0, 1.0);
+    auto interpolated = points.at(i);
+    const auto & p0 = points.at(i);
+    const auto & p1 = points.at(i + 1);
+    interpolated.pose.position.x =
+      autoware::interpolation::lerp(p0.pose.position.x, p1.pose.position.x, ratio);
+    interpolated.pose.position.y =
+      autoware::interpolation::lerp(p0.pose.position.y, p1.pose.position.y, ratio);
+    interpolated.pose.position.z =
+      autoware::interpolation::lerp(p0.pose.position.z, p1.pose.position.z, ratio);
+    interpolated.pose.orientation =
+      autoware::interpolation::lerpOrientation(p0.pose.orientation, p1.pose.orientation, ratio);
+    interpolated.longitudinal_velocity_mps = autoware::interpolation::lerp(
+      p0.longitudinal_velocity_mps, p1.longitudinal_velocity_mps, ratio);
+    interpolated.lateral_velocity_mps =
+      autoware::interpolation::lerp(p0.lateral_velocity_mps, p1.lateral_velocity_mps, ratio);
+    interpolated.acceleration_mps2 =
+      autoware::interpolation::lerp(p0.acceleration_mps2, p1.acceleration_mps2, ratio);
+    interpolated.heading_rate_rps =
+      autoware::interpolation::lerp(p0.heading_rate_rps, p1.heading_rate_rps, ratio);
+    interpolated.time_from_start = rclcpp::Duration::from_seconds(target_time);
+    return std::make_pair(interpolated, i);
+  }
+
+  return std::make_pair(points.back(), points.size() - 1);
+}
+
+std::optional<double> estimateTrajectoryTimeFromPose(
+  const std::vector<TrajectoryPoint> & points, const Pose & pose, const double max_dist,
+  const double max_yaw, const double min_time_window_sec, const double max_time_window_sec)
+{
+  if (points.empty()) {
+    return std::nullopt;
+  }
+
+  const double min_time_sec = std::min(min_time_window_sec, max_time_window_sec);
+  const double max_time_sec = std::max(min_time_window_sec, max_time_window_sec);
+  std::vector<size_t> candidates;
+  candidates.reserve(points.size());
+  for (size_t i = 0; i < points.size(); ++i) {
+    const double t = rclcpp::Duration(points.at(i).time_from_start).seconds();
+    if (min_time_sec <= t && t <= max_time_sec) {
+      candidates.push_back(i);
+    }
+  }
+  if (candidates.empty()) {
+    return std::nullopt;
+  }
+
+  const double self_yaw = tf2::getYaw(pose.orientation);
+  size_t best_relaxed_idx = candidates.front();
+  double best_relaxed_dist2 = std::numeric_limits<double>::max();
+  size_t best_strict_idx = candidates.front();
+  double best_strict_dist2 = std::numeric_limits<double>::max();
+  bool has_strict_candidate = false;
+  for (const auto idx : candidates) {
+    const double dx = points.at(idx).pose.position.x - pose.position.x;
+    const double dy = points.at(idx).pose.position.y - pose.position.y;
+    const double dist2 = dx * dx + dy * dy;
+    if (dist2 < best_relaxed_dist2) {
+      best_relaxed_dist2 = dist2;
+      best_relaxed_idx = idx;
+    }
+
+    const double yaw_error = std::fabs(
+      autoware_utils::normalize_radian(self_yaw - tf2::getYaw(points.at(idx).pose.orientation)));
+    if (std::sqrt(dist2) <= max_dist && yaw_error <= max_yaw && dist2 < best_strict_dist2) {
+      best_strict_dist2 = dist2;
+      best_strict_idx = idx;
+      has_strict_candidate = true;
+    }
+  }
+
+  const size_t nearest_index = has_strict_candidate ? best_strict_idx : best_relaxed_idx;
+  if (points.size() == 1) {
+    return rclcpp::Duration(points.front().time_from_start).seconds();
+  }
+
+  const auto [prev, next] = [&]() -> std::pair<size_t, size_t> {
+    if (nearest_index == 0) {
+      return std::make_pair(0, 1);
+    }
+    if (nearest_index == points.size() - 1) {
+      return std::make_pair(points.size() - 2, points.size() - 1);
+    }
+
+    const double signed_length =
+      autoware::motion_utils::calcLongitudinalOffsetToSegment(points, nearest_index, pose.position);
+    if (signed_length <= 0.0) {
+      return std::make_pair(nearest_index - 1, nearest_index);
+    }
+    return std::make_pair(nearest_index, nearest_index + 1);
+  }();
+
+  const double seg_length = autoware::motion_utils::calcSignedArcLength(points, prev, next);
+  if (std::fabs(seg_length) < 1.0e-5) {
+    return rclcpp::Duration(points.at(nearest_index).time_from_start).seconds();
+  }
+
+  const double len_to_interpolated =
+    autoware::motion_utils::calcLongitudinalOffsetToSegment(points, prev, pose.position);
+  const double ratio = std::clamp(len_to_interpolated / seg_length, 0.0, 1.0);
+  const double prev_time = rclcpp::Duration(points.at(prev).time_from_start).seconds();
+  const double next_time = rclcpp::Duration(points.at(next).time_from_start).seconds();
+  return autoware::interpolation::lerp(prev_time, next_time, ratio);
+}
+
+double estimateLocalTrajectoryTimeStep(
+  const std::vector<TrajectoryPoint> & points, const double target_time)
+{
+  if (points.size() < 2) {
+    return 0.0;
+  }
+
+  const double front_time = rclcpp::Duration(points.front().time_from_start).seconds();
+  if (target_time <= front_time) {
+    return rclcpp::Duration(points.at(1).time_from_start).seconds() - front_time;
+  }
+
+  const double back_time = rclcpp::Duration(points.back().time_from_start).seconds();
+  if (target_time >= back_time) {
+    return back_time - rclcpp::Duration(points.at(points.size() - 2).time_from_start).seconds();
+  }
+
+  for (size_t i = 0; i < points.size() - 1; ++i) {
+    const double t0 = rclcpp::Duration(points.at(i).time_from_start).seconds();
+    const double t1 = rclcpp::Duration(points.at(i + 1).time_from_start).seconds();
+    if (target_time <= t1) {
+      return t1 - t0;
+    }
+  }
+
+  return back_time - rclcpp::Duration(points.at(points.size() - 2).time_from_start).seconds();
 }
 }  // namespace longitudinal_utils
 }  // namespace autoware::motion::control::pid_longitudinal_controller

--- a/control/autoware_pid_longitudinal_controller/src/longitudinal_controller_utils.cpp
+++ b/control/autoware_pid_longitudinal_controller/src/longitudinal_controller_utils.cpp
@@ -28,7 +28,6 @@
 #include <optional>
 #include <utility>
 #include <vector>
-#include <utility>
 
 namespace autoware::motion::control::pid_longitudinal_controller
 {

--- a/control/autoware_pid_longitudinal_controller/src/pid_longitudinal_controller.cpp
+++ b/control/autoware_pid_longitudinal_controller/src/pid_longitudinal_controller.cpp
@@ -24,6 +24,7 @@
 #include <algorithm>
 #include <limits>
 #include <memory>
+#include <stdexcept>
 #include <string>
 #include <utility>
 #include <vector>
@@ -42,6 +43,19 @@ PidLongitudinalController::PidLongitudinalController(
 
   // parameters timer
   m_longitudinal_ctrl_period = node.get_parameter("ctrl_period").as_double();
+
+  const auto trajectory_reference_mode =
+    node.has_parameter("trajectory_reference_mode")
+      ? node.get_parameter("trajectory_reference_mode").as_string()
+      : node.declare_parameter<std::string>("trajectory_reference_mode", "spatial");
+  if (trajectory_reference_mode == "temporal") {
+    m_use_temporal_trajectory = true;
+  } else if (trajectory_reference_mode == "spatial") {
+    m_use_temporal_trajectory = false;
+  } else {
+    throw std::invalid_argument(
+      "Invalid trajectory_reference_mode. Expected \"spatial\" or \"temporal\".");
+  }
 
   m_wheel_base = autoware::vehicle_info_utils::VehicleInfoUtils(node).getVehicleInfo().wheel_base_m;
   m_vehicle_width =
@@ -248,7 +262,7 @@ void PidLongitudinalController::setCurrentOperationMode(const OperationModeState
 
 void PidLongitudinalController::setTrajectory(const autoware_planning_msgs::msg::Trajectory & msg)
 {
-  if (!longitudinal_utils::isValidTrajectory(msg)) {
+  if (!longitudinal_utils::isValidTrajectory(msg, m_use_temporal_trajectory)) {
     RCLCPP_ERROR_THROTTLE(logger_, *clock_, 3000, "received invalid trajectory. ignore.");
     return;
   }
@@ -256,6 +270,13 @@ void PidLongitudinalController::setTrajectory(const autoware_planning_msgs::msg:
   if (msg.points.size() < 2) {
     RCLCPP_WARN_THROTTLE(logger_, *clock_, 3000, "Unexpected trajectory size < 2. Ignored.");
     return;
+  }
+
+  if (m_use_temporal_trajectory) {
+    const rclcpp::Time current_stamp(msg.header.stamp);
+    m_prev_trajectory_stamp = current_stamp;
+  } else {
+    m_prev_trajectory_stamp.reset();
   }
 
   m_trajectory = msg;
@@ -457,19 +478,74 @@ PidLongitudinalController::ControlData PidLongitudinalController::getControlData
   control_data.current_motion.vel = m_current_kinematic_state.twist.twist.linear.x;
   control_data.current_motion.acc = m_current_accel.accel.accel.linear.x;
   control_data.interpolated_traj = m_trajectory;
+  const double traj_start_time =
+    rclcpp::Duration(control_data.interpolated_traj.points.front().time_from_start).seconds();
+  const double traj_end_time =
+    rclcpp::Duration(control_data.interpolated_traj.points.back().time_from_start).seconds();
 
-  // calculate the interpolated point and segment
-  const auto current_interpolated_pose =
-    calcInterpolatedTrajPointAndSegment(control_data.interpolated_traj, current_pose);
+  autoware_planning_msgs::msg::TrajectoryPoint nearest_point;
+  autoware_planning_msgs::msg::TrajectoryPoint target_point;
 
-  // Insert the interpolated point
-  control_data.interpolated_traj.points.insert(
-    control_data.interpolated_traj.points.begin() + current_interpolated_pose.second + 1,
-    current_interpolated_pose.first);
-  control_data.nearest_idx = current_interpolated_pose.second + 1;
-  control_data.target_idx = control_data.nearest_idx;
-  const auto nearest_point = current_interpolated_pose.first;
-  auto target_point = current_interpolated_pose.first;
+  if (m_use_temporal_trajectory) {
+    const double prev_nearest_time = [&]() {
+      if (!m_prev_nearest_time.has_value()) {
+        return traj_start_time;
+      }
+      return std::clamp(*m_prev_nearest_time, traj_start_time, traj_end_time);
+    }();
+    const double predicted_time = std::clamp(
+      prev_nearest_time + std::max(control_data.dt, 0.0), traj_start_time, traj_end_time);
+    const double local_dt = std::max(
+      longitudinal_utils::estimateLocalTrajectoryTimeStep(
+        control_data.interpolated_traj.points, predicted_time),
+      std::max(control_data.dt, 1.0e-3));
+    const double backward_window = std::max(local_dt, std::max(control_data.dt, 0.0));
+    const double forward_window = std::max(3.0 * local_dt, std::max(control_data.dt, 0.0));
+    control_data.temporal_predicted_time = predicted_time;
+    control_data.temporal_window_min = predicted_time - backward_window;
+    control_data.temporal_window_max = predicted_time + forward_window;
+    const auto observed_time = longitudinal_utils::estimateTrajectoryTimeFromPose(
+      control_data.interpolated_traj.points, current_pose, m_ego_nearest_dist_threshold,
+      m_ego_nearest_yaw_threshold, predicted_time - backward_window,
+      predicted_time + forward_window);
+
+    double nearest_time = predicted_time;
+    if (observed_time.has_value()) {
+      control_data.temporal_observed_time = *observed_time;
+      control_data.temporal_observation_used = true;
+      const double max_phase_correction = std::max(2.0 * local_dt, std::max(control_data.dt, 0.0));
+      const double bounded_correction =
+        std::clamp(*observed_time - predicted_time, -max_phase_correction, max_phase_correction);
+      constexpr double observation_gain = 0.5;
+      nearest_time = std::clamp(
+        predicted_time + observation_gain * bounded_correction, traj_start_time, traj_end_time);
+    }
+    control_data.temporal_fused_time = nearest_time;
+    m_prev_nearest_time = nearest_time;
+
+    const auto nearest_interpolated_point = longitudinal_utils::lerpTrajectoryPointByTime(
+      control_data.interpolated_traj.points, nearest_time);
+    control_data.nearest_idx = nearest_interpolated_point.second + 1;
+    control_data.target_idx = control_data.nearest_idx;
+    control_data.interpolated_traj.points.insert(
+      control_data.interpolated_traj.points.begin() + control_data.nearest_idx,
+      nearest_interpolated_point.first);
+    nearest_point = nearest_interpolated_point.first;
+    target_point = nearest_interpolated_point.first;
+  } else {
+    // Calculate the interpolated nearest point from geometric projection.
+    const auto current_interpolated_pose =
+      calcInterpolatedTrajPointAndSegment(control_data.interpolated_traj, current_pose);
+
+    // Insert the interpolated point
+    control_data.interpolated_traj.points.insert(
+      control_data.interpolated_traj.points.begin() + current_interpolated_pose.second + 1,
+      current_interpolated_pose.first);
+    control_data.nearest_idx = current_interpolated_pose.second + 1;
+    control_data.target_idx = control_data.nearest_idx;
+    nearest_point = current_interpolated_pose.first;
+    target_point = current_interpolated_pose.first;
+  }
 
   // Delay compensation - Calculate the distance we got, predicted velocity and predicted
   // acceleration after delay
@@ -478,7 +554,17 @@ PidLongitudinalController::ControlData PidLongitudinalController::getControlData
 
   // calculate the target motion for delay compensation
   constexpr double min_running_dist = 0.01;
-  if (control_data.state_after_delay.running_distance > min_running_dist) {
+  if (m_use_temporal_trajectory) {
+    const double nearest_time = rclcpp::Duration(nearest_point.time_from_start).seconds();
+    const double target_time = nearest_time + m_delay_compensation_time;
+    const auto target_interpolated_point = longitudinal_utils::lerpTrajectoryPointByTime(
+      control_data.interpolated_traj.points, target_time);
+    control_data.target_idx = target_interpolated_point.second + 1;
+    control_data.interpolated_traj.points.insert(
+      control_data.interpolated_traj.points.begin() + control_data.target_idx,
+      target_interpolated_point.first);
+    target_point = target_interpolated_point.first;
+  } else if (control_data.state_after_delay.running_distance > min_running_dist) {
     control_data.interpolated_traj.points =
       autoware::motion_utils::removeOverlapPoints(control_data.interpolated_traj.points);
     const auto target_pose = longitudinal_utils::findTrajectoryPoseAfterDistance(
@@ -494,21 +580,23 @@ PidLongitudinalController::ControlData PidLongitudinalController::getControlData
   }
 
   // ==========================================================================================
-  // NOTE: due to removeOverlapPoints(), the obtained control_data.target_idx and
-  // control_data.nearest_idx may become invalid if the number of points decreased.
-  // current API does not provide the way to check duplication beforehand and this function
-  // does not tell how many/which index points were removed, so there is no way
-  // to tell if our `control_data.target_idx` point still exists or removed.
+  // NOTE (spatial path): removeOverlapPoints() may change point indices, so previously computed
+  // nearest/target indices can become invalid and must be re-acquired after de-duplication.
+  // Temporal path intentionally skips removeOverlapPoints() to preserve same-position points with
+  // different timestamps.
   // ==========================================================================================
-  // Remove overlapped points after inserting the interpolated points
-  control_data.interpolated_traj.points =
-    autoware::motion_utils::removeOverlapPoints(control_data.interpolated_traj.points);
-  control_data.nearest_idx = autoware::motion_utils::findFirstNearestIndexWithSoftConstraints(
-    control_data.interpolated_traj.points, nearest_point.pose, m_ego_nearest_dist_threshold,
-    m_ego_nearest_yaw_threshold);
-  control_data.target_idx = autoware::motion_utils::findFirstNearestIndexWithSoftConstraints(
-    control_data.interpolated_traj.points, target_point.pose, m_ego_nearest_dist_threshold,
-    m_ego_nearest_yaw_threshold);
+  // Spatial-only de-duplication and index re-acquisition after inserting interpolated points.
+  if (!m_use_temporal_trajectory) {
+    m_prev_nearest_time.reset();
+    control_data.interpolated_traj.points =
+      autoware::motion_utils::removeOverlapPoints(control_data.interpolated_traj.points);
+    control_data.nearest_idx = autoware::motion_utils::findFirstNearestIndexWithSoftConstraints(
+      control_data.interpolated_traj.points, nearest_point.pose, m_ego_nearest_dist_threshold,
+      m_ego_nearest_yaw_threshold);
+    control_data.target_idx = autoware::motion_utils::findFirstNearestIndexWithSoftConstraints(
+      control_data.interpolated_traj.points, target_point.pose, m_ego_nearest_dist_threshold,
+      m_ego_nearest_yaw_threshold);
+  }
 
   // send debug values
   m_debug_values.setValues(DebugValues::TYPE::PREDICTED_VEL, control_data.state_after_delay.vel);
@@ -936,6 +1024,19 @@ void PidLongitudinalController::publishDebugData(
   m_debug_values.setValues(DebugValues::TYPE::STOP_DIST, control_data.stop_dist);
   m_debug_values.setValues(DebugValues::TYPE::CONTROL_STATE, static_cast<double>(m_control_state));
   m_debug_values.setValues(DebugValues::TYPE::ACC_CMD_PUBLISHED, ctrl_cmd.acc);
+  m_debug_values.setValues(
+    DebugValues::TYPE::TEMPORAL_PREDICTED_TIME, control_data.temporal_predicted_time);
+  m_debug_values.setValues(
+    DebugValues::TYPE::TEMPORAL_OBSERVED_TIME, control_data.temporal_observed_time);
+  m_debug_values.setValues(
+    DebugValues::TYPE::TEMPORAL_FUSED_TIME, control_data.temporal_fused_time);
+  m_debug_values.setValues(
+    DebugValues::TYPE::TEMPORAL_OBSERVATION_USED,
+    control_data.temporal_observation_used ? 1.0 : 0.0);
+  m_debug_values.setValues(
+    DebugValues::TYPE::TEMPORAL_WINDOW_MIN, control_data.temporal_window_min);
+  m_debug_values.setValues(
+    DebugValues::TYPE::TEMPORAL_WINDOW_MAX, control_data.temporal_window_max);
 
   // publish debug values
   autoware_internal_debug_msgs::msg::Float32MultiArrayStamped debug_msg{};

--- a/control/autoware_pid_longitudinal_controller/test/test_longitudinal_controller_utils.cpp
+++ b/control/autoware_pid_longitudinal_controller/test/test_longitudinal_controller_utils.cpp
@@ -26,7 +26,9 @@
 #include "geometry_msgs/msg/quaternion.hpp"
 #include "tf2_geometry_msgs/tf2_geometry_msgs.hpp"
 
+#include <cmath>
 #include <limits>
+#include <vector>
 
 namespace longitudinal_utils =
   ::autoware::motion::control::pid_longitudinal_controller::longitudinal_utils;
@@ -456,6 +458,118 @@ TEST(TestLongitudinalControllerUtils, lerpTrajectoryPoint)
   EXPECT_NEAR(result.first.pose.position.z, pose.position.z, abs_err);
   EXPECT_NEAR(result.first.longitudinal_velocity_mps, 15.0, abs_err);
   EXPECT_NEAR(result.first.acceleration_mps2, 15.0, abs_err);
+}
+
+TEST(TestLongitudinalControllerUtils, lerpTrajectoryPointByTimeStopHold)
+{
+  using autoware_planning_msgs::msg::TrajectoryPoint;
+  std::vector<TrajectoryPoint> points;
+
+  TrajectoryPoint p;
+  p.pose.position.x = 0.0;
+  p.longitudinal_velocity_mps = 0.0;
+  p.time_from_start = rclcpp::Duration::from_seconds(0.0);
+  points.push_back(p);
+
+  p.time_from_start = rclcpp::Duration::from_seconds(0.1);
+  points.push_back(p);
+
+  p.time_from_start = rclcpp::Duration::from_seconds(0.2);
+  points.push_back(p);
+
+  p.pose.position.x = 0.2;
+  p.longitudinal_velocity_mps = 1.0;
+  p.time_from_start = rclcpp::Duration::from_seconds(0.3);
+  points.push_back(p);
+
+  const auto stop_hold = longitudinal_utils::lerpTrajectoryPointByTime(points, 0.15);
+  EXPECT_EQ(stop_hold.second, 1U);
+  EXPECT_DOUBLE_EQ(rclcpp::Duration(stop_hold.first.time_from_start).seconds(), 0.15);
+  EXPECT_DOUBLE_EQ(stop_hold.first.pose.position.x, 0.0);
+  EXPECT_DOUBLE_EQ(stop_hold.first.longitudinal_velocity_mps, 0.0);
+}
+
+TEST(TestLongitudinalControllerUtils, lerpTrajectoryPointByTimeRestartIsSmooth)
+{
+  using autoware_planning_msgs::msg::TrajectoryPoint;
+  std::vector<TrajectoryPoint> points;
+
+  TrajectoryPoint p;
+  p.pose.position.x = 0.0;
+  p.longitudinal_velocity_mps = 0.0;
+  p.time_from_start = rclcpp::Duration::from_seconds(0.0);
+  points.push_back(p);
+
+  p.time_from_start = rclcpp::Duration::from_seconds(0.1);
+  points.push_back(p);
+
+  p.pose.position.x = 0.1;
+  p.longitudinal_velocity_mps = 0.5;
+  p.time_from_start = rclcpp::Duration::from_seconds(0.2);
+  points.push_back(p);
+
+  p.pose.position.x = 0.3;
+  p.longitudinal_velocity_mps = 1.0;
+  p.time_from_start = rclcpp::Duration::from_seconds(0.3);
+  points.push_back(p);
+
+  const auto early_restart = longitudinal_utils::lerpTrajectoryPointByTime(points, 0.15);
+  EXPECT_EQ(early_restart.second, 1U);
+  EXPECT_DOUBLE_EQ(rclcpp::Duration(early_restart.first.time_from_start).seconds(), 0.15);
+  EXPECT_NEAR(early_restart.first.pose.position.x, 0.05, 1e-12);
+  EXPECT_NEAR(early_restart.first.longitudinal_velocity_mps, 0.25, 1e-12);
+
+  const auto late_restart = longitudinal_utils::lerpTrajectoryPointByTime(points, 0.25);
+  EXPECT_EQ(late_restart.second, 2U);
+  EXPECT_DOUBLE_EQ(rclcpp::Duration(late_restart.first.time_from_start).seconds(), 0.25);
+  EXPECT_NEAR(late_restart.first.pose.position.x, 0.2, 1e-12);
+  EXPECT_NEAR(late_restart.first.longitudinal_velocity_mps, 0.75, 1e-12);
+
+  EXPECT_LT(
+    early_restart.first.longitudinal_velocity_mps, late_restart.first.longitudinal_velocity_mps);
+}
+
+TEST(TestLongitudinalControllerUtils, estimateTrajectoryTimeFromPoseWithinWindow)
+{
+  using autoware_planning_msgs::msg::TrajectoryPoint;
+  std::vector<TrajectoryPoint> points;
+
+  for (size_t i = 0; i < 4; ++i) {
+    TrajectoryPoint p;
+    p.pose.position.x = static_cast<double>(i);
+    p.pose.orientation.w = 1.0;
+    p.time_from_start = rclcpp::Duration::from_seconds(static_cast<double>(i));
+    points.push_back(p);
+  }
+
+  geometry_msgs::msg::Pose pose;
+  pose.position.x = 2.1;
+  pose.orientation.w = 1.0;
+
+  const auto estimated_time =
+    longitudinal_utils::estimateTrajectoryTimeFromPose(points, pose, 10.0, M_PI, 1.8, 2.2);
+  ASSERT_TRUE(estimated_time.has_value());
+  EXPECT_GE(*estimated_time, 1.8);
+  EXPECT_LE(*estimated_time, 2.2);
+}
+
+TEST(TestLongitudinalControllerUtils, estimateLocalTrajectoryTimeStep)
+{
+  using autoware_planning_msgs::msg::TrajectoryPoint;
+  std::vector<TrajectoryPoint> points;
+
+  TrajectoryPoint p;
+  p.time_from_start = rclcpp::Duration::from_seconds(0.1);
+  points.push_back(p);
+  p.time_from_start = rclcpp::Duration::from_seconds(0.3);
+  points.push_back(p);
+  p.time_from_start = rclcpp::Duration::from_seconds(0.8);
+  points.push_back(p);
+
+  EXPECT_DOUBLE_EQ(longitudinal_utils::estimateLocalTrajectoryTimeStep(points, 0.0), 0.2);
+  EXPECT_DOUBLE_EQ(longitudinal_utils::estimateLocalTrajectoryTimeStep(points, 0.2), 0.2);
+  EXPECT_DOUBLE_EQ(longitudinal_utils::estimateLocalTrajectoryTimeStep(points, 0.5), 0.5);
+  EXPECT_DOUBLE_EQ(longitudinal_utils::estimateLocalTrajectoryTimeStep(points, 1.0), 0.5);
 }
 
 TEST(TestLongitudinalControllerUtils, applyDiffLimitFilter)

--- a/control/autoware_trajectory_follower_node/include/autoware/trajectory_follower_node/controller_node.hpp
+++ b/control/autoware_trajectory_follower_node/include/autoware/trajectory_follower_node/controller_node.hpp
@@ -82,9 +82,8 @@ private:
   bool enable_control_cmd_horizon_pub_{false};
   boost::optional<LongitudinalOutput> longitudinal_output_{boost::none};
 
-  std::shared_ptr<diagnostic_updater::Updater> diag_updater_ =
-    std::make_shared<diagnostic_updater::Updater>(
-      this);  // Diagnostic updater for publishing diagnostic data.
+  std::shared_ptr<diagnostic_updater::Updater>
+    diag_updater_;  // Diagnostic updater for publishing diagnostic data.
 
   std::shared_ptr<trajectory_follower::LongitudinalControllerBase> longitudinal_controller_;
   std::shared_ptr<trajectory_follower::LateralControllerBase> lateral_controller_;

--- a/control/autoware_trajectory_follower_node/param/trajectory_follower_node.param.yaml
+++ b/control/autoware_trajectory_follower_node/param/trajectory_follower_node.param.yaml
@@ -1,4 +1,8 @@
 /**:
   ros__parameters:
+    # common trajectory reference mode for controllers
+    # spatial: distance-based tracking (current behavior)
+    # temporal: time-step-based tracking
+    trajectory_reference_mode: "spatial"
     ctrl_period: 0.03
     timeout_thr_sec: 0.5

--- a/control/autoware_trajectory_follower_node/src/controller_node.cpp
+++ b/control/autoware_trajectory_follower_node/src/controller_node.cpp
@@ -24,6 +24,7 @@
 #include <algorithm>
 #include <limits>
 #include <memory>
+#include <stdexcept>
 #include <string>
 #include <utility>
 #include <vector>
@@ -50,11 +51,19 @@ std::vector<T> resampleHorizonByZeroOrderHold(
 
 namespace autoware::motion::control::trajectory_follower_node
 {
-Controller::Controller(const rclcpp::NodeOptions & node_options) : Node("controller", node_options)
+Controller::Controller(const rclcpp::NodeOptions & node_options)
+: Node("controller", node_options),
+  diag_updater_(std::make_shared<diagnostic_updater::Updater>(this))
 {
   using std::placeholders::_1;
 
   const double ctrl_period = declare_parameter<double>("ctrl_period");
+  const auto trajectory_reference_mode =
+    declare_parameter<std::string>("trajectory_reference_mode", "spatial");
+  if (trajectory_reference_mode != "spatial" && trajectory_reference_mode != "temporal") {
+    throw std::invalid_argument(
+      "Invalid trajectory_reference_mode. Expected \"spatial\" or \"temporal\".");
+  }
   timeout_thr_sec_ = declare_parameter<double>("timeout_thr_sec");
   // NOTE: It is possible that using control_horizon could be expected to enhance performance,
   // but it is not a formal interface topic, only an experimental one.


### PR DESCRIPTION
## description
Related PR https://github.com/tier4/autoware_universe/pull/2938.
This PR just cherry-picks the temporal controller part.
Once the temporal controller is implemented in AWF using TrajectoryClass, this PR shoud be reverted.