### PR TITLE
feat(boundary_departure, trajectory_validator): cherry-pick boundary departure prevention library and filter

### DIFF
--- a/common/.pages
+++ b/common/.pages
@@ -9,6 +9,7 @@ nav:
       - 'comparisons': common/autoware_auto_common/design/comparisons
     - 'autoware_grid_map_utils': common/autoware_grid_map_utils
     - 'autoware_point_types': common/autoware_point_types
+    - 'Boundary Departure Checker': common/autoware_boundary_departure_checker
     - 'Geography Utils': common/autoware_geography_utils
     - 'Global Parameter Loader': common/autoware_global_parameter_loader/Readme
     - 'Glog Component': common/autoware_glog_component

--- a/common/autoware_boundary_departure_checker/CMakeLists.txt
+++ b/common/autoware_boundary_departure_checker/CMakeLists.txt
@@ -1,0 +1,41 @@
+cmake_minimum_required(VERSION 3.14)
+project(autoware_boundary_departure_checker)
+
+find_package(autoware_cmake REQUIRED)
+autoware_package()
+
+ament_auto_add_library(utils SHARED
+  src/detail/conversion.cpp
+  src/detail/geometry_projection.cpp
+  src/detail/uncrossable_boundaries_rtree.cpp
+  src/detail/boundary_segment_finder.cpp
+  src/detail/severity_evaluator.cpp
+  src/detail/hysteresis_logic.cpp
+  src/detail/boundary_departure_evaluator.cpp
+  src/detail/footprints_generator.cpp
+  src/detail/debug.cpp
+)
+
+ament_auto_add_library(uncrossable_boundary_checker SHARED
+  src/uncrossable_boundary_checker.cpp
+)
+
+target_link_libraries(uncrossable_boundary_checker
+  utils
+)
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+
+  file(GLOB_RECURSE TEST_SOURCES test/*.cpp)
+  ament_add_gtest(test_${PROJECT_NAME}
+    ${TEST_SOURCES}
+  )
+  target_link_libraries(test_${PROJECT_NAME}
+    utils
+    uncrossable_boundary_checker
+  )
+endif()
+
+ament_auto_package()

--- a/common/autoware_boundary_departure_checker/README.md
+++ b/common/autoware_boundary_departure_checker/README.md
@@ -1,0 +1,67 @@
+# Boundary Departure Checker
+
+## 1. Introduction
+
+The Boundary Departure Checker is a trajectory validation module designed to prevent the autonomous vehicle from crossing uncrossable road boundaries. It continuously evaluates the ego vehicle's predicted path and outputs a departure severity status to the planning system to ensure safe lane following.
+
+## 2. Input and Output
+
+### Input
+
+- **Vehicle Information (`vehicle_info`):** Used to generate geometric footprints and filter boundaries based on the vehicle's elevation.
+- **Kinematic State (`/localization/kinematic_state`):** Provides ego vehicle velocity, used to calculate the minimum physical braking distance.
+- **Acceleration (`/localization/acceleration`):** Used alongside velocity to calculate the minimum braking distance.
+- **Candidate Trajectories (`/planning/generator/concatenated/candidate_trajectories`):** The predicted paths to be evaluated, requiring accurate time-from-start values.
+- **Vector Map (`/map/vector_map`):** The Lanelet2 map used to extract uncrossable boundary locations, such as `road_border`.
+
+### Output
+
+- **Status:** The departure severity classification (`NONE`, `APPROACHING_DEPARTURE`, or `CRITICAL_DEPARTURE`).
+- **Score:** A numerical value used for trajectory cost evaluation.
+- **Processing Time:** Execution time in milliseconds for system monitoring.
+- **Debug Markers:** Visualizations for the ego footprint, boundaries, and geometric projections.
+
+## 3. What the Module Does
+
+The module evaluates whether the ego vehicle's predicted trajectory will safely stay within the road boundaries. It splits the vehicle's footprint into distinct left and right sides to evaluate the environment asymmetrically. By computing the geometric intersection between the vehicle's predicted footprint and mapped uncrossable boundaries, it classifies the trajectory's safety based on physical braking limits and predefined time thresholds. It also applies time-based hysteresis to prevent status flickering caused by noisy trajectory predictions.
+
+## 4. Parameters
+
+The module uses a structured parameter configuration to define thresholds, footprint margins, and buffer times. Below is a high-level representation of the parameter schema:
+
+{{ json_to_markdown("common/autoware_boundary_departure_checker/schema/boundary_departure_checker.schema.json") }}
+
+## 5. Process Overview
+
+1. **Footprint Generation:** The module generates geometric footprints for the ego vehicle at every point along the candidate trajectory. It expands the footprint size using margins to account for localization uncertainty.
+2. **Boundary Extraction and Filtering:** Uncrossable boundaries (e.g., `road_border`) are extracted from the Lanelet2 map and stored in a spatial R-tree. Boundaries significantly above or below the vehicle's Z-axis height are filtered out to prevent false positives from overpasses.
+3. **Distance Calculation:** The system calculates the shortest lateral distance from the left and right footprint segments to the nearest filtered boundary.
+4. **Severity Evaluation:** A minimum physical braking distance is dynamically calculated using current speed, acceleration, maximum allowed deceleration, jerk, and brake delay. The departure severity is assigned as follows:
+   - **NONE:** The footprint lateral distance is greater than the critical lateral margin.
+   - **APPROACHING:** A departure is detected, but it is farther than the braking distance AND the time to departure is greater than the cutoff threshold.
+   - **CRITICAL:** A departure is detected within the braking distance OR before the cutoff time expires.
+5. **Hysteresis Logic:** To ensure stability, an **ON-Time buffer** suppresses the `CRITICAL` state until the departure is continuously detected for a set duration. If a collision is imminent, this buffer is bypassed. An **OFF-Time buffer** ensures the status does not revert to `NONE` until the trajectory is continuously evaluated as safe.
+
+## 6. Possible Scenarios and Expected Behavior
+
+- **Scenario 1:** The ego vehicle's footprint overlaps with a map boundary that does not have the `road_border` tag (or other defined uncrossable tags).
+  - **Expected Behavior:** Evaluated as safe (`NONE`).
+- **Scenario 2:** The ego vehicle's footprint does not overlap the defined lateral gap to the `road_border`.
+  - **Expected Behavior:** Evaluated as safe (`NONE`).
+- **Scenario 3:** The footprint overlaps the lateral gap to the `road_border`, AND the arc length to the overlap is less than the minimum braking distance, AND the time to reach it is less than the cutoff time.
+  - **Expected Behavior:** Evaluated as a departure (`CRITICAL_DEPARTURE`).
+- **Scenario 4:** The footprint overlaps the lateral gap, and the time to reach the overlap is less than the cutoff time, even if the arc length is greater than the minimum braking distance.
+  - **Expected Behavior:** Evaluated as a departure (`CRITICAL_DEPARTURE`).
+- **Scenario 5:** The footprint overlaps the lateral gap, and the arc length to the overlap is less than the minimum braking distance, even if the time to reach the overlap exceeds the cutoff time.
+  - **Expected Behavior:** Evaluated as a departure (`CRITICAL_DEPARTURE`).
+- **Scenario 6:** The footprint overlaps the lateral gap, the longitudinal distance to the overlap is greater than the minimum braking distance, and the time to reach it is greater than the cutoff time.
+  - **Expected Behavior:** Evaluated as approaching departure (`APPROACHING_DEPARTURE`)
+
+| Scenario            | Condition / Description             | Lateral Overlap? | Lon > Braking Dist? | Time > Cutoff? | Expected Result |
+| ------------------- | ----------------------------------- | ---------------- | ------------------- | -------------- | --------------- |
+| **1: Wrong Tag**    | Boundary lacks `road_border` tag    | N/A              | N/A                 | N/A            | **NONE**        |
+| **2: Safe Lateral** | Vehicle stays within lateral gap    | No               | N/A                 | N/A            | **NONE**        |
+| **3: Imminent**     | Too close and too fast              | Yes              | No                  | No             | **CRITICAL**    |
+| **4: Late Warning** | Low time buffer to crossing         | Yes              | Yes                 | **No**         | **CRITICAL**    |
+| **5: High Speed**   | Insufficient braking distance       | Yes              | **No**              | Yes            | **CRITICAL**    |
+| **6: Approaching**  | Within margin, but buffers are safe | Yes              | **Yes**             | **Yes**        | **APPROACHING** |

--- a/common/autoware_boundary_departure_checker/include/autoware/boundary_departure_checker/detail/boundary_departure_evaluator.hpp
+++ b/common/autoware_boundary_departure_checker/include/autoware/boundary_departure_checker/detail/boundary_departure_evaluator.hpp
@@ -1,0 +1,73 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef AUTOWARE__BOUNDARY_DEPARTURE_CHECKER__DETAIL__BOUNDARY_DEPARTURE_EVALUATOR_HPP_
+#define AUTOWARE__BOUNDARY_DEPARTURE_CHECKER__DETAIL__BOUNDARY_DEPARTURE_EVALUATOR_HPP_
+
+#include "autoware/boundary_departure_checker/detail/data_structs.hpp"
+#include "autoware/boundary_departure_checker/detail/type_alias.hpp"
+#include "autoware/boundary_departure_checker/detail/uncrossable_boundaries_rtree.hpp"
+#include "autoware/boundary_departure_checker/parameters.hpp"
+
+#include <autoware_vehicle_info_utils/vehicle_info.hpp>
+
+#include <lanelet2_core/LaneletMap.h>
+
+#include <optional>
+
+namespace autoware::boundary_departure_checker
+{
+/**
+ * @brief Stateless pipeline class for evaluating boundary departures.
+ */
+class BoundaryDepartureEvaluator
+{
+public:
+  /**
+   * @brief Constructor.
+   * @param[in] map lanelet map
+   * @param[in] param checker parameters
+   * @param[in] vehicle_info vehicle information
+   */
+  BoundaryDepartureEvaluator(
+    const lanelet::LaneletMapPtr & map, const UncrossableBoundaryDepartureParam & param,
+    const vehicle_info_utils::VehicleInfo & vehicle_info);
+
+  /**
+   * @brief Evaluate boundary departure along a predicted trajectory.
+   * @param[in] predicted_traj predicted trajectory
+   * @param[in] footprints_sides side segments of footprints along trajectory
+   * @param[in] ego_state current ego dynamic state
+   * @return evaluated critical point pairs if successful
+   */
+  [[nodiscard]] std::optional<Side<std::optional<CriticalPointPair>>> evaluate(
+    const TrajectoryPoints & predicted_traj, const FootprintSideSegmentsArray & footprints_sides,
+    const EgoDynamicState & ego_state) const;
+
+  /**
+   * @brief Update parameters.
+   * @param[in] param parameters
+   */
+  void update_parameters(const UncrossableBoundaryDepartureParam & param) { param_ = param; }
+
+private:
+  lanelet::LaneletMapPtr map_;
+  UncrossableBoundaryDepartureParam param_;
+  vehicle_info_utils::VehicleInfo vehicle_info_;
+  UncrossableBoundariesRTree rtree_;
+};
+
+}  // namespace autoware::boundary_departure_checker
+
+#endif  // AUTOWARE__BOUNDARY_DEPARTURE_CHECKER__DETAIL__BOUNDARY_DEPARTURE_EVALUATOR_HPP_

--- a/common/autoware_boundary_departure_checker/include/autoware/boundary_departure_checker/detail/boundary_segment_finder.hpp
+++ b/common/autoware_boundary_departure_checker/include/autoware/boundary_departure_checker/detail/boundary_segment_finder.hpp
@@ -1,0 +1,101 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef AUTOWARE__BOUNDARY_DEPARTURE_CHECKER__DETAIL__BOUNDARY_SEGMENT_FINDER_HPP_
+#define AUTOWARE__BOUNDARY_DEPARTURE_CHECKER__DETAIL__BOUNDARY_SEGMENT_FINDER_HPP_
+
+#include "autoware/boundary_departure_checker/detail/data_structs.hpp"
+#include "autoware/boundary_departure_checker/detail/type_alias.hpp"
+#include "autoware/boundary_departure_checker/detail/uncrossable_boundaries_rtree.hpp"
+#include "autoware/boundary_departure_checker/parameters.hpp"
+
+#include <lanelet2_core/LaneletMap.h>
+
+#include <unordered_set>
+#include <vector>
+
+namespace autoware::boundary_departure_checker::boundary_segment_finder
+{
+/**
+ * @brief Calculate closest projections from ego footprint sides to road boundaries.
+ * @param[in] ego_pred_traj predicted trajectory
+ * @param[in] boundaries R-tree indexed boundary segments
+ * @param[in] footprints_sides list of side segments for each footprint
+ * @return closest projections to boundaries for both sides
+ */
+Side<ProjectionsToBound> get_closest_boundary_segments_from_side(
+  const TrajectoryPoints & ego_pred_traj, const BoundarySegmentsBySide & boundaries,
+  const FootprintSideSegmentsArray & footprints_sides);
+
+/**
+ * @brief Check if a boundary segment is closer to the reference ego side than the opposite side.
+ * @param[in] boundary_segment boundary segment to check
+ * @param[in] ego_side_ref_segment reference side of the ego vehicle
+ * @param[in] ego_side_opposite_ref_segment opposite side of the ego vehicle
+ * @return true if closer to reference side
+ */
+bool is_closest_to_boundary_segment(
+  const autoware_utils_geometry::Segment2d & boundary_segment,
+  const autoware_utils_geometry::Segment2d & ego_side_ref_segment,
+  const autoware_utils_geometry::Segment2d & ego_side_opposite_ref_segment);
+
+/**
+ * @brief Check if a 3D boundary segment is vertically within the height range of the ego vehicle.
+ * @param[in] boundary_segment 3D boundary segment to check
+ * @param[in] ego_z_position vertical position of ego base
+ * @param[in] ego_height height of ego vehicle
+ * @return true if within height range
+ */
+bool is_segment_within_ego_height(
+  const autoware_utils_geometry::Segment3d & boundary_segment, const double ego_z_position,
+  const double ego_height);
+
+/**
+ * @brief Find closest boundary segments from R-tree.
+ * @param[in] rtree R-tree of boundary segments
+ * @param[in] lanelet_map_ptr pointer to lanelet map
+ * @param[in] param checker parameters
+ * @param[in] ego_ref_segment reference segment of ego vehicle
+ * @param[in] ego_opposite_ref_segment opposite reference segment of ego vehicle
+ * @param[in] ego_z_position z-position of ego vehicle
+ * @param[in] ego_vehicle_height height of ego vehicle
+ * @param[in] unique_id set of already processed segment IDs
+ * @return list of closest boundary segments
+ */
+std::vector<SegmentWithIdx> find_closest_boundary_segments(
+  const UncrossableBoundariesRTree & rtree, const lanelet::LaneletMapPtr & lanelet_map_ptr,
+  const UncrossableBoundaryDepartureParam & param, const Segment2d & ego_ref_segment,
+  const Segment2d & ego_opposite_ref_segment, const double ego_z_position,
+  const double ego_vehicle_height,
+  std::unordered_set<IdxForRTreeSegment, IdxForRTreeSegmentHash> & unique_id);
+
+/**
+ * @brief Get boundary segments along the footprints.
+ * @param[in] rtree R-tree of boundary segments
+ * @param[in] lanelet_map_ptr pointer to lanelet map
+ * @param[in] param checker parameters
+ * @param[in] footprints_sides side segments of footprints along trajectory
+ * @param[in] trimmed_pred_trajectory trimmed predicted trajectory
+ * @param[in] ego_vehicle_height height of ego vehicle
+ * @return boundary segments grouped by side
+ */
+BoundarySegmentsBySide get_boundary_segments(
+  const UncrossableBoundariesRTree & rtree, const lanelet::LaneletMapPtr & lanelet_map_ptr,
+  const UncrossableBoundaryDepartureParam & param,
+  const FootprintSideSegmentsArray & footprints_sides,
+  const TrajectoryPoints & trimmed_pred_trajectory, const double ego_vehicle_height);
+
+}  // namespace autoware::boundary_departure_checker::boundary_segment_finder
+
+#endif  // AUTOWARE__BOUNDARY_DEPARTURE_CHECKER__DETAIL__BOUNDARY_SEGMENT_FINDER_HPP_

--- a/common/autoware_boundary_departure_checker/include/autoware/boundary_departure_checker/detail/conversion.hpp
+++ b/common/autoware_boundary_departure_checker/include/autoware/boundary_departure_checker/detail/conversion.hpp
@@ -1,0 +1,48 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef AUTOWARE__BOUNDARY_DEPARTURE_CHECKER__DETAIL__CONVERSION_HPP_
+#define AUTOWARE__BOUNDARY_DEPARTURE_CHECKER__DETAIL__CONVERSION_HPP_
+
+#include "autoware/boundary_departure_checker/detail/type_alias.hpp"
+
+#include <lanelet2_core/primitives/Lanelet.h>
+#include <lanelet2_core/primitives/Polygon.h>
+
+namespace autoware::boundary_departure_checker::utils
+{
+/**
+ * @brief Convert a 3D Eigen vector to a 2D point by dropping the z-coordinate.
+ * @param[in] ll_pt 3D point in Eigen format
+ * @return 2D point
+ */
+Point2d to_point_2d(const Eigen::Matrix<double, 3, 1> & ll_pt);
+
+/**
+ * @brief Convert two 3D Eigen points to a 2D line segment.
+ * @param[in] ll_pt1 first 3D point
+ * @param[in] ll_pt2 second 3D point
+ * @return 2D line segment
+ */
+Segment2d to_segment_2d(
+  const Eigen::Matrix<double, 3, 1> & ll_pt1, const Eigen::Matrix<double, 3, 1> & ll_pt2);
+
+/**
+ * @brief Convert a 3D segment to a 2D segment.
+ * @param[in] segment input 3D segment
+ * @return 2D segment
+ */
+Segment2d to_segment_2d(const Segment3d & segment);
+}  // namespace autoware::boundary_departure_checker::utils
+#endif  // AUTOWARE__BOUNDARY_DEPARTURE_CHECKER__DETAIL__CONVERSION_HPP_

