### PR TITLE
for diagnostics topic drop evaluation

### DIFF
--- a/control/autoware_control_validator/include/autoware/control_validator/control_validator.hpp
+++ b/control/autoware_control_validator/include/autoware/control_validator/control_validator.hpp
@@ -31,6 +31,7 @@
 #include <autoware_internal_debug_msgs/msg/float64_stamped.hpp>
 #include <autoware_planning_msgs/msg/trajectory.hpp>
 #include <diagnostic_msgs/msg/diagnostic_array.hpp>
+#include <diagnostic_msgs/msg/key_value.hpp>
 #include <geometry_msgs/msg/accel_with_covariance_stamped.hpp>
 #include <nav_msgs/msg/odometry.hpp>
 
@@ -286,6 +287,11 @@ private:
     DiagnosticStatusWrapper & stat, const bool & is_ok, const std::string & msg) const;
 
   /**
+   * @brief Add common diagnostic values shared by all control validator statuses
+   */
+  void add_common_diag_values(DiagnosticStatusWrapper & stat) const;
+
+  /**
    * @brief Infer autonomous control state
    */
   bool infer_autonomous_control_state(const OperationModeState::ConstSharedPtr);
@@ -313,6 +319,7 @@ private:
   int64_t diag_error_count_threshold_ = 0;
   bool display_on_terminal_ = true;
   Updater diag_updater_{this};
+  uint64_t diag_sequence_id_{0};
   ControlValidatorStatus validation_status_;
   vehicle_info_utils::VehicleInfo vehicle_info_;
   bool flag_autonomous_control_enabled_ = false;

--- a/control/autoware_control_validator/src/control_validator.cpp
+++ b/control/autoware_control_validator/src/control_validator.cpp
@@ -303,6 +303,7 @@ void ControlValidator::setup_parameters()
 void ControlValidator::set_status(
   DiagnosticStatusWrapper & stat, const bool & is_ok, const std::string & msg) const
 {
+  add_common_diag_values(stat);
   if (is_ok) {
     stat.summary(DiagnosticStatus::OK, "validated.");
   } else if (validation_status_.invalid_count < diag_error_count_threshold_) {
@@ -313,6 +314,14 @@ void ControlValidator::set_status(
   } else {
     stat.summary(DiagnosticStatus::ERROR, msg);
   }
+}
+
+void ControlValidator::add_common_diag_values(DiagnosticStatusWrapper & stat) const
+{
+  diagnostic_msgs::msg::KeyValue sequence_id;
+  sequence_id.key = "sequence_id";
+  sequence_id.value = std::to_string(diag_sequence_id_);
+  stat.values.push_back(sequence_id);
 }
 
 void ControlValidator::setup_diag()
@@ -474,6 +483,7 @@ void ControlValidator::on_control_cmd(const Control::ConstSharedPtr msg)
   validation_status_.invalid_count =
     is_all_valid(validation_status_) ? 0 : validation_status_.invalid_count + 1;
 
+  ++diag_sequence_id_;
   diag_updater_.force_update();
 
   publish_debug_info(kinematics_msg->pose.pose);

--- a/localization/autoware_pose_instability_detector/include/autoware/pose_instability_detector/pose_instability_detector.hpp
+++ b/localization/autoware_pose_instability_detector/include/autoware/pose_instability_detector/pose_instability_detector.hpp
@@ -23,6 +23,7 @@
 #include <nav_msgs/msg/odometry.hpp>
 
 #include <deque>
+#include <cstdint>
 #include <tuple>
 #include <vector>
 
@@ -95,6 +96,7 @@ private:
   std::optional<Odometry> latest_odometry_ = std::nullopt;
   std::optional<Odometry> prev_odometry_ = std::nullopt;
   std::deque<TwistWithCovarianceStamped> twist_buffer_;
+  uint64_t diag_sequence_id_{0};
 
   std::vector<bool> enable_validation_flags_;  // must be 6D for x, y, z, roll, pitch, yaw
 };

