### PR TITLE
feat(control_evaluator): add lateral deviation between ego and centerline (#12598)

### DIFF
--- a/evaluator/autoware_control_evaluator/include/autoware/control_evaluator/control_evaluator_node.hpp
+++ b/evaluator/autoware_control_evaluator/include/autoware/control_evaluator/control_evaluator_node.hpp
@@ -82,6 +82,7 @@ public:
     const Metric & metric, const double & metric_value, const bool & accumulate_metric = true);
   void AddLateralDeviationMetricMsg(const Trajectory & traj, const Point & ego_point);
   void AddYawDeviationMetricMsg(const Trajectory & traj, const Pose & ego_pose);
+  void AddLateralDeviationCenterlineMetricMsg(const Pose & ego_pose);
   void AddGoalDeviationMetricMsg(const Odometry & odom);
   void AddObjectMetricMsg(const Odometry & odom, const PredictedObjects & objects);
   void AddBoundaryDistanceMetricMsg(const PathWithLaneId & behavior_path, const Pose & ego_pose);
@@ -140,6 +141,8 @@ private:
     Metric::jerk,
     Metric::lateral_deviation,
     Metric::lateral_deviation_abs,
+    Metric::lateral_deviation_centerline,
+    Metric::lateral_deviation_centerline_abs,
     Metric::yaw_deviation,
     Metric::yaw_deviation_abs,
     Metric::goal_longitudinal_deviation,

--- a/evaluator/autoware_control_evaluator/include/autoware/control_evaluator/metrics/metric.hpp
+++ b/evaluator/autoware_control_evaluator/include/autoware/control_evaluator/metrics/metric.hpp
@@ -32,6 +32,8 @@ enum class Metric {
   jerk,
   lateral_deviation,
   lateral_deviation_abs,
+  lateral_deviation_centerline,
+  lateral_deviation_centerline_abs,
   yaw_deviation,
   yaw_deviation_abs,
   goal_longitudinal_deviation,
@@ -64,6 +66,8 @@ static const std::unordered_map<std::string, Metric> str_to_metric = {
   {"jerk", Metric::jerk},
   {"lateral_deviation", Metric::lateral_deviation},
   {"lateral_deviation_abs", Metric::lateral_deviation_abs},
+  {"lateral_deviation_centerline", Metric::lateral_deviation_centerline},
+  {"lateral_deviation_centerline_abs", Metric::lateral_deviation_centerline_abs},
   {"yaw_deviation", Metric::yaw_deviation},
   {"yaw_deviation_abs", Metric::yaw_deviation_abs},
   {"goal_longitudinal_deviation", Metric::goal_longitudinal_deviation},
@@ -95,6 +99,8 @@ static const std::unordered_map<Metric, std::string> metric_to_str = {
   {Metric::jerk, "jerk"},
   {Metric::lateral_deviation, "lateral_deviation"},
   {Metric::lateral_deviation_abs, "lateral_deviation_abs"},
+  {Metric::lateral_deviation_centerline, "lateral_deviation_centerline"},
+  {Metric::lateral_deviation_centerline_abs, "lateral_deviation_centerline_abs"},
   {Metric::yaw_deviation, "yaw_deviation"},
   {Metric::yaw_deviation_abs, "yaw_deviation_abs"},
   {Metric::goal_longitudinal_deviation, "goal_longitudinal_deviation"},
@@ -129,6 +135,10 @@ static const std::unordered_map<Metric, std::string> metric_descriptions = {
    "Lateral deviation from the reference trajectory[m], positive value means the ego is on the "
    "left side of the reference trajectory"},
   {Metric::lateral_deviation_abs, "Absolute lateral deviation from the reference trajectory[m]"},
+  {Metric::lateral_deviation_centerline,
+   "Lateral deviation from the centerline[m], positive value means the ego is on the left side of "
+   "the centerline"},
+  {Metric::lateral_deviation_centerline_abs, "Absolute lateral deviation from the centerline[m]"},
   {Metric::yaw_deviation,
    "Yaw deviation from the reference trajectory[rad], positive value means the ego is "
    "counterclockwise from the reference trajectory"},

--- a/evaluator/autoware_control_evaluator/src/control_evaluator_node.cpp
+++ b/evaluator/autoware_control_evaluator/src/control_evaluator_node.cpp
@@ -458,6 +458,17 @@ void ControlEvaluatorNode::AddYawDeviationMetricMsg(const Trajectory & traj, con
   AddMetricMsg(Metric::yaw_deviation_abs, metric_value_abs);
 }
 
+void ControlEvaluatorNode::AddLateralDeviationCenterlineMetricMsg(const Pose & ego_pose)
+{
+  const auto current_lanelets = metrics::utils::get_current_lanes(route_handler_, ego_pose);
+  const auto arc_coordinates = lanelet::utils::getArcCoordinates(current_lanelets, ego_pose);
+  const double metric_value = arc_coordinates.distance;
+  const double metric_value_abs = std::abs(metric_value);
+
+  AddMetricMsg(Metric::lateral_deviation_centerline, metric_value);
+  AddMetricMsg(Metric::lateral_deviation_centerline_abs, metric_value_abs);
+}
+
 void ControlEvaluatorNode::AddGoalDeviationMetricMsg(const Odometry & odom)
 {
   const Pose ego_pose = odom.pose.pose;
@@ -636,6 +647,7 @@ void ControlEvaluatorNode::onTimer()
     if (route_handler_.isHandlerReady()) {
       // add goal deviation metrics
       AddLaneletInfoMsg(ego_pose);
+      AddLateralDeviationCenterlineMetricMsg(ego_pose);
       AddGoalDeviationMetricMsg(*odom);
 
       // add boundary distance metrics


### PR DESCRIPTION
# summary

Cherry-pick of 
* https://github.com/autowarefoundation/autoware_universe/pull/12598

And I fixed build fail.

Before: `autoware::experimental::lanelet2_utils::get_arc_coordinates` 
After: `lanelet::utils::getArcCoordinates`

# How to Test

- local test

<img width="720" height="405" alt="image_720" src="https://github.com/user-attachments/assets/49cda946-e88e-4f79-bd6f-07302488fbd3" />