--- a/common/autoware_boundary_departure_checker/include/autoware/boundary_departure_checker/detail/data_structs.hpp
+++ b/common/autoware_boundary_departure_checker/include/autoware/boundary_departure_checker/detail/data_structs.hpp
@@ -1,0 +1,221 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef AUTOWARE__BOUNDARY_DEPARTURE_CHECKER__DETAIL__DATA_STRUCTS_HPP_
+#define AUTOWARE__BOUNDARY_DEPARTURE_CHECKER__DETAIL__DATA_STRUCTS_HPP_
+
+#include "autoware/boundary_departure_checker/detail/side_struct.hpp"
+#include "autoware/boundary_departure_checker/detail/type_alias.hpp"
+
+#include <autoware_utils_geometry/boost_geometry.hpp>
+#include <autoware_utils_geometry/geometry.hpp>
+#include <autoware_utils_geometry/pose_deviation.hpp>
+#include <autoware_utils_system/stop_watch.hpp>
+#include <autoware_utils_uuid/uuid_helper.hpp>
+#include <magic_enum.hpp>
+
+#include <nav_msgs/msg/odometry.hpp>
+#include <visualization_msgs/msg/marker_array.hpp>
+
+#include <boost/functional/hash.hpp>
+#include <boost/geometry/geometry.hpp>
+
+#include <lanelet2_core/LaneletMap.h>
+
+#include <limits>
+#include <utility>
+#include <vector>
+
+namespace autoware::boundary_departure_checker
+{
+
+/**
+ * @brief Type of boundary departure.
+ */
+enum class DepartureType {
+  NONE = 0,     ///< no departure
+  APPROACHING,  ///< approaching the boundary
+  CRITICAL,     ///< critical departure from the boundary
+};
+
+/**
+ * @brief Information about a projection to a boundary.
+ */
+struct ProjectionToBound
+{
+  ProjectionToBound() = default;
+  explicit ProjectionToBound(size_t idx) : pose_index(idx) {}
+  ProjectionToBound(
+    Point2d pt_on_ego, Point2d pt_on_bound, Segment2d seg, double lat_dist,
+    double ego_front_to_proj_offset_m, size_t idx)
+  : pt_on_ego(std::move(pt_on_ego)),
+    pt_on_bound(std::move(pt_on_bound)),
+    nearest_bound_seg(std::move(seg)),
+    lat_dist(lat_dist),
+    ego_front_to_proj_offset_m(ego_front_to_proj_offset_m),
+    pose_index(idx)
+  {
+  }
+
+  /**
+   * @brief Check if the departure type is NONE.
+   * @return true if NONE
+   */
+  [[nodiscard]] bool is_none_departure() const { return departure_type == DepartureType::NONE; }
+
+  /**
+   * @brief Check if the departure type is APPROACHING.
+   * @return true if APPROACHING
+   */
+  [[nodiscard]] bool is_approaching() const { return departure_type == DepartureType::APPROACHING; }
+
+  /**
+   * @brief Check if the departure type is CRITICAL.
+   * @return true if CRITICAL
+   */
+  [[nodiscard]] bool is_critical() const { return departure_type == DepartureType::CRITICAL; }
+
+  DepartureType departure_type{DepartureType::NONE};  ///< type of departure
+  Point2d pt_on_ego;                                  ///< point on the ego footprint
+  Point2d pt_on_bound;                                ///< point on the boundary
+  double dist_along_trajectory_m{
+    std::numeric_limits<double>::max()};  ///< longitudinal distance along trajectory [m]
+  Segment2d nearest_bound_seg;            ///< nearest boundary segment
+  double lat_dist{std::numeric_limits<double>::max()};  ///< lateral distance to the boundary [m]
+  double ego_front_to_proj_offset_m{};  ///< offset between pt_on_ego and front of ego segment [m]
+  size_t pose_index{0};                 ///< index of the pose
+  double time_from_start{
+    std::numeric_limits<double>::max()};  ///< time from the start of the trajectory [s]
+};
+using ProjectionsToBound = std::vector<ProjectionToBound>;
+
+/**
+ * @brief A pair of critical points: physical departure point and safety buffer start.
+ */
+struct CriticalPointPair
+{
+  ProjectionToBound physical_departure_point;  ///< physical departure point
+  ProjectionToBound safety_buffer_start;       ///< point where safety buffer starts
+};
+
+using BoundarySide = Side<std::vector<Segment2d>>;
+
+/**
+ * @brief Indices for a segment in the R-tree.
+ */
+struct IdxForRTreeSegment
+{
+  IdxForRTreeSegment() = default;
+  IdxForRTreeSegment(lanelet::Id linestring_id, size_t segment_start_idx, size_t segment_end_idx)
+  : linestring_id(linestring_id),
+    segment_start_idx(segment_start_idx),
+    segment_end_idx(segment_end_idx)
+  {
+  }
+
+  /**
+   * @brief Equality operator.
+   * @param[in] rhs other segment index
+   * @return true if equal
+   */
+  [[nodiscard]] constexpr bool operator==(const IdxForRTreeSegment & rhs) const noexcept
+  {
+    return linestring_id == rhs.linestring_id && segment_start_idx == rhs.segment_start_idx &&
+           segment_end_idx == rhs.segment_end_idx;
+  }
+
+  /**
+   * @brief Inequality operator.
+   * @param[in] rhs other segment index
+   * @return true if not equal
+   */
+  [[nodiscard]] constexpr bool operator!=(const IdxForRTreeSegment & rhs) const noexcept
+  {
+    return !(*this == rhs);
+  }
+
+  lanelet::Id linestring_id{lanelet::InvalId};                   ///< ID of the linestring
+  size_t segment_start_idx{std::numeric_limits<size_t>::max()};  ///< start index of the segment
+  size_t segment_end_idx{std::numeric_limits<size_t>::max()};    ///< end index of the segment
+};
+
+/**
+ * @brief Hash function for IdxForRTreeSegment.
+ */
+struct IdxForRTreeSegmentHash
+{
+  /**
+   * @brief Calculate hash.
+   * @param[in] s segment index
+   * @return hash value
+   */
+  size_t operator()(const IdxForRTreeSegment & s) const noexcept
+  {
+    size_t seed = 0;
+    // Boost hash_combine is a good choice for combining hashes
+    boost::hash_combine(seed, s.linestring_id);
+    boost::hash_combine(seed, s.segment_start_idx);
+    boost::hash_combine(seed, s.segment_end_idx);
+    return seed;
+  }
+};
+
+using SegmentWithIdx = std::pair<Segment2d, IdxForRTreeSegment>;
+using UncrossableBoundsRTree = boost::geometry::index::rtree<SegmentWithIdx, bgi::rstar<16>>;
+using BoundarySegmentsBySide = Side<std::vector<SegmentWithIdx>>;
+using FootprintSideSegments = Side<Segment2d>;
+using FootprintSideSegmentsArray = std::vector<FootprintSideSegments>;
+
+/**
+ * @brief Result of boundary departure check.
+ */
+struct DepartureResult
+{
+  DepartureType status{DepartureType::NONE};           ///< current departure status
+  visualization_msgs::msg::MarkerArray debug_markers;  ///< debug markers for visualization
+};
+
+/**
+ * @brief Dynamic state of the ego vehicle.
+ */
+struct EgoDynamicState
+{
+  geometry_msgs::msg::PoseWithCovariance pose_with_cov;  ///< pose with covariance
+  double velocity{0.0};                                  ///< velocity [m/s]
+  double acceleration{0.0};                              ///< acceleration [m/s^2]
+  double current_time_s{0.0};                            ///< current time [s]
+};
+
+/**
+ * @brief Thresholds for boundary departure check.
+ */
+struct DepartureCheckThresholds
+{
+  double min_braking_distance{0.0};  ///< minimum braking distance [m]
+  double cutoff_time{0.0};           ///< time cutoff for departure check [s]
+  double th_lat_critical{0.0};       ///< lateral distance threshold for critical departure [m]
+};
+
+/**
+ * @brief Metrics for evaluating a projection.
+ */
+struct ProjectionEvaluationMetrics
+{
+  double lon_dist_to_departure{0.0};  ///< longitudinal distance to departure [m]
+  double time_from_start{0.0};        ///< time from the start of the trajectory [s]
+  double lat_dist{0.0};               ///< lateral distance to the boundary [m]
+};
+}  // namespace autoware::boundary_departure_checker
+
+#endif  // AUTOWARE__BOUNDARY_DEPARTURE_CHECKER__DETAIL__DATA_STRUCTS_HPP_

--- a/common/autoware_boundary_departure_checker/include/autoware/boundary_departure_checker/detail/debug.hpp
+++ b/common/autoware_boundary_departure_checker/include/autoware/boundary_departure_checker/detail/debug.hpp
@@ -1,0 +1,40 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef AUTOWARE__BOUNDARY_DEPARTURE_CHECKER__DETAIL__DEBUG_HPP_
+#define AUTOWARE__BOUNDARY_DEPARTURE_CHECKER__DETAIL__DEBUG_HPP_
+
+#include "autoware/boundary_departure_checker/detail/footprints_generator.hpp"
+#include "autoware/boundary_departure_checker/detail/hysteresis_logic.hpp"
+
+#include <visualization_msgs/msg/marker_array.hpp>
+
+namespace autoware::boundary_departure_checker::debug
+{
+using visualization_msgs::msg::Marker;
+using visualization_msgs::msg::MarkerArray;
+
+/**
+ * @brief Create debug markers for boundary departure.
+ * @param[in] departure_data data about the departure check
+ * @param[in] curr_time current time
+ * @param[in] base_link_z z-coordinate of the base_link
+ * @return array of markers for visualization
+ */
+MarkerArray create_debug_markers(
+  const HysteresisState & hysteresis_state, const footprints::Footprints & footprints,
+  const EgoDynamicState & ego_state, const bool enable_developer_marker);
+}  // namespace autoware::boundary_departure_checker::debug
+
+#endif  // AUTOWARE__BOUNDARY_DEPARTURE_CHECKER__DETAIL__DEBUG_HPP_

--- a/common/autoware_boundary_departure_checker/include/autoware/boundary_departure_checker/detail/footprints_generator.hpp
+++ b/common/autoware_boundary_departure_checker/include/autoware/boundary_departure_checker/detail/footprints_generator.hpp
@@ -1,0 +1,73 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef AUTOWARE__BOUNDARY_DEPARTURE_CHECKER__DETAIL__FOOTPRINTS_GENERATOR_HPP_
+#define AUTOWARE__BOUNDARY_DEPARTURE_CHECKER__DETAIL__FOOTPRINTS_GENERATOR_HPP_
+
+#include <autoware/boundary_departure_checker/detail/side_struct.hpp>
+#include <autoware_utils_geometry/boost_geometry.hpp>
+#include <autoware_utils_geometry/geometry.hpp>
+#include <autoware_vehicle_info_utils/vehicle_info.hpp>
+
+#include <autoware_planning_msgs/msg/trajectory_point.hpp>
+
+#include <vector>
+
+namespace autoware::boundary_departure_checker::footprints
+{
+using Footprint = autoware_utils_geometry::LinearRing2d;
+using Footprints = std::vector<Footprint>;
+using autoware_planning_msgs::msg::TrajectoryPoint;
+
+/**
+ * @brief Margin for the footprint.
+ */
+struct FootprintMargin
+{
+  double lat_m{1000.0};  ///< lateral margin [m]
+  double lon_m{1000.0};  ///< longitudinal margin [m]
+};
+
+/**
+ * @brief Generate vehicle footprints along a trajectory.
+ * @param[in] trajectory_points points along the trajectory
+ * @param[in] vehicle_info information about the vehicle
+ * @param[in] covariance pose covariance to consider for margin
+ * @return list of generated footprints
+ */
+Footprints generate(
+  const std::vector<TrajectoryPoint> & trajectory_points,
+  const vehicle_info_utils::VehicleInfo & vehicle_info,
+  const geometry_msgs::msg::PoseWithCovariance & covariance);
+
+/**
+ * @brief Extract left and right side segments from footprints.
+ * @param[in] footprints list of vehicle footprints
+ * @return list of side segments for each footprint
+ */
+std::vector<Side<autoware_utils_geometry::Segment2d>> get_sides_from_footprints(
+  const Footprints & footprints);
+
+/**
+ * @brief Calculate margin based on pose covariance.
+ * @param[in] covariance pose covariance
+ * @param[in] scale scale factor for the covariance
+ * @return calculated footprint margin
+ */
+FootprintMargin calc_margin_from_covariance(
+  const geometry_msgs::msg::PoseWithCovariance & covariance, const double scale = 0.0);
+
+}  // namespace autoware::boundary_departure_checker::footprints
+
+#endif  // AUTOWARE__BOUNDARY_DEPARTURE_CHECKER__DETAIL__FOOTPRINTS_GENERATOR_HPP_

--- a/common/autoware_boundary_departure_checker/include/autoware/boundary_departure_checker/detail/geometry_projection.hpp
+++ b/common/autoware_boundary_departure_checker/include/autoware/boundary_departure_checker/detail/geometry_projection.hpp
@@ -1,0 +1,70 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef AUTOWARE__BOUNDARY_DEPARTURE_CHECKER__DETAIL__GEOMETRY_PROJECTION_HPP_
+#define AUTOWARE__BOUNDARY_DEPARTURE_CHECKER__DETAIL__GEOMETRY_PROJECTION_HPP_
+
+#include "autoware/boundary_departure_checker/detail/data_structs.hpp"
+#include "autoware/boundary_departure_checker/detail/type_alias.hpp"
+
+#include <optional>
+#include <utility>
+#include <vector>
+
+namespace autoware::boundary_departure_checker::geometry_projection
+{
+/**
+ * @brief Project a point onto a line segment.
+ * @param[in] p point to be projected
+ * @param[in] segment line segment to project onto
+ * @return pair of projected point and distance if successful
+ */
+std::optional<std::pair<Point2d, double>> point_to_segment_projection(
+  const Point2d & p, const Segment2d & segment);
+
+/**
+ * @brief Calculate the nearest projection between two segments.
+ * @param[in] ego_seg ego vehicle's footprint segment
+ * @param[in] lane_seg road boundary segment
+ * @param[in] pose_index index of the footprint point
+ * @return closest projection data if successful
+ */
+std::optional<ProjectionToBound> calc_nearest_projection(
+  const Segment2d & ego_seg, const Segment2d & lane_seg, const size_t pose_index);
+
+/**
+ * @brief Find the nearest boundary segment to an ego side segment.
+ * @param[in] ego_side_seg side segment of the ego footprint
+ * @param[in] ego_front_seg front segment of the ego footprint
+ * @param[in] ego_rear_seg rear segment of the ego footprint
+ * @param[in] curr_fp_idx index of the current footprint
+ * @param[in] boundary_segments candidate boundary segments
+ * @return closest projection data
+ */
+ProjectionToBound find_closest_segment(
+  const Segment2d & ego_side_seg, const Segment2d & ego_front_seg, const Segment2d & ego_rear_seg,
+  const size_t curr_fp_idx, const std::vector<SegmentWithIdx> & boundary_segments);
+
+/**
+ * @brief Calculate signed lateral distance to a boundary.
+ * @param[in] boundary boundary line string
+ * @param[in] reference_pose reference pose
+ * @return signed lateral distance if successful
+ */
+std::optional<double> calc_signed_lateral_distance_to_boundary(
+  const lanelet::ConstLineString3d & boundary, const Pose & reference_pose);
+
+}  // namespace autoware::boundary_departure_checker::geometry_projection
+
+#endif  // AUTOWARE__BOUNDARY_DEPARTURE_CHECKER__DETAIL__GEOMETRY_PROJECTION_HPP_

--- a/common/autoware_boundary_departure_checker/include/autoware/boundary_departure_checker/detail/hysteresis_logic.hpp
+++ b/common/autoware_boundary_departure_checker/include/autoware/boundary_departure_checker/detail/hysteresis_logic.hpp
@@ -1,0 +1,59 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef AUTOWARE__BOUNDARY_DEPARTURE_CHECKER__DETAIL__HYSTERESIS_LOGIC_HPP_
+#define AUTOWARE__BOUNDARY_DEPARTURE_CHECKER__DETAIL__HYSTERESIS_LOGIC_HPP_
+
+#include "autoware/boundary_departure_checker/detail/data_structs.hpp"
+#include "autoware/boundary_departure_checker/parameters.hpp"
+
+#include <optional>
+
+namespace autoware::boundary_departure_checker
+{
+/**
+ * @brief State for hysteresis logic.
+ */
+struct HysteresisState
+{
+  double last_no_critical_dpt_time{0.0};     ///< last time no critical departure was found [s]
+  double last_found_critical_dpt_time{0.0};  ///< last time critical departure was found [s]
+  Side<ProjectionsToBound> critical_departure_history;  ///< history of critical departures
+};
+
+/**
+ * @brief Result of hysteresis logic.
+ */
+struct HysteresisResult
+{
+  DepartureType status{DepartureType::NONE};
+  HysteresisState updated_state;
+};
+
+/**
+ * @brief Pure function to determine departure status using hysteresis.
+ * @param[in] state current hysteresis state
+ * @param[in] evaluation_result result from stateless evaluator
+ * @param[in] param parameters
+ * @param[in] current_time_s current time in seconds
+ * @return updated status and state
+ */
+HysteresisResult update_and_judge(
+  const HysteresisState & state,
+  const std::optional<Side<std::optional<CriticalPointPair>>> & evaluation_result,
+  const UncrossableBoundaryDepartureParam & param, const double current_time_s);
+
+}  // namespace autoware::boundary_departure_checker
+
+#endif  // AUTOWARE__BOUNDARY_DEPARTURE_CHECKER__DETAIL__HYSTERESIS_LOGIC_HPP_

--- a/common/autoware_boundary_departure_checker/include/autoware/boundary_departure_checker/detail/severity_evaluator.hpp
+++ b/common/autoware_boundary_departure_checker/include/autoware/boundary_departure_checker/detail/severity_evaluator.hpp
@@ -1,0 +1,89 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef AUTOWARE__BOUNDARY_DEPARTURE_CHECKER__DETAIL__SEVERITY_EVALUATOR_HPP_
+#define AUTOWARE__BOUNDARY_DEPARTURE_CHECKER__DETAIL__SEVERITY_EVALUATOR_HPP_
+
+#include "autoware/boundary_departure_checker/detail/data_structs.hpp"
+#include "autoware/boundary_departure_checker/parameters.hpp"
+
+#include <autoware_vehicle_info_utils/vehicle_info.hpp>
+
+#include <optional>
+
+namespace autoware::boundary_departure_checker::severity_evaluator
+{
+/**
+ * @brief Filter projections and assign departure types based on parameters.
+ * @param[in] side_value list of projections for a side
+ * @param[in] param checker parameters
+ * @param[in] min_braking_dist minimum braking distance [m]
+ * @return filtered projections with assigned types
+ */
+ProjectionsToBound filter_and_assign_departure_types(
+  const ProjectionsToBound & side_value, const UncrossableBoundaryDepartureParam & param,
+  const double min_braking_dist);
+
+/**
+ * @brief Apply backward buffer to projections and filter them.
+ * @param[in] side_value list of projections for a side
+ * @param[in] param checker parameters
+ * @return evaluated critical point pair if found
+ */
+std::optional<CriticalPointPair> apply_backward_buffer_and_filter(
+  const ProjectionsToBound & side_value, const UncrossableBoundaryDepartureParam & param);
+
+/**
+ * @brief Assign departure type based on evaluation metrics and thresholds.
+ * @param[in] metrics evaluation metrics
+ * @param[in] thresholds departure check thresholds
+ * @return assigned departure type
+ */
+DepartureType assign_departure_type(
+  const ProjectionEvaluationMetrics & metrics, const DepartureCheckThresholds & thresholds);
+
+/**
+ * @brief Evaluate the severity of projections for both sides.
+ * @param[in] projections_to_bound projections for both sides
+ * @param[in] param checker parameters
+ * @param[in] ego_state current ego dynamic state
+ * @param[in] vehicle_info vehicle information
+ * @return evaluated critical point pairs for both sides
+ */
+Side<std::optional<CriticalPointPair>> evaluate_projections_severity(
+  const Side<ProjectionsToBound> & projections_to_bound,
+  const UncrossableBoundaryDepartureParam & param, const EgoDynamicState & ego_state,
+  const vehicle_info_utils::VehicleInfo & vehicle_info);
+
+/**
+ * @brief Check if any side has a critical departure.
+ * @param[in] evaluated_projections evaluated critical point pairs for both sides
+ * @return true if critical
+ */
+bool is_critical(const Side<std::optional<CriticalPointPair>> & evaluated_projections);
+
+/**
+ * @brief Calculate minimum braking distance.
+ * @param[in] ego_state current ego dynamic state
+ * @param[in] param checker parameters
+ * @param[in] vehicle_info vehicle information
+ * @return minimum braking distance [m]
+ */
+double calc_minimum_braking_distance(
+  const EgoDynamicState & ego_state, const UncrossableBoundaryDepartureParam & param,
+  const vehicle_info_utils::VehicleInfo & vehicle_info);
+
+}  // namespace autoware::boundary_departure_checker::severity_evaluator
+
+#endif  // AUTOWARE__BOUNDARY_DEPARTURE_CHECKER__DETAIL__SEVERITY_EVALUATOR_HPP_

--- a/common/autoware_boundary_departure_checker/include/autoware/boundary_departure_checker/detail/side_struct.hpp
+++ b/common/autoware_boundary_departure_checker/include/autoware/boundary_departure_checker/detail/side_struct.hpp
@@ -1,0 +1,225 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef AUTOWARE__BOUNDARY_DEPARTURE_CHECKER__DETAIL__SIDE_STRUCT_HPP_
+#define AUTOWARE__BOUNDARY_DEPARTURE_CHECKER__DETAIL__SIDE_STRUCT_HPP_
+
+#include <magic_enum.hpp>
+
+#include <algorithm>
+#include <stdexcept>
+#include <string>
+#include <type_traits>
+
+namespace autoware::boundary_departure_checker
+{
+/**
+ * @brief Key for side (left or right).
+ */
+enum class SideKey { LEFT, RIGHT };
+
+/**
+ * @brief Convert SideKey to string.
+ * @param[in] key side key
+ * @return string representation ("left", "right", or "unknown")
+ */
+inline std::string to_string(const SideKey key)
+{
+  if (key == SideKey::LEFT) return "left";
+  if (key == SideKey::RIGHT) return "right";
+  return "unknown";
+}
+
+/**
+ * @brief Helper to check if a type has an empty() method.
+ */
+template <typename T, typename = void>
+struct HasEmpty : std::false_type
+{
+};
+
+/**
+ * @brief Specialization of HasEmpty for types with empty().
+ */
+template <typename T>
+struct HasEmpty<T, std::void_t<decltype(std::declval<T>().empty())>> : std::true_type
+{
+};
+
+/**
+ * @brief Template struct to hold data for both sides.
+ * @tparam T type of data to hold
+ */
+template <typename T>
+struct Side
+{
+  /**
+   * @brief Access element by SideKey.
+   * @param[in] key side key
+   * @return reference to the element
+   */
+  T & operator[](const SideKey key)
+  {
+    if (key == SideKey::LEFT) return left;
+    if (key == SideKey::RIGHT) return right;
+    throw std::invalid_argument("Invalid key: " + std::string(magic_enum::enum_name(key)));
+  }
+
+  /**
+   * @brief Access element by SideKey (const version).
+   * @param[in] key side key
+   * @return const reference to the element
+   */
+  const T & operator[](const SideKey key) const
+  {
+    if (key == SideKey::LEFT) return left;
+    if (key == SideKey::RIGHT) return right;
+    throw std::invalid_argument("Invalid key: " + std::string(magic_enum::enum_name(key)));
+  }
+
+  /**
+   * @brief Apply a function to each side with side key information.
+   * @tparam Func function type
+   * @param[in] fn function to apply
+   */
+  template <typename Func>
+  void for_each(Func && fn)
+  {
+    fn(std::integral_constant<SideKey, SideKey::LEFT>{}, left);
+    fn(std::integral_constant<SideKey, SideKey::RIGHT>{}, right);
+  }
+
+  /**
+   * @brief Apply a function to each side with side key information (const version).
+   * @tparam Func function type
+   * @param[in] fn function to apply
+   */
+  template <typename Func>
+  void for_each(Func && fn) const
+  {
+    fn(std::integral_constant<SideKey, SideKey::LEFT>{}, left);
+    fn(std::integral_constant<SideKey, SideKey::RIGHT>{}, right);
+  }
+
+  /**
+   * @brief Apply a function to each side.
+   * @tparam Func function type
+   * @param[in] fn function to apply
+   */
+  template <typename Func>
+  void for_each_side(Func && fn)
+  {
+    fn(left);
+    fn(right);
+  }
+
+  /**
+   * @brief Apply a function to each side (const version).
+   * @tparam Func function type
+   * @param[in] fn function to apply
+   */
+  template <typename Func>
+  void for_each_side(Func && fn) const
+  {
+    fn(left);
+    fn(right);
+  }
+
+  /**
+   * @brief Transform each side using a function and return a new Side object.
+   * @tparam Func function type
+   * @param[in] fn transformation function
+   * @return new Side object with transformed elements
+   */
+  template <typename Func>
+  auto transform_each_side(Func && fn) const
+  {
+    using ResultType = decltype(fn(left));
+    Side<ResultType> result;
+    result.left = fn(left);
+    result.right = fn(right);
+    return result;
+  }
+
+  /**
+   * @brief Check if both sides are empty.
+   * @return true if both sides are empty
+   */
+  template <typename U = T, std::enable_if_t<HasEmpty<U>::value, int> = 0>
+  [[nodiscard]] bool all_empty() const
+  {
+    return left.empty() && right.empty();
+  }
+
+  /**
+   * @brief Reserve space on both sides.
+   * @param[in] size size to reserve
+   */
+  template <typename U = T, std::enable_if_t<HasEmpty<U>::value, int> = 0>
+  void reserve_all(const size_t size)
+  {
+    left.reserve(size);
+    right.reserve(size);
+  }
+
+  /**
+   * @brief Check if both sides have the same size.
+   * @return true if sizes are equal
+   */
+  template <typename U = T, std::enable_if_t<HasEmpty<U>::value, int> = 0>
+  [[nodiscard]] bool equal_size() const
+  {
+    return left.size() == right.size();
+  }
+
+  /**
+   * @brief Get the maximum size among both sides.
+   * @return maximum size
+   */
+  template <typename U = T, std::enable_if_t<HasEmpty<U>::value, int> = 0>
+  [[nodiscard]] size_t max_size() const
+  {
+    return std::max(left.size(), right.size());
+  }
+
+  /**
+   * @brief Check if any side satisfies a condition.
+   * @tparam Func condition function type
+   * @param[in] fn condition function
+   * @return true if any side satisfies the condition
+   */
+  template <typename Func>
+  [[nodiscard]] bool any_of_side(Func && fn) const
+  {
+    return fn(left) || fn(right);
+  }
+
+  /**
+   * @brief Check if all sides satisfy a condition.
+   * @tparam Func condition function type
+   * @param[in] fn condition function
+   * @return true if all sides satisfy the condition
+   */
+  template <typename Func>
+  [[nodiscard]] bool all_of_side(Func && fn) const
+  {
+    return fn(left) && fn(right);
+  }
+
+  T right;  ///< data for the right side
+  T left;   ///< data for the left side
+};
+}  // namespace autoware::boundary_departure_checker
+
+#endif  // AUTOWARE__BOUNDARY_DEPARTURE_CHECKER__DETAIL__SIDE_STRUCT_HPP_

