### PR TITLE
fix(trajectory_validator): RSS metric value and risk level always 0.0 / SAFE

### DIFF
--- a/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/assessment.cpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/assessment.cpp
@@ -467,7 +467,7 @@ RssArtifact assess(
       ego_trajectory, context.odometry->twist.twist, object, rss_params,
       context.predicted_objects->header.stamp);
     const auto risk_level =
-      rss_detail.rss_acceleration > -rss_params.error_threshold.ego_acceleration
+      rss_detail.rss_acceleration > std::abs(rss_params.error_threshold.ego_acceleration)
         ? RiskLevel::ERROR
         : RiskLevel::SAFE;
     rss_evaluations.push_back(RssEvaluation{risk_level, rss_detail});

--- a/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/assessment.cpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/assessment.cpp
@@ -467,8 +467,9 @@ RssArtifact assess(
       ego_trajectory, context.odometry->twist.twist, object, rss_params,
       context.predicted_objects->header.stamp);
     const auto risk_level =
-      rss_detail.rss_acceleration < rss_params.error_threshold.ego_acceleration ? RiskLevel::ERROR
-                                                                                : RiskLevel::SAFE;
+      rss_detail.rss_acceleration > -rss_params.error_threshold.ego_acceleration
+        ? RiskLevel::ERROR
+        : RiskLevel::SAFE;
     rss_evaluations.push_back(RssEvaluation{risk_level, rss_detail});
   }
 

--- a/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/collision_check_filter.cpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/collision_check_filter.cpp
@@ -114,14 +114,14 @@ std::vector<MetricReport> CollisionCheckFilter::generate_metric_reports(
 
   // RSS
   const auto rss_val = [&rss_artifact]() {
-    double min_rss = 0.0;
+    double max_rss = 0.0;
     for (const auto & evaluation : rss_artifact.object_evaluations) {
       const double rss = evaluation.detail.rss_acceleration;
-      if (rss < min_rss) {
-        min_rss = rss;
+      if (rss > max_rss) {
+        max_rss = rss;
       }
     }
-    return min_rss;
+    return max_rss;
   }();
   add_report("RSS", rss_val, rss_artifact.risk);
 


### PR DESCRIPTION
## Summary

  `safety::CollisionCheckFilter` の RSS 処理にある 2 つのバグを修正する。これらが重なって、
  `RSS` metric_value が常に `0.0`、level が常に `OK` となり、実際の衝突リスクを反映しない状態
  だった。

  ### 原因

  `RssDetail::rss_acceleration` は `assess_required_deceleration()`
  (`assessment.cpp:418`) が **必要減速度の大きさ (常に `0.0` / 正値 / `+∞`) として**
  算出している値だが、利用側 2 箇所はフィールド名から「符号付きの ego acceleration
  (負値が入りうる)」だと誤解して書かれていた。

  1. **level 判定** — `assessment.cpp:470`
     `rss_acceleration < error_threshold.ego_acceleration` (デフォルト `-4.0`)
     で比較しているが、左辺は常に `>= 0`、右辺は負値なので **常に false**。
     → level は常に `SAFE` になる。

  2. **metric 集計** — `collision_check_filter.cpp:117-124`
     `min_rss = 0.0` で初期化し、`rss < min_rss` となる値を探している。
     左辺は常に `>= 0` なので **`min_rss` は一度も更新されない**。
     → `metric_value` は常に `0.0` になる。
  ### Test

  - `colcon test --packages-select autoware_trajectory_validator` 全 11 件 pass
  - bag-replay スタンドアロン検証 (`21ae3bd9` bag):
  
  | | BEFORE | AFTER |
  | --- | --- | --- |
  | `RSS` value 分布 | 全 `0.0` | `0.0` ×431 + 有限正値 17 件 (最大 `64.85`) |
  | `RSS` level 分布 | 全 OK | OK ×443、ERROR ×5 |
  | ERROR を発火させた値 | (一度も発火せず) | `4.63`, `9.71`, `24.95`, `32.86`, `64.85` m/s² (全て `> 4.0`) |
 

- senario test  https://github.com/tier4/autoware_universe/pull/2970においてはRSSの値は出力されていなかったが、変更後値が出力されることを確認。
 
[Screencast from 2026年05月21日 14時49分55秒.webm](https://github.com/user-attachments/assets/1bcbd7f0-060e-456f-9cef-7c4f12b255dc)

