### PR TITLE
fix(trajecotry_modifier): make sure planning_factor distance value is not NaN

### DIFF
--- a/planning/autoware_trajectory_modifier/src/trajectory_modifier_plugins/obstacle_stop.cpp
+++ b/planning/autoware_trajectory_modifier/src/trajectory_modifier_plugins/obstacle_stop.cpp
@@ -18,6 +18,7 @@
 #include "autoware/trajectory_modifier/trajectory_modifier_utils/utils.hpp"
 
 #include <autoware/motion_utils/distance/distance.hpp>
+#include <autoware/motion_utils/trajectory/trajectory.hpp>
 #include <autoware/trajectory/interpolator/akima_spline.hpp>
 #include <autoware/trajectory/interpolator/interpolator.hpp>
 #include <autoware/trajectory/trajectory_point.hpp>
@@ -260,8 +261,10 @@ bool ObstacleStop::set_stop_point(TrajectoryPoints & traj_points, const InputDat
 
   const auto & stop_pose = traj_points.back().pose;
   const auto & ego_pose = input.current_odometry->pose.pose;
-  planning_factor_interface_->add(
-    traj_points, ego_pose, stop_pose, PlanningFactor::STOP, safety_factors_);
+  auto distance =
+    motion_utils::calcSignedArcLength(traj_points, ego_pose.position, stop_pose.position);
+  if (std::isnan(distance)) distance = 0.0;
+  planning_factor_interface_->add(distance, stop_pose, PlanningFactor::STOP, safety_factors_);
 
   RCLCPP_WARN_THROTTLE(
     get_node_ptr()->get_logger(), *get_clock(), 1000,

--- a/planning/autoware_trajectory_optimizer/src/trajectory_optimizer.cpp
+++ b/planning/autoware_trajectory_optimizer/src/trajectory_optimizer.cpp
@@ -175,14 +175,6 @@ void TrajectoryOptimizer::set_up_params()
   params_.use_mpt_optimizer = get_or_declare_parameter<bool>(*this, "use_mpt_optimizer");
 }
 
-void TrajectoryOptimizer::publish_processing_time_ms(const double processing_time_ms)
-{
-  autoware_internal_debug_msgs::msg::Float64Stamped msg;
-  msg.stamp = get_clock()->now();
-  msg.data = processing_time_ms;
-  debug_processing_time_pub_->publish(msg);
-}
-
 void TrajectoryOptimizer::on_traj([[maybe_unused]] const CandidateTrajectories::ConstSharedPtr msg)
 {
   stop_watch_ptr_ = std::make_unique<autoware_utils_system::StopWatch<std::chrono::milliseconds>>();


### PR DESCRIPTION
`motion_utils::calcSignedArcLength()` sometimes returns `std::nan`, this PR manually sets planning_factor distance to 0.0 if function returns `std::nan`