--- a/common/autoware_boundary_departure_checker/include/autoware/boundary_departure_checker/detail/type_alias.hpp
+++ b/common/autoware_boundary_departure_checker/include/autoware/boundary_departure_checker/detail/type_alias.hpp
@@ -1,0 +1,67 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef AUTOWARE__BOUNDARY_DEPARTURE_CHECKER__DETAIL__TYPE_ALIAS_HPP_
+#define AUTOWARE__BOUNDARY_DEPARTURE_CHECKER__DETAIL__TYPE_ALIAS_HPP_
+
+#include <autoware/trajectory/trajectory_point.hpp>
+#include <autoware_utils_geometry/boost_geometry.hpp>
+#include <autoware_utils_geometry/pose_deviation.hpp>
+#include <autoware_vehicle_info_utils/vehicle_info.hpp>
+
+#include <autoware_internal_planning_msgs/msg/path_with_lane_id.hpp>
+#include <autoware_planning_msgs/msg/lanelet_route.hpp>
+#include <autoware_planning_msgs/msg/trajectory.hpp>
+#include <autoware_planning_msgs/msg/trajectory_point.hpp>
+#include <autoware_vehicle_msgs/msg/steering_report.hpp>
+
+#include <boost/geometry.hpp>
+
+#include <lanelet2_core/geometry/Polygon.h>
+
+#include <vector>
+
+namespace autoware::boundary_departure_checker
+{
+using autoware_internal_planning_msgs::msg::PathWithLaneId;
+
+using autoware_planning_msgs::msg::LaneletRoute;
+using autoware_planning_msgs::msg::Trajectory;
+using autoware_planning_msgs::msg::TrajectoryPoint;
+using autoware_vehicle_msgs::msg::SteeringReport;
+
+using autoware_utils_geometry::Box2d;
+using autoware_utils_geometry::LinearRing2d;
+using autoware_utils_geometry::LineString2d;
+using autoware_utils_geometry::MultiPoint2d;
+using autoware_utils_geometry::MultiPolygon2d;
+using autoware_utils_geometry::Point2d;  // NOLINT
+using autoware_utils_geometry::Polygon2d;
+using autoware_utils_geometry::Segment2d;
+using autoware_utils_geometry::Segment3d;
+
+using autoware::vehicle_info_utils::VehicleInfo;  // NOLINT
+
+namespace bg = boost::geometry;
+namespace bgi = bg::index;                        // NOLINT
+namespace trajectory = experimental::trajectory;  // NOLINT
+
+using geometry_msgs::msg::Point;
+using geometry_msgs::msg::Pose;
+
+using TrajectoryPoints = std::vector<TrajectoryPoint>;
+
+}  // namespace autoware::boundary_departure_checker
+
+#endif  // AUTOWARE__BOUNDARY_DEPARTURE_CHECKER__DETAIL__TYPE_ALIAS_HPP_

--- a/common/autoware_boundary_departure_checker/include/autoware/boundary_departure_checker/detail/uncrossable_boundaries_rtree.hpp
+++ b/common/autoware_boundary_departure_checker/include/autoware/boundary_departure_checker/detail/uncrossable_boundaries_rtree.hpp
@@ -1,0 +1,82 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef AUTOWARE__BOUNDARY_DEPARTURE_CHECKER__DETAIL__UNCROSSABLE_BOUNDARIES_RTREE_HPP_
+#define AUTOWARE__BOUNDARY_DEPARTURE_CHECKER__DETAIL__UNCROSSABLE_BOUNDARIES_RTREE_HPP_
+
+#include "autoware/boundary_departure_checker/detail/data_structs.hpp"
+#include "autoware/boundary_departure_checker/detail/type_alias.hpp"
+
+#include <lanelet2_core/LaneletMap.h>
+
+#include <string>
+#include <vector>
+
+namespace autoware::boundary_departure_checker
+{
+/**
+ * @brief Class to handle construction and querying of an R-tree for uncrossable boundary segments.
+ */
+class UncrossableBoundariesRTree
+{
+public:
+  /**
+   * @brief Constructor that builds the R-tree from a LaneletMap.
+   * @param[in] lanelet_map input map containing all line strings
+   * @param[in] boundary_types_to_detect list of boundary type names to consider as uncrossable
+   */
+  UncrossableBoundariesRTree(
+    lanelet::LaneletMapPtr lanelet_map_ptr,
+    const std::vector<std::string> & boundary_types_to_detect);
+
+  /**
+   * @brief Retrieve a 3D line segment from the Lanelet2 map.
+   * @param[in] seg_id identifier for the segment
+   * @return corresponding 3D segment
+   */
+  [[nodiscard]] autoware_utils_geometry::Segment3d get_segment_3d_from_id(
+    const IdxForRTreeSegment & seg_id) const;
+
+  /**
+   * @brief Query the R-tree for segments near a point.
+   * @param[in] point query point
+   * @param[in] max_results maximum number of results to return
+   * @return list of nearby segments
+   */
+  [[nodiscard]] std::vector<SegmentWithIdx> query(const Point2d & point, size_t max_results) const;
+
+  /**
+   * @brief Check if the R-tree is empty.
+   * @return true if empty
+   */
+  [[nodiscard]] bool empty() const { return rtree_.empty(); }
+
+  /**
+   * @brief Check if a line string matches one of the uncrossable boundary types.
+   * @param[in] boundary_types_to_detect list of boundary type strings to match
+   * @param[in] ls lanelet line string to inspect
+   * @return true if the line string is uncrossable
+   */
+  static bool is_uncrossable_type(
+    const std::vector<std::string> & boundary_types_to_detect,
+    const lanelet::ConstLineString3d & ls);
+
+private:
+  autoware::boundary_departure_checker::UncrossableBoundsRTree rtree_;
+  lanelet::LaneletMapPtr lanelet_map_ptr_;
+};
+
+}  // namespace autoware::boundary_departure_checker
+
+#endif  // AUTOWARE__BOUNDARY_DEPARTURE_CHECKER__DETAIL__UNCROSSABLE_BOUNDARIES_RTREE_HPP_

--- a/common/autoware_boundary_departure_checker/include/autoware/boundary_departure_checker/parameters.hpp
+++ b/common/autoware_boundary_departure_checker/include/autoware/boundary_departure_checker/parameters.hpp
@@ -1,0 +1,42 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef AUTOWARE__BOUNDARY_DEPARTURE_CHECKER__PARAMETERS_HPP_
+#define AUTOWARE__BOUNDARY_DEPARTURE_CHECKER__PARAMETERS_HPP_
+
+#include <string>
+#include <vector>
+
+namespace autoware::boundary_departure_checker
+{
+/**
+ * @brief Parameters for checking uncrossable boundary departure.
+ */
+struct UncrossableBoundaryDepartureParam
+{
+  int max_lateral_rtree_queries{5};        ///< maximum number of lateral R-tree queries
+  double lateral_margin_m{0.01};           ///< lateral margin [m]
+  double longitudinal_margin_m{1.0};       ///< longitudinal margin [m]
+  double max_deceleration_mps2{-4.0};      ///< maximum deceleration [m/s^2]
+  double max_jerk_mps3{-5.0};              ///< maximum jerk [m/s^3]
+  double brake_delay_s{1.0};               ///< brake delay [s]
+  double time_to_departure_cutoff_s{2.0};  ///< time to departure cutoff [s]
+  double on_time_buffer_s{0.15};           ///< buffer for activating departure detection [s]
+  double off_time_buffer_s{0.15};          ///< buffer for deactivating departure detection [s]
+  bool enable_developer_marker{true};      ///< flag marker only for developer
+  std::vector<std::string> boundary_types_to_detect{"road_border"};  ///< boundary types to detect
+};
+}  // namespace autoware::boundary_departure_checker
+
+#endif  // AUTOWARE__BOUNDARY_DEPARTURE_CHECKER__PARAMETERS_HPP_

--- a/common/autoware_boundary_departure_checker/include/autoware/boundary_departure_checker/uncrossable_boundary_checker.hpp
+++ b/common/autoware_boundary_departure_checker/include/autoware/boundary_departure_checker/uncrossable_boundary_checker.hpp
@@ -1,0 +1,71 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef AUTOWARE__BOUNDARY_DEPARTURE_CHECKER__UNCROSSABLE_BOUNDARY_CHECKER_HPP_
+#define AUTOWARE__BOUNDARY_DEPARTURE_CHECKER__UNCROSSABLE_BOUNDARY_CHECKER_HPP_
+
+#include "autoware/boundary_departure_checker/detail/boundary_departure_evaluator.hpp"
+#include "autoware/boundary_departure_checker/detail/data_structs.hpp"
+#include "autoware/boundary_departure_checker/detail/hysteresis_logic.hpp"
+#include "autoware/boundary_departure_checker/parameters.hpp"
+
+#include <autoware_utils_debug/time_keeper.hpp>
+#include <autoware_vehicle_info_utils/vehicle_info_utils.hpp>
+
+#include <lanelet2_core/LaneletMap.h>
+
+#include <memory>
+
+namespace autoware::boundary_departure_checker
+{
+/**
+ * @brief Orchestrator class for checking uncrossable boundary departure.
+ */
+class UncrossableBoundaryChecker
+{
+public:
+  /**
+   * @brief Constructor.
+   */
+  UncrossableBoundaryChecker(
+    const lanelet::LaneletMapPtr & map, const UncrossableBoundaryDepartureParam & param,
+    const VehicleInfo & vehicle_info);
+
+  /**
+   * @brief Update parameters for the checker.
+   * @param[in] param parameters
+   */
+  void update_parameters(const UncrossableBoundaryDepartureParam & param);
+
+  /**
+   * @brief Update departure status along a predicted trajectory.
+   * @param[in] predicted_traj predicted trajectory
+   * @param[in] ego_state current ego dynamic state
+   * @return departure result
+   */
+  DepartureResult update_departure_status(
+    const TrajectoryPoints & predicted_traj, const EgoDynamicState & ego_state);
+
+private:
+  UncrossableBoundaryDepartureParam param_;
+  VehicleInfo vehicle_info_;
+  std::unique_ptr<BoundaryDepartureEvaluator> evaluator_ptr_;
+  HysteresisState hysteresis_state_;
+
+  mutable std::shared_ptr<autoware_utils_debug::TimeKeeper> time_keeper_ =
+    std::make_shared<autoware_utils_debug::TimeKeeper>();
+};
+}  // namespace autoware::boundary_departure_checker
+
+#endif  // AUTOWARE__BOUNDARY_DEPARTURE_CHECKER__UNCROSSABLE_BOUNDARY_CHECKER_HPP_

--- a/common/autoware_boundary_departure_checker/package.xml
+++ b/common/autoware_boundary_departure_checker/package.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>autoware_boundary_departure_checker</name>
+  <version>0.50.0</version>
+  <description>The autoware_boundary_departure_checker package</description>
+  <maintainer email="alqudah.mohammad@tier4.jp">Alqudah Mohammad</maintainer>
+  <maintainer email="maxime.clement@tier4.jp">Maxime Clement</maintainer>
+  <maintainer email="zulfaqar.azmi@tier4.jp">Zulfaqar Azmi</maintainer>
+
+  <license>Apache License 2.0</license>
+
+  <buildtool_depend>ament_cmake_auto</buildtool_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
+
+  <depend>autoware_motion_utils</depend>
+  <depend>autoware_planning_msgs</depend>
+  <depend>autoware_trajectory</depend>
+  <depend>autoware_universe_utils</depend>
+  <depend>autoware_utils_debug</depend>
+  <depend>autoware_utils_geometry</depend>
+  <depend>autoware_utils_system</depend>
+  <depend>autoware_utils_uuid</depend>
+  <depend>autoware_vehicle_info_utils</depend>
+  <depend>autoware_vehicle_msgs</depend>
+  <depend>boost</depend>
+  <depend>eigen</depend>
+  <depend>geometry_msgs</depend>
+  <depend>magic_enum</depend>
+  <depend>nav_msgs</depend>
+  <depend>tf2</depend>
+  <depend>visualization_msgs</depend>
+
+  <test_depend>ament_cmake_ros</test_depend>
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>autoware_lint_common</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/common/autoware_boundary_departure_checker/schema/boundary_departure_checker.schema.json
+++ b/common/autoware_boundary_departure_checker/schema/boundary_departure_checker.schema.json
@@ -1,0 +1,102 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Parameters for boundary_departure_checker",
+  "type": "object",
+  "definitions": {
+    "boundary_departure_checker": {
+      "type": "object",
+      "properties": {
+        "boundary_types_to_detect": {
+          "type": "array",
+          "items": { "type": "string" },
+          "description": "Linestring boundary tags to be treated as uncrossable.",
+          "default": ["road_border"]
+        },
+        "max_lateral_rtree_queries": {
+          "type": "integer",
+          "description": "Maximum number of lateral R-tree queries.",
+          "default": 5
+        },
+        "lateral_margin_m": {
+          "type": "number",
+          "description": "Lateral margin threshold [m].",
+          "default": 0.01
+        },
+        "longitudinal_margin_m": {
+          "type": "number",
+          "description": "Longitudinal safety buffer margin [m].",
+          "default": 1.0
+        },
+        "max_deceleration_mps2": {
+          "type": "number",
+          "description": "Maximum deceleration [m/s^2].",
+          "default": -4.0
+        },
+        "max_jerk_mps3": {
+          "type": "number",
+          "description": "Maximum jerk [m/s^3].",
+          "default": -5.0
+        },
+        "brake_delay_s": {
+          "type": "number",
+          "description": "Brake system reaction delay [s].",
+          "default": 1.0
+        },
+        "time_to_departure_cutoff_s": {
+          "type": "number",
+          "description": "Look-ahead time limit for departure evaluation [s].",
+          "default": 2.0
+        },
+        "on_time_buffer_s": {
+          "type": "number",
+          "description": "Continuous detection time required to trigger a departure alert [s].",
+          "default": 0.15
+        },
+        "off_time_buffer_s": {
+          "type": "number",
+          "description": "Continuous safe detection time required to clear a departure alert [s].",
+          "default": 0.15
+        },
+        "enable_developer_marker": {
+          "type": "boolean",
+          "description": "Enable advanced debug markers for developers.",
+          "default": true
+        }
+      },
+      "required": [
+        "boundary_types_to_detect",
+        "max_lateral_rtree_queries",
+        "lateral_margin_m",
+        "longitudinal_margin_m",
+        "max_deceleration_mps2",
+        "max_jerk_mps3",
+        "brake_delay_s",
+        "time_to_departure_cutoff_s",
+        "on_time_buffer_s",
+        "off_time_buffer_s",
+        "enable_developer_marker"
+      ],
+      "additionalProperties": false
+    }
+  },
+  "properties": {
+    "/**": {
+      "properties": {
+        "ros__parameters": {
+          "type": "object",
+          "properties": {
+            "boundary_departure_checker": {
+              "$ref": "#/definitions/boundary_departure_checker"
+            }
+          },
+          "required": ["boundary_departure_checker"],
+          "additionalProperties": false
+        }
+      },
+      "required": ["ros__parameters"],
+      "additionalProperties": false
+    }
+  },
+  "required": ["/**"],
+  "additionalProperties": false
+}

--- a/common/autoware_boundary_departure_checker/src/detail/boundary_departure_evaluator.cpp
+++ b/common/autoware_boundary_departure_checker/src/detail/boundary_departure_evaluator.cpp
@@ -1,0 +1,61 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/boundary_departure_checker/detail/boundary_departure_evaluator.hpp"
+
+#include "autoware/boundary_departure_checker/detail/boundary_segment_finder.hpp"
+#include "autoware/boundary_departure_checker/detail/severity_evaluator.hpp"
+
+#include <stdexcept>
+
+namespace autoware::boundary_departure_checker
+{
+BoundaryDepartureEvaluator::BoundaryDepartureEvaluator(
+  const lanelet::LaneletMapPtr & map, const UncrossableBoundaryDepartureParam & param,
+  const vehicle_info_utils::VehicleInfo & vehicle_info)
+: map_(map), param_(param), vehicle_info_(vehicle_info), rtree_(map, param.boundary_types_to_detect)
+{
+  if (!map_) {
+    throw std::runtime_error("BoundaryDepartureEvaluator: Map is NULL");
+  }
+
+  if (map_->lineStringLayer.empty()) {
+    throw std::runtime_error("BoundaryDepartureEvaluator: Map without any linestrings.");
+  }
+}
+
+std::optional<Side<std::optional<CriticalPointPair>>> BoundaryDepartureEvaluator::evaluate(
+  const TrajectoryPoints & predicted_traj, const FootprintSideSegmentsArray & footprints_sides,
+  const EgoDynamicState & ego_state) const
+{
+  if (predicted_traj.empty() || rtree_.empty()) {
+    return std::nullopt;
+  }
+
+  const auto boundary_segments = boundary_segment_finder::get_boundary_segments(
+    rtree_, map_, param_, footprints_sides, predicted_traj, vehicle_info_.vehicle_height_m);
+
+  if (boundary_segments.all_empty()) {
+    return std::nullopt;
+  }
+
+  const auto projections_to_bound =
+    boundary_segment_finder::get_closest_boundary_segments_from_side(
+      predicted_traj, boundary_segments, footprints_sides);
+
+  return severity_evaluator::evaluate_projections_severity(
+    projections_to_bound, param_, ego_state, vehicle_info_);
+}
+
+}  // namespace autoware::boundary_departure_checker

--- a/common/autoware_boundary_departure_checker/src/detail/boundary_segment_finder.cpp
+++ b/common/autoware_boundary_departure_checker/src/detail/boundary_segment_finder.cpp
@@ -1,0 +1,182 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/boundary_departure_checker/detail/boundary_segment_finder.hpp"
+
+#include "autoware/boundary_departure_checker/detail/conversion.hpp"
+#include "autoware/boundary_departure_checker/detail/geometry_projection.hpp"
+
+#include <autoware/universe_utils/geometry/geometry.hpp>
+#include <range/v3/view.hpp>
+
+#include <algorithm>
+#include <limits>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+namespace autoware::boundary_departure_checker::boundary_segment_finder
+{
+Side<ProjectionsToBound> get_closest_boundary_segments_from_side(
+  const TrajectoryPoints & ego_pred_traj, const BoundarySegmentsBySide & boundaries,
+  const FootprintSideSegmentsArray & footprints_sides)
+{
+  Side<ProjectionsToBound> side;
+  side.reserve_all(footprints_sides.size());
+  Side<bool> has_passed_boundary{false, false};
+
+  auto s = 0.0;
+  for (size_t i = 0; i < ego_pred_traj.size(); ++i) {
+    if (i > 0) {
+      s += autoware_utils_geometry::calc_distance2d(ego_pred_traj[i - 1], ego_pred_traj[i]);
+    }
+
+    const auto & fp = footprints_sides[i];
+
+    const auto front_seg = Segment2d(fp.left.first, fp.right.first);
+    const auto rear_seg = Segment2d(fp.left.second, fp.right.second);
+
+    side.for_each([&](auto key_constant, auto & side_value) {
+      constexpr SideKey side_key = key_constant.value;
+      auto closest_bound = geometry_projection::find_closest_segment(
+        fp[side_key], front_seg, rear_seg, i, boundaries[side_key]);
+
+      if (
+        closest_bound.lat_dist > 0.0 &&
+        closest_bound.lat_dist < std::numeric_limits<double>::max() &&
+        has_passed_boundary[side_key]) {
+        const auto & ego_front = fp[side_key].first;
+        const auto & ego_rear = fp[side_key].second;
+
+        // forward vector of ego side
+        const double v_fwd_x = ego_front.x() - ego_rear.x();
+        const double v_fwd_y = ego_front.y() - ego_rear.y();
+
+        // lateral vector from ego to boundary
+        const double v_lat_x = closest_bound.pt_on_bound.x() - closest_bound.pt_on_ego.x();
+        const double v_lat_y = closest_bound.pt_on_bound.y() - closest_bound.pt_on_ego.y();
+
+        // cross product for crossing direction
+        const double cross_prod = v_fwd_x * v_lat_y - v_fwd_y * v_lat_x;
+
+        const bool is_crossing_left_boundary = side_key == SideKey::LEFT && cross_prod < 0.0;
+        const bool is_crossing_right_boundary = side_key == SideKey::RIGHT && cross_prod > 0.0;
+        if (is_crossing_left_boundary || is_crossing_right_boundary) {
+          closest_bound.lat_dist = -closest_bound.lat_dist;
+        }
+      }
+
+      closest_bound.time_from_start =
+        ego_pred_traj[i].time_from_start.sec + ego_pred_traj[i].time_from_start.nanosec * 1e-9;
+      closest_bound.dist_along_trajectory_m = s;
+      side_value.push_back(closest_bound);
+      if (closest_bound.lat_dist < 0.01 && !has_passed_boundary[side_key]) {
+        has_passed_boundary[side_key] = true;
+      }
+    });
+  }
+
+  return side;
+}
+
+bool is_closest_to_boundary_segment(
+  const autoware_utils_geometry::Segment2d & boundary_segment,
+  const autoware_utils_geometry::Segment2d & ego_side_ref_segment,
+  const autoware_utils_geometry::Segment2d & ego_side_opposite_ref_segment)
+{
+  const auto dist_from_curr_side =
+    boost::geometry::comparable_distance(ego_side_ref_segment, boundary_segment);
+  const auto dist_from_compare_side =
+    boost::geometry::comparable_distance(ego_side_opposite_ref_segment, boundary_segment);
+
+  return dist_from_curr_side <= dist_from_compare_side;
+}
+
+bool is_segment_within_ego_height(
+  const autoware_utils_geometry::Segment3d & boundary_segment, const double ego_z_position,
+  const double ego_height)
+{
+  auto height_diff = std::min(
+    std::abs(boundary_segment.first.z() - ego_z_position),
+    std::abs(boundary_segment.second.z() - ego_z_position));
+  return height_diff < ego_height;
+}
+
+std::vector<SegmentWithIdx> find_closest_boundary_segments(
+  const UncrossableBoundariesRTree & rtree, const lanelet::LaneletMapPtr & lanelet_map_ptr,
+  const UncrossableBoundaryDepartureParam & param, const Segment2d & ego_ref_segment,
+  const Segment2d & ego_opposite_ref_segment, const double ego_z_position,
+  const double ego_vehicle_height,
+  std::unordered_set<IdxForRTreeSegment, IdxForRTreeSegmentHash> & unique_id)
+{
+  if (!lanelet_map_ptr || rtree.empty()) {
+    return {};
+  }
+
+  std::vector<SegmentWithIdx> nearest_raw = rtree.query(
+    Point2d{ego_ref_segment.first.x(), ego_ref_segment.first.y()}, param.max_lateral_rtree_queries);
+
+  std::vector<SegmentWithIdx> new_segments;
+  for (const auto & nearest : nearest_raw) {
+    const auto & id = nearest.second;
+    if (unique_id.find(id) != unique_id.end()) {
+      continue;
+    }
+
+    auto boundary_segment_3d = rtree.get_segment_3d_from_id(id);
+
+    if (!is_segment_within_ego_height(boundary_segment_3d, ego_z_position, ego_vehicle_height)) {
+      continue;
+    }
+
+    auto boundary_segment = utils::to_segment_2d(boundary_segment_3d);
+
+    if (is_closest_to_boundary_segment(
+          boundary_segment, ego_ref_segment, ego_opposite_ref_segment)) {
+      new_segments.emplace_back(boundary_segment, id);
+    }
+  }
+  return new_segments;
+}
+
+BoundarySegmentsBySide get_boundary_segments(
+  const UncrossableBoundariesRTree & rtree, const lanelet::LaneletMapPtr & lanelet_map_ptr,
+  const UncrossableBoundaryDepartureParam & param,
+  const FootprintSideSegmentsArray & footprints_sides,
+  const TrajectoryPoints & trimmed_pred_trajectory, const double ego_vehicle_height)
+{
+  BoundarySegmentsBySide boundary_sides_with_idx;
+  std::unordered_set<IdxForRTreeSegment, IdxForRTreeSegmentHash> unique_ids;
+
+  for (const auto & [fp, traj_pt] : ranges::views::zip(footprints_sides, trimmed_pred_trajectory)) {
+    const auto ego_z = traj_pt.pose.position.z;
+
+    auto left_segs = find_closest_boundary_segments(
+      rtree, lanelet_map_ptr, param, fp.left, fp.right, ego_z, ego_vehicle_height, unique_ids);
+    for (auto & seg : left_segs) {
+      unique_ids.insert(seg.second);
+      boundary_sides_with_idx.left.emplace_back(std::move(seg));
+    }
+
+    auto right_segs = find_closest_boundary_segments(
+      rtree, lanelet_map_ptr, param, fp.right, fp.left, ego_z, ego_vehicle_height, unique_ids);
+    for (auto & seg : right_segs) {
+      unique_ids.insert(seg.second);
+      boundary_sides_with_idx.right.emplace_back(std::move(seg));
+    }
+  }
+  return boundary_sides_with_idx;
+}
+
+}  // namespace autoware::boundary_departure_checker::boundary_segment_finder

--- a/common/autoware_boundary_departure_checker/src/detail/conversion.cpp
+++ b/common/autoware_boundary_departure_checker/src/detail/conversion.cpp
@@ -1,0 +1,34 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/boundary_departure_checker/detail/conversion.hpp"
+
+namespace autoware::boundary_departure_checker::utils
+{
+Point2d to_point_2d(const Eigen::Matrix<double, 3, 1> & ll_pt)
+{
+  return {ll_pt.x(), ll_pt.y()};
+}
+
+Segment2d to_segment_2d(
+  const Eigen::Matrix<double, 3, 1> & ll_pt1, const Eigen::Matrix<double, 3, 1> & ll_pt2)
+{
+  return {to_point_2d(ll_pt1), to_point_2d(ll_pt2)};
+}
+
+Segment2d to_segment_2d(const Segment3d & segment)
+{
+  return {to_point_2d(segment.first), to_point_2d(segment.second)};
+}
+}  // namespace autoware::boundary_departure_checker::utils

--- a/common/autoware_boundary_departure_checker/src/detail/debug.cpp
+++ b/common/autoware_boundary_departure_checker/src/detail/debug.cpp
@@ -1,0 +1,204 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/boundary_departure_checker/detail/debug.hpp"
+
+#include "autoware/boundary_departure_checker/detail/footprints_generator.hpp"
+#include "autoware/boundary_departure_checker/detail/hysteresis_logic.hpp"
+#include "autoware/boundary_departure_checker/detail/type_alias.hpp"
+
+#include <autoware_utils_geometry/boost_geometry.hpp>
+#include <autoware_utils_visualization/marker_helper.hpp>
+
+#include <std_msgs/msg/detail/color_rgba__struct.hpp>
+
+#include <string>
+
+namespace color
+{
+using std_msgs::msg::ColorRGBA;
+
+inline ColorRGBA blue(float a = 0.99)
+{
+  return autoware_utils_visualization::create_marker_color(0., 0., 1., a);
+}
+
+inline ColorRGBA yellow(float a = 0.99)
+{
+  return autoware_utils_visualization::create_marker_color(1., 1., 0., a);
+}
+
+inline ColorRGBA red(float a = 0.99)
+{
+  return autoware_utils_visualization::create_marker_color(1., 0., 0., a);
+}
+
+inline ColorRGBA aqua(float a = 0.99)
+{
+  return autoware_utils_visualization::create_marker_color(0., 1., 1., a);
+}
+
+inline ColorRGBA magenta(float a = 0.99)
+{
+  return autoware_utils_visualization::create_marker_color(1., 0., 1., a);
+}
+
+}  // namespace color
+
+namespace autoware::boundary_departure_checker::debug
+{
+MarkerArray create_departure_footprint_marker(
+  const ProjectionsToBound & projections_to_bound, const footprints::Footprints & footprints,
+  const builtin_interfaces::msg::Time & curr_time, const double base_link_z)
+{
+  int32_t id{0};
+  const auto add_marker = [&](
+                            const auto color, const ProjectionToBound & projection_to_bound,
+                            const std::string & type) -> Marker {
+    auto marker_ll = autoware_utils_visualization::create_default_marker(
+      "map", curr_time, "footprint_" + type, ++id, visualization_msgs::msg::Marker::LINE_LIST,
+      autoware_utils_visualization::create_marker_scale(0.05, 0, 0), color);
+
+    const auto & footprint = footprints.at(projection_to_bound.pose_index);
+    for (size_t i = 0; i + 1 < footprint.size(); ++i) {
+      const auto & p1 = footprint.at(i);
+      const auto & p2 = footprint.at(i + 1);
+
+      marker_ll.points.push_back(autoware_utils_geometry::to_msg(p1.to_3d(base_link_z)));
+      marker_ll.points.push_back(autoware_utils_geometry::to_msg(p2.to_3d(base_link_z)));
+    }
+    return marker_ll;
+  };
+
+  MarkerArray marker_array;
+  marker_array.markers.reserve(footprints.size());
+
+  for (const auto & pt : projections_to_bound) {
+    if (pt.is_none_departure()) {
+      continue;
+    }
+
+    if (footprints.size() <= pt.pose_index) {
+      continue;
+    }
+
+    if (pt.is_critical()) {
+      marker_array.markers.push_back(add_marker(color::red(), pt, "critical"));
+    }
+  }
+  return marker_array;
+}
+
+Marker create_projections_points_marker(
+  const ProjectionsToBound & projections_to_bound, const std::string & side_key_str,
+  const builtin_interfaces::msg::Time & curr_time, const double base_link_z)
+{
+  auto marker = autoware_utils_visualization::create_default_marker(
+    "map", curr_time, "" + side_key_str, 0, visualization_msgs::msg::Marker::SPHERE_LIST,
+    autoware_utils_visualization::create_marker_scale(0.25, 0.25, 1.0), color::yellow());
+  marker.ns = side_key_str + "_projected_points";
+
+  const auto to_geom = [base_link_z](const auto & p) {
+    return autoware_utils_geometry::to_msg(p.to_3d(base_link_z));
+  };
+
+  for (const auto & pt : projections_to_bound) {
+    marker.points.push_back(to_geom(pt.pt_on_ego));
+    marker.points.push_back(to_geom(pt.pt_on_bound));
+    marker.points.push_back(to_geom(pt.nearest_bound_seg.first));
+    marker.points.push_back(to_geom(pt.nearest_bound_seg.second));
+  }
+  return marker;
+}
+
+Marker create_projections_points_connection_marker(
+  const ProjectionsToBound & projections_to_bound, const std::string & side_key_str,
+  const builtin_interfaces::msg::Time & curr_time, const double base_link_z)
+{
+  auto marker = autoware_utils_visualization::create_default_marker(
+    "map", curr_time, "" + side_key_str, 0, visualization_msgs::msg::Marker::LINE_LIST,
+    autoware_utils_visualization::create_marker_scale(0.25, 0.25, 1.0), color::blue());
+  marker.ns = side_key_str + "_projected_points_connection";
+
+  const auto to_geom = [base_link_z](const auto & p) {
+    return autoware_utils_geometry::to_msg(p.to_3d(base_link_z));
+  };
+
+  for (const auto & pt : projections_to_bound) {
+    marker.points.push_back(to_geom(pt.pt_on_ego));
+    marker.points.push_back(to_geom(pt.pt_on_bound));
+  }
+
+  return marker;
+}
+
+Marker create_projected_segment_bound_marker(
+  const ProjectionsToBound & projections_to_bound, const std::string & side_key_str,
+  const builtin_interfaces::msg::Time & curr_time, const double base_link_z)
+{
+  auto marker = autoware_utils_visualization::create_default_marker(
+    "map", curr_time, "" + side_key_str, 0, visualization_msgs::msg::Marker::LINE_LIST,
+    autoware_utils_visualization::create_marker_scale(0.1, 0.0, 0.0), color::aqua());
+  marker.ns = side_key_str + "_projected_segment_bound";
+
+  const auto to_geom = [base_link_z](const auto & p) {
+    return autoware_utils_geometry::to_msg(p.to_3d(base_link_z));
+  };
+
+  for (const auto & pt : projections_to_bound) {
+    marker.points.push_back(to_geom(pt.nearest_bound_seg.first));
+    marker.points.push_back(to_geom(pt.nearest_bound_seg.second));
+  }
+
+  return marker;
+}
+
+MarkerArray create_debug_markers(
+  const HysteresisState & hysteresis_state, const footprints::Footprints & footprints,
+  const EgoDynamicState & ego_state, const bool enable_developer_marker)
+{
+  builtin_interfaces::msg::Time curr_time = std::invoke([&ego_state]() {
+    const auto current_time_s = ego_state.current_time_s;
+    builtin_interfaces::msg::Time stamp;
+    stamp.sec = static_cast<int32_t>(current_time_s);
+    stamp.nanosec = static_cast<uint32_t>((current_time_s - stamp.sec) * 1e9);
+    return stamp;
+  });
+  const double base_link_z = ego_state.pose_with_cov.pose.position.z;
+  MarkerArray marker_array;
+  hysteresis_state.critical_departure_history.for_each_side([&](const auto & side_value) {
+    autoware_utils_visualization::append_marker_array(
+      create_departure_footprint_marker(side_value, footprints, curr_time, base_link_z),
+      &marker_array);
+  });
+
+  if (!enable_developer_marker) {
+    return marker_array;
+  }
+
+  hysteresis_state.critical_departure_history.for_each(
+    [&](const auto key_constant, const auto & side_value) {
+      const std::string side_str = to_string(key_constant.value);
+      marker_array.markers.push_back(
+        create_projections_points_marker(side_value, side_str, curr_time, base_link_z));
+      marker_array.markers.push_back(
+        create_projections_points_connection_marker(side_value, side_str, curr_time, base_link_z));
+      marker_array.markers.push_back(
+        create_projected_segment_bound_marker(side_value, side_str, curr_time, base_link_z));
+    });
+
+  return marker_array;
+}
+
+}  // namespace autoware::boundary_departure_checker::debug

--- a/common/autoware_boundary_departure_checker/src/detail/footprints_generator.cpp
+++ b/common/autoware_boundary_departure_checker/src/detail/footprints_generator.cpp
@@ -1,0 +1,115 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/boundary_departure_checker/detail/footprints_generator.hpp"
+
+#include <vector>
+
+namespace autoware::boundary_departure_checker::footprints
+{
+using autoware_utils_geometry::pose2transform;
+using autoware_utils_geometry::transform_vector;
+
+FootprintMargin calc_margin_from_covariance(
+  const geometry_msgs::msg::PoseWithCovariance & covariance, const double scale)
+{
+  const auto cov_in_map = covariance.covariance;
+  Eigen::Matrix2d cov_xy_map;
+  cov_xy_map << cov_in_map[0 * 6 + 0], cov_in_map[0 * 6 + 1], cov_in_map[1 * 6 + 0],
+    cov_in_map[1 * 6 + 1];
+
+  const double yaw_vehicle = tf2::getYaw(covariance.pose.orientation);
+
+  // rotate inverse to transform from map frame to vehicle frame
+  Eigen::Matrix2d r_map2vehicle;
+  r_map2vehicle << std::cos(-yaw_vehicle), -std::sin(-yaw_vehicle), std::sin(-yaw_vehicle),
+    std::cos(-yaw_vehicle);
+
+  // transform covariance matrix to vehicle frame
+  const Eigen::Matrix2d cov_xy_vehicle = r_map2vehicle * cov_xy_map * r_map2vehicle.transpose();
+
+  return FootprintMargin{cov_xy_vehicle(0, 0) * scale, cov_xy_vehicle(1, 1) * scale};
+}
+// clang-format off
+/**
+ * footprints::generate:
+ *
+ *          [V]--[V]        [V]--[V]
+ *           | Ego |         | Ego |
+ *     >>>  [V]--[V]  --->  [V]--[V]  --->  ...
+ *        (Pose 0)        (Pose 1)        (Trajectory)
+ *
+ * Generates full vehicle footprints at each pose along the trajectory,
+ * accounting for vehicle dimensions (overhangs, wheelbase).
+ */
+// clang-format on
+Footprints generate(
+  const std::vector<TrajectoryPoint> & trajectory_points,
+  const vehicle_info_utils::VehicleInfo & vehicle_info,
+  const geometry_msgs::msg::PoseWithCovariance & covariance)
+{
+  const auto margin = calc_margin_from_covariance(covariance, 0.0);
+  const auto local_vehicle_footprint = vehicle_info.createFootprint(margin.lat_m, margin.lon_m);
+
+  Footprints footprints{};
+  footprints.reserve(trajectory_points.size());
+  for (const auto & pt : trajectory_points) {
+    footprints.push_back(transform_vector(local_vehicle_footprint, pose2transform(pt.pose)));
+  }
+  return footprints;
+}
+
+// clang-format off
+/**
+ * get_sides_from_footprints:
+ *
+ *          V (Front Left)  Left Side Segment   V (Rear Left)
+ *           +---------------------------------+
+ *           |                                 |
+ *   Forward |               Ego               |
+ *     >>>   |             Vehicle             |
+ *           |                                 |
+ *           +---------------------------------+
+ *          V (Front Right) Right Side Segment  V (Rear Right)
+ *
+ * Extracts the longitudinal side segments (Left/Right) from a
+ * 4-point (or more) vehicle footprint.
+ */
+// clang-format on
+std::vector<Side<autoware_utils_geometry::Segment2d>> get_sides_from_footprints(
+  const Footprints & footprints)
+{
+  std::vector<Side<autoware_utils_geometry::Segment2d>> footprints_sides;
+  footprints_sides.reserve(footprints.size());
+  for (const auto & footprint : footprints) {
+    const auto & right_front = footprint[vehicle_info_utils::VehicleInfo::FrontRightIndex];
+    const auto & right_back = footprint[vehicle_info_utils::VehicleInfo::RearRightIndex];
+
+    const auto & left_front = footprint[vehicle_info_utils::VehicleInfo::FrontLeftIndex];
+    const auto & left_back = footprint[vehicle_info_utils::VehicleInfo::RearLeftIndex];
+
+    Side<autoware_utils_geometry::Segment2d> side;
+    side.right = {
+      autoware_utils_geometry::Point2d(right_front.x(), right_front.y()),
+      autoware_utils_geometry::Point2d(right_back.x(), right_back.y())};
+    side.left = {
+      autoware_utils_geometry::Point2d(left_front.x(), left_front.y()),
+      autoware_utils_geometry::Point2d(left_back.x(), left_back.y())};
+
+    footprints_sides.push_back(side);
+  }
+  return footprints_sides;
+}
+
+}  // namespace autoware::boundary_departure_checker::footprints

