### PR TITLE
feat(processing_time_checker): add processing_time_ms for trajectory_optimizer and diffusion_planner

### DIFF
--- a/planning/autoware_diffusion_planner/include/autoware/diffusion_planner/diffusion_planner_node.hpp
+++ b/planning/autoware_diffusion_planner/include/autoware/diffusion_planner/diffusion_planner_node.hpp
@@ -25,11 +25,13 @@
 #include <autoware_utils/ros/update_param.hpp>
 #include <autoware_utils/system/time_keeper.hpp>
 #include <autoware_utils_diagnostics/diagnostics_interface.hpp>
+#include <autoware_utils_system/stop_watch.hpp>
 #include <autoware_vehicle_info_utils/vehicle_info_utils.hpp>
 #include <rclcpp/rclcpp.hpp>
 #include <rclcpp/subscription.hpp>
 #include <rclcpp/timer.hpp>
 
+#include <autoware_internal_debug_msgs/msg/float64_stamped.hpp>
 #include <autoware_internal_planning_msgs/msg/candidate_trajectories.hpp>
 #include <autoware_map_msgs/msg/lanelet_map_bin.hpp>
 #include <autoware_perception_msgs/msg/predicted_objects.hpp>
@@ -181,6 +183,8 @@ private:
   rclcpp::TimerBase::SharedPtr timer_;
   rclcpp::Publisher<autoware_utils::ProcessingTimeDetail>::SharedPtr
     debug_processing_time_detail_pub_;
+  rclcpp::Publisher<autoware_internal_debug_msgs::msg::Float64Stamped>::SharedPtr
+    debug_processing_time_pub_;
   rclcpp::Publisher<Trajectory>::SharedPtr pub_trajectory_{nullptr};
   rclcpp::Publisher<CandidateTrajectories>::SharedPtr pub_trajectories_{nullptr};
   rclcpp::Publisher<PredictedObjects>::SharedPtr pub_objects_{nullptr};
@@ -214,6 +218,8 @@ private:
 
   std::unique_ptr<DiagnosticsInterface> diagnostics_inference_;
   std::shared_ptr<const lanelet::LaneletMap> lanelet_map_ptr_{nullptr};
+
+  std::unique_ptr<autoware_utils_system::StopWatch<std::chrono::milliseconds>> stop_watch_ptr_;
 
   std::unique_ptr<autoware::planning_factor_interface::PlanningFactorInterface>
     planning_factor_interface_;

--- a/planning/autoware_diffusion_planner/package.xml
+++ b/planning/autoware_diffusion_planner/package.xml
@@ -17,6 +17,7 @@
 
   <depend>autoware_cuda_dependency_meta</depend>
   <depend>autoware_cuda_utils</depend>
+  <depend>autoware_internal_debug_msgs</depend>
   <depend>autoware_internal_planning_msgs</depend>
   <depend>autoware_lanelet2_extension</depend>
   <depend>autoware_lanelet2_utils</depend>

--- a/planning/autoware_diffusion_planner/src/diffusion_planner_node.cpp
+++ b/planning/autoware_diffusion_planner/src/diffusion_planner_node.cpp
@@ -50,6 +50,9 @@ DiffusionPlanner::DiffusionPlanner(const rclcpp::NodeOptions & options)
     "~/output/debug/traffic_signal", 1);
   debug_processing_time_detail_pub_ = this->create_publisher<autoware_utils::ProcessingTimeDetail>(
     "~/debug/processing_time_detail_ms", 1);
+  debug_processing_time_pub_ =
+    this->create_publisher<autoware_internal_debug_msgs::msg::Float64Stamped>(
+      "~/debug/processing_time_ms", 1);
   time_keeper_ = std::make_shared<autoware_utils::TimeKeeper>(debug_processing_time_detail_pub_);
 
   set_up_params();
@@ -270,6 +273,8 @@ void DiffusionPlanner::on_timer()
 {
   // Timer callback function
   autoware_utils_debug::ScopedTimeTrack st(__func__, *time_keeper_);
+  stop_watch_ptr_ = std::make_unique<autoware_utils_system::StopWatch<std::chrono::milliseconds>>();
+  stop_watch_ptr_->tic("processing_time");
 
   diagnostics_inference_->clear();
 
@@ -391,6 +396,10 @@ void DiffusionPlanner::on_timer()
 
   // Publish diagnostics
   diagnostics_inference_->publish(frame_time);
+  autoware_internal_debug_msgs::msg::Float64Stamped processing_time_msg;
+  processing_time_msg.stamp = get_clock()->now();
+  processing_time_msg.data = stop_watch_ptr_->toc("processing_time", true);
+  debug_processing_time_pub_->publish(processing_time_msg);
 }
 
 void DiffusionPlanner::publish_planning_factor(const Trajectory & trajectory)

--- a/planning/autoware_trajectory_optimizer/include/autoware/trajectory_optimizer/trajectory_optimizer.hpp
+++ b/planning/autoware_trajectory_optimizer/include/autoware/trajectory_optimizer/trajectory_optimizer.hpp
@@ -20,10 +20,12 @@
 
 #include <autoware_utils/ros/polling_subscriber.hpp>
 #include <autoware_utils/system/time_keeper.hpp>
+#include <autoware_utils_system/stop_watch.hpp>
 #include <pluginlib/class_loader.hpp>
 #include <rclcpp/rclcpp.hpp>
 #include <rclcpp/subscription.hpp>
 
+#include <autoware_internal_debug_msgs/msg/float64_stamped.hpp>
 #include <autoware_internal_planning_msgs/msg/candidate_trajectories.hpp>
 #include <autoware_planning_msgs/msg/trajectory.hpp>
 #include <geometry_msgs/msg/accel_with_covariance_stamped.hpp>
