### PR TITLE
refactor(trajectory_validator): emit per-prediction-type worst metric…

### DIFF
--- a/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/assessment.cpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/assessment.cpp
@@ -467,8 +467,9 @@ RssArtifact assess(
       ego_trajectory, context.odometry->twist.twist, object, rss_params,
       context.predicted_objects->header.stamp);
     const auto risk_level =
-      rss_detail.rss_acceleration < rss_params.error_threshold.ego_acceleration ? RiskLevel::ERROR
-                                                                                : RiskLevel::SAFE;
+      rss_detail.rss_acceleration > std::abs(rss_params.error_threshold.ego_acceleration)
+        ? RiskLevel::ERROR
+        : RiskLevel::SAFE;
     rss_evaluations.push_back(RssEvaluation{risk_level, rss_detail});
   }
 

--- a/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/assessment.cpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/assessment.cpp
@@ -467,9 +467,8 @@ RssArtifact assess(
       ego_trajectory, context.odometry->twist.twist, object, rss_params,
       context.predicted_objects->header.stamp);
     const auto risk_level =
-      rss_detail.rss_acceleration > std::abs(rss_params.error_threshold.ego_acceleration)
-        ? RiskLevel::ERROR
-        : RiskLevel::SAFE;
+      rss_detail.rss_acceleration < rss_params.error_threshold.ego_acceleration ? RiskLevel::ERROR
+                                                                                : RiskLevel::SAFE;
     rss_evaluations.push_back(RssEvaluation{risk_level, rss_detail});
   }
 

--- a/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/assessment.cpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/assessment.cpp
@@ -467,9 +467,8 @@ RssArtifact assess(
       ego_trajectory, context.odometry->twist.twist, object, rss_params,
       context.predicted_objects->header.stamp);
     const auto risk_level =
-      rss_detail.rss_acceleration > -rss_params.error_threshold.ego_acceleration
-        ? RiskLevel::ERROR
-        : RiskLevel::SAFE;
+      rss_detail.rss_acceleration > -rss_params.error_threshold.ego_acceleration ? RiskLevel::ERROR
+                                                                                 : RiskLevel::SAFE;
     rss_evaluations.push_back(RssEvaluation{risk_level, rss_detail});
   }
 

--- a/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/assessment.cpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/assessment.cpp
@@ -467,8 +467,8 @@ RssArtifact assess(
       ego_trajectory, context.odometry->twist.twist, object, rss_params,
       context.predicted_objects->header.stamp);
     const auto risk_level =
-      rss_detail.rss_acceleration > -rss_params.error_threshold.ego_acceleration ? RiskLevel::ERROR
-                                                                                 : RiskLevel::SAFE;
+      rss_detail.rss_acceleration < rss_params.error_threshold.ego_acceleration ? RiskLevel::ERROR
+                                                                                : RiskLevel::SAFE;
     rss_evaluations.push_back(RssEvaluation{risk_level, rss_detail});
   }
 

--- a/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/assessment.cpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/assessment.cpp
@@ -467,8 +467,9 @@ RssArtifact assess(
       ego_trajectory, context.odometry->twist.twist, object, rss_params,
       context.predicted_objects->header.stamp);
     const auto risk_level =
-      rss_detail.rss_acceleration < rss_params.error_threshold.ego_acceleration ? RiskLevel::ERROR
-                                                                                : RiskLevel::SAFE;
+      rss_detail.rss_acceleration > -rss_params.error_threshold.ego_acceleration
+        ? RiskLevel::ERROR
+        : RiskLevel::SAFE;
     rss_evaluations.push_back(RssEvaluation{risk_level, rss_detail});
   }
 