--- a/common/autoware_boundary_departure_checker/src/detail/geometry_projection.cpp
+++ b/common/autoware_boundary_departure_checker/src/detail/geometry_projection.cpp
@@ -1,0 +1,204 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/boundary_departure_checker/detail/geometry_projection.hpp"
+
+#include <autoware/universe_utils/geometry/geometry.hpp>
+#include <tf2/utils.hpp>
+
+#include <algorithm>
+#include <limits>
+#include <utility>
+#include <vector>
+
+namespace autoware::boundary_departure_checker::geometry_projection
+{
+Point to_geom_pt(const Point2d & point, const double z = 0.0)
+{
+  return autoware_utils_geometry::to_msg(point.to_3d(z));
+}
+
+std::optional<std::pair<Point2d, double>> point_to_segment_projection(
+  const Point2d & p, const Segment2d & segment)
+{
+  const auto & p1 = segment.first;
+  const auto & p2 = segment.second;
+
+  const Point2d p2_vec = {p2.x() - p1.x(), p2.y() - p1.y()};
+  const Point2d p_vec = {p.x() - p1.x(), p.y() - p1.y()};
+
+  const auto c1 = boost::geometry::dot_product(p_vec, p2_vec);
+  if (c1 < 0.0) return std::nullopt;
+
+  const auto c2 = boost::geometry::dot_product(p2_vec, p2_vec);
+  if (c1 > c2) return std::nullopt;
+
+  const auto projection = p1 + (p2_vec * c1 / c2);
+  const auto projection_point = Point2d{projection.x(), projection.y()};
+
+  return std::make_pair(projection_point, boost::geometry::distance(p, projection_point));
+}
+
+std::optional<ProjectionToBound> calc_nearest_projection(
+  const Segment2d & ego_seg, const Segment2d & lane_seg, const size_t pose_index)
+{
+  const auto & [ego_f, ego_b] = ego_seg;
+  const auto & [lane_pt1, lane_pt2] = lane_seg;
+
+  if (
+    const auto is_intersecting = autoware_utils_geometry::intersect(
+      to_geom_pt(ego_f), to_geom_pt(ego_b), to_geom_pt(lane_pt1), to_geom_pt(lane_pt2))) {
+    Point2d point(is_intersecting->x, is_intersecting->y);
+    return ProjectionToBound{
+      point, point, lane_seg, 0.0, boost::geometry::distance(point, ego_f), pose_index};
+  }
+
+  ProjectionsToBound projections;
+  projections.reserve(4);
+  if (const auto projection_opt = point_to_segment_projection(ego_f, lane_seg)) {
+    const auto & [proj, dist] = *projection_opt;
+    constexpr auto ego_front_to_proj_offset_m = 0.0;
+    projections.emplace_back(ego_f, proj, lane_seg, dist, ego_front_to_proj_offset_m, pose_index);
+  }
+
+  if (const auto projection_opt = point_to_segment_projection(ego_b, lane_seg)) {
+    const auto & [proj, dist] = *projection_opt;
+    const auto ego_front_to_proj_offset_m = boost::geometry::distance(ego_b, ego_f);
+    projections.emplace_back(ego_b, proj, lane_seg, dist, ego_front_to_proj_offset_m, pose_index);
+  }
+
+  if (const auto projection_opt = point_to_segment_projection(lane_pt1, ego_seg)) {
+    const auto & [proj, dist] = *projection_opt;
+    const auto ego_front_to_proj_offset_m = boost::geometry::distance(proj, ego_f);
+    projections.emplace_back(
+      proj, lane_pt1, lane_seg, dist, ego_front_to_proj_offset_m, pose_index);
+  }
+
+  if (const auto projection_opt = point_to_segment_projection(lane_pt2, ego_seg)) {
+    const auto & [proj, dist] = *projection_opt;
+    const auto ego_front_to_proj_offset_m = boost::geometry::distance(proj, ego_f);
+    projections.emplace_back(
+      proj, lane_pt2, lane_seg, dist, ego_front_to_proj_offset_m, pose_index);
+  }
+
+  if (projections.empty()) return std::nullopt;
+  if (projections.size() == 1) return projections.front();
+
+  auto min_elem = std::min_element(
+    projections.begin(), projections.end(),
+    [](const ProjectionToBound & proj1, const ProjectionToBound & proj2) {
+      return std::abs(proj1.lat_dist) < std::abs(proj2.lat_dist);
+    });
+
+  return *min_elem;
+}
+
+ProjectionToBound find_closest_segment(
+  const Segment2d & ego_side_seg, const Segment2d & ego_front_seg, const Segment2d & ego_rear_seg,
+  const size_t curr_fp_idx, const std::vector<SegmentWithIdx> & boundary_segments)
+{
+  std::optional<ProjectionToBound> closest_proj;
+
+  const auto is_intersecting = [curr_fp_idx](
+                                 const Segment2d & ego_seg, const Segment2d & boundary_seg,
+                                 double front_to_proj_offset) -> std::optional<ProjectionToBound> {
+    const auto & [ego_lr, ego_rr] = ego_seg;
+    const auto & [seg_f, seg_r] = boundary_seg;
+    if (
+      const auto intersected = autoware_utils_geometry::intersect(
+        to_geom_pt(ego_lr), to_geom_pt(ego_rr), to_geom_pt(seg_f), to_geom_pt(seg_r))) {
+      Point2d point(intersected->x, intersected->y);
+      return ProjectionToBound{point, point, boundary_seg, 0.0, front_to_proj_offset, curr_fp_idx};
+    }
+    return std::nullopt;
+  };
+
+  for (const auto & [seg, id] : boundary_segments) {
+    if (const auto intersecting_front = is_intersecting(ego_front_seg, seg, 0.0)) {
+      closest_proj = intersecting_front;
+      break;
+    }
+
+    if (
+      const auto intersecting_rear = is_intersecting(
+        ego_rear_seg, seg, boost::geometry::distance(ego_side_seg.first, ego_side_seg.second))) {
+      closest_proj = intersecting_rear;
+      break;
+    }
+
+    if (const auto proj_opt = calc_nearest_projection(ego_side_seg, seg, curr_fp_idx)) {
+      if (!closest_proj || proj_opt->lat_dist < closest_proj->lat_dist) {
+        closest_proj = *proj_opt;
+      }
+    }
+    if (closest_proj) {
+      continue;
+    }
+  }
+
+  if (closest_proj) {
+    return *closest_proj;
+  }
+
+  return ProjectionToBound(curr_fp_idx);
+}
+
+std::optional<double> calc_signed_lateral_distance_to_boundary(
+  const lanelet::ConstLineString3d & boundary, const Pose & reference_pose)
+{
+  if (boundary.size() < 2) {
+    return std::nullopt;
+  }
+
+  const double yaw = tf2::getYaw(reference_pose.orientation);
+  const Eigen::Vector2d y_axis_direction(-std::sin(yaw), std::cos(yaw));
+  const Eigen::Vector2d reference_point(reference_pose.position.x, reference_pose.position.y);
+
+  double min_distance = std::numeric_limits<double>::max();
+  std::optional<double> signed_lateral_distance;
+
+  for (size_t i = 0; i + 1 < boundary.size(); ++i) {
+    const auto & p1 = boundary[i];
+    const auto & p2 = boundary[i + 1];
+
+    const Eigen::Vector2d segment_start(p1.x(), p1.y());
+    const Eigen::Vector2d segment_end(p2.x(), p2.y());
+    const Eigen::Vector2d segment_direction = segment_end - segment_start;
+
+    const double det = y_axis_direction.x() * (-segment_direction.y()) -
+                       y_axis_direction.y() * (-segment_direction.x());
+
+    if (std::abs(det) < 1e-10) {
+      continue;
+    }
+
+    const Eigen::Vector2d rhs = segment_start - reference_point;
+    const double t =
+      ((-segment_direction.y()) * rhs.x() - (-segment_direction.x()) * rhs.y()) / det;
+    const double s = (y_axis_direction.x() * rhs.y() - y_axis_direction.y() * rhs.x()) / det;
+
+    if (s >= 0.0 && s <= 1.0) {
+      const double distance = std::abs(t);
+
+      if (distance < min_distance) {
+        min_distance = distance;
+        signed_lateral_distance = t;
+      }
+    }
+  }
+
+  return signed_lateral_distance;
+}
+
+}  // namespace autoware::boundary_departure_checker::geometry_projection

--- a/common/autoware_boundary_departure_checker/src/detail/hysteresis_logic.cpp
+++ b/common/autoware_boundary_departure_checker/src/detail/hysteresis_logic.cpp
@@ -1,0 +1,78 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/boundary_departure_checker/detail/hysteresis_logic.hpp"
+
+#include "autoware/boundary_departure_checker/detail/severity_evaluator.hpp"
+
+namespace autoware::boundary_departure_checker
+{
+HysteresisResult update_and_judge(
+  const HysteresisState & state,
+  const std::optional<Side<std::optional<CriticalPointPair>>> & evaluation_result,
+  const UncrossableBoundaryDepartureParam & param, const double current_time_s)
+{
+  HysteresisResult result;
+  result.updated_state = state;
+  result.status = DepartureType::NONE;
+
+  if (!evaluation_result.has_value()) {
+    result.updated_state.last_no_critical_dpt_time = current_time_s;
+    result.updated_state.critical_departure_history.for_each_side(
+      [](auto & side) { side.clear(); });
+    return result;
+  }
+
+  const bool current_is_critical = severity_evaluator::is_critical(*evaluation_result);
+
+  if (current_is_critical) {
+    const bool is_imminent_critical =
+      evaluation_result->any_of_side([&param](const auto & side_value) {
+        return side_value.has_value() && side_value->physical_departure_point.is_critical() &&
+               side_value->physical_departure_point.time_from_start < param.on_time_buffer_s;
+      });
+
+    if (
+      is_imminent_critical ||
+      current_time_s - state.last_no_critical_dpt_time >= param.on_time_buffer_s) {
+      result.updated_state.last_found_critical_dpt_time = current_time_s;
+      result.updated_state.critical_departure_history.for_each_side(
+        [](auto & side) { side.clear(); });
+      evaluation_result->for_each([&](auto key_constant, auto & side_value) {
+        if (side_value.has_value() && side_value->safety_buffer_start.is_critical()) {
+          result.updated_state.critical_departure_history[key_constant.value].push_back(
+            side_value->physical_departure_point);
+        }
+      });
+      result.status = DepartureType::CRITICAL;
+      return result;
+    }
+    return result;
+  }
+
+  result.updated_state.last_no_critical_dpt_time = current_time_s;
+
+  if (!state.critical_departure_history.all_empty()) {
+    if (current_time_s - state.last_found_critical_dpt_time < param.off_time_buffer_s) {
+      result.status = DepartureType::CRITICAL;
+      return result;
+    }
+    result.updated_state.critical_departure_history.for_each_side(
+      [](auto & side) { side.clear(); });
+  }
+
+  return result;
+}
+
+}  // namespace autoware::boundary_departure_checker

--- a/common/autoware_boundary_departure_checker/src/detail/severity_evaluator.cpp
+++ b/common/autoware_boundary_departure_checker/src/detail/severity_evaluator.cpp
@@ -1,0 +1,134 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/boundary_departure_checker/detail/severity_evaluator.hpp"
+
+#include <autoware/motion_utils/distance/distance.hpp>
+
+#include <algorithm>
+#include <limits>
+
+namespace autoware::boundary_departure_checker::severity_evaluator
+{
+ProjectionsToBound filter_and_assign_departure_types(
+  const ProjectionsToBound & side_value, const UncrossableBoundaryDepartureParam & param,
+  const double min_braking_dist)
+{
+  ProjectionsToBound out;
+  out.reserve(side_value.size());
+
+  DepartureCheckThresholds thresholds;
+  thresholds.min_braking_distance = min_braking_dist;
+  thresholds.cutoff_time = param.time_to_departure_cutoff_s;
+  thresholds.th_lat_critical = param.lateral_margin_m;
+
+  for (size_t idx = 0; idx < side_value.size(); ++idx) {
+    const auto & original_candidate = side_value[idx];
+    if (original_candidate.pose_index != idx) continue;
+
+    ProjectionEvaluationMetrics metrics;
+    metrics.lon_dist_to_departure =
+      original_candidate.dist_along_trajectory_m - original_candidate.ego_front_to_proj_offset_m;
+    metrics.time_from_start = original_candidate.time_from_start;
+    metrics.lat_dist = original_candidate.lat_dist;
+
+    out.push_back(original_candidate);
+    out.back().departure_type = assign_departure_type(metrics, thresholds);
+
+    if (out.back().is_critical()) break;
+  }
+
+  return out;
+}
+
+std::optional<CriticalPointPair> apply_backward_buffer_and_filter(
+  const ProjectionsToBound & side_value, const UncrossableBoundaryDepartureParam & param)
+{
+  if (side_value.empty() || side_value.back().is_none_departure()) return std::nullopt;
+
+  const auto & departure_point = side_value.back();
+
+  CriticalPointPair result;
+  result.physical_departure_point = departure_point;
+  result.safety_buffer_start = departure_point;
+
+  if (!departure_point.is_critical()) {
+    return result;
+  }
+
+  for (auto it = std::next(side_value.rbegin()); it != side_value.rend(); ++it) {
+    const double dist_between_proj =
+      boost::geometry::distance(result.physical_departure_point.pt_on_ego, it->pt_on_ego);
+
+    if (dist_between_proj >= param.longitudinal_margin_m) {
+      result.safety_buffer_start = *it;
+      result.safety_buffer_start.departure_type = DepartureType::CRITICAL;
+      break;
+    }
+  }
+
+  return result;
+}
+
+DepartureType assign_departure_type(
+  const ProjectionEvaluationMetrics & metrics, const DepartureCheckThresholds & thresholds)
+{
+  if (metrics.lat_dist > thresholds.th_lat_critical) {
+    return DepartureType::NONE;
+  }
+
+  if (
+    metrics.lon_dist_to_departure > thresholds.min_braking_distance &&
+    metrics.time_from_start > thresholds.cutoff_time) {
+    return DepartureType::APPROACHING;
+  }
+
+  return DepartureType::CRITICAL;
+}
+
+Side<std::optional<CriticalPointPair>> evaluate_projections_severity(
+  const Side<ProjectionsToBound> & projections_to_bound,
+  const UncrossableBoundaryDepartureParam & param, const EgoDynamicState & ego_state,
+  const vehicle_info_utils::VehicleInfo & vehicle_info)
+{
+  const auto min_braking_dist = calc_minimum_braking_distance(ego_state, param, vehicle_info);
+
+  return projections_to_bound.transform_each_side([&](const auto & side_value) {
+    const auto min_to_bounds =
+      filter_and_assign_departure_types(side_value, param, min_braking_dist);
+    return apply_backward_buffer_and_filter(min_to_bounds, param);
+  });
+}
+
+bool is_critical(const Side<std::optional<CriticalPointPair>> & evaluated_projections)
+{
+  return evaluated_projections.any_of_side([](const auto & critical_pair_opt) {
+    return critical_pair_opt.has_value() &&
+           critical_pair_opt->physical_departure_point.is_critical();
+  });
+}
+
+double calc_minimum_braking_distance(
+  const EgoDynamicState & ego_state, const UncrossableBoundaryDepartureParam & param,
+  const vehicle_info_utils::VehicleInfo & vehicle_info)
+{
+  const auto kinematic_stop_dist = motion_utils::calculate_stop_distance(
+    ego_state.velocity, ego_state.acceleration, param.max_deceleration_mps2, param.max_jerk_mps3,
+    param.brake_delay_s);
+
+  return vehicle_info.front_overhang_m +
+         (kinematic_stop_dist ? std::max(0.0, *kinematic_stop_dist) : 0.0);
+}
+
+}  // namespace autoware::boundary_departure_checker::severity_evaluator

--- a/common/autoware_boundary_departure_checker/src/detail/uncrossable_boundaries_rtree.cpp
+++ b/common/autoware_boundary_departure_checker/src/detail/uncrossable_boundaries_rtree.cpp
@@ -1,0 +1,104 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/boundary_departure_checker/detail/uncrossable_boundaries_rtree.hpp"
+
+#include "autoware/boundary_departure_checker/detail/conversion.hpp"
+
+#include <algorithm>
+#include <iterator>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace autoware::boundary_departure_checker
+{
+namespace
+{
+std::vector<SegmentWithIdx> create_local_segments(const lanelet::ConstLineString3d & linestring)
+{
+  std::vector<SegmentWithIdx> local_segments;
+  local_segments.reserve(linestring.size());
+  const auto basic_ls = linestring.basicLineString();
+  for (size_t i = 0; i + 1 < basic_ls.size(); ++i) {
+    const auto segment = utils::to_segment_2d(basic_ls.at(i), basic_ls.at(i + 1));
+    local_segments.emplace_back(
+      boost::geometry::return_envelope<Segment2d>(segment),
+      IdxForRTreeSegment(linestring.id(), i, i + 1));
+  }
+  return local_segments;
+}
+}  // namespace
+
+UncrossableBoundariesRTree::UncrossableBoundariesRTree(
+  lanelet::LaneletMapPtr lanelet_map_ptr, const std::vector<std::string> & boundary_types_to_detect)
+: lanelet_map_ptr_(std::move(lanelet_map_ptr))
+{
+  if (!lanelet_map_ptr_) {
+    throw std::runtime_error("UncrossableBoundariesRTree: Map is NULL");
+  }
+
+  std::vector<SegmentWithIdx> segments;
+  for (const auto & linestring : lanelet_map_ptr_->lineStringLayer) {
+    if (!is_uncrossable_type(boundary_types_to_detect, linestring)) {
+      continue;
+    }
+
+    auto local_segments = create_local_segments(linestring);
+    std::move(local_segments.begin(), local_segments.end(), std::back_inserter(segments));
+  }
+
+  rtree_ =
+    autoware::boundary_departure_checker::UncrossableBoundsRTree(segments.begin(), segments.end());
+}
+
+autoware_utils_geometry::Segment3d UncrossableBoundariesRTree::get_segment_3d_from_id(
+  const IdxForRTreeSegment & seg_id) const
+{
+  const auto & linestring_layer = lanelet_map_ptr_->lineStringLayer;
+  const auto basic_ls = linestring_layer.get(seg_id.linestring_id).basicLineString();
+
+  auto p_start = autoware_utils_geometry::Point3d{
+    basic_ls.at(seg_id.segment_start_idx).x(), basic_ls.at(seg_id.segment_start_idx).y(),
+    basic_ls.at(seg_id.segment_start_idx).z()};
+
+  auto p_end = autoware_utils_geometry::Point3d{
+    basic_ls.at(seg_id.segment_end_idx).x(), basic_ls.at(seg_id.segment_end_idx).y(),
+    basic_ls.at(seg_id.segment_end_idx).z()};
+
+  return {p_start, p_end};
+}
+
+std::vector<SegmentWithIdx> UncrossableBoundariesRTree::query(
+  const Point2d & point, size_t max_results) const
+{
+  std::vector<SegmentWithIdx> results;
+  rtree_.query(
+    boost::geometry::index::nearest(lanelet::BasicPoint2d{point.x(), point.y()}, max_results),
+    std::back_inserter(results));
+  return results;
+}
+
+bool UncrossableBoundariesRTree::is_uncrossable_type(
+  const std::vector<std::string> & boundary_types_to_detect, const lanelet::ConstLineString3d & ls)
+{
+  constexpr auto no_type = "";
+  const auto type = ls.attributeOr(lanelet::AttributeName::Type, no_type);
+  return (
+    type != no_type &&
+    std::find(boundary_types_to_detect.begin(), boundary_types_to_detect.end(), type) !=
+      boundary_types_to_detect.end());
+}
+
+}  // namespace autoware::boundary_departure_checker

--- a/common/autoware_boundary_departure_checker/src/uncrossable_boundary_checker.cpp
+++ b/common/autoware_boundary_departure_checker/src/uncrossable_boundary_checker.cpp
@@ -1,0 +1,68 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/boundary_departure_checker/uncrossable_boundary_checker.hpp"
+
+#include "autoware/boundary_departure_checker/detail/debug.hpp"
+#include "autoware/boundary_departure_checker/detail/footprints_generator.hpp"
+
+#include <autoware_utils_system/stop_watch.hpp>
+
+#include <memory>
+
+namespace autoware::boundary_departure_checker
+{
+UncrossableBoundaryChecker::UncrossableBoundaryChecker(
+  const lanelet::LaneletMapPtr & map, const UncrossableBoundaryDepartureParam & param,
+  const VehicleInfo & vehicle_info)
+: param_(param), vehicle_info_(vehicle_info)
+{
+  evaluator_ptr_ = std::make_unique<BoundaryDepartureEvaluator>(map, param, vehicle_info);
+}
+
+void UncrossableBoundaryChecker::update_parameters(const UncrossableBoundaryDepartureParam & param)
+{
+  param_ = param;
+  evaluator_ptr_->update_parameters(param);
+}
+
+DepartureResult UncrossableBoundaryChecker::update_departure_status(
+  const TrajectoryPoints & predicted_traj, const EgoDynamicState & ego_state)
+{
+  autoware_utils_debug::ScopedTimeTrack st(__func__, *time_keeper_);
+
+  DepartureResult result;
+  if (predicted_traj.empty()) {
+    return result;
+  }
+
+  const auto footprints =
+    footprints::generate(predicted_traj, vehicle_info_, ego_state.pose_with_cov);
+  const auto footprints_sides = footprints::get_sides_from_footprints(footprints);
+
+  const auto evaluation_result =
+    evaluator_ptr_->evaluate(predicted_traj, footprints_sides, ego_state);
+
+  const auto hysteresis_result =
+    update_and_judge(hysteresis_state_, evaluation_result, param_, ego_state.current_time_s);
+
+  hysteresis_state_ = hysteresis_result.updated_state;
+
+  result.status = hysteresis_result.status;
+  result.debug_markers = debug::create_debug_markers(
+    hysteresis_state_, footprints, ego_state, param_.enable_developer_marker);
+  return result;
+}
+
+}  // namespace autoware::boundary_departure_checker

--- a/common/autoware_boundary_departure_checker/test/test_uncrossable_boundary_checker.cpp
+++ b/common/autoware_boundary_departure_checker/test/test_uncrossable_boundary_checker.cpp
@@ -1,0 +1,214 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/boundary_departure_checker/detail/type_alias.hpp"
+#include "autoware/boundary_departure_checker/uncrossable_boundary_checker.hpp"
+
+#include <autoware_vehicle_info_utils/vehicle_info_utils.hpp>
+
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <vector>
+
+namespace autoware::boundary_departure_checker
+{
+UncrossableBoundaryChecker create_default_checker()
+{
+  // 1. Setup Vehicle Info (Standard Sedan Size)
+  auto vehicle_info = autoware::vehicle_info_utils::createVehicleInfo(
+    0.383,  // front_overhang [m]
+    0.235,  // rear_overhang [m]
+    2.79,   // wheel_base [m]
+    1.64,   // wheel_tread [m]
+    1.0,    // left_overhang [m]
+    1.1,    // right_overhang [m]
+    2.5,    // vehicle_height [m]
+    0.128,  // cg_to_rear [m]
+    0.128,  // max_steer_angle [rad]
+    0.70    // min_steer_angle [rad]
+  );
+
+  // 2. Param
+  UncrossableBoundaryDepartureParam param;
+  param.lateral_margin_m = 0.01;   // [m]
+  param.on_time_buffer_s = 0.15;   // 150ms of continuous violation to trigger CRITICAL
+  param.off_time_buffer_s = 0.15;  // 150ms of continuous safety to clear CRITICAL
+  param.max_deceleration_mps2 = -4.0;
+  param.max_jerk_mps3 = -5.0;
+  param.brake_delay_s = 1.0;
+  param.time_to_departure_cutoff_s = 3.0;
+  param.boundary_types_to_detect = {"road_border"};
+
+  // 3. Create a LaneletMap with a straight road border at Y = 2.0
+  auto map = std::make_shared<lanelet::LaneletMap>();
+  lanelet::Point3d p1(lanelet::utils::getId(), -100.0, 2.0, 0.0);
+  lanelet::Point3d p2(lanelet::utils::getId(), 100.0, 2.0, 0.0);
+  lanelet::LineString3d boundary_ls(lanelet::utils::getId(), {p1, p2});
+  boundary_ls.attributes()[lanelet::AttributeName::Type] = "road_border";
+  map->add(boundary_ls);
+
+  return {map, param, vehicle_info};
+}
+
+TrajectoryPoints create_trajectory(
+  double start_x, double start_y, double velocity, double yaw = 0.0)
+{
+  TrajectoryPoints traj;
+  for (int i = 0; i < 5; ++i) {
+    TrajectoryPoint p;
+    p.pose.position.x = start_x + i * 5.0 * std::cos(yaw);
+    p.pose.position.y = start_y + i * 5.0 * std::sin(yaw);
+    p.pose.orientation = autoware_utils_geometry::create_quaternion_from_yaw(yaw);
+    const double time = i * 0.5;
+    p.time_from_start.sec = static_cast<int32_t>(time);
+    p.time_from_start.nanosec = static_cast<uint32_t>((time - p.time_from_start.sec) * 1e9);
+    p.longitudinal_velocity_mps = static_cast<float>(velocity);
+    traj.push_back(p);
+  }
+  return traj;
+}
+
+EgoDynamicState create_ego_state(
+  const TrajectoryPoints & traj, double velocity, double current_time_s = 0.0)
+{
+  EgoDynamicState state;
+  if (!traj.empty()) {
+    state.pose_with_cov.pose = traj.front().pose;
+  }
+  for (auto & c : state.pose_with_cov.covariance) c = 0.0;
+  state.velocity = velocity;
+  state.acceleration = 0.0;
+  state.current_time_s = current_time_s;
+  return state;
+}
+
+// ==============================================================================
+// 1. Initialization and Edge Cases
+// ==============================================================================
+TEST(UncrossableBoundaryCheckerTest, TestCheckDepartureEmptyTrajectory)
+{
+  // Arrange:
+  TrajectoryPoints empty_traj;
+  constexpr double init_time = 0.0;
+  auto ego_state = create_ego_state(empty_traj, 0.0, init_time);
+
+  // Act:
+  auto checker = create_default_checker();
+  auto result = checker.update_departure_status(empty_traj, ego_state);
+
+  // Assert:
+  EXPECT_TRUE(result.status == DepartureType::NONE);
+}
+
+TEST(UncrossableBoundaryCheckerTest, TestCheckDepartureZeroVelocity)
+{
+  // Arrange:
+  auto traj = create_trajectory(0.0, -3.0, 0.0);
+  constexpr double init_time = 0.0;
+  auto ego_state = create_ego_state(traj, 0.0, init_time);
+
+  // Act:
+  auto checker = create_default_checker();
+  auto result = checker.update_departure_status(traj, ego_state);
+
+  // Assert:
+  EXPECT_TRUE(result.status == DepartureType::NONE);
+}
+
+// ==============================================================================
+// 2. Hysteresis and Time Buffering Tests
+// ==============================================================================
+
+// clang-format off
+/**
+ * TestTimeBufferingHysteresis:
+ *
+ *    Y ^
+ *      |   Boundary (Uncrossable)
+ *  2.0 +-------------------------------------------------
+ *      |          / V_danger (Yaw=0.1, crosses at Y=2.0)
+ *  1.0 |         V
+ *      |        /   >>> Predicted Trajectory
+ *  0.0 +-------V-----------------------------------------> X
+ *              V_safe (Safe Y=0.0)
+ *
+ * Evaluates hysteresis logic: CRITICAL is held during OFF-buffer even if
+ * the vehicle returns to Safe Zone, and delayed during ON-buffer.
+ */
+// clang-format on
+TEST(UncrossableBoundaryCheckerTest, TestTimeBufferingHysteresis)
+{
+  // 1-line summary: Evaluates the hysteresis logic and time buffering (ON/OFF) for critical
+  // departures.
+
+  // Arrange:
+  // Since the test vehicle has a massive left overhang (effectively 3.32m left edge),
+  // we must start at Y = -2.0 so the left edge is at Y = 1.32 (safely below the Y=2.0 boundary).
+  double safe_y = -2.5;         // safe lateral position [m]
+  double danger_yaw = 0.2;      // yaw [rad] to steer into the boundary in the future
+  double test_velocity = 10.0;  // velocity [m/s]
+
+  // STEP 1: Safe Driving
+  auto traj_safe = create_trajectory(0.0, safe_y, test_velocity, 0.0);
+  auto state_safe = create_ego_state(traj_safe, test_velocity, 0.0);
+
+  // Act:
+  auto checker = create_default_checker();
+  auto res1 = checker.update_departure_status(traj_safe, state_safe);
+
+  // Assert:
+  EXPECT_TRUE(res1.status == DepartureType::NONE) << "Should be NONE when far from boundary.";
+
+  // STEP 2: Switch to Danger Trajectory.
+  // Starting at Y = -2.0 with yaw = 0.2, the vehicle is safe at t=0.0, but collides at t=0.5s.
+  // Because the collision is at t=0.5s (which is > the 0.15s ON buffer), the imminent bypass
+  // does NOT trigger. The ON-time buffer correctly catches and debounces it.
+  auto traj_danger = create_trajectory(0.0, safe_y, test_velocity, danger_yaw);
+  auto state_danger = create_ego_state(traj_danger, test_velocity, 0.1);
+
+  // Act:
+  auto res2 = checker.update_departure_status(traj_danger, state_danger);
+
+  // Assert:
+  EXPECT_TRUE(res2.status == DepartureType::NONE) << "Should be NONE due to ON time buffer.";
+
+  // STEP 3: Wait for ON buffer to expire. Time increases by 0.2 seconds.
+  // Act:
+  auto res3 =
+    checker.update_departure_status(traj_danger, create_ego_state(traj_danger, test_velocity, 0.2));
+
+  // Assert:
+  EXPECT_TRUE(res3.status == DepartureType::CRITICAL)
+    << "Should trigger CRITICAL after ON buffer expires.";
+
+  // STEP 4: Instantly teleport back to Safe Trajectory
+  // Act:
+  auto res4 =
+    checker.update_departure_status(traj_safe, create_ego_state(traj_safe, test_velocity, 0.3));
+
+  // Assert:
+  EXPECT_TRUE(res4.status == DepartureType::CRITICAL)
+    << "Should hold CRITICAL due to OFF time buffer.";
+
+  // STEP 5: Wait for OFF buffer to expire (Safety is continuous)
+  // Act:
+  auto res5 =
+    checker.update_departure_status(traj_safe, create_ego_state(traj_safe, test_velocity, 0.6));
+
+  // Assert:
+  EXPECT_TRUE(res5.status == DepartureType::NONE)
+    << "Should return to NONE after OFF buffer expires.";
+}
+}  // namespace autoware::boundary_departure_checker

--- a/common/autoware_boundary_departure_checker/test/utils/test_boundary_utils.cpp
+++ b/common/autoware_boundary_departure_checker/test/utils/test_boundary_utils.cpp
@@ -1,0 +1,288 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/boundary_departure_checker/detail/boundary_segment_finder.hpp"
+#include "autoware/boundary_departure_checker/detail/geometry_projection.hpp"
+#include "autoware/boundary_departure_checker/detail/severity_evaluator.hpp"
+#include "autoware/boundary_departure_checker/detail/type_alias.hpp"
+#include "autoware/boundary_departure_checker/detail/uncrossable_boundaries_rtree.hpp"
+
+#include <gtest/gtest.h>
+
+#include <limits>
+#include <memory>
+#include <vector>
+
+namespace autoware::boundary_departure_checker
+{
+// ==============================================================================
+// 1. geometry_projection Tests
+// ==============================================================================
+
+TEST(UncrossableBoundaryUtilsTest, TestSegmentToSegmentProjection)
+{
+  // Arrange:
+  Segment2d ego_seg{{0.0, 0.0}, {0.0, 2.0}};
+  Segment2d boundary_seg{{1.0, 0.0}, {1.0, 2.0}};
+
+  // Act:
+  auto result = geometry_projection::calc_nearest_projection(ego_seg, boundary_seg, 0);
+
+  // Assert:
+  ASSERT_TRUE(result.has_value());
+  EXPECT_NEAR(result->lat_dist, 1.0, 1e-6);
+}
+
+TEST(UncrossableBoundaryUtilsTest, TestIntersectionDetection)
+{
+  // Arrange:
+  Segment2d ego_seg{{0.0, 0.0}, {1.0, 2.0}};
+  Segment2d boundary_seg{{1.0, 0.0}, {1.0, 2.0}};
+
+  // Act:
+  auto result = geometry_projection::calc_nearest_projection(ego_seg, boundary_seg, 0);
+
+  // Assert:
+  ASSERT_TRUE(result.has_value());
+  EXPECT_DOUBLE_EQ(result->lat_dist, 0.0);
+}
+
+TEST(UncrossableBoundaryUtilsTest, TestPointBeyondSegmentEnd)
+{
+  // Arrange:
+  Segment2d ego_seg{{0.0, 0.0}, {1.0, 0.0}};
+  Segment2d boundary_seg{{3.0, 2.0}, {4.0, 2.0}};
+
+  // Act:
+  auto result = geometry_projection::calc_nearest_projection(ego_seg, boundary_seg, 0);
+
+  // Assert:
+  ASSERT_FALSE(result.has_value());
+}
+
+TEST(UncrossableBoundaryUtilsTest, TestFindClosestSegmentRearIntersection)
+{
+  // Arrange:
+  Segment2d ego_side_seg{{0.0, 4.0}, {0.0, 2.0}};
+  Segment2d ego_rear_seg{{0.0, 0.0}, {2.0, 0.0}};
+  Segment2d ego_front_seg{{0.0, 4.0}, {2.0, 4.0}};
+  size_t curr_fp_idx = 42;
+
+  std::vector<SegmentWithIdx> boundary_segments;
+  IdxForRTreeSegment id{1, 0, 1};
+  boundary_segments.emplace_back(Segment2d{{1.0, -1.0}, {1.0, 1.0}}, id);
+
+  // Act:
+  auto result = geometry_projection::find_closest_segment(
+    ego_side_seg, ego_front_seg, ego_rear_seg, curr_fp_idx, boundary_segments);
+
+  // Assert:
+  EXPECT_EQ(result.pose_index, curr_fp_idx);
+  EXPECT_DOUBLE_EQ(result.lat_dist, 0.0);
+  EXPECT_DOUBLE_EQ(result.pt_on_ego.x(), 1.0);
+  EXPECT_DOUBLE_EQ(result.pt_on_ego.y(), 0.0);
+}
+
+TEST(UncrossableBoundaryUtilsTest, TestFindClosestSegmentFrontIntersection)
+{
+  // Arrange:
+  Segment2d ego_side_seg{{0.0, 4.0}, {0.0, 2.0}};
+  Segment2d ego_rear_seg{{0.0, -4.0}, {2.0, -4.0}};
+  Segment2d ego_front_seg{{0.0, 4.0}, {2.0, 4.0}};
+  size_t curr_fp_idx = 42;
+
+  std::vector<SegmentWithIdx> boundary_segments;
+  IdxForRTreeSegment id{1, 0, 1};
+  boundary_segments.emplace_back(Segment2d{{1.0, 5.0}, {1.0, 3.0}}, id);
+
+  // Act:
+  auto result = geometry_projection::find_closest_segment(
+    ego_side_seg, ego_front_seg, ego_rear_seg, curr_fp_idx, boundary_segments);
+
+  // Assert:
+  EXPECT_EQ(result.pose_index, curr_fp_idx);
+  EXPECT_DOUBLE_EQ(result.lat_dist, 0.0);
+  EXPECT_DOUBLE_EQ(result.pt_on_ego.x(), 1.0);
+  EXPECT_DOUBLE_EQ(result.pt_on_ego.y(), 4.0);
+}
+
+TEST(UncrossableBoundaryUtilsTest, TestFindClosestSegmentFallback)
+{
+  // Arrange:
+  Segment2d ego_side_seg{{0.0, 4.0}, {0.0, 2.0}};
+  Segment2d ego_rear_seg{{0.0, 0.0}, {2.0, 0.0}};
+  Segment2d ego_front_seg{{0.0, 4.0}, {2.0, 4.0}};
+
+  size_t curr_fp_idx = 99;
+
+  std::vector<SegmentWithIdx> boundary_segments;
+  IdxForRTreeSegment id{1, 0, 1};
+  boundary_segments.emplace_back(Segment2d{{4.0, -2.0}, {5.0, -2.0}}, id);
+
+  // Act:
+  auto result = geometry_projection::find_closest_segment(
+    ego_side_seg, ego_front_seg, ego_rear_seg, curr_fp_idx, boundary_segments);
+
+  // Assert:
+  EXPECT_EQ(result.pose_index, curr_fp_idx);
+  EXPECT_DOUBLE_EQ(result.lat_dist, std::numeric_limits<double>::max());
+}
+
+TEST(UncrossableBoundaryUtilsTest, TestCalcSignedLateralDistanceToBoundary)
+{
+  // Arrange:
+  geometry_msgs::msg::Pose ego_pose;
+  ego_pose.position.x = 0.0;
+  ego_pose.position.y = 0.0;
+  ego_pose.orientation = autoware_utils_geometry::create_quaternion_from_yaw(0.0);
+
+  // Act & Assert:
+  lanelet::LineString3d empty_ls(lanelet::utils::getId());
+  EXPECT_FALSE(
+    geometry_projection::calc_signed_lateral_distance_to_boundary(empty_ls, ego_pose).has_value());
+
+  lanelet::Point3d p1(lanelet::utils::getId(), -5.0, 5.0, 0.0);
+  lanelet::LineString3d single_pt_ls(lanelet::utils::getId(), {p1});
+  EXPECT_FALSE(
+    geometry_projection::calc_signed_lateral_distance_to_boundary(single_pt_ls, ego_pose)
+      .has_value());
+
+  lanelet::Point3d p2(lanelet::utils::getId(), 5.0, 5.0, 0.0);
+  lanelet::LineString3d left_boundary(lanelet::utils::getId(), {p1, p2});
+  auto dist_left =
+    geometry_projection::calc_signed_lateral_distance_to_boundary(left_boundary, ego_pose);
+  ASSERT_TRUE(dist_left.has_value());
+  EXPECT_DOUBLE_EQ(dist_left.value(), 5.0);
+
+  lanelet::Point3d p3(lanelet::utils::getId(), -5.0, -3.0, 0.0);
+  lanelet::Point3d p4(lanelet::utils::getId(), 5.0, -3.0, 0.0);
+  lanelet::LineString3d right_boundary(lanelet::utils::getId(), {p3, p4});
+  auto dist_right =
+    geometry_projection::calc_signed_lateral_distance_to_boundary(right_boundary, ego_pose);
+  ASSERT_TRUE(dist_right.has_value());
+  EXPECT_DOUBLE_EQ(dist_right.value(), -3.0);
+
+  lanelet::Point3d p5(lanelet::utils::getId(), 2.0, 5.0, 0.0);
+  lanelet::Point3d p6(lanelet::utils::getId(), 10.0, 5.0, 0.0);
+  lanelet::LineString3d missed_boundary(lanelet::utils::getId(), {p5, p6});
+  auto dist_miss =
+    geometry_projection::calc_signed_lateral_distance_to_boundary(missed_boundary, ego_pose);
+  EXPECT_FALSE(dist_miss.has_value());
+
+  lanelet::Point3d p7(lanelet::utils::getId(), 5.0, -10.0, 0.0);
+  lanelet::Point3d p8(lanelet::utils::getId(), 5.0, 10.0, 0.0);
+  lanelet::LineString3d parallel_boundary(lanelet::utils::getId(), {p7, p8});
+  auto dist_parallel =
+    geometry_projection::calc_signed_lateral_distance_to_boundary(parallel_boundary, ego_pose);
+  EXPECT_FALSE(dist_parallel.has_value());
+
+  lanelet::Point3d p9(lanelet::utils::getId(), -10.0, 8.0, 0.0);
+  lanelet::Point3d p10(lanelet::utils::getId(), 10.0, 8.0, 0.0);
+  lanelet::Point3d p11(lanelet::utils::getId(), 10.0, 4.0, 0.0);
+  lanelet::Point3d p12(lanelet::utils::getId(), -10.0, 4.0, 0.0);
+  lanelet::LineString3d multi_boundary(lanelet::utils::getId(), {p9, p10, p11, p12});
+  auto dist_multi =
+    geometry_projection::calc_signed_lateral_distance_to_boundary(multi_boundary, ego_pose);
+  ASSERT_TRUE(dist_multi.has_value());
+  EXPECT_DOUBLE_EQ(dist_multi.value(), 4.0);
+}
+
+// ==============================================================================
+// 2. UncrossableBoundariesRTree Tests
+// ==============================================================================
+
+TEST(UncrossableBoundaryUtilsTest, TestGetSegment3DFromId)
+{
+  // Arrange:
+  auto map = std::make_shared<lanelet::LaneletMap>();
+  lanelet::Point3d p1(lanelet::utils::getId(), 1.0, 2.0, 3.0);
+  lanelet::Point3d p2(lanelet::utils::getId(), 4.0, 5.0, 6.0);
+  lanelet::Point3d p3(lanelet::utils::getId(), 7.0, 8.0, 9.0);
+  lanelet::LineString3d ls(lanelet::utils::getId(), {p1, p2, p3});
+  ls.attributes()[lanelet::AttributeName::Type] = "road_border";
+  map->add(ls);
+
+  UncrossableBoundariesRTree rtree(map, {"road_border"});
+
+  // Act & Assert:
+  IdxForRTreeSegment id1{ls.id(), 0, 1};
+  auto seg1 = rtree.get_segment_3d_from_id(id1);
+  EXPECT_DOUBLE_EQ(seg1.first.x(), 1.0);
+  EXPECT_DOUBLE_EQ(seg1.second.x(), 4.0);
+
+  IdxForRTreeSegment id2{ls.id(), 1, 2};
+  auto seg2 = rtree.get_segment_3d_from_id(id2);
+  EXPECT_DOUBLE_EQ(seg2.first.x(), 4.0);
+  EXPECT_DOUBLE_EQ(seg2.second.x(), 7.0);
+}
+
+// ==============================================================================
+// 3. boundary_segment_finder Tests
+// ==============================================================================
+
+TEST(UncrossableBoundaryUtilsTest, TestIsClosestToBoundarySegment)
+{
+  // Arrange:
+  Segment2d left_side{{0.0, 2.0}, {2.0, 2.0}};
+  Segment2d right_side{{0.0, -2.0}, {2.0, -2.0}};
+
+  // Act & Assert:
+  Segment2d bound_left{{0.0, 3.0}, {2.0, 3.0}};
+  EXPECT_TRUE(
+    boundary_segment_finder::is_closest_to_boundary_segment(bound_left, left_side, right_side));
+
+  Segment2d bound_right{{0.0, -3.0}, {2.0, -3.0}};
+  EXPECT_TRUE(
+    boundary_segment_finder::is_closest_to_boundary_segment(bound_right, right_side, left_side));
+
+  Segment2d bound_center{{0.0, 0.0}, {2.0, 0.0}};
+  EXPECT_TRUE(
+    boundary_segment_finder::is_closest_to_boundary_segment(bound_center, left_side, right_side));
+}
+
+TEST(UncrossableBoundaryUtilsTest, TestIsSegmentWithinEgoHeight)
+{
+  // Arrange:
+  const double ego_z = 0.0;
+  const double ego_height = 2.5;
+
+  // Act & Assert:
+  Segment3d seg_within{{0.0, 0.0, 1.0}, {1.0, 0.0, 1.5}};
+  EXPECT_TRUE(boundary_segment_finder::is_segment_within_ego_height(seg_within, ego_z, ego_height));
+
+  Segment3d seg_above{{0.0, 0.0, 3.0}, {1.0, 0.0, 4.0}};
+  EXPECT_FALSE(boundary_segment_finder::is_segment_within_ego_height(seg_above, ego_z, ego_height));
+
+  Segment3d seg_below{{0.0, 0.0, -3.0}, {1.0, 0.0, -4.0}};
+  EXPECT_FALSE(boundary_segment_finder::is_segment_within_ego_height(seg_below, ego_z, ego_height));
+}
+
+// ==============================================================================
+// 4. severity_evaluator Tests
+// ==============================================================================
+
+TEST(UncrossableBoundaryUtilsTest, TestIsCritical)
+{
+  // Arrange:
+  Side<std::optional<CriticalPointPair>> projections;
+
+  // Act & Assert:
+  EXPECT_FALSE(severity_evaluator::is_critical(projections));
+
+  CriticalPointPair pair_crit;
+  pair_crit.physical_departure_point.departure_type = DepartureType::CRITICAL;
+  projections.left = pair_crit;
+  EXPECT_TRUE(severity_evaluator::is_critical(projections));
+}
+}  // namespace autoware::boundary_departure_checker