--- a/localization/autoware_pose_instability_detector/src/pose_instability_detector.cpp
+++ b/localization/autoware_pose_instability_detector/src/pose_instability_detector.cpp
@@ -164,10 +164,14 @@ void PoseInstabilityDetector::callback_timer()
   status.hardware_id = this->get_name();
   bool all_ok = true;
 
+  diagnostic_msgs::msg::KeyValue kv;
+  kv.key = "sequence_id";
+  kv.value = std::to_string(++diag_sequence_id_);
+  status.values.push_back(kv);
+
   for (size_t i = 0; i < values.size(); ++i) {
     const bool ok = (std::abs(values[i]) < thresholds[i]) || !enable_validation_flags_[i];
     all_ok &= ok;
-    diagnostic_msgs::msg::KeyValue kv;
     kv.key = labels[i] + ":validation_enabled";
     kv.value = enable_validation_flags_[i] ? "True" : "False";
     status.values.push_back(kv);

--- a/perception/autoware_compare_map_segmentation/src/voxel_based_approximate_compare_map_filter/node.cpp
+++ b/perception/autoware_compare_map_segmentation/src/voxel_based_approximate_compare_map_filter/node.cpp
@@ -120,6 +120,8 @@ VoxelBasedApproximateCompareMapFilterComponent::VoxelBasedApproximateCompareMapF
 void VoxelBasedApproximateCompareMapFilterComponent::checkStatus(
   diagnostic_updater::DiagnosticStatusWrapper & stat)
 {
+  ++diag_sequence_id_;
+
   // map loader status
   DiagStatus & map_loader_status =
     (*voxel_based_approximate_map_loader_).diagnostics_map_voxel_status_;
@@ -128,6 +130,7 @@ void VoxelBasedApproximateCompareMapFilterComponent::checkStatus(
   } else {
     stat.add("Map loader status", "NG");
   }
+  stat.add("sequence_id", std::to_string(diag_sequence_id_));
 
   // final status = map loader status
   stat.summary(map_loader_status.level, map_loader_status.message);

--- a/perception/autoware_compare_map_segmentation/src/voxel_based_approximate_compare_map_filter/node.hpp
+++ b/perception/autoware_compare_map_segmentation/src/voxel_based_approximate_compare_map_filter/node.hpp
@@ -24,6 +24,7 @@
 #include <pcl/filters/voxel_grid.h>
 #include <pcl/search/pcl_search.h>
 
+#include <cstdint>
 #include <memory>
 #include <string>
 
@@ -70,6 +71,7 @@ private:
 
   // diagnostics
   diagnostic_updater::Updater diagnostic_updater_;
+  uint64_t diag_sequence_id_{0};
   void checkStatus(diagnostic_updater::DiagnosticStatusWrapper & stat);
 
 public:

--- a/perception/autoware_compare_map_segmentation/src/voxel_based_compare_map_filter/node.cpp
+++ b/perception/autoware_compare_map_segmentation/src/voxel_based_compare_map_filter/node.cpp
@@ -82,6 +82,8 @@ VoxelBasedCompareMapFilterComponent::VoxelBasedCompareMapFilterComponent(
 void VoxelBasedCompareMapFilterComponent::checkStatus(
   diagnostic_updater::DiagnosticStatusWrapper & stat)
 {
+  ++diag_sequence_id_;
+
   // map loader status
   DiagStatus & map_loader_status = (*voxel_grid_map_loader_).diagnostics_map_voxel_status_;
   if (map_loader_status.level == diagnostic_msgs::msg::DiagnosticStatus::OK) {
@@ -89,6 +91,7 @@ void VoxelBasedCompareMapFilterComponent::checkStatus(
   } else {
     stat.add("Map loader status", "NG");
   }
+  stat.add("sequence_id", std::to_string(diag_sequence_id_));
 
   // final status = map loader status
   stat.summary(map_loader_status.level, map_loader_status.message);

--- a/perception/autoware_compare_map_segmentation/src/voxel_based_compare_map_filter/node.hpp
+++ b/perception/autoware_compare_map_segmentation/src/voxel_based_compare_map_filter/node.hpp
@@ -26,6 +26,7 @@
 #include <tf2_ros/buffer.h>
 #include <tf2_ros/transform_listener.h>
 
+#include <cstdint>
 #include <memory>
 
 namespace autoware::compare_map_segmentation
@@ -62,6 +63,7 @@ private:
 
   // diagnostics
   diagnostic_updater::Updater diagnostic_updater_;
+  uint64_t diag_sequence_id_{0};
   void checkStatus(diagnostic_updater::DiagnosticStatusWrapper & stat);
 
 public:

--- a/perception/autoware_compare_map_segmentation/src/voxel_distance_based_compare_map_filter/node.cpp
+++ b/perception/autoware_compare_map_segmentation/src/voxel_distance_based_compare_map_filter/node.cpp
@@ -161,6 +161,8 @@ VoxelDistanceBasedCompareMapFilterComponent::VoxelDistanceBasedCompareMapFilterC
 void VoxelDistanceBasedCompareMapFilterComponent::checkStatus(
   diagnostic_updater::DiagnosticStatusWrapper & stat)
 {
+  ++diag_sequence_id_;
+
   // map loader status
   DiagStatus & map_loader_status =
     (*voxel_distance_based_map_loader_).diagnostics_map_voxel_status_;
@@ -169,6 +171,7 @@ void VoxelDistanceBasedCompareMapFilterComponent::checkStatus(
   } else {
     stat.add("Map loader status", "NG");
   }
+  stat.add("sequence_id", std::to_string(diag_sequence_id_));
 
   // final status = map loader status
   stat.summary(map_loader_status.level, map_loader_status.message);

--- a/perception/autoware_compare_map_segmentation/src/voxel_distance_based_compare_map_filter/node.hpp
+++ b/perception/autoware_compare_map_segmentation/src/voxel_distance_based_compare_map_filter/node.hpp
@@ -24,6 +24,7 @@
 #include <pcl/filters/voxel_grid.h>
 #include <pcl/search/pcl_search.h>
 
+#include <cstdint>
 #include <map>
 #include <memory>
 #include <string>
@@ -143,6 +144,7 @@ private:
 
   // diagnostics
   diagnostic_updater::Updater diagnostic_updater_;
+  uint64_t diag_sequence_id_{0};
   void checkStatus(diagnostic_updater::DiagnosticStatusWrapper & stat);
 
 public:

--- a/planning/planning_validator/autoware_planning_validator/include/autoware/planning_validator/types.hpp
+++ b/planning/planning_validator/autoware_planning_validator/include/autoware/planning_validator/types.hpp
@@ -26,6 +26,7 @@
 #include <diagnostic_updater/diagnostic_updater.hpp>
 
 #include <autoware_perception_msgs/msg/traffic_light_group_array.hpp>
+#include <diagnostic_msgs/msg/key_value.hpp>
 #include <autoware_planning_msgs/msg/trajectory.hpp>
 #include <diagnostic_msgs/msg/diagnostic_array.hpp>
 #include <geometry_msgs/msg/accel_with_covariance_stamped.hpp>
@@ -49,6 +50,7 @@ using autoware_planning_msgs::msg::Trajectory;
 using autoware_planning_msgs::msg::TrajectoryPoint;
 using autoware_planning_validator::msg::PlanningValidatorStatus;
 using diagnostic_msgs::msg::DiagnosticStatus;
+using diagnostic_msgs::msg::KeyValue;
 using diagnostic_updater::DiagnosticStatusWrapper;
 using diagnostic_updater::Updater;
 using geometry_msgs::msg::AccelWithCovarianceStamped;
@@ -235,11 +237,24 @@ struct PlanningValidatorContext
     }
   }
 
+  void prepare_diag_update()
+  {
+    ++diag_sequence_id_;
+  }
+
   void update_diag()
   {
     if (diag_updater) {
       diag_updater->force_update();
     }
+  }
+
+  void add_common_diag_values(DiagnosticStatusWrapper & stat) const
+  {
+    KeyValue sequence_id;
+    sequence_id.key = "sequence_id";
+    sequence_id.value = std::to_string(diag_sequence_id_);
+    stat.values.push_back(sequence_id);
   }
 
   void init_validation_status()
@@ -279,6 +294,7 @@ struct PlanningValidatorContext
 
 private:
   InvalidTrajectoryHandlingType inv_traj_handling;
+  uint64_t diag_sequence_id_{0};
 };
 
 }  // namespace autoware::planning_validator

--- a/planning/planning_validator/autoware_planning_validator/src/node.cpp
+++ b/planning/planning_validator/autoware_planning_validator/src/node.cpp
@@ -141,6 +141,7 @@ void PlanningValidatorNode::onTrajectory(const Trajectory::ConstSharedPtr & traj
 
   s->invalid_count = isAllValid(*s) ? 0 : s->invalid_count + 1;
 
+  context_->prepare_diag_update();
   context_->update_diag();
 
   publishTrajectory();

--- a/planning/planning_validator/autoware_planning_validator_intersection_collision_checker/src/intersection_collision_checker.cpp
+++ b/planning/planning_validator/autoware_planning_validator_intersection_collision_checker/src/intersection_collision_checker.cpp
@@ -94,6 +94,7 @@ void IntersectionCollisionChecker::setup_diag()
 void IntersectionCollisionChecker::set_diag_status(
   DiagnosticStatusWrapper & stat, const bool & is_ok, const std::string & msg) const
 {
+  context_->add_common_diag_values(stat);
   if (is_ok) {
     stat.summary(DiagnosticStatus::OK, "validated.");
     return;

--- a/planning/planning_validator/autoware_planning_validator_latency_checker/src/latency_checker.cpp
+++ b/planning/planning_validator/autoware_planning_validator_latency_checker/src/latency_checker.cpp
@@ -69,6 +69,7 @@ void LatencyChecker::setup_diag()
 void LatencyChecker::set_diag_status(
   DiagnosticStatusWrapper & stat, const bool & is_ok, const std::string & msg) const
 {
+  context_->add_common_diag_values(stat);
   if (is_ok) {
     stat.summary(DiagnosticStatus::OK, "validated.");
     return;

--- a/planning/planning_validator/autoware_planning_validator_rear_collision_checker/src/rear_collision_checker.cpp
+++ b/planning/planning_validator/autoware_planning_validator_rear_collision_checker/src/rear_collision_checker.cpp
@@ -124,6 +124,7 @@ void RearCollisionChecker::setup_diag()
 void RearCollisionChecker::set_diag_status(
   DiagnosticStatusWrapper & stat, const bool & is_ok, const std::string & msg) const
 {
+  context_->add_common_diag_values(stat);
   if (is_ok) {
     stat.summary(DiagnosticStatus::OK, "validated.");
     return;

--- a/planning/planning_validator/autoware_planning_validator_trajectory_checker/src/trajectory_checker.cpp
+++ b/planning/planning_validator/autoware_planning_validator_trajectory_checker/src/trajectory_checker.cpp
@@ -142,6 +142,7 @@ void TrajectoryChecker::setup_diag()
 void TrajectoryChecker::set_diag_status(
   DiagnosticStatusWrapper & stat, const bool & is_ok, const std::string & msg) const
 {
+  context_->add_common_diag_values(stat);
   if (is_ok) {
     stat.summary(DiagnosticStatus::OK, "validated.");
     return;

--- a/sensing/autoware_cuda_pointcloud_preprocessor/include/autoware/cuda_pointcloud_preprocessor/cuda_outlier_filter/cuda_polar_voxel_outlier_filter_node.hpp
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/include/autoware/cuda_pointcloud_preprocessor/cuda_outlier_filter/cuda_polar_voxel_outlier_filter_node.hpp
@@ -27,6 +27,7 @@
 
 #include <autoware_internal_debug_msgs/msg/float32_stamped.hpp>
 
+#include <cstdint>
 #include <memory>
 #include <mutex>
 #include <string>
@@ -93,6 +94,7 @@ private:
   // Diagnostics members
   std::optional<double> visibility_;    // Current visibility value
   std::optional<double> filter_ratio_;  // Current filter ratio
+  uint64_t diag_sequence_id_{0};
   diagnostic_updater::Updater updater_;
 
   // CUDA sub

--- a/sensing/autoware_cuda_pointcloud_preprocessor/src/cuda_outlier_filter/cuda_polar_voxel_outlier_filter_node.cpp
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/src/cuda_outlier_filter/cuda_polar_voxel_outlier_filter_node.cpp
@@ -435,6 +435,7 @@ void CudaPolarVoxelOutlierFilterNode::on_visibility_check(
     stat.summary(diagnostic_msgs::msg::DiagnosticStatus::OK, "Visibility within normal range");
   }
 
+  stat.add("sequence_id", std::to_string(++diag_sequence_id_));
   stat.add("Visibility", visibility_value);
   stat.add("Error Threshold", filter_params_.visibility_error_threshold);
   stat.add("Warning Threshold", filter_params_.visibility_warn_threshold);
@@ -468,6 +469,7 @@ void CudaPolarVoxelOutlierFilterNode::on_filter_ratio_check(
     stat.summary(diagnostic_msgs::msg::DiagnosticStatus::OK, "Filter ratio within normal range");
   }
 
+  stat.add("sequence_id", std::to_string(++diag_sequence_id_));
   stat.add("Filter Ratio", ratio_value);
   stat.add("Error Threshold", filter_params_.filter_ratio_error_threshold);
   stat.add("Warning Threshold", filter_params_.filter_ratio_warn_threshold);

--- a/sensing/autoware_pointcloud_preprocessor/include/autoware/pointcloud_preprocessor/concatenate_data/concatenate_and_time_sync_node.hpp
+++ b/sensing/autoware_pointcloud_preprocessor/include/autoware/pointcloud_preprocessor/concatenate_data/concatenate_and_time_sync_node.hpp
@@ -17,6 +17,7 @@
 #include <list>
 #include <memory>
 #include <string>
+#include <cstdint>
 #include <unordered_map>
 #include <vector>
 
@@ -94,6 +95,7 @@ private:
 
   double current_concatenate_cloud_timestamp_{0.0};
   double latest_concatenate_cloud_timestamp_{0.0};
+  uint64_t diag_sequence_id_{0};
 
   struct DiagnosticInfo
   {

--- a/sensing/autoware_pointcloud_preprocessor/include/autoware/pointcloud_preprocessor/concatenate_data/concatenate_and_time_sync_node.ipp
+++ b/sensing/autoware_pointcloud_preprocessor/include/autoware/pointcloud_preprocessor/concatenate_data/concatenate_and_time_sync_node.ipp
@@ -434,6 +434,7 @@ void PointCloudConcatenateDataSynchronizerComponentTemplated<MsgTraits>::check_c
   const DiagnosticInfo & diagnostic_info)
 {
   diagnostics_interface_->clear();
+  diagnostics_interface_->add_key_value("sequence_id", std::to_string(++diag_sequence_id_));
 
   const bool should_publish_diag =
     diagnostic_info.publish_pointcloud || diagnostic_info.drop_previous_but_late_pointcloud;

--- a/system/autoware_diagnostic_graph_aggregator/src/node/aggregator.cpp
+++ b/system/autoware_diagnostic_graph_aggregator/src/node/aggregator.cpp
@@ -17,7 +17,9 @@
 #include <yaml-cpp/yaml.h>
 
 #include <memory>
+#include <optional>
 #include <sstream>
+#include <set>
 #include <string>
 #include <unordered_map>
 
@@ -100,7 +102,75 @@ void AggregatorNode::on_timer()
 
 void AggregatorNode::on_diag(const DiagnosticArray & msg)
 {
+  check_sequence_gaps(msg);
   graph_->update(now(), msg);
+}
+
+std::optional<uint64_t> AggregatorNode::find_sequence_id(const DiagnosticStatus & status)
+{
+  const auto iter = std::find_if(status.values.begin(), status.values.end(), [](const auto & kv) {
+    return kv.key == "sequence_id";
+  });
+  if (iter == status.values.end()) {
+    return std::nullopt;
+  }
+
+  try {
+    return std::stoull(iter->value);
+  } catch (const std::exception &) {
+    return std::nullopt;
+  }
+}
+
+void AggregatorNode::check_sequence_gaps(const DiagnosticArray & msg)
+{
+  std::unordered_map<std::string, std::set<uint64_t>> sequences_by_name;
+
+  for (const auto & status : msg.status) {
+    const auto sequence_id = find_sequence_id(status);
+    if (!sequence_id || status.name.empty()) {
+      continue;
+    }
+    sequences_by_name[status.name].insert(*sequence_id);
+  }
+
+  for (const auto & [name, sequence_ids] : sequences_by_name) {
+    if (sequence_ids.size() > 1) {
+      std::ostringstream oss;
+      bool first = true;
+      for (const auto sequence_id : sequence_ids) {
+        if (!first) {
+          oss << ", ";
+        }
+        oss << sequence_id;
+        first = false;
+      }
+      RCLCPP_WARN(
+        get_logger(),
+        "diagnostics with name '%s' contain inconsistent sequence_id values in one "
+        "DiagnosticArray: [%s]",
+        name.c_str(), oss.str().c_str());
+    }
+
+    const auto current_sequence_id = *sequence_ids.begin();
+    const auto iter = last_sequence_by_name_.find(name);
+    if (iter != last_sequence_by_name_.end()) {
+      const auto last_sequence_id = iter->second;
+      if (current_sequence_id > last_sequence_id + 1) {
+        RCLCPP_WARN(
+          get_logger(),
+          "diagnostics sequence_id gap detected for name '%s': last=%lu current=%lu missing=[%lu,%lu]",
+          name.c_str(), last_sequence_id, current_sequence_id, last_sequence_id + 1,
+          current_sequence_id - 1);
+      } else if (current_sequence_id <= last_sequence_id) {
+        RCLCPP_WARN(
+          get_logger(),
+          "diagnostics sequence_id went backward or duplicated for name '%s': last=%lu current=%lu",
+          name.c_str(), last_sequence_id, current_sequence_id);
+      }
+    }
+    last_sequence_by_name_[name] = current_sequence_id;
+  }
 }
 
 void AggregatorNode::on_reset(

--- a/system/autoware_diagnostic_graph_aggregator/src/node/aggregator.cpp
+++ b/system/autoware_diagnostic_graph_aggregator/src/node/aggregator.cpp
@@ -157,13 +157,13 @@ void AggregatorNode::check_sequence_gaps(const DiagnosticArray & msg)
     if (iter != last_sequence_by_name_.end()) {
       const auto last_sequence_id = iter->second;
       if (current_sequence_id > last_sequence_id + 1) {
-        RCLCPP_WARN(
+        RCLCPP_ERROR(
           get_logger(),
           "diagnostics sequence_id gap detected for name '%s': last=%lu current=%lu missing=[%lu,%lu]",
           name.c_str(), last_sequence_id, current_sequence_id, last_sequence_id + 1,
           current_sequence_id - 1);
       } else if (current_sequence_id <= last_sequence_id) {
-        RCLCPP_WARN(
+        RCLCPP_DEBUG(
           get_logger(),
           "diagnostics sequence_id went backward or duplicated for name '%s': last=%lu current=%lu",
           name.c_str(), last_sequence_id, current_sequence_id);

--- a/system/autoware_diagnostic_graph_aggregator/src/node/aggregator.hpp
+++ b/system/autoware_diagnostic_graph_aggregator/src/node/aggregator.hpp
@@ -23,6 +23,7 @@
 #include <std_srvs/srv/set_bool.hpp>
 
 #include <memory>
+#include <optional>
 #include <string>
 #include <unordered_map>
 
@@ -47,9 +48,12 @@ private:
   rclcpp::Publisher<DiagnosticArray>::SharedPtr pub_unknown_;
   rclcpp::Service<ResetDiagGraph>::SharedPtr srv_reset_;
   rclcpp::Service<SetBool>::SharedPtr srv_set_initializing_;
+  std::unordered_map<std::string, uint64_t> last_sequence_by_name_;
 
   void on_timer();
   void on_diag(const DiagnosticArray & msg);
+  void check_sequence_gaps(const DiagnosticArray & msg);
+  static std::optional<uint64_t> find_sequence_id(const DiagnosticStatus & status);
   void on_reset(
     const ResetDiagGraph::Request::SharedPtr request,
     const ResetDiagGraph::Response::SharedPtr response);

--- a/system/autoware_topic_state_monitor/src/topic_state_monitor_core.cpp
+++ b/system/autoware_topic_state_monitor/src/topic_state_monitor_core.cpp
@@ -14,6 +14,8 @@
 
 #include "topic_state_monitor_core.hpp"
 
+#include <diagnostic_msgs/msg/key_value.hpp>
+
 #include <memory>
 #include <string>
 #include <utility>
@@ -126,11 +128,13 @@ rcl_interfaces::msg::SetParametersResult TopicStateMonitorNode::onParameter(
 void TopicStateMonitorNode::checkTopicStatus(diagnostic_updater::DiagnosticStatusWrapper & stat)
 {
   using diagnostic_msgs::msg::DiagnosticStatus;
+  using diagnostic_msgs::msg::KeyValue;
 
   // Get information
   const auto topic_status = topic_state_monitor_->getTopicStatus();
   const auto last_message_time = topic_state_monitor_->getLastMessageTime();
   const auto topic_rate = topic_state_monitor_->getTopicRate();
+  ++diag_sequence_id_;
 
   // Add topic name
   if (node_param_.is_transform) {
@@ -179,6 +183,10 @@ void TopicStateMonitorNode::checkTopicStatus(diagnostic_updater::DiagnosticStatu
   stat.addf("measured_rate", "%.2f [Hz]", topic_rate);
   stat.addf("now", "%.2f [s]", this->now().seconds());
   stat.addf("last_message_time", "%.2f [s]", last_message_time.seconds());
+  KeyValue sequence_id;
+  sequence_id.key = "sequence_id";
+  sequence_id.value = std::to_string(diag_sequence_id_);
+  stat.values.push_back(sequence_id);
 
   // Create message
   std::string msg;

--- a/system/autoware_topic_state_monitor/src/topic_state_monitor_core.hpp
+++ b/system/autoware_topic_state_monitor/src/topic_state_monitor_core.hpp
@@ -20,6 +20,7 @@
 #include <diagnostic_updater/diagnostic_updater.hpp>
 #include <rclcpp/rclcpp.hpp>
 
+#include <cstdint>
 #include <tf2_msgs/msg/tf_message.hpp>
 
 #include <deque>
@@ -67,6 +68,7 @@ private:
 
   // Diagnostic Updater
   diagnostic_updater::Updater updater_;
+  uint64_t diag_sequence_id_{0};
 
   void checkTopicStatus(diagnostic_updater::DiagnosticStatusWrapper & stat);
 };


### PR DESCRIPTION
以下diagnosticに関する改善の結果`/diagnostics`のドロップが発生していないことを検証する。
改善に関する詳細：https://tier4.atlassian.net/wiki/spaces/CB/pages/5075964108/PDD+diagnostics

方法：代表的なmonitorをピックアップしてsequence idを出力し、monitor側ではpubするたびにidをインクリメント、aggregator側ではidのjumpがないか監視する。