--- a/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/assessment.hpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/assessment.hpp
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef AUTOWARE__TRAJECTORY_VALIDATOR__FILTERS__SAFETY__COLLISION_CHECK_FILTER__ASSESSMENT_HPP_
-#define AUTOWARE__TRAJECTORY_VALIDATOR__FILTERS__SAFETY__COLLISION_CHECK_FILTER__ASSESSMENT_HPP_
+#ifndef FILTERS__SAFETY__COLLISION_CHECK_FILTER__ASSESSMENT_HPP_
+#define FILTERS__SAFETY__COLLISION_CHECK_FILTER__ASSESSMENT_HPP_
 
 #include "autoware/trajectory_validator/validator_interface.hpp"
 #include "parameter.hpp"
@@ -74,8 +74,8 @@ std::optional<double> compute_distance_to_collision(
   const autoware_perception_msgs::msg::PredictedObject & object);
 
 RssArtifact assess(
-  const TrajectoryPoints & traj_points, const FilterContext & context, const RssParamMap & rss_param_map,
-  double time_resolution, VehicleInfo & vehicle_info);
+  const TrajectoryPoints & traj_points, const FilterContext & context,
+  const RssParamMap & rss_param_map, double time_resolution, VehicleInfo & vehicle_info);
 }  // namespace autoware::trajectory_validator::plugin::safety::rss_deceleration
 
-#endif  // AUTOWARE__TRAJECTORY_VALIDATOR__FILTERS__SAFETY__COLLISION_CHECK_FILTER__ASSESSMENT_HPP_
+#endif  // FILTERS__SAFETY__COLLISION_CHECK_FILTER__ASSESSMENT_HPP_

--- a/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/collision_check_filter.cpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/collision_check_filter.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 
 #include "collision_check_filter.hpp"
+
 #include "assessment.hpp"
 
 #include <fmt/core.h>