--- a/common/autoware_boundary_departure_checker/test/utils/test_create_vehicle_footprints.cpp
+++ b/common/autoware_boundary_departure_checker/test/utils/test_create_vehicle_footprints.cpp
@@ -1,0 +1,175 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/boundary_departure_checker/detail/footprints_generator.hpp"
+
+#include <Eigen/Core>
+
+#include <gtest/gtest.h>
+
+#include <string>
+#include <vector>
+
+namespace
+{
+using autoware_internal_planning_msgs::msg::PathPointWithLaneId;
+using autoware_internal_planning_msgs::msg::PathWithLaneId;
+using autoware_planning_msgs::msg::TrajectoryPoint;
+using autoware_utils_geometry::LinearRing2d;
+using geometry_msgs::msg::PoseWithCovariance;
+using TrajectoryPoints = std::vector<TrajectoryPoint>;
+using autoware::boundary_departure_checker::footprints::Footprints;
+
+PoseWithCovariance create_pose_with_covariance(
+  const Eigen::Matrix2d & covariance_xy, const double yaw)
+{
+  PoseWithCovariance pose_with_covariance;
+  pose_with_covariance.covariance[0 * 6 + 0] = covariance_xy(0, 0);
+  pose_with_covariance.covariance[0 * 6 + 1] = covariance_xy(0, 1);
+  pose_with_covariance.covariance[1 * 6 + 0] = covariance_xy(1, 0);
+  pose_with_covariance.covariance[1 * 6 + 1] = covariance_xy(1, 1);
+  pose_with_covariance.pose.orientation.z = std::sin(yaw / 2);
+  pose_with_covariance.pose.orientation.w = std::cos(yaw / 2);
+  return pose_with_covariance;
+}
+
+TrajectoryPoints create_trajectory_points(
+  const std::vector<std::pair<Eigen::Vector2d, double>> & xy_yaws)
+{
+  TrajectoryPoints trajectory_points;
+  for (const auto & [xy, yaw] : xy_yaws) {
+    TrajectoryPoint p;
+    p.pose.position.x = xy(0);
+    p.pose.position.y = xy(1);
+    p.pose.orientation.z = std::sin(yaw / 2);
+    p.pose.orientation.w = std::cos(yaw / 2);
+    trajectory_points.push_back(p);
+  }
+  return trajectory_points;
+}
+
+// reference:
+// https://github.com/autowarefoundation/autoware_core/blob/main/description/autoware_sample_vehicle_description/config/vehicle_info.param.yaml
+constexpr double wheel_radius_m = 0.383;
+constexpr double wheel_width_m = 0.235;
+constexpr double wheel_base_m = 2.79;
+constexpr double wheel_tread_m = 1.64;
+constexpr double front_overhang_m = 1.0;
+constexpr double rear_overhang_m = 1.1;
+constexpr double left_overhang_m = 0.128;
+constexpr double right_overhang_m = 0.128;
+constexpr double vehicle_height_m = 2.5;
+constexpr double max_steer_angle_rad = 0.70;
+constexpr double wheel_base_to_front_overhang = front_overhang_m + wheel_base_m;
+constexpr double half_wheel_base = wheel_base_m / 2.0;
+constexpr double half_width_left = wheel_tread_m / 2.0 + left_overhang_m;
+constexpr double half_width_right = wheel_tread_m / 2.0 + right_overhang_m;
+}  // namespace
+
+namespace autoware::boundary_departure_checker
+{
+
+struct CreateVehicleFootprintsAlongTrajectoryParam
+{
+  std::string description;
+  Eigen::Matrix2d covariance_xy;
+  double yaw;
+  std::vector<std::pair<Eigen::Vector2d, double>> trajectory_points;
+  std::vector<LinearRing2d> expected_footprints;
+};
+
+std::ostream & operator<<(std::ostream & os, const CreateVehicleFootprintsAlongTrajectoryParam & p)
+{
+  return os << p.description;
+}
+
+class CreateVehicleFootprintsAlongTrajectoryTest
+: public ::testing::TestWithParam<CreateVehicleFootprintsAlongTrajectoryParam>
+{
+protected:
+  void SetUp() override
+  {
+    vehicle_info = autoware::vehicle_info_utils::createVehicleInfo(
+      wheel_radius_m, wheel_width_m, wheel_base_m, wheel_tread_m, front_overhang_m, rear_overhang_m,
+      left_overhang_m, right_overhang_m, vehicle_height_m, max_steer_angle_rad);
+  }
+
+  autoware::vehicle_info_utils::VehicleInfo vehicle_info;
+};
+
+TEST_P(CreateVehicleFootprintsAlongTrajectoryTest, test_create_vehicle_footprints)
+{
+  // 1-line summary: Verifies vehicle footprint generation along various trajectory configurations.
+
+  // Arrange:
+  const auto & p = GetParam();
+  const auto trajectory_points = create_trajectory_points(p.trajectory_points);
+  const auto pose_with_covariance = create_pose_with_covariance(p.covariance_xy, p.yaw);
+
+  // Act:
+  const auto footprints =
+    footprints::generate(trajectory_points, vehicle_info, pose_with_covariance);
+
+  // Assert:
+  ASSERT_EQ(footprints.size(), p.expected_footprints.size());
+  for (size_t i = 0; i < footprints.size(); ++i) {
+    const auto & footprint = footprints.at(i);
+    const auto & expected_footprint = p.expected_footprints.at(i);
+    ASSERT_EQ(footprint.size(), expected_footprint.size());
+    for (size_t j = 0; j < footprint.size(); ++j) {
+      EXPECT_DOUBLE_EQ(footprint.at(j).x(), expected_footprint.at(j).x());
+      EXPECT_DOUBLE_EQ(footprint.at(j).y(), expected_footprint.at(j).y());
+    }
+  }
+}
+
+INSTANTIATE_TEST_SUITE_P(
+  LaneDepartureCheckerTest, CreateVehicleFootprintsAlongTrajectoryTest,
+  ::testing::Values(
+    CreateVehicleFootprintsAlongTrajectoryParam{
+      "EmptyTrajectory", Eigen::Matrix2d{{0.0, 0.0}, {0.0, 0.0}}, 0.0, {}, {}},
+    CreateVehicleFootprintsAlongTrajectoryParam{
+      "SinglePointTrajectory",
+      Eigen::Matrix2d{{0.0, 0.0}, {0.0, 0.0}},
+      0.0,
+      {{{0.0, 0.0}, 0.0}},
+      {{{wheel_base_to_front_overhang, half_width_left},
+        {wheel_base_to_front_overhang, -(half_width_right)},
+        {half_wheel_base, -(half_width_right)},
+        {-rear_overhang_m, -(half_width_right)},
+        {-rear_overhang_m, half_width_left},
+        {half_wheel_base, half_width_left},
+        {wheel_base_to_front_overhang, half_width_left}}}},
+    CreateVehicleFootprintsAlongTrajectoryParam{
+      "CurvedPathAtNinetyDeg",
+      Eigen::Matrix2d::Zero(),
+      0.0,
+      {{{10.0, 0.0}, M_PI_2}, {{0.0, 10.0}, M_PI}},
+      {{{10.0 - half_width_left, wheel_base_to_front_overhang},
+        {10.0 + half_width_right, wheel_base_to_front_overhang},
+        {10.0 + half_width_right, half_wheel_base},
+        {10.0 + half_width_right, -rear_overhang_m},
+        {10.0 - half_width_left, -rear_overhang_m},
+        {10.0 - half_width_left, half_wheel_base},
+        {10.0 - half_width_left, wheel_base_to_front_overhang}},
+
+       {{-wheel_base_to_front_overhang, 10.0 - half_width_left},
+        {-wheel_base_to_front_overhang, 10.0 + half_width_right},
+        {-half_wheel_base, 10.0 + half_width_right},
+        {rear_overhang_m, 10.0 + half_width_right},
+        {rear_overhang_m, 10.0 - half_width_left},
+        {-half_wheel_base, 10.0 - half_width_left},
+        {-wheel_base_to_front_overhang, 10.0 - half_width_left}}}}),
+  ::testing::PrintToStringParamName());
+}  // namespace autoware::boundary_departure_checker

--- a/common/autoware_boundary_departure_checker/test/utils/test_footprint_generator.cpp
+++ b/common/autoware_boundary_departure_checker/test/utils/test_footprint_generator.cpp
@@ -1,0 +1,140 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/boundary_departure_checker/detail/footprints_generator.hpp"
+#include "autoware/boundary_departure_checker/detail/type_alias.hpp"
+
+#include <autoware_vehicle_info_utils/vehicle_info_utils.hpp>
+
+#include <gtest/gtest.h>
+
+#include <vector>
+
+namespace autoware::boundary_departure_checker
+{
+namespace
+{
+}  // namespace
+
+class FootprintGeneratorTest : public ::testing::Test
+{
+protected:
+  void SetUp() override
+  {
+    // 1. Setup Vehicle Info
+    vehicle_info_ = autoware::vehicle_info_utils::createVehicleInfo(
+      0.383, 0.235, 2.79, 1.64, 1.0, 1.1, 2.5, 0.128, 0.128, 0.70);
+
+    // 2. Setup Trajectory
+    TrajectoryPoint p1;
+    p1.pose.position.x = 0.0;
+    p1.pose.position.y = 0.0;
+    p1.pose.orientation.w = 1.0;
+    p1.longitudinal_velocity_mps = 10.0;
+    p1.time_from_start.sec = static_cast<int32_t>(0.0);
+    p1.time_from_start.nanosec = static_cast<uint32_t>((0.0 - p1.time_from_start.sec) * 1e9);
+    pred_traj_.push_back(p1);
+
+    TrajectoryPoint p2 = p1;
+    p2.pose.position.x = 1.0;
+    p2.time_from_start.sec = static_cast<int32_t>(0.1);
+    p2.time_from_start.nanosec = static_cast<uint32_t>((0.1 - p2.time_from_start.sec) * 1e9);
+    pred_traj_.push_back(p2);
+
+    // 3. Setup covariance
+    pose_with_cov_.pose.orientation.w = 1.0;
+    for (auto & c : pose_with_cov_.covariance) {
+      c = 0.0;
+    }
+  }
+
+  autoware::vehicle_info_utils::VehicleInfo vehicle_info_;
+  TrajectoryPoints pred_traj_;
+  geometry_msgs::msg::PoseWithCovariance pose_with_cov_;
+};
+
+TEST_F(FootprintGeneratorTest, TestNormalFootprintGenerator)
+{
+  // 1-line summary: Verifies that footprints are correctly generated along a trajectory.
+
+  // Act:
+  const auto footprints = footprints::generate(pred_traj_, vehicle_info_, pose_with_cov_);
+
+  // Assert:
+  ASSERT_EQ(footprints.size(), pred_traj_.size());
+  const double expected_x = vehicle_info_.wheel_base_m + vehicle_info_.front_overhang_m;
+  EXPECT_DOUBLE_EQ(footprints[0][VehicleInfo::FrontLeftIndex].x(), expected_x);
+}
+
+TEST_F(FootprintGeneratorTest, TestSteeringFootprintGeneratorEmptyTrajectory)
+{
+  // Arrange:
+  TrajectoryPoints empty_traj;
+
+  // Act:
+  const auto footprints = footprints::generate(empty_traj, vehicle_info_, pose_with_cov_);
+
+  // Assert:
+  EXPECT_TRUE(footprints.empty());
+}
+
+TEST_F(FootprintGeneratorTest, TestGetSidesFromFootprintsEmpty)
+{
+  // Arrange:
+  footprints::Footprints empty_footprints;
+
+  // Act:
+  const auto sides_array = footprints::get_sides_from_footprints(empty_footprints);
+
+  // Assert:
+  EXPECT_TRUE(sides_array.empty());
+}
+
+TEST_F(FootprintGeneratorTest, TestGetSidesFromFootprints)
+{
+  // 1-line summary: Verifies extraction of left and right side segments from footprints.
+
+  // Arrange:
+  using autoware::vehicle_info_utils::VehicleInfo;
+  const auto base_fp = vehicle_info_.createFootprint(0.0, 0.0);
+  footprints::Footprints test_footprints = {base_fp};
+
+  auto offset_fp = base_fp;
+  for (auto & p : offset_fp) {
+    p = autoware_utils_geometry::Point2d{p.x() + 5.0, p.y()};  // 5.0m offset
+  }
+  test_footprints.push_back(offset_fp);
+
+  // Act:
+  const auto sides_array = footprints::get_sides_from_footprints(test_footprints);
+
+  // Assert:
+  ASSERT_EQ(sides_array.size(), 2);
+
+  EXPECT_DOUBLE_EQ(sides_array[0].left.first.x(), base_fp[VehicleInfo::FrontLeftIndex].x());
+  EXPECT_DOUBLE_EQ(sides_array[0].left.first.y(), base_fp[VehicleInfo::FrontLeftIndex].y());
+  EXPECT_DOUBLE_EQ(sides_array[0].left.second.x(), base_fp[VehicleInfo::RearLeftIndex].x());
+  EXPECT_DOUBLE_EQ(sides_array[0].left.second.y(), base_fp[VehicleInfo::RearLeftIndex].y());
+
+  EXPECT_DOUBLE_EQ(sides_array[0].right.first.x(), base_fp[VehicleInfo::FrontRightIndex].x());
+  EXPECT_DOUBLE_EQ(sides_array[0].right.first.y(), base_fp[VehicleInfo::FrontRightIndex].y());
+  EXPECT_DOUBLE_EQ(sides_array[0].right.second.x(), base_fp[VehicleInfo::RearRightIndex].x());
+  EXPECT_DOUBLE_EQ(sides_array[0].right.second.y(), base_fp[VehicleInfo::RearRightIndex].y());
+
+  EXPECT_DOUBLE_EQ(sides_array[1].left.first.x(), offset_fp[VehicleInfo::FrontLeftIndex].x());
+  EXPECT_DOUBLE_EQ(sides_array[1].left.first.y(), offset_fp[VehicleInfo::FrontLeftIndex].y());
+  EXPECT_DOUBLE_EQ(sides_array[1].right.second.x(), offset_fp[VehicleInfo::RearRightIndex].x());
+  EXPECT_DOUBLE_EQ(sides_array[1].right.second.y(), offset_fp[VehicleInfo::RearRightIndex].y());
+}
+}  // namespace autoware::boundary_departure_checker