@@ -48,6 +50,7 @@ public:
 
 private:
   void on_traj(const CandidateTrajectories::ConstSharedPtr msg);
+  void publish_processing_time_ms(double processing_time_ms);
   void set_up_params();
   void initialize_optimizers();
   void load_plugin(const std::string & plugin_name);
@@ -78,9 +81,12 @@ private:
 
   Odometry::ConstSharedPtr current_odometry_ptr_;  // current odometry
   AccelWithCovarianceStamped::ConstSharedPtr current_acceleration_ptr_;
+  std::unique_ptr<autoware_utils_system::StopWatch<std::chrono::milliseconds>> stop_watch_ptr_;
 
   rclcpp::Publisher<autoware_utils::ProcessingTimeDetail>::SharedPtr
     debug_processing_time_detail_pub_;
+  rclcpp::Publisher<autoware_internal_debug_msgs::msg::Float64Stamped>::SharedPtr
+    debug_processing_time_pub_;
   mutable std::shared_ptr<autoware_utils::TimeKeeper> time_keeper_{nullptr};
 
   TrajectoryOptimizerParams params_;

--- a/planning/autoware_trajectory_optimizer/package.xml
+++ b/planning/autoware_trajectory_optimizer/package.xml
@@ -15,6 +15,7 @@
 
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
+  <depend>autoware_internal_debug_msgs</depend>
   <depend>autoware_internal_planning_msgs</depend>
   <depend>autoware_motion_utils</depend>
   <depend>autoware_osqp_interface</depend>

--- a/planning/autoware_trajectory_optimizer/src/trajectory_optimizer.cpp
+++ b/planning/autoware_trajectory_optimizer/src/trajectory_optimizer.cpp
@@ -20,6 +20,7 @@
 #include <autoware/motion_utils/trajectory/trajectory.hpp>
 #include <autoware_utils/ros/parameter.hpp>
 #include <autoware_utils/ros/update_param.hpp>
+#include <autoware_utils_debug/time_keeper.hpp>
 #include <autoware_utils_geometry/geometry.hpp>
 #include <autoware_vehicle_info_utils/vehicle_info_utils.hpp>
 #include <rclcpp/logging.hpp>
@@ -43,6 +44,8 @@ TrajectoryOptimizer::TrajectoryOptimizer(const rclcpp::NodeOptions & options)
 {
   debug_processing_time_detail_pub_ = create_publisher<autoware_utils_debug::ProcessingTimeDetail>(
     "~/debug/processing_time_detail_ms", 1);
+  debug_processing_time_pub_ = create_publisher<autoware_internal_debug_msgs::msg::Float64Stamped>(
+    "~/debug/processing_time_ms", 1);
   time_keeper_ =
     std::make_shared<autoware_utils_debug::TimeKeeper>(debug_processing_time_detail_pub_);
 
@@ -164,8 +167,18 @@ void TrajectoryOptimizer::set_up_params()
   params_.use_mpt_optimizer = get_or_declare_parameter<bool>(*this, "use_mpt_optimizer");
 }
 
+void TrajectoryOptimizer::publish_processing_time_ms(const double processing_time_ms)
+{
+  autoware_internal_debug_msgs::msg::Float64Stamped msg;
+  msg.stamp = get_clock()->now();
+  msg.data = processing_time_ms;
+  debug_processing_time_pub_->publish(msg);
+}
+
 void TrajectoryOptimizer::on_traj([[maybe_unused]] const CandidateTrajectories::ConstSharedPtr msg)
 {
+  stop_watch_ptr_ = std::make_unique<autoware_utils_system::StopWatch<std::chrono::milliseconds>>();
+  stop_watch_ptr_->tic("processing_time");
   autoware_utils_debug::ScopedTimeTrack st(__func__, *time_keeper_);
   initialize_optimizers();
 
@@ -174,6 +187,7 @@ void TrajectoryOptimizer::on_traj([[maybe_unused]] const CandidateTrajectories::
 
   if (!current_odometry_ptr_ || !current_acceleration_ptr_) {
     RCLCPP_WARN_THROTTLE(get_logger(), *get_clock(), 5000, "No odometry or acceleration data");
+    publish_processing_time_ms(stop_watch_ptr_->toc("processing_time", true));
     return;
   }
 
@@ -203,6 +217,8 @@ void TrajectoryOptimizer::on_traj([[maybe_unused]] const CandidateTrajectories::
   output_trajectory.points = output_trajectories.candidate_trajectories.front().points;
 
   trajectory_pub_->publish(output_trajectory);
+
+  publish_processing_time_ms(stop_watch_ptr_->toc("processing_time", true));
 }
 
 }  // namespace autoware::trajectory_optimizer

--- a/system/autoware_processing_time_checker/config/processing_time_checker.param.yaml
+++ b/system/autoware_processing_time_checker/config/processing_time_checker.param.yaml
@@ -53,3 +53,7 @@
       - /planning/scenario_planning/scenario_selector/debug/processing_time_ms
       - /planning/scenario_planning/velocity_smoother/debug/processing_time_ms
       - /simulation/shape_estimation/debug/processing_time_ms
+
+    # E2E metrics
+      - /planning/trajectory_generator/neural_network_based_planner/diffusion_planner_node/debug/processing_time_ms
+      - /planning/trajectory_generator/neural_network_based_planner/trajectory_optimizer_node/debug/processing_time_ms


### PR DESCRIPTION
## Summary
Cherry-pick of autowarefoundation/autoware.universe#12529

- Adds `processing_time_ms` topic publishing to `autoware_trajectory_optimizer` and `autoware_diffusion_planner`
- Updates `processing_time_checker` config to include the new neural_network_based_planner nodes