@@ -167,9 +168,8 @@ CollisionCheckFilter::result_t CollisionCheckFilter::is_feasible(
     traj_points, context, rss_param_map_, global_params_.time_resolution, *vehicle_info_ptr_);
 
   auto planning_factors = reporter::process_collision_artifacts(
-    *context.odometry, pet_artifact, pet_continuous_times_, drac_artifact,
-    drac_continuous_times_, rss_artifact, rss_continuous_times_, debug_markers_,
-    global_params_.time_resolution);
+    *context.odometry, pet_artifact, pet_continuous_times_, drac_artifact, drac_continuous_times_,
+    rss_artifact, rss_continuous_times_, debug_markers_, global_params_.time_resolution);
 
   return ValidationResult{
     calc_worst_risk({pet_artifact.risk, drac_artifact.risk, rss_artifact.risk}) != RiskLevel::ERROR,

--- a/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/collision_check_filter.cpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/collision_check_filter.cpp
@@ -114,14 +114,14 @@ std::vector<MetricReport> CollisionCheckFilter::generate_metric_reports(
 
   // RSS
   const auto rss_val = [&rss_artifact]() {
-    double min_rss = 0.0;
+    double max_rss = 0.0;
     for (const auto & evaluation : rss_artifact.object_evaluations) {
       const double rss = evaluation.detail.rss_acceleration;
-      if (rss < min_rss) {
-        min_rss = rss;
+      if (rss > max_rss) {
+        max_rss = rss;
       }
     }
-    return min_rss;
+    return max_rss;
   }();
   add_report("RSS", rss_val, rss_artifact.risk);
 

--- a/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/collision_check_filter.cpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/collision_check_filter.cpp
@@ -114,14 +114,14 @@ std::vector<MetricReport> CollisionCheckFilter::generate_metric_reports(
 
   // RSS
   const auto rss_val = [&rss_artifact]() {
-    double max_rss = 0.0;
+    double min_rss = 0.0;
     for (const auto & evaluation : rss_artifact.object_evaluations) {
       const double rss = evaluation.detail.rss_acceleration;
-      if (rss > max_rss) {
-        max_rss = rss;
+      if (rss < min_rss) {
+        min_rss = rss;
       }
     }
-    return max_rss;
+    return min_rss;
   }();
   add_report("RSS", rss_val, rss_artifact.risk);
 

--- a/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/collision_check_filter.cpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/collision_check_filter.cpp
@@ -80,68 +80,50 @@ std::vector<MetricReport> CollisionCheckFilter::generate_metric_reports(
     "diffusion_based_trajectory",
   };
 
-  const auto canonical_type_index = [&](const std::string & raw) -> int {
-    for (size_t i = 0; i < kCanonicalTrajectoryTypes.size(); ++i) {
-      if (raw.find(kCanonicalTrajectoryTypes[i]) != std::string::npos) {
-        return static_cast<int>(i);
+  // DRAC
+  for (const auto * type : kCanonicalTrajectoryTypes) {
+    bool has_finding = false;
+    for (const auto & ev : drac_artifact.object_evaluations) {
+      if (ev.detail.object_identification.trajectory_type.find(type) != std::string::npos) {
+        has_finding = true;
+        break;
       }
     }
-    return -1;
-  };
-
-  struct PetTypeWorst
-  {
-    bool has_finding{false};
-    double pet{0.0};
-    RiskLevel risk{RiskLevel::SAFE};
-  };
-  std::array<PetTypeWorst, 3> pet_worst{};
-  for (const auto & ev : pet_artifact.object_evaluations) {
-    const int idx = canonical_type_index(ev.detail.object_identification.trajectory_type);
-    if (idx < 0) continue;
-    auto & cur = pet_worst[idx];
-    if (!cur.has_finding || std::abs(ev.detail.pet) < std::abs(cur.pet)) {
-      cur.has_finding = true;
-      cur.pet = ev.detail.pet;
-      cur.risk = ev.risk;
-    }
-  }
-  for (size_t i = 0; i < kCanonicalTrajectoryTypes.size(); ++i) {
-    const auto & w = pet_worst[i];
-    const double value = w.has_finding ? w.pet : std::numeric_limits<double>::quiet_NaN();
-    const RiskLevel level = w.has_finding ? w.risk : RiskLevel::SAFE;
-    add_report(fmt::format("check_PET_{}", kCanonicalTrajectoryTypes[i]), value, level);
+    const double drac_val = has_finding && drac_artifact.required_acceleration.has_value()
+                              ? drac_artifact.required_acceleration.value()
+                              : std::numeric_limits<double>::quiet_NaN();
+    const RiskLevel drac_risk = has_finding ? drac_artifact.risk : RiskLevel::SAFE;
+    add_report(fmt::format("DRAC_{}", type), drac_val, drac_risk);
   }
 
-  std::array<bool, 3> drac_has_finding{};
-  for (const auto & ev : drac_artifact.object_evaluations) {
-    const int idx = canonical_type_index(ev.detail.object_identification.trajectory_type);
-    if (idx >= 0) drac_has_finding[idx] = true;
-  }
-  for (size_t i = 0; i < kCanonicalTrajectoryTypes.size(); ++i) {
-    double value;
-    RiskLevel level;
-    if (!drac_has_finding[i]) {
-      value = std::numeric_limits<double>::quiet_NaN();
-      level = RiskLevel::SAFE;
-    } else if (!drac_artifact.required_acceleration.has_value()) {
-      value = std::numeric_limits<double>::quiet_NaN();
-      level = drac_artifact.risk;
-    } else {
-      value = drac_artifact.required_acceleration.value();
-      level = drac_artifact.risk;
+  // PET
+  for (const auto * type : kCanonicalTrajectoryTypes) {
+    double pet_val = std::numeric_limits<double>::quiet_NaN();
+    RiskLevel pet_risk = RiskLevel::SAFE;
+    for (const auto & ev : pet_artifact.object_evaluations) {
+      if (ev.detail.object_identification.trajectory_type.find(type) == std::string::npos) {
+        continue;
+      }
+      if (std::isnan(pet_val) || std::abs(ev.detail.pet) < std::abs(pet_val)) {
+        pet_val = ev.detail.pet;
+        pet_risk = ev.risk;
+      }
     }
-    add_report(fmt::format("check_DRAC_{}", kCanonicalTrajectoryTypes[i]), value, level);
+    add_report(fmt::format("PET_{}", type), pet_val, pet_risk);
   }
 
-  double max_rss = 0.0;
-  for (const auto & ev : rss_artifact.object_evaluations) {
-    const double rss = ev.detail.rss_acceleration;
-    if (rss > max_rss) {
-      max_rss = rss;
+  // RSS
+  const auto rss_val = [&rss_artifact]() {
+    double max_rss = 0.0;
+    for (const auto & evaluation : rss_artifact.object_evaluations) {
+      const double rss = evaluation.detail.rss_acceleration;
+      if (rss > max_rss) {
+        max_rss = rss;
+      }
     }
-  }
-  add_report("check_RSS", max_rss, rss_artifact.risk);
+    return max_rss;
+  }();
+  add_report("RSS", rss_val, rss_artifact.risk);
 
   return reports;
 }

--- a/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/collision_check_filter.cpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/collision_check_filter.cpp
@@ -15,7 +15,15 @@
 #include "collision_check_filter.hpp"
 #include "assessment.hpp"
 
+#include <fmt/core.h>
+
+#include <algorithm>
+#include <array>
+#include <cmath>
+#include <limits>
+#include <optional>
 #include <string>
+#include <string_view>
 #include <vector>
 
 namespace autoware::trajectory_validator::plugin::safety
@@ -65,34 +73,74 @@ std::vector<MetricReport> CollisionCheckFilter::generate_metric_reports(
                           .level(convert_metrics_level(risk)));
     };
 
-  const double drac_val = drac_artifact.required_acceleration.has_value()
-                            ? drac_artifact.required_acceleration.value()
-                            : std::numeric_limits<double>::quiet_NaN();
-  add_report("DRAC", drac_val, drac_artifact.risk);
+  static constexpr std::array<const char *, 3> kCanonicalTrajectoryTypes = {
+    "map_based_predicted_path",
+    "constant_curvature_path",
+    "diffusion_based_trajectory",
+  };
 
-  const auto pet_val = [&pet_artifact]() {
-    double min_abs_pet = std::numeric_limits<double>::quiet_NaN();
-    for (const auto & evaluation : pet_artifact.object_evaluations) {
-      const double pet = evaluation.detail.pet;
-      if (std::isnan(min_abs_pet) || std::abs(pet) < std::abs(min_abs_pet)) {
-        min_abs_pet = pet;
+  const auto canonical_type_index = [&](const std::string & raw) -> int {
+    for (size_t i = 0; i < kCanonicalTrajectoryTypes.size(); ++i) {
+      if (raw.find(kCanonicalTrajectoryTypes[i]) != std::string::npos) {
+        return static_cast<int>(i);
       }
     }
-    return min_abs_pet;
-  }();
-  add_report("PET", pet_val, pet_artifact.risk);
+    return -1;
+  };
 
-  const auto rss_val = [&rss_artifact]() {
-    double min_rss = 0.0;
-    for (const auto & evaluation : rss_artifact.object_evaluations) {
-      const double rss = evaluation.detail.rss_acceleration;
-      if (rss < min_rss) {
-        min_rss = rss;
-      }
+  struct PetTypeWorst
+  {
+    bool has_finding{false};
+    double pet{0.0};
+    RiskLevel risk{RiskLevel::SAFE};
+  };
+  std::array<PetTypeWorst, 3> pet_worst{};
+  for (const auto & ev : pet_artifact.object_evaluations) {
+    const int idx = canonical_type_index(ev.detail.object_identification.trajectory_type);
+    if (idx < 0) continue;
+    auto & cur = pet_worst[idx];
+    if (!cur.has_finding || std::abs(ev.detail.pet) < std::abs(cur.pet)) {
+      cur.has_finding = true;
+      cur.pet = ev.detail.pet;
+      cur.risk = ev.risk;
     }
-    return min_rss;
-  }();
-  add_report("RSS", rss_val, rss_artifact.risk);
+  }
+  for (size_t i = 0; i < kCanonicalTrajectoryTypes.size(); ++i) {
+    const auto & w = pet_worst[i];
+    const double value = w.has_finding ? w.pet : std::numeric_limits<double>::quiet_NaN();
+    const RiskLevel level = w.has_finding ? w.risk : RiskLevel::SAFE;
+    add_report(fmt::format("check_PET_{}", kCanonicalTrajectoryTypes[i]), value, level);
+  }
+
+  std::array<bool, 3> drac_has_finding{};
+  for (const auto & ev : drac_artifact.object_evaluations) {
+    const int idx = canonical_type_index(ev.detail.object_identification.trajectory_type);
+    if (idx >= 0) drac_has_finding[idx] = true;
+  }
+  for (size_t i = 0; i < kCanonicalTrajectoryTypes.size(); ++i) {
+    double value;
+    RiskLevel level;
+    if (!drac_has_finding[i]) {
+      value = std::numeric_limits<double>::quiet_NaN();
+      level = RiskLevel::SAFE;
+    } else if (!drac_artifact.required_acceleration.has_value()) {
+      value = std::numeric_limits<double>::quiet_NaN();
+      level = drac_artifact.risk;
+    } else {
+      value = drac_artifact.required_acceleration.value();
+      level = drac_artifact.risk;
+    }
+    add_report(fmt::format("check_DRAC_{}", kCanonicalTrajectoryTypes[i]), value, level);
+  }
+
+  double max_rss = 0.0;
+  for (const auto & ev : rss_artifact.object_evaluations) {
+    const double rss = ev.detail.rss_acceleration;
+    if (rss > max_rss) {
+      max_rss = rss;
+    }
+  }
+  add_report("check_RSS", max_rss, rss_artifact.risk);
 
   return reports;
 }

--- a/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/collision_check_filter.cpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/collision_check_filter.cpp
@@ -83,8 +83,8 @@ std::vector<MetricReport> CollisionCheckFilter::generate_metric_reports(
   // DRAC
   for (const auto * type : kCanonicalTrajectoryTypes) {
     bool has_finding = false;
-    for (const auto & ev : drac_artifact.object_evaluations) {
-      if (ev.detail.object_identification.trajectory_type.find(type) != std::string::npos) {
+    for (const auto & evaluation : drac_artifact.object_evaluations) {
+      if (evaluation.detail.object_identification.trajectory_type.find(type) != std::string::npos) {
         has_finding = true;
         break;
       }
@@ -100,13 +100,13 @@ std::vector<MetricReport> CollisionCheckFilter::generate_metric_reports(
   for (const auto * type : kCanonicalTrajectoryTypes) {
     double pet_val = std::numeric_limits<double>::quiet_NaN();
     RiskLevel pet_risk = RiskLevel::SAFE;
-    for (const auto & ev : pet_artifact.object_evaluations) {
-      if (ev.detail.object_identification.trajectory_type.find(type) == std::string::npos) {
+    for (const auto & evaluation : pet_artifact.object_evaluations) {
+      if (evaluation.detail.object_identification.trajectory_type.find(type) == std::string::npos) {
         continue;
       }
-      if (std::isnan(pet_val) || std::abs(ev.detail.pet) < std::abs(pet_val)) {
-        pet_val = ev.detail.pet;
-        pet_risk = ev.risk;
+      if (std::isnan(pet_val) || std::abs(evaluation.detail.pet) < std::abs(pet_val)) {
+        pet_val = evaluation.detail.pet;
+        pet_risk = evaluation.risk;
       }
     }
     add_report(fmt::format("PET_{}", type), pet_val, pet_risk);

--- a/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/parameter.hpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/parameter.hpp
@@ -12,11 +12,11 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef AUTOWARE__TRAJECTORY_VALIDATOR__FILTERS__SAFETY__COLLISION_CHECK_FILTER__PARAMETER_HPP_
-#define AUTOWARE__TRAJECTORY_VALIDATOR__FILTERS__SAFETY__COLLISION_CHECK_FILTER__PARAMETER_HPP_
+#ifndef FILTERS__SAFETY__COLLISION_CHECK_FILTER__PARAMETER_HPP_
+#define FILTERS__SAFETY__COLLISION_CHECK_FILTER__PARAMETER_HPP_
 
-#include <autoware_trajectory_validator/autoware_trajectory_validator_param.hpp>
 #include <autoware/object_recognition_utils/object_recognition_utils.hpp>
+#include <autoware_trajectory_validator/autoware_trajectory_validator_param.hpp>
 
 #include <cmath>
 #include <map>
@@ -248,4 +248,4 @@ using RssParamMap = std::map<std::string_view, RssParams>;
 
 }  // namespace autoware::trajectory_validator::plugin::safety
 
-#endif  // AUTOWARE__TRAJECTORY_VALIDATOR__FILTERS__SAFETY__COLLISION_CHECK_FILTER__PARAMETER_HPP_
+#endif  // FILTERS__SAFETY__COLLISION_CHECK_FILTER__PARAMETER_HPP_

--- a/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/reporter.hpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/reporter.hpp
@@ -12,16 +12,17 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef AUTOWARE__TRAJECTORY_VALIDATOR__FILTERS__SAFETY__COLLISION_CHECK_FILTER__REPORTER_HPP_
-#define AUTOWARE__TRAJECTORY_VALIDATOR__FILTERS__SAFETY__COLLISION_CHECK_FILTER__REPORTER_HPP_
+#ifndef FILTERS__SAFETY__COLLISION_CHECK_FILTER__REPORTER_HPP_
+#define FILTERS__SAFETY__COLLISION_CHECK_FILTER__REPORTER_HPP_
 
 #include "types.hpp"
 
-#include <autoware_internal_planning_msgs/msg/planning_factor_array.hpp>
 #include <autoware_utils_geometry/geometry.hpp>
+#include <rclcpp/time.hpp>
+
+#include <autoware_internal_planning_msgs/msg/planning_factor_array.hpp>
 #include <geometry_msgs/msg/pose.hpp>
 #include <nav_msgs/msg/odometry.hpp>
-#include <rclcpp/time.hpp>
 #include <visualization_msgs/msg/marker_array.hpp>
 
 #include <cstdint>
@@ -91,4 +92,4 @@ autoware_internal_planning_msgs::msg::PlanningFactorArray process_collision_arti
   visualization_msgs::msg::MarkerArray & debug_markers, double time_resolution);
 }  // namespace autoware::trajectory_validator::plugin::safety::reporter
 
-#endif  // AUTOWARE__TRAJECTORY_VALIDATOR__FILTERS__SAFETY__COLLISION_CHECK_FILTER__REPORTER_HPP_
+#endif  // FILTERS__SAFETY__COLLISION_CHECK_FILTER__REPORTER_HPP_

--- a/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/trajectory_utils.hpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/trajectory_utils.hpp
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef AUTOWARE__TRAJECTORY_VALIDATOR__FILTERS__SAFETY__COLLISION_CHECK_FILTER__TRAJECTORY_UTILS_HPP_
-#define AUTOWARE__TRAJECTORY_VALIDATOR__FILTERS__SAFETY__COLLISION_CHECK_FILTER__TRAJECTORY_UTILS_HPP_
+#ifndef FILTERS__SAFETY__COLLISION_CHECK_FILTER__TRAJECTORY_UTILS_HPP_
+#define FILTERS__SAFETY__COLLISION_CHECK_FILTER__TRAJECTORY_UTILS_HPP_
 
 #include "autoware/trajectory_validator/validator_interface.hpp"
 #include "types.hpp"
@@ -26,7 +26,6 @@
 #include <geometry_msgs/msg/pose.hpp>
 
 #include <boost/geometry.hpp>
-
 
 #include <algorithm>
 #include <iterator>
@@ -363,4 +362,4 @@ TrajectoryData generate_object_trajectory(
   const std::string & traj_type_str, double acc, double time_resolution, double time_horizon);
 }  // namespace autoware::trajectory_validator::plugin::safety::trajectory
 
-#endif  // AUTOWARE__TRAJECTORY_VALIDATOR__FILTERS__SAFETY__COLLISION_CHECK_FILTER__TRAJECTORY_UTILS_HPP_
+#endif  // FILTERS__SAFETY__COLLISION_CHECK_FILTER__TRAJECTORY_UTILS_HPP_

--- a/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/types.hpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/types.hpp
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef AUTOWARE__TRAJECTORY_VALIDATOR__FILTERS__SAFETY__COLLISION_CHECK_FILTER__TYPES_HPP_
-#define AUTOWARE__TRAJECTORY_VALIDATOR__FILTERS__SAFETY__COLLISION_CHECK_FILTER__TYPES_HPP_
+#ifndef FILTERS__SAFETY__COLLISION_CHECK_FILTER__TYPES_HPP_
+#define FILTERS__SAFETY__COLLISION_CHECK_FILTER__TYPES_HPP_
 
 #include "parameter.hpp"
 
@@ -159,4 +159,4 @@ inline RiskLevel calc_worst_risk(std::initializer_list<RiskLevel> risks)
 
 }  // namespace autoware::trajectory_validator::plugin::safety
 
-#endif  // AUTOWARE__TRAJECTORY_VALIDATOR__FILTERS__SAFETY__COLLISION_CHECK_FILTER__TYPES_HPP_
+#endif  // FILTERS__SAFETY__COLLISION_CHECK_FILTER__TYPES_HPP_


### PR DESCRIPTION
 ## Summary

  Split `safety::CollisionCheckFilter`'s `MetricReport` output from 3 metrics (`DRAC` / `PET` / `RSS`)
  into 7 metrics, so the per-trajectory-type worst can be tracked on a continuous time series.

  ### Metric names emitted

  ```
  DRAC_map_based_predicted_path
  DRAC_constant_curvature_path
  DRAC_diffusion_based_trajectory
  PET_map_based_predicted_path
  PET_constant_curvature_path
  PET_diffusion_based_trajectory
  RSS
  ```

  ### Semantics

  - **DRAC** (×3): emits the shared overall `drac_artifact.required_acceleration`
    (the worst across all enabled types, computed by a single `assess_drac` call; internal
    sign convention is negative). The value is reported only for types whose finding exists
    in `object_evaluations`; types without a finding emit `NaN` / OK.
  - **PET** (×3): groups `object_evaluations` by canonical trajectory_type and picks the
    finding with the smallest `|pet|` (closest to collision). Types without a finding emit
    `NaN` / OK.
  - **RSS** (×1): unchanged behavior.

  ### Test

  - `colcon test --packages-select autoware_trajectory_validator` — 11/11 pass
  -  local senario test https://evaluation.tier4.jp/evaluation/reports/a09e654c-c973-5a66-a483-ac296cf5a980/tests/7c5aa14e-9aef-5712-9ae6-d572d8fac791/1b9880f6-f500-5510-a0be-77857552ed83/a7a2862e-d975-5475-97dd-e322c610a314?project_id=x2_dev&state=failed

[Screencast from 2026年05月21日 14時55分20秒.webm](https://github.com/user-attachments/assets/922c29c3-f96f-415d-9f51-2947bf050d9b)

## ART Result
Before https://evaluation.tier4.jp/evaluation/reports/944c5723-22f9-5b97-accd-7587a6ba178f?project_id=x2_dev  
 https://github.com/tier4/autoware_universe/pull/2990  
<img width="1409" height="1743" alt="Screenshot from 2026-05-25 11-50-10" src="https://github.com/user-attachments/assets/1f2a81ae-1a23-4e0b-b9b1-7d70e7108889" />

After
<img width="1409" height="1726" alt="Screenshot from 2026-05-25 11-05-36" src="https://github.com/user-attachments/assets/78e71ad8-a35a-4a29-b466-a57817a8a0d0" />