--- a/common/autoware_boundary_departure_checker/test/utils/test_uncrossable_boundary_checker_non_class.cpp
+++ b/common/autoware_boundary_departure_checker/test/utils/test_uncrossable_boundary_checker_non_class.cpp
@@ -1,0 +1,371 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/boundary_departure_checker/detail/boundary_segment_finder.hpp"
+#include "autoware/boundary_departure_checker/detail/geometry_projection.hpp"
+#include "autoware/boundary_departure_checker/detail/severity_evaluator.hpp"
+#include "autoware/boundary_departure_checker/detail/type_alias.hpp"
+#include "autoware/boundary_departure_checker/detail/uncrossable_boundaries_rtree.hpp"
+
+#include <autoware/motion_utils/distance/distance.hpp>
+
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace autoware::boundary_departure_checker
+{
+namespace
+{
+TrajectoryPoint make_trajectory_point(double x, double y, double time)
+{
+  TrajectoryPoint p;
+  p.pose.position.x = x;
+  p.pose.position.y = y;
+  p.time_from_start.sec = static_cast<int32_t>(time);
+  p.time_from_start.nanosec = static_cast<uint32_t>((time - p.time_from_start.sec) * 1e9);
+  return p;
+}
+
+FootprintSideSegments make_footprint_sides(Segment2d left, Segment2d right)
+{
+  FootprintSideSegments s;
+  s.left = std::move(left);
+  s.right = std::move(right);
+  return s;
+}
+
+BoundarySegmentsBySide make_boundaries(
+  const std::vector<Segment2d> & left_segments, const std::vector<Segment2d> & right_segments = {})
+{
+  BoundarySegmentsBySide boundaries;
+  for (const auto & seg : left_segments) {
+    boundaries.left.emplace_back(seg, IdxForRTreeSegment{1, 0, 1});
+  }
+  for (const auto & seg : right_segments) {
+    boundaries.right.emplace_back(seg, IdxForRTreeSegment{2, 0, 1});
+  }
+  return boundaries;
+}
+}  // namespace
+
+// clang-format off
+/**
+ * TestParallelSegments:
+ *
+ *    Y ^
+ *  1.0 |       [ Boundary Segment ] (X: 1.0 to 3.0)
+ *      |       +------------------+
+ *      |       : <--- lat_dist=1.0
+ *  0.0 | +------------------+             ---> X
+ *      | [   Ego Segment    ] (X: 0.0 to 2.0)
+ *
+ * Verifies shortest distance between two parallel segments with overlap.
+ */
+// clang-format on
+TEST(UncrossableBoundaryTest, TestParallelSegments)
+{
+  // Verifies projection distance between parallel segments with partial longitudinal overlap.
+
+  // Arrange:
+  Segment2d ego_seg{{0.0, 0.0}, {2.0, 0.0}};
+  Segment2d boundary_seg{{1.0, 1.0}, {3.0, 1.0}};
+
+  // Act:
+  auto result = geometry_projection::calc_nearest_projection(ego_seg, boundary_seg, 0);
+
+  // Assert:
+  ASSERT_TRUE(result.has_value());
+  EXPECT_NEAR(result->lat_dist, 1.0, 1e-6);
+  EXPECT_GE(result->pt_on_ego.x(), 0.0);
+  EXPECT_LE(result->pt_on_ego.x(), 2.0);
+}
+
+// clang-format off
+/**
+ * TestPerpendicularNonIntersecting:
+ *
+ *    Y ^
+ *  1.0 |               | [ Boundary ]
+ *      |               | (X=2.0, Y: -1 to 1)
+ *  0.0 | +-------+     | lat_dist=1.0     ---> X
+ *      | (Ego)         |
+ * -1.0 | (X: 0 to 1)   |
+ *
+ * Verifies shortest distance between perpendicular segments.
+ */
+// clang-format on
+TEST(UncrossableBoundaryTest, TestPerpendicularNonIntersecting)
+{
+  // Verifies that perpendicular non-intersecting segments yield correct shortest distance.
+
+  // Arrange:
+  Segment2d ego_seg{{0.0, 0.0}, {1.0, 0.0}};
+  Segment2d boundary_seg{{2.0, -1.0}, {2.0, 1.0}};
+
+  // Act:
+  auto result = geometry_projection::calc_nearest_projection(ego_seg, boundary_seg, 0);
+
+  // Assert:
+  ASSERT_TRUE(result.has_value());
+  EXPECT_NEAR(result->lat_dist, 1.0, 1e-6);
+  EXPECT_DOUBLE_EQ(result->pt_on_ego.x(), 1.0);
+  EXPECT_DOUBLE_EQ(result->pt_on_bound.x(), 2.0);
+}
+
+// clang-format off
+/**
+ * TestCollinearSegments:
+ *
+ *    Y ^
+ *      |
+ *  0.0 | +-------+     +-------+          ---> X
+ *      |  (Ego)         (Boundary)
+ *      |  (X:0 to 1)    (X:2 to 3)
+ *      |         (Gap: No Projection)
+ *
+ * Verifies that no projection is found for collinear separated segments.
+ */
+// clang-format on
+TEST(UncrossableBoundaryTest, TestCollinearSegments)
+{
+  // Verifies that no projection is found for collinear but longitudinally separated segments.
+
+  // Arrange:
+  Segment2d ego_seg{{0.0, 0.0}, {1.0, 0.0}};
+  Segment2d boundary_seg{{2.0, 0.0}, {3.0, 0.0}};
+
+  // Act:
+  auto result = geometry_projection::calc_nearest_projection(ego_seg, boundary_seg, 0);
+
+  // Assert:
+  ASSERT_FALSE(result.has_value());
+}
+
+TEST(UncrossableBoundaryTest, TestMiddleOfSegmentCrossingForLonDist)
+{
+  // Verifies accurate longitudinal distance calculation when boundary crosses in the middle of an
+  // ego segment.
+
+  // Arrange:
+  TrajectoryPoints ego_pred_traj = {
+    make_trajectory_point(0.0, 0.0, 0.0), make_trajectory_point(10.0, 0.0, 1.0),
+    make_trajectory_point(20.0, 0.0, 2.0)};
+
+  FootprintSideSegmentsArray ego_sides = {
+    make_footprint_sides(Segment2d{{2.0, 1.0}, {-2.0, 1.0}}, Segment2d{{2.0, -1.0}, {-2.0, -1.0}}),
+    make_footprint_sides(Segment2d{{12.0, 1.0}, {8.0, 1.0}}, Segment2d{{12.0, -1.0}, {8.0, -1.0}}),
+    make_footprint_sides(
+      Segment2d{{22.0, 1.0}, {18.0, 1.0}}, Segment2d{{22.0, -1.0}, {18.0, -1.0}})};
+
+  BoundarySegmentsBySide boundaries = make_boundaries({Segment2d{{10.0, 0.0}, {10.0, 2.0}}});
+
+  // Act:
+  auto result = boundary_segment_finder::get_closest_boundary_segments_from_side(
+    ego_pred_traj, boundaries, ego_sides);
+
+  // Assert:
+  ASSERT_EQ(result.left.size(), 3);
+  const auto & proj_at_i = result.left[1];
+  EXPECT_DOUBLE_EQ(proj_at_i.lat_dist, 0.0);
+  EXPECT_DOUBLE_EQ(proj_at_i.pt_on_ego.x(), 10.0);
+  EXPECT_DOUBLE_EQ(proj_at_i.ego_front_to_proj_offset_m, 2.0);
+  EXPECT_DOUBLE_EQ(proj_at_i.dist_along_trajectory_m, 10.0);
+}
+
+TEST(UncrossableBoundaryTest, TestRealisticLaneDeparture)
+{
+  // Verifies signed lateral distance transitions during a realistic left-side departure.
+
+  // Arrange:
+  TrajectoryPoints ego_pred_traj = {
+    make_trajectory_point(0.0, 0.0, 0.0), make_trajectory_point(24.0, 7.0, 1.0),
+    make_trajectory_point(48.0, 14.0, 2.0), make_trajectory_point(72.0, 21.0, 3.0),
+    make_trajectory_point(96.0, 28.0, 4.0)};
+
+  FootprintSideSegmentsArray ego_sides = {
+    make_footprint_sides(Segment2d{{4.1, 3.8}, {-5.5, 1.0}}, Segment2d{{5.5, -1.0}, {-4.1, -3.8}}),
+    make_footprint_sides(Segment2d{{28.1, 10.8}, {18.5, 8.0}}, Segment2d{{29.5, 6.0}, {19.9, 3.2}}),
+    make_footprint_sides(
+      Segment2d{{52.1, 17.8}, {42.5, 15.0}}, Segment2d{{53.5, 13.0}, {43.9, 10.2}}),
+    make_footprint_sides(
+      Segment2d{{76.1, 24.8}, {66.5, 22.0}}, Segment2d{{77.5, 20.0}, {67.9, 17.2}}),
+    make_footprint_sides(
+      Segment2d{{100.1, 31.8}, {90.5, 29.0}}, Segment2d{{101.5, 27.0}, {91.9, 24.2}})};
+
+  BoundarySegmentsBySide boundaries = make_boundaries(
+    {Segment2d{{-10.0, 9.4}, {120.0, 9.4}}}, {Segment2d{{-10.0, -5.0}, {120.0, -5.0}}});
+
+  // Act:
+  auto result = boundary_segment_finder::get_closest_boundary_segments_from_side(
+    ego_pred_traj, boundaries, ego_sides);
+
+  // Assert:
+  EXPECT_NEAR(result.left[0].lat_dist, 5.6, 1e-6);
+  EXPECT_NEAR(result.left[1].lat_dist, 0.0, 1e-6);
+  EXPECT_NEAR(result.left[2].lat_dist, -5.6, 1e-6);
+}
+
+TEST(UncrossableBoundaryTest, TestRealisticRightLaneDeparture)
+{
+  // Verifies signed lateral distance transitions during a realistic right-side departure.
+
+  // Arrange:
+  TrajectoryPoints ego_pred_traj = {
+    make_trajectory_point(0.0, 0.0, 0.0), make_trajectory_point(24.0, -7.0, 1.0),
+    make_trajectory_point(48.0, -14.0, 2.0), make_trajectory_point(72.0, -21.0, 3.0),
+    make_trajectory_point(96.0, -28.0, 4.0)};
+
+  FootprintSideSegmentsArray ego_sides = {
+    make_footprint_sides(Segment2d{{5.5, 1.0}, {-4.1, 3.8}}, Segment2d{{4.1, -3.8}, {-5.5, -1.0}}),
+    make_footprint_sides(
+      Segment2d{{29.5, -6.0}, {19.9, -3.2}}, Segment2d{{28.1, -10.8}, {18.5, -8.0}}),
+    make_footprint_sides(
+      Segment2d{{53.5, -13.0}, {43.9, -10.2}}, Segment2d{{52.1, -17.8}, {42.5, -15.0}}),
+    make_footprint_sides(
+      Segment2d{{77.5, -20.0}, {67.9, -17.2}}, Segment2d{{76.1, -24.8}, {66.5, -22.0}}),
+    make_footprint_sides(
+      Segment2d{{101.5, -27.0}, {91.9, -24.2}}, Segment2d{{100.1, -31.8}, {90.5, -29.0}})};
+
+  BoundarySegmentsBySide boundaries = make_boundaries(
+    {Segment2d{{-10.0, 5.0}, {120.0, 5.0}}}, {Segment2d{{-10.0, -9.4}, {120.0, -9.4}}});
+
+  // Act:
+  auto result = boundary_segment_finder::get_closest_boundary_segments_from_side(
+    ego_pred_traj, boundaries, ego_sides);
+
+  // Assert:
+  EXPECT_NEAR(result.right[0].lat_dist, 5.6, 1e-6);
+  EXPECT_NEAR(result.right[1].lat_dist, 0.0, 1e-6);
+  EXPECT_NEAR(result.right[2].lat_dist, -5.6, 1e-6);
+}
+
+TEST(UncrossableBoundaryUtilsTest, TestCalcJudgeLineDist)
+{
+  // Verifies braking distance calculation with jerk and acceleration limits.
+
+  // Arrange:
+  constexpr double acceleration = 0.0;
+  constexpr double max_stop_accel = -4.0;
+  constexpr double max_stop_jerk = -10.0;
+  constexpr double delay_time = 1.0;
+  constexpr double v_test = 10.0;
+
+  // Act:
+  const auto dist_opt = autoware::motion_utils::calculate_stop_distance(
+    v_test, acceleration, max_stop_accel, max_stop_jerk, delay_time);
+
+  // Assert:
+  ASSERT_TRUE(dist_opt.has_value());
+  EXPECT_GT(*dist_opt, 22.5);
+}
+
+TEST(UncrossableBoundaryUtilsTest, TestPointToSegmentProjection)
+{
+  // Verifies point-to-segment projection and resulting distance.
+
+  // Arrange:
+  autoware_utils_geometry::Point2d p{0.5, 1.0};
+  Segment2d segment{{0.0, 0.0}, {1.0, 0.0}};
+
+  // Act:
+  auto result = geometry_projection::point_to_segment_projection(p, segment);
+
+  // Assert:
+  ASSERT_TRUE(result.has_value());
+  EXPECT_DOUBLE_EQ(result->second, 1.0);
+}
+
+TEST(UncrossableBoundaryUtilsTest, TestIsUncrossableType)
+{
+  // Verifies boundary type filtering logic.
+
+  // Arrange:
+  lanelet::LineString3d ls(lanelet::utils::getId());
+  ls.attributes()[lanelet::AttributeName::Type] = "road_border";
+  std::vector<std::string> types = {"road_border", "curb"};
+
+  // Act & Assert:
+  EXPECT_TRUE(UncrossableBoundariesRTree::is_uncrossable_type(types, ls));
+  ls.attributes()[lanelet::AttributeName::Type] = "lane_divider";
+  EXPECT_FALSE(UncrossableBoundariesRTree::is_uncrossable_type(types, ls));
+}
+
+TEST(UncrossableBoundaryUtilsTest, TestEvaluateProjectionsSeverityBackwardBuffer)
+{
+  // Verifies that backward buffering correctly identifies the start of a critical departure zone.
+
+  // Arrange:
+  Side<ProjectionsToBound> input;
+  UncrossableBoundaryDepartureParam param;
+  param.lateral_margin_m = 0.5;
+  param.time_to_departure_cutoff_s = 2.0;
+  param.longitudinal_margin_m = 1.0;
+  double min_braking_dist = 10.0;
+
+  auto create_pt = [](size_t idx, double s, double time) {
+    ProjectionToBound pt(idx);
+    pt.lat_dist = 0.1;
+    pt.dist_along_trajectory_m = s;
+    pt.ego_front_to_proj_offset_m = 0.0;
+    pt.time_from_start = time;
+    pt.pt_on_ego = {s, 0.1};
+    pt.pt_on_bound = {s, 0.0};
+    return pt;
+  };
+
+  input.left.push_back(create_pt(0, 12.0, 2.4));
+  input.left.push_back(create_pt(1, 13.0, 2.6));
+  input.left.push_back(create_pt(2, 14.0, 2.8));
+  input.left.push_back(create_pt(3, 15.0, 1.9));
+
+  // Act:
+  auto result = input.transform_each_side([&](const auto & side_value) {
+    const auto min_to_bounds =
+      severity_evaluator::filter_and_assign_departure_types(side_value, param, min_braking_dist);
+    return severity_evaluator::apply_backward_buffer_and_filter(min_to_bounds, param);
+  });
+
+  // Assert:
+  ASSERT_TRUE(result.left.has_value());
+  EXPECT_DOUBLE_EQ(result.left->physical_departure_point.dist_along_trajectory_m, 15.0);
+  EXPECT_DOUBLE_EQ(result.left->safety_buffer_start.dist_along_trajectory_m, 14.0);
+}
+
+TEST(UncrossableBoundaryUtilsTest, TestBuildUncrossableBoundariesRTree)
+{
+  // Verifies the construction and querying of an R-tree for uncrossable boundary segments.
+
+  // Arrange
+  lanelet::LaneletMapPtr map = std::make_shared<lanelet::LaneletMap>();
+  lanelet::Point3d p1(lanelet::utils::getId(), 0.0, 0.0, 0.0);
+  lanelet::Point3d p2(lanelet::utils::getId(), 1.0, 0.0, 0.0);
+  lanelet::Point3d p3(lanelet::utils::getId(), 2.0, 0.0, 0.0);
+  lanelet::LineString3d ls1(lanelet::utils::getId(), {p1, p2, p3});
+  ls1.attributes()[lanelet::AttributeName::Type] = "road_border";
+  map->add(ls1);
+  std::vector<std::string> types = {"road_border"};
+
+  // Act:
+  UncrossableBoundariesRTree rtree(map, types);
+
+  // Assert:
+  std::vector<SegmentWithIdx> results = rtree.query(Point2d{0.5, 0.0}, 1);
+  ASSERT_EQ(results.size(), 1);
+  EXPECT_EQ(results.front().second.linestring_id, ls1.id());
+}
+}  // namespace autoware::boundary_departure_checker

--- a/planning/autoware_trajectory_validator/CMakeLists.txt
+++ b/planning/autoware_trajectory_validator/CMakeLists.txt
@@ -35,6 +35,7 @@ rclcpp_components_register_node(${trajectory_validator_lib_target}
 )
 
 ament_auto_add_library(autoware_trajectory_validator_plugins SHARED
+  src/filters/safety/uncrossable_boundary_departure.cpp
   src/filters/safety/out_of_lane_filter.cpp
   src/filters/safety/vehicle_constraint_filter.cpp
   src/filters/traffic_rule/traffic_light_filter.cpp

--- a/planning/autoware_trajectory_validator/config/trajectory_validator.param.yaml
+++ b/planning/autoware_trajectory_validator/config/trajectory_validator.param.yaml
@@ -5,6 +5,7 @@
 
     shadow_mode_filter_names:
       [
+        "safety::UncrossableBoundaryDepartureFilter",
         "safety::OutOfLaneFilter",
         "safety::VehicleConstraintFilter",
         "traffic_rule::TrafficLightFilter",

--- a/planning/autoware_trajectory_validator/config/trajectory_validator.param.yaml
+++ b/planning/autoware_trajectory_validator/config/trajectory_validator.param.yaml
@@ -31,3 +31,15 @@
       checked_trajectory_length:  # maximum length of the planned trajectory that is scanned for traffic light stop lines.
         deceleration_limit: 2.0  # [m/s^2] deceleration limit to calculate the stop distance used as trajectory length limit
         jerk_limit: 2.0  # [m/s^3] jerk limit to calculate the stop distance used as trajectory length limit
+
+    boundary_departure:
+      boundary_types: ["road_border"]
+      brake_delay_s: 1.0
+      enable_developer_marker: false
+      lateral_margin_m: 0.01
+      longitudinal_margin_m: 1.0
+      max_deceleration_mps2: -4.0
+      max_jerk_mps3: -5.0
+      off_time_buffer_s: 0.10
+      on_time_buffer_s: 0.20
+      time_to_departure_cutoff_s: 2.0

--- a/planning/autoware_trajectory_validator/include/autoware/trajectory_validator/filters/safety/uncrossable_boundary_departure.hpp
+++ b/planning/autoware_trajectory_validator/include/autoware/trajectory_validator/filters/safety/uncrossable_boundary_departure.hpp
@@ -1,0 +1,46 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef AUTOWARE__TRAJECTORY_VALIDATOR__FILTERS__SAFETY__UNCROSSABLE_BOUNDARY_DEPARTURE_HPP_
+#define AUTOWARE__TRAJECTORY_VALIDATOR__FILTERS__SAFETY__UNCROSSABLE_BOUNDARY_DEPARTURE_HPP_
+
+#include "autoware/trajectory_validator/validator_interface.hpp"
+
+#include <autoware/boundary_departure_checker/uncrossable_boundary_checker.hpp>
+#include <rclcpp/rclcpp.hpp>
+
+#include <memory>
+#include <string>
+namespace autoware::trajectory_validator::plugin::safety
+{
+class UncrossableBoundaryDepartureFilter : public plugin::ValidatorInterface
+{
+public:
+  UncrossableBoundaryDepartureFilter() : ValidatorInterface("uncrossable_boundary_departure_filter")
+  {
+  }
+
+  result_t is_feasible(const TrajectoryPoints & traj_points, const FilterContext & context) final;
+
+  void update_parameters(const validator::Params & params) final;
+
+private:
+  std::unique_ptr<boundary_departure_checker::UncrossableBoundaryChecker> checker_;
+  boundary_departure_checker::UncrossableBoundaryDepartureParam params_;
+
+  tl::expected<void, std::string> validate_filter_context(const FilterContext & context) const;
+};
+}  // namespace autoware::trajectory_validator::plugin::safety
+
+#endif  // AUTOWARE__TRAJECTORY_VALIDATOR__FILTERS__SAFETY__UNCROSSABLE_BOUNDARY_DEPARTURE_HPP_

--- a/planning/autoware_trajectory_validator/package.xml
+++ b/planning/autoware_trajectory_validator/package.xml
@@ -23,6 +23,7 @@
 
   <exec_depend>rosidl_default_runtime</exec_depend>
 
+  <depend>autoware_boundary_departure_checker</depend>
   <depend>autoware_deprecated_boundary_departure_checker</depend>
   <depend>autoware_internal_planning_msgs</depend>
   <depend>autoware_lanelet2_utils</depend>

--- a/planning/autoware_trajectory_validator/param/parameter_struct.yaml
+++ b/planning/autoware_trajectory_validator/param/parameter_struct.yaml
@@ -93,6 +93,58 @@ validator:
         description: jerk limit to calculate the stop distance used as trajectory length limit
         read_only: false
 
+  boundary_departure:
+    lateral_margin_m:
+      type: double
+      default_value: 0.01
+      description: lateral margin [m]
+      read_only: false
+    longitudinal_margin_m:
+      type: double
+      default_value: 1.0
+      description: longitudinal margin [m]
+      read_only: false
+    max_deceleration_mps2:
+      type: double
+      default_value: -4.0
+      description: maximum deceleration [m/s^2]
+      read_only: false
+    max_jerk_mps3:
+      type: double
+      default_value: -5.0
+      description: maximum jerk [m/s^3]
+      read_only: false
+    brake_delay_s:
+      type: double
+      default_value: 1.0
+      description: brake delay [s]
+      read_only: false
+    time_to_departure_cutoff_s:
+      type: double
+      default_value: 2.0
+      description: time to departure cutoff [s]
+      read_only: false
+    on_time_buffer_s:
+      type: double
+      default_value: 0.15
+      description: buffer for activating departure detection [s]
+      read_only: false
+    off_time_buffer_s:
+      type: double
+      default_value: 0.15
+      description: buffer for deactivating departure detection [s]
+      read_only: false
+    enable_developer_marker:
+      type: bool
+      default_value: true
+      description: flag marker only for developer
+      read_only: false
+    boundary_types:
+      type: string_array
+      default_value: [road_border]
+      description: boundary types to detect
+      read_only: true
+
   pseudo_emergency_stop:
     enable:
       type: bool

--- a/planning/autoware_trajectory_validator/plugins.xml
+++ b/planning/autoware_trajectory_validator/plugins.xml
@@ -1,5 +1,11 @@
 <?xml version="1.0"?>
 <library path="autoware_trajectory_validator_plugins">
+  <class type="safety::UncrossableBoundaryDepartureFilter"
+    base_class_type="autoware::trajectory_validator::plugin::ValidatorInterface">
+    <description>
+      Filters trajectories that cross uncrossable boundaries
+    </description>
+  </class>
   <class type="safety::OutOfLaneFilter"
     base_class_type="autoware::trajectory_validator::plugin::ValidatorInterface">
     <description>

--- a/planning/autoware_trajectory_validator/src/filters/safety/uncrossable_boundary_departure.cpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/uncrossable_boundary_departure.cpp
@@ -1,0 +1,101 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/trajectory_validator/filters/safety/uncrossable_boundary_departure.hpp"
+
+#include <memory>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace autoware::trajectory_validator::plugin::safety
+{
+UncrossableBoundaryDepartureFilter::result_t UncrossableBoundaryDepartureFilter::is_feasible(
+  const TrajectoryPoints & traj_points, const FilterContext & context)
+{
+  if (const auto validate_context = validate_filter_context(context); !validate_context) {
+    return tl::make_unexpected(validate_context.error());
+  }
+
+  if (!checker_) {
+    checker_ = std::make_unique<boundary_departure_checker::UncrossableBoundaryChecker>(
+      context.lanelet_map, params_, *vehicle_info_ptr_);
+  }
+
+  boundary_departure_checker::EgoDynamicState ego_state;
+  ego_state.pose_with_cov = context.odometry->pose;
+  ego_state.velocity = context.odometry->twist.twist.linear.x;
+  ego_state.acceleration = context.acceleration->accel.accel.linear.x;
+  ego_state.current_time_s = rclcpp::Time(context.odometry->header.stamp).seconds();
+
+  auto status = checker_->update_departure_status(traj_points, ego_state);
+
+  const bool is_feasible = status.status != boundary_departure_checker::DepartureType::CRITICAL;
+
+  if (!is_feasible) {
+    std::move(
+      status.debug_markers.markers.begin(), status.debug_markers.markers.end(),
+      std::back_inserter(debug_markers_.markers));
+  }
+
+  std::vector<MetricReport> metrics{
+    autoware_trajectory_validator::build<MetricReport>()
+      .validator_name(get_name())
+      .validator_category(category())
+      .metric_name("check_critical_departure")
+      .metric_value(is_feasible ? 1.0 : 0.0)
+      .level(!is_feasible ? MetricReport::ERROR : MetricReport::OK)};
+
+  return ValidationResult{is_feasible, std::move(metrics)};
+}
+
+void UncrossableBoundaryDepartureFilter::update_parameters(const validator::Params & params)
+{
+  params_.lateral_margin_m = params.boundary_departure.lateral_margin_m;
+  params_.longitudinal_margin_m = params.boundary_departure.longitudinal_margin_m;
+  params_.max_deceleration_mps2 = params.boundary_departure.max_deceleration_mps2;
+  params_.max_jerk_mps3 = params.boundary_departure.max_jerk_mps3;
+  params_.brake_delay_s = params.boundary_departure.brake_delay_s;
+  params_.time_to_departure_cutoff_s = params.boundary_departure.time_to_departure_cutoff_s;
+  params_.on_time_buffer_s = params.boundary_departure.on_time_buffer_s;
+  params_.off_time_buffer_s = params.boundary_departure.off_time_buffer_s;
+  params_.enable_developer_marker = params.boundary_departure.enable_developer_marker;
+  params_.boundary_types_to_detect = params.boundary_departure.boundary_types;
+
+  if (checker_) {
+    checker_->update_parameters(params_);
+  }
+}
+
+tl::expected<void, std::string> UncrossableBoundaryDepartureFilter::validate_filter_context(
+  const FilterContext & context) const
+{
+  if (!context.lanelet_map || context.lanelet_map->lineStringLayer.empty()) {
+    return tl::make_unexpected("Lanelet map is not available in the context.");
+  }
+
+  if (!vehicle_info_ptr_) {
+    return tl::make_unexpected("Vehicle info is not set.");
+  }
+
+  return {};
+}
+}  // namespace autoware::trajectory_validator::plugin::safety
+
+#include <pluginlib/class_list_macros.hpp>
+namespace safety = autoware::trajectory_validator::plugin::safety;
+
+PLUGINLIB_EXPORT_CLASS(
+  safety::UncrossableBoundaryDepartureFilter,
+  autoware::trajectory_validator::plugin::ValidatorInterface)


### PR DESCRIPTION
cherry-pick `boundary_departure_checker` library and `trajectory_validator`'s new plugin `uncrossable_boundary_departure` filter. 

- https://github.com/autowarefoundation/autoware_universe/pull/12421
- https://github.com/autowarefoundation/autoware_universe/pull/12587

corresponding launcher PR
https://github.com/tier4/autoware_launch.x2/pull/2267