### PR TITLE
feat(trajectory_validator): add ego footprint margins for collision checks

### DIFF
--- a/planning/autoware_trajectory_validator/config/trajectory_validator.param.yaml
+++ b/planning/autoware_trajectory_validator/config/trajectory_validator.param.yaml
@@ -13,10 +13,6 @@
     collision_check:
       global_setting:
         time_resolution: 0.1
-        ego_footprint_margin:
-          lateral: 0.0
-          front: 0.0
-          rear: 0.0
       drac:
         enable_assessment:
           # default value is true.
@@ -26,6 +22,10 @@
           constant_curvature: true
           diffusion_based: true
         ego_total_braking_delay: 0.4
+        ego_footprint_margin:
+          lateral: 0.0
+          front: 0.0
+          rear: 0.0
         warn_threshold:
           ego_acceleration: -2.0
         error_threshold:
@@ -39,6 +39,10 @@
           constant_curvature: true
           diffusion_based: true
         ego_total_braking_delay: 0.4
+        ego_footprint_margin:
+          lateral: 0.0
+          front: 0.0
+          rear: 0.0
         ego_assumed_acceleration: -4.0
         warn_threshold:
           ego_first_passing_time_gap: 1.0
@@ -52,6 +56,10 @@
           unknown: false
         stop_distance_margin: 2.0
         ego_total_braking_delay: 0.4
+        ego_footprint_margin:
+          lateral: 0.0
+          front: 0.0
+          rear: 0.0
         object_assumed_acceleration: -4.0
         error_threshold:
           ego_acceleration: -4.0

--- a/planning/autoware_trajectory_validator/config/trajectory_validator.param.yaml
+++ b/planning/autoware_trajectory_validator/config/trajectory_validator.param.yaml
@@ -13,6 +13,10 @@
     collision_check:
       global_setting:
         time_resolution: 0.1
+        ego_footprint_margin:
+          lateral: 0.0
+          front: 0.0
+          rear: 0.0
       drac:
         enable_assessment:
           # default value is true.

--- a/planning/autoware_trajectory_validator/param/parameter_struct.yaml
+++ b/planning/autoware_trajectory_validator/param/parameter_struct.yaml
@@ -45,6 +45,22 @@ validator:
         default_value: 0.1
         description: sampling interval used in collision check trajectory generation
         read_only: false
+      ego_footprint_margin:
+        lateral:
+          type: double
+          default_value: 0.0
+          description: lateral margin added to both sides of the ego footprint for collision checks
+          read_only: false
+        front:
+          type: double
+          default_value: 0.0
+          description: front margin added to the ego footprint for collision checks
+          read_only: false
+        rear:
+          type: double
+          default_value: 0.0
+          description: rear margin added to the ego footprint for collision checks
+          read_only: false
     drac:
       enable_assessment:
         base:

--- a/planning/autoware_trajectory_validator/param/parameter_struct.yaml
+++ b/planning/autoware_trajectory_validator/param/parameter_struct.yaml
@@ -45,22 +45,6 @@ validator:
         default_value: 0.1
         description: sampling interval used in collision check trajectory generation
         read_only: false
-      ego_footprint_margin:
-        lateral:
-          type: double
-          default_value: 0.0
-          description: lateral margin added to both sides of the ego footprint for collision checks
-          read_only: false
-        front:
-          type: double
-          default_value: 0.0
-          description: front margin added to the ego footprint for collision checks
-          read_only: false
-        rear:
-          type: double
-          default_value: 0.0
-          description: rear margin added to the ego footprint for collision checks
-          read_only: false
     drac:
       enable_assessment:
         base:
@@ -103,6 +87,22 @@ validator:
         default_value: 0.4
         description: Total ego braking delay for DRAC assessment
         read_only: false
+      ego_footprint_margin:
+        lateral:
+          type: double
+          default_value: 0.0
+          description: lateral margin added to both sides of the ego footprint for DRAC assessment
+          read_only: false
+        front:
+          type: double
+          default_value: 0.0
+          description: front margin added to the ego footprint for DRAC assessment
+          read_only: false
+        rear:
+          type: double
+          default_value: 0.0
+          description: rear margin added to the ego footprint for DRAC assessment
+          read_only: false
       warn_threshold:
         ego_acceleration:
           type: double
@@ -157,6 +157,22 @@ validator:
         default_value: 0.4
         description: Total ego braking delay for PET assessment
         read_only: false
+      ego_footprint_margin:
+        lateral:
+          type: double
+          default_value: 0.0
+          description: lateral margin added to both sides of the ego footprint for PET assessment
+          read_only: false
+        front:
+          type: double
+          default_value: 0.0
+          description: front margin added to the ego footprint for PET assessment
+          read_only: false
+        rear:
+          type: double
+          default_value: 0.0
+          description: rear margin added to the ego footprint for PET assessment
+          read_only: false
       ego_assumed_acceleration:
         type: double
         default_value: -5.0
@@ -215,6 +231,22 @@ validator:
         default_value: 0.4
         description: Total ego braking delay for RSS calculation
         read_only: false
+      ego_footprint_margin:
+        lateral:
+          type: double
+          default_value: 0.0
+          description: lateral margin added to both sides of the ego footprint for RSS assessment
+          read_only: false
+        front:
+          type: double
+          default_value: 0.0
+          description: front margin added to the ego footprint for RSS assessment
+          read_only: false
+        rear:
+          type: double
+          default_value: 0.0
+          description: rear margin added to the ego footprint for RSS assessment
+          read_only: false
       object_assumed_acceleration:
         type: double
         default_value: -1.0

--- a/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/assessment.cpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/assessment.cpp
@@ -163,8 +163,8 @@ std::optional<CollisionDetail> find_collision_timing(
 
 PetArtifact assess_planned_speed_collision_timing(
   const TrajectoryPoints & traj_points, const FilterContext & context,
-  const PetParamMap & pet_param_map, const GlobalParams & global_params, VehicleInfo & vehicle_info,
-  const std::vector<TrajectoryData> & object_trajectories)
+  const PetParamMap & pet_param_map, const GlobalParams & global_params,
+  const VehicleInfo & vehicle_info, const std::vector<TrajectoryData> & object_trajectories)
 {
   // todo (takagi): ego_trajectory options can not set for each object type because cache structure
   // is not implemented yet.
@@ -204,7 +204,7 @@ PetArtifact assess_planned_speed_collision_timing(
 
 DracArtifact assess_drac(
   const TrajectoryPoints & traj_points, const FilterContext & context,
-  const DracParamMap & drac_param_map, VehicleInfo & vehicle_info,
+  const DracParamMap & drac_param_map, const VehicleInfo & vehicle_info,
   const std::vector<TrajectoryData> & object_trajectories, const GlobalParams & global_params)
 {
   const double ego_time_horizon = rclcpp::Duration(traj_points.back().time_from_start).seconds();
@@ -364,7 +364,7 @@ std::vector<TrajectoryData> generate_object_trajectories(
 std::pair<PetArtifact, DracArtifact> assess(
   const TrajectoryPoints & traj_points, const FilterContext & context,
   const PetParamMap & pet_param_map, const DracParamMap & drac_param_map,
-  const GlobalParams & global_params, VehicleInfo & vehicle_info)
+  const GlobalParams & global_params, const VehicleInfo & vehicle_info)
 {
   const double required_time_horizon =
     rclcpp::Duration(traj_points.back().time_from_start).seconds();
@@ -413,7 +413,7 @@ std::optional<double> compute_distance_to_collision(
 
 TrajectoryData generate_rss_ego_trajectory(
   const TrajectoryPoints & traj_points, const FilterContext & context,
-  const GlobalParams & global_params, VehicleInfo & vehicle_info)
+  const GlobalParams & global_params, const VehicleInfo & vehicle_info)
 {
   const double ego_time_horizon_for_rss =
     rclcpp::Duration(traj_points.back().time_from_start).seconds();
@@ -453,7 +453,8 @@ RssDetail assess_required_acceleration(
 
 RssArtifact assess(
   const TrajectoryPoints & traj_points, const FilterContext & context,
-  const RssParamMap & rss_param_map, const GlobalParams & global_params, VehicleInfo & vehicle_info)
+  const RssParamMap & rss_param_map, const GlobalParams & global_params,
+  const VehicleInfo & vehicle_info)
 {
   if (!context.predicted_objects || context.predicted_objects->objects.empty()) {
     return {};

--- a/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/assessment.cpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/assessment.cpp
@@ -163,7 +163,7 @@ std::optional<CollisionDetail> find_collision_timing(
 
 PetArtifact assess_planned_speed_collision_timing(
   const TrajectoryPoints & traj_points, const FilterContext & context,
-  const PetParamMap & pet_param_map, double time_resolution, VehicleInfo & vehicle_info,
+  const PetParamMap & pet_param_map, const GlobalParams & global_params, VehicleInfo & vehicle_info,
   const std::vector<TrajectoryData> & object_trajectories)
 {
   // todo (takagi): ego_trajectory options can not set for each object type because cache structure
@@ -173,7 +173,7 @@ PetArtifact assess_planned_speed_collision_timing(
                                             -ego_pet_params.ego_assumed_acceleration +
                                           ego_pet_params.ego_total_braking_delay;
   auto ego_trajectory = trajectory::generate_ego_trajectory(
-    traj_points, context, ego_time_horizon_for_pet, time_resolution, vehicle_info);
+    traj_points, context, ego_time_horizon_for_pet, vehicle_info, global_params);
 
   std::vector<CollisionEvaluation> collision_evaluations{};
   for (const auto & object_trajectory : object_trajectories) {
@@ -186,7 +186,7 @@ PetArtifact assess_planned_speed_collision_timing(
     }
 
     auto collision = find_collision_timing(
-      ego_trajectory, object_trajectory, pet_params.warn_threshold, time_resolution);
+      ego_trajectory, object_trajectory, pet_params.warn_threshold, global_params.time_resolution);
 
     if (collision.has_value()) {
       const auto risk_level =
@@ -223,15 +223,15 @@ DracArtifact assess_drac(
     const auto ego_deceleration_trajectory = [&]() {
       if (ego_dec == 0.0) {
         return trajectory::generate_ego_trajectory(
-          traj_points, context, ego_time_horizon, global_params.time_resolution, vehicle_info);
+          traj_points, context, ego_time_horizon, vehicle_info, global_params);
       } else if (ego_dec > default_max_ego_deceleration - 1e-3) {
         return trajectory::generate_ego_trajectory(
-          context.odometry->twist.twist, 0.0, -ego_dec, ego_time_horizon,
-          global_params.time_resolution, traj_points, vehicle_info);
+          context.odometry->twist.twist, 0.0, -ego_dec, ego_time_horizon, traj_points, vehicle_info,
+          global_params);
       }
       return trajectory::generate_ego_trajectory(
         context.odometry->twist.twist, ego_drac_params.ego_total_braking_delay, -ego_dec,
-        ego_time_horizon, global_params.time_resolution, traj_points, vehicle_info);
+        ego_time_horizon, traj_points, vehicle_info, global_params);
     }();
 
     std::vector<CollisionEvaluation> collision_evaluations{};
@@ -374,7 +374,7 @@ std::pair<PetArtifact, DracArtifact> assess(
 
   PetArtifact pet_artifact{};
   pet_artifact = assess_planned_speed_collision_timing(
-    traj_points, context, pet_param_map, global_params.time_resolution, vehicle_info,
+    traj_points, context, pet_param_map, global_params, vehicle_info,
     nominal_speed_object_trajectories);
 
   DracArtifact drac_artifact{};
@@ -412,14 +412,14 @@ std::optional<double> compute_distance_to_collision(
 }
 
 TrajectoryData generate_rss_ego_trajectory(
-  const TrajectoryPoints & traj_points, const FilterContext & context, double time_resolution,
-  VehicleInfo & vehicle_info)
+  const TrajectoryPoints & traj_points, const FilterContext & context,
+  const GlobalParams & global_params, VehicleInfo & vehicle_info)
 {
   const double ego_time_horizon_for_rss =
     rclcpp::Duration(traj_points.back().time_from_start).seconds();
 
   return trajectory::generate_ego_trajectory(
-    traj_points, context, ego_time_horizon_for_rss, time_resolution, vehicle_info);
+    traj_points, context, ego_time_horizon_for_rss, vehicle_info, global_params);
 }
 
 RssDetail assess_required_acceleration(
@@ -453,14 +453,14 @@ RssDetail assess_required_acceleration(
 
 RssArtifact assess(
   const TrajectoryPoints & traj_points, const FilterContext & context,
-  const RssParamMap & rss_param_map, double time_resolution, VehicleInfo & vehicle_info)
+  const RssParamMap & rss_param_map, const GlobalParams & global_params, VehicleInfo & vehicle_info)
 {
   if (!context.predicted_objects || context.predicted_objects->objects.empty()) {
     return {};
   }
 
   const auto ego_trajectory =
-    generate_rss_ego_trajectory(traj_points, context, time_resolution, vehicle_info);
+    generate_rss_ego_trajectory(traj_points, context, global_params, vehicle_info);
 
   std::vector<RssEvaluation> rss_evaluations{};
   rss_evaluations.reserve(context.predicted_objects->objects.size());

--- a/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/assessment.cpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/assessment.cpp
@@ -66,12 +66,12 @@ RiskLevel to_drac_risk_level(const std::optional<double> & acc, const DracParams
 }
 
 trajectory::footprint::EgoDimensions make_ego_dimensions(
-  const VehicleInfo & vehicle_info, const GlobalParams & global_params)
+  const VehicleInfo & vehicle_info, const EgoFootprintMargin & ego_footprint_margin)
 {
   return trajectory::footprint::EgoDimensions{
-    vehicle_info.max_longitudinal_offset_m + global_params.ego_footprint_margin.front,
-    -vehicle_info.min_longitudinal_offset_m + global_params.ego_footprint_margin.rear,
-    vehicle_info.vehicle_width_m + 2.0 * global_params.ego_footprint_margin.lateral};
+    vehicle_info.max_longitudinal_offset_m + ego_footprint_margin.front,
+    -vehicle_info.min_longitudinal_offset_m + ego_footprint_margin.rear,
+    vehicle_info.vehicle_width_m + 2.0 * ego_footprint_margin.lateral};
 }
 
 std::optional<CollisionDetail> find_collision_timing(
@@ -178,8 +178,8 @@ PetArtifact assess_planned_speed_collision_timing(
   // todo (takagi): ego_trajectory options can not set for each object type because cache structure
   // is not implemented yet.
   const auto & ego_pet_params = pet_param_map.at(kCollisionCheckParamBaseKey);
-  const auto ego_dimensions =
-    collision_timing_assessment::make_ego_dimensions(vehicle_info, global_params);
+  const auto ego_dimensions = collision_timing_assessment::make_ego_dimensions(
+    vehicle_info, ego_pet_params.ego_footprint_margin);
   const double ego_time_horizon_for_pet = std::abs(context.odometry->twist.twist.linear.x) * 0.5 /
                                             -ego_pet_params.ego_assumed_acceleration +
                                           ego_pet_params.ego_total_braking_delay;
@@ -223,7 +223,8 @@ DracArtifact assess_drac(
   // todo (takagi): ego_trajectory options can not set for each object type because cache structure
   // is not implemented yet.
   const auto & ego_drac_params = drac_param_map.at(kCollisionCheckParamBaseKey);
-  const auto ego_dimensions = make_ego_dimensions(vehicle_info, global_params);
+  const auto ego_dimensions =
+    make_ego_dimensions(vehicle_info, ego_drac_params.ego_footprint_margin);
   constexpr double default_ego_deceleration_step = 1.0;
   constexpr double default_max_ego_deceleration = 6.0;
   constexpr PetThreshold error_pet_th{0.6, 0.3};
@@ -424,13 +425,13 @@ std::optional<double> compute_distance_to_collision(
 }
 
 TrajectoryData generate_rss_ego_trajectory(
-  const TrajectoryPoints & traj_points, const FilterContext & context,
+  const TrajectoryPoints & traj_points, const FilterContext & context, const RssParams & rss_params,
   const GlobalParams & global_params, const VehicleInfo & vehicle_info)
 {
   const double ego_time_horizon_for_rss =
     rclcpp::Duration(traj_points.back().time_from_start).seconds();
   const auto ego_dimensions =
-    collision_timing_assessment::make_ego_dimensions(vehicle_info, global_params);
+    collision_timing_assessment::make_ego_dimensions(vehicle_info, rss_params.ego_footprint_margin);
 
   return trajectory::generate_ego_trajectory(
     traj_points, context, ego_time_horizon_for_rss, ego_dimensions, global_params.time_resolution);
@@ -474,8 +475,9 @@ RssArtifact assess(
     return {};
   }
 
+  const auto & ego_rss_params = rss_param_map.at(kCollisionCheckParamBaseKey);
   const auto ego_trajectory =
-    generate_rss_ego_trajectory(traj_points, context, global_params, vehicle_info);
+    generate_rss_ego_trajectory(traj_points, context, ego_rss_params, global_params, vehicle_info);
 
   std::vector<RssEvaluation> rss_evaluations{};
   rss_evaluations.reserve(context.predicted_objects->objects.size());

--- a/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/assessment.cpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/assessment.cpp
@@ -65,6 +65,15 @@ RiskLevel to_drac_risk_level(const std::optional<double> & acc, const DracParams
   return RiskLevel::SAFE;
 }
 
+trajectory::footprint::EgoDimensions make_ego_dimensions(
+  const VehicleInfo & vehicle_info, const GlobalParams & global_params)
+{
+  return trajectory::footprint::EgoDimensions{
+    vehicle_info.max_longitudinal_offset_m + global_params.ego_footprint_margin.front,
+    -vehicle_info.min_longitudinal_offset_m + global_params.ego_footprint_margin.rear,
+    vehicle_info.vehicle_width_m + 2.0 * global_params.ego_footprint_margin.lateral};
+}
+
 std::optional<CollisionDetail> find_collision_timing(
   const TrajectoryData & ref_trajectory, const TrajectoryData & test_trajectory,
   PetThreshold pet_find_range, double time_resolution)
@@ -169,11 +178,13 @@ PetArtifact assess_planned_speed_collision_timing(
   // todo (takagi): ego_trajectory options can not set for each object type because cache structure
   // is not implemented yet.
   const auto & ego_pet_params = pet_param_map.at(kCollisionCheckParamBaseKey);
+  const auto ego_dimensions =
+    collision_timing_assessment::make_ego_dimensions(vehicle_info, global_params);
   const double ego_time_horizon_for_pet = std::abs(context.odometry->twist.twist.linear.x) * 0.5 /
                                             -ego_pet_params.ego_assumed_acceleration +
                                           ego_pet_params.ego_total_braking_delay;
   auto ego_trajectory = trajectory::generate_ego_trajectory(
-    traj_points, context, ego_time_horizon_for_pet, vehicle_info, global_params);
+    traj_points, context, ego_time_horizon_for_pet, ego_dimensions, global_params.time_resolution);
 
   std::vector<CollisionEvaluation> collision_evaluations{};
   for (const auto & object_trajectory : object_trajectories) {
@@ -212,6 +223,7 @@ DracArtifact assess_drac(
   // todo (takagi): ego_trajectory options can not set for each object type because cache structure
   // is not implemented yet.
   const auto & ego_drac_params = drac_param_map.at(kCollisionCheckParamBaseKey);
+  const auto ego_dimensions = make_ego_dimensions(vehicle_info, global_params);
   constexpr double default_ego_deceleration_step = 1.0;
   constexpr double default_max_ego_deceleration = 6.0;
   constexpr PetThreshold error_pet_th{0.6, 0.3};
@@ -223,15 +235,15 @@ DracArtifact assess_drac(
     const auto ego_deceleration_trajectory = [&]() {
       if (ego_dec == 0.0) {
         return trajectory::generate_ego_trajectory(
-          traj_points, context, ego_time_horizon, vehicle_info, global_params);
+          traj_points, context, ego_time_horizon, ego_dimensions, global_params.time_resolution);
       } else if (ego_dec > default_max_ego_deceleration - 1e-3) {
         return trajectory::generate_ego_trajectory(
-          context.odometry->twist.twist, 0.0, -ego_dec, ego_time_horizon, traj_points, vehicle_info,
-          global_params);
+          context.odometry->twist.twist, 0.0, -ego_dec, ego_time_horizon, traj_points,
+          ego_dimensions, global_params.time_resolution);
       }
       return trajectory::generate_ego_trajectory(
         context.odometry->twist.twist, ego_drac_params.ego_total_braking_delay, -ego_dec,
-        ego_time_horizon, traj_points, vehicle_info, global_params);
+        ego_time_horizon, traj_points, ego_dimensions, global_params.time_resolution);
     }();
 
     std::vector<CollisionEvaluation> collision_evaluations{};
@@ -417,9 +429,11 @@ TrajectoryData generate_rss_ego_trajectory(
 {
   const double ego_time_horizon_for_rss =
     rclcpp::Duration(traj_points.back().time_from_start).seconds();
+  const auto ego_dimensions =
+    collision_timing_assessment::make_ego_dimensions(vehicle_info, global_params);
 
   return trajectory::generate_ego_trajectory(
-    traj_points, context, ego_time_horizon_for_rss, vehicle_info, global_params);
+    traj_points, context, ego_time_horizon_for_rss, ego_dimensions, global_params.time_resolution);
 }
 
 RssDetail assess_required_acceleration(

--- a/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/assessment.cpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/assessment.cpp
@@ -184,7 +184,7 @@ PetArtifact assess_planned_speed_collision_timing(
                                             -ego_pet_params.ego_assumed_acceleration +
                                           ego_pet_params.ego_total_braking_delay;
   auto ego_trajectory = trajectory::generate_ego_trajectory(
-    traj_points, context, ego_time_horizon_for_pet, ego_dimensions, global_params.time_resolution);
+    traj_points, context, ego_time_horizon_for_pet, global_params.time_resolution, ego_dimensions);
 
   std::vector<CollisionEvaluation> collision_evaluations{};
   for (const auto & object_trajectory : object_trajectories) {
@@ -236,15 +236,15 @@ DracArtifact assess_drac(
     const auto ego_deceleration_trajectory = [&]() {
       if (ego_dec == 0.0) {
         return trajectory::generate_ego_trajectory(
-          traj_points, context, ego_time_horizon, ego_dimensions, global_params.time_resolution);
+          traj_points, context, ego_time_horizon, global_params.time_resolution, ego_dimensions);
       } else if (ego_dec > default_max_ego_deceleration - 1e-3) {
         return trajectory::generate_ego_trajectory(
-          context.odometry->twist.twist, 0.0, -ego_dec, ego_time_horizon, traj_points,
-          ego_dimensions, global_params.time_resolution);
+          context.odometry->twist.twist, 0.0, -ego_dec, ego_time_horizon,
+          global_params.time_resolution, traj_points, ego_dimensions);
       }
       return trajectory::generate_ego_trajectory(
         context.odometry->twist.twist, ego_drac_params.ego_total_braking_delay, -ego_dec,
-        ego_time_horizon, traj_points, ego_dimensions, global_params.time_resolution);
+        ego_time_horizon, global_params.time_resolution, traj_points, ego_dimensions);
     }();
 
     std::vector<CollisionEvaluation> collision_evaluations{};
@@ -434,7 +434,7 @@ TrajectoryData generate_rss_ego_trajectory(
     collision_timing_assessment::make_ego_dimensions(vehicle_info, rss_params.ego_footprint_margin);
 
   return trajectory::generate_ego_trajectory(
-    traj_points, context, ego_time_horizon_for_rss, ego_dimensions, global_params.time_resolution);
+    traj_points, context, ego_time_horizon_for_rss, global_params.time_resolution, ego_dimensions);
 }
 
 RssDetail assess_required_acceleration(

--- a/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/assessment.hpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/assessment.hpp
@@ -76,7 +76,8 @@ std::optional<double> compute_distance_to_collision(
 
 RssArtifact assess(
   const TrajectoryPoints & traj_points, const FilterContext & context,
-  const RssParamMap & rss_param_map, double time_resolution, VehicleInfo & vehicle_info);
+  const RssParamMap & rss_param_map, const GlobalParams & global_params,
+  VehicleInfo & vehicle_info);
 }  // namespace autoware::trajectory_validator::plugin::safety::rss_deceleration
 
 #endif  // FILTERS__SAFETY__COLLISION_CHECK_FILTER__ASSESSMENT_HPP_

--- a/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/assessment.hpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/assessment.hpp
@@ -38,7 +38,7 @@ std::vector<TrajectoryData> generate_object_trajectories(
 std::pair<PetArtifact, DracArtifact> assess(
   const TrajectoryPoints & traj_points, const FilterContext & context,
   const PetParamMap & pet_param_map, const DracParamMap & drac_param_map,
-  const GlobalParams & global_params, VehicleInfo & vehicle_info);
+  const GlobalParams & global_params, const VehicleInfo & vehicle_info);
 }  // namespace autoware::trajectory_validator::plugin::safety::collision_timing_assessment
 
 namespace autoware::trajectory_validator::plugin::safety::rss_deceleration
@@ -77,7 +77,7 @@ std::optional<double> compute_distance_to_collision(
 RssArtifact assess(
   const TrajectoryPoints & traj_points, const FilterContext & context,
   const RssParamMap & rss_param_map, const GlobalParams & global_params,
-  VehicleInfo & vehicle_info);
+  const VehicleInfo & vehicle_info);
 }  // namespace autoware::trajectory_validator::plugin::safety::rss_deceleration
 
 #endif  // FILTERS__SAFETY__COLLISION_CHECK_FILTER__ASSESSMENT_HPP_

--- a/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/collision_check_filter.cpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/collision_check_filter.cpp
@@ -149,7 +149,7 @@ CollisionCheckFilter::result_t CollisionCheckFilter::is_feasible(
   const auto [pet_artifact, drac_artifact] = collision_timing_assessment::assess(
     traj_points, context, pet_param_map_, drac_param_map_, global_params_, *vehicle_info_ptr_);
   const auto rss_artifact = rss_deceleration::assess(
-    traj_points, context, rss_param_map_, global_params_.time_resolution, *vehicle_info_ptr_);
+    traj_points, context, rss_param_map_, global_params_, *vehicle_info_ptr_);
 
   auto planning_factors = reporter::process_collision_artifacts(
     *context.odometry, pet_artifact, pet_continuous_times_, drac_artifact, drac_continuous_times_,

--- a/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/parameter.hpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/parameter.hpp
@@ -111,12 +111,23 @@ OutT extract_labeled_param(const ParamStruct & params_struct, const std::string_
 
 struct GlobalParams
 {
+  struct EgoFootprintMargin
+  {
+    double lateral{0.0};
+    double front{0.0};
+    double rear{0.0};
+  };
+
   double time_resolution{0.1};
+  EgoFootprintMargin ego_footprint_margin{};
 
   GlobalParams() = default;
   explicit GlobalParams(const validator::Params::CollisionCheck::GlobalSetting & params)
   {
     time_resolution = params.time_resolution;
+    ego_footprint_margin.lateral = params.ego_footprint_margin.lateral;
+    ego_footprint_margin.front = params.ego_footprint_margin.front;
+    ego_footprint_margin.rear = params.ego_footprint_margin.rear;
   }
 };
 

--- a/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/parameter.hpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/parameter.hpp
@@ -109,25 +109,21 @@ OutT extract_labeled_param(const ParamStruct & params_struct, const std::string_
   }
 }
 
+struct EgoFootprintMargin
+{
+  double lateral{0.0};
+  double front{0.0};
+  double rear{0.0};
+};
+
 struct GlobalParams
 {
-  struct EgoFootprintMargin
-  {
-    double lateral{0.0};
-    double front{0.0};
-    double rear{0.0};
-  };
-
   double time_resolution{0.1};
-  EgoFootprintMargin ego_footprint_margin{};
 
   GlobalParams() = default;
   explicit GlobalParams(const validator::Params::CollisionCheck::GlobalSetting & params)
   {
     time_resolution = params.time_resolution;
-    ego_footprint_margin.lateral = params.ego_footprint_margin.lateral;
-    ego_footprint_margin.front = params.ego_footprint_margin.front;
-    ego_footprint_margin.rear = params.ego_footprint_margin.rear;
   }
 };
 
@@ -165,6 +161,9 @@ struct DracParams
       enable_assessment &&
       extract_labeled_param<bool>(drac.assessment_trajectories.diffusion_based, key);
     ego_total_braking_delay = extract_labeled_param<double>(drac.ego_total_braking_delay, key);
+    ego_footprint_margin.lateral = drac.ego_footprint_margin.lateral;
+    ego_footprint_margin.front = drac.ego_footprint_margin.front;
+    ego_footprint_margin.rear = drac.ego_footprint_margin.rear;
     warn_threshold.ego_acceleration =
       extract_labeled_param<double>(drac.warn_threshold.ego_acceleration, key);
     error_threshold.ego_acceleration =
@@ -174,6 +173,7 @@ struct DracParams
   bool enable_assessment{false};
   AssessmentTrajectories assessment_trajectories{};
   double ego_total_braking_delay{0.4};
+  EgoFootprintMargin ego_footprint_margin{};
   Threshold warn_threshold{-2.0};
   Threshold error_threshold{};
 };
@@ -183,6 +183,7 @@ struct PetParams
   bool enable_assessment{true};
   AssessmentTrajectories assessment_trajectories{};
   double ego_total_braking_delay{0.4};
+  EgoFootprintMargin ego_footprint_margin{};
   double ego_assumed_acceleration{-5.0};
   PetThreshold warn_threshold{};
   PetThreshold error_threshold{0.6, 0.3};
@@ -201,6 +202,9 @@ struct PetParams
       enable_assessment &&
       extract_labeled_param<bool>(pet.assessment_trajectories.diffusion_based, key);
     ego_total_braking_delay = extract_labeled_param<double>(pet.ego_total_braking_delay, key);
+    ego_footprint_margin.lateral = pet.ego_footprint_margin.lateral;
+    ego_footprint_margin.front = pet.ego_footprint_margin.front;
+    ego_footprint_margin.rear = pet.ego_footprint_margin.rear;
     ego_assumed_acceleration = extract_labeled_param<double>(pet.ego_assumed_acceleration, key);
 
     warn_threshold.ego_first_passing_time_gap =
@@ -228,6 +232,9 @@ struct RssParams
     enable_assessment = extract_labeled_param<bool>(rss.enable_assessment, key);
     stop_distance_margin = extract_labeled_param<double>(rss.stop_distance_margin, key);
     ego_total_braking_delay = extract_labeled_param<double>(rss.ego_total_braking_delay, key);
+    ego_footprint_margin.lateral = rss.ego_footprint_margin.lateral;
+    ego_footprint_margin.front = rss.ego_footprint_margin.front;
+    ego_footprint_margin.rear = rss.ego_footprint_margin.rear;
     object_assumed_acceleration =
       extract_labeled_param<double>(rss.object_assumed_acceleration, key);
     error_threshold.ego_acceleration =
@@ -237,6 +244,7 @@ struct RssParams
   bool enable_assessment{true};
   double stop_distance_margin{2.0};
   double ego_total_braking_delay{0.4};
+  EgoFootprintMargin ego_footprint_margin{};
   double object_assumed_acceleration{-1.0};
   ErrorThreshold error_threshold{};
 };

--- a/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/trajectory_utils.cpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/trajectory_utils.cpp
@@ -497,8 +497,8 @@ geometry_msgs::msg::Pose interpolate_predicted_path_pose(
 
 TrajectoryData generate_ego_trajectory(
   const geometry_msgs::msg::Twist & initial_twist, double braking_lag, double assumed_acceleration,
-  double max_time, const TrajectoryPoints & traj_points,
-  const footprint::EgoDimensions & ego_dimensions, double time_resolution)
+  double max_time, double time_resolution, const TrajectoryPoints & traj_points,
+  const footprint::EgoDimensions & ego_dimensions)
 {
   auto [times, distances] = time_distance::compute_motion_profile_1d(
     initial_twist, braking_lag, assumed_acceleration, 0.0, max_time, time_resolution);
@@ -518,7 +518,7 @@ TrajectoryData generate_ego_trajectory(
 
 TrajectoryData generate_ego_trajectory(
   const TrajectoryPoints & traj_points, const FilterContext & context, double max_time,
-  const footprint::EgoDimensions & ego_dimensions, double time_resolution)
+  double time_resolution, const footprint::EgoDimensions & ego_dimensions)
 {
   if (traj_points.empty()) {
     throw std::invalid_argument("points must not be empty");

--- a/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/trajectory_utils.cpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/trajectory_utils.cpp
@@ -374,22 +374,15 @@ FootprintTrajectory compute_footprint_trajectory(
 }
 
 FootprintTrajectory compute_footprint_trajectory(
-  const PoseTrajectory & pose_trajectory, const VehicleInfo & vehicle_info,
-  const GlobalParams & global_params)
+  const PoseTrajectory & pose_trajectory, const EgoDimensions & ego_dimensions)
 {
   FootprintTrajectory footprint_trajectory;
   footprint_trajectory.reserve(pose_trajectory.size());
 
-  const double front_offset =
-    vehicle_info.max_longitudinal_offset_m + global_params.ego_footprint_margin.front;
-  const double rear_overhang =
-    -vehicle_info.min_longitudinal_offset_m + global_params.ego_footprint_margin.rear;
-  const double vehicle_width =
-    vehicle_info.vehicle_width_m + 2.0 * global_params.ego_footprint_margin.lateral;
-
   for (const auto & pose : pose_trajectory) {
-    footprint_trajectory.push_back(
-      autoware_utils_geometry::to_footprint(pose, front_offset, rear_overhang, vehicle_width));
+    footprint_trajectory.push_back(autoware_utils_geometry::to_footprint(
+      pose, ego_dimensions.front_offset, ego_dimensions.rear_overhang,
+      ego_dimensions.vehicle_width));
   }
   return footprint_trajectory;
 }
@@ -510,11 +503,11 @@ geometry_msgs::msg::Pose interpolate_predicted_path_pose(
 
 TrajectoryData generate_ego_trajectory(
   const geometry_msgs::msg::Twist & initial_twist, double braking_lag, double assumed_acceleration,
-  double max_time, const TrajectoryPoints & traj_points, const VehicleInfo & vehicle_info,
-  const GlobalParams & global_params)
+  double max_time, const TrajectoryPoints & traj_points,
+  const footprint::EgoDimensions & ego_dimensions, double time_resolution)
 {
   auto [times, distances] = time_distance::compute_motion_profile_1d(
-    initial_twist, braking_lag, assumed_acceleration, 0.0, max_time, global_params.time_resolution);
+    initial_twist, braking_lag, assumed_acceleration, 0.0, max_time, time_resolution);
 
   double distance_offset =
     autoware::motion_utils::calcSignedArcLength(traj_points, traj_points.front().pose.position, 0);
@@ -522,7 +515,7 @@ TrajectoryData generate_ego_trajectory(
     val += distance_offset;
   }
   auto poses = pose::compute_pose_trajectory(traj_points, distances);
-  auto footprints = footprint::compute_footprint_trajectory(poses, vehicle_info, global_params);
+  auto footprints = footprint::compute_footprint_trajectory(poses, ego_dimensions);
 
   return TrajectoryData(
     TrajectoryIdentification{"EGO"}, std::move(times), std::move(distances), std::move(poses),
@@ -531,7 +524,7 @@ TrajectoryData generate_ego_trajectory(
 
 TrajectoryData generate_ego_trajectory(
   const TrajectoryPoints & traj_points, const FilterContext & context, double max_time,
-  const VehicleInfo & vehicle_info, const GlobalParams & global_params)
+  const footprint::EgoDimensions & ego_dimensions, double time_resolution)
 {
   if (traj_points.empty()) {
     throw std::invalid_argument("points must not be empty");
@@ -544,18 +537,16 @@ TrajectoryData generate_ego_trajectory(
 
   TimeTrajectory relative_times{0.0};
   TimeTrajectory absolute_times{start_time};
-  for (double sample_time = global_params.time_resolution; start_time + sample_time < end_time;
+  for (double sample_time = time_resolution; start_time + sample_time < end_time;
        sample_time =
-         std::floor(
-           (sample_time + global_params.time_resolution + 1e-6) / global_params.time_resolution) *
-         global_params.time_resolution) {
+         std::floor((sample_time + time_resolution + 1e-6) / time_resolution) * time_resolution) {
     relative_times.push_back(sample_time);
     absolute_times.push_back(start_time + sample_time);
   }
 
   auto poses = pose::compute_pose_trajectory_from_time(traj_points, absolute_times);
   auto distances = detail::compute_cumulative_distances(poses);
-  auto footprints = footprint::compute_footprint_trajectory(poses, vehicle_info, global_params);
+  auto footprints = footprint::compute_footprint_trajectory(poses, ego_dimensions);
 
   return TrajectoryData(
     TrajectoryIdentification{"EGO"}, std::move(relative_times), std::move(distances),

--- a/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/trajectory_utils.cpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/trajectory_utils.cpp
@@ -374,9 +374,24 @@ FootprintTrajectory compute_footprint_trajectory(
 }
 
 FootprintTrajectory compute_footprint_trajectory(
-  const PoseTrajectory & pose_trajectory, const VehicleInfo & vehicle_info)
+  const PoseTrajectory & pose_trajectory, const VehicleInfo & vehicle_info,
+  const GlobalParams & global_params)
 {
-  return compute_footprint_trajectory(pose_trajectory, geometry::create_base_polygon(vehicle_info));
+  FootprintTrajectory footprint_trajectory;
+  footprint_trajectory.reserve(pose_trajectory.size());
+
+  const double front_offset =
+    vehicle_info.max_longitudinal_offset_m + global_params.ego_footprint_margin.front;
+  const double rear_overhang =
+    -vehicle_info.min_longitudinal_offset_m + global_params.ego_footprint_margin.rear;
+  const double vehicle_width =
+    vehicle_info.vehicle_width_m + 2.0 * global_params.ego_footprint_margin.lateral;
+
+  for (const auto & pose : pose_trajectory) {
+    footprint_trajectory.push_back(
+      autoware_utils_geometry::to_footprint(pose, front_offset, rear_overhang, vehicle_width));
+  }
+  return footprint_trajectory;
 }
 }  // namespace footprint
 
@@ -495,11 +510,11 @@ geometry_msgs::msg::Pose interpolate_predicted_path_pose(
 
 TrajectoryData generate_ego_trajectory(
   const geometry_msgs::msg::Twist & initial_twist, double braking_lag, double assumed_acceleration,
-  double max_time, double time_resolution, const TrajectoryPoints & traj_points,
-  VehicleInfo & vehicle_info)
+  double max_time, const TrajectoryPoints & traj_points, VehicleInfo & vehicle_info,
+  const GlobalParams & global_params)
 {
   auto [times, distances] = time_distance::compute_motion_profile_1d(
-    initial_twist, braking_lag, assumed_acceleration, 0.0, max_time, time_resolution);
+    initial_twist, braking_lag, assumed_acceleration, 0.0, max_time, global_params.time_resolution);
 
   double distance_offset =
     autoware::motion_utils::calcSignedArcLength(traj_points, traj_points.front().pose.position, 0);
@@ -507,7 +522,7 @@ TrajectoryData generate_ego_trajectory(
     val += distance_offset;
   }
   auto poses = pose::compute_pose_trajectory(traj_points, distances);
-  auto footprints = footprint::compute_footprint_trajectory(poses, vehicle_info);
+  auto footprints = footprint::compute_footprint_trajectory(poses, vehicle_info, global_params);
 
   return TrajectoryData(
     TrajectoryIdentification{"EGO"}, std::move(times), std::move(distances), std::move(poses),
@@ -516,7 +531,7 @@ TrajectoryData generate_ego_trajectory(
 
 TrajectoryData generate_ego_trajectory(
   const TrajectoryPoints & traj_points, const FilterContext & context, double max_time,
-  double time_resolution, VehicleInfo & vehicle_info)
+  VehicleInfo & vehicle_info, const GlobalParams & global_params)
 {
   if (traj_points.empty()) {
     throw std::invalid_argument("points must not be empty");
@@ -529,16 +544,18 @@ TrajectoryData generate_ego_trajectory(
 
   TimeTrajectory relative_times{0.0};
   TimeTrajectory absolute_times{start_time};
-  for (double sample_time = time_resolution; start_time + sample_time < end_time;
+  for (double sample_time = global_params.time_resolution; start_time + sample_time < end_time;
        sample_time =
-         std::floor((sample_time + time_resolution + 1e-6) / time_resolution) * time_resolution) {
+         std::floor(
+           (sample_time + global_params.time_resolution + 1e-6) / global_params.time_resolution) *
+         global_params.time_resolution) {
     relative_times.push_back(sample_time);
     absolute_times.push_back(start_time + sample_time);
   }
 
   auto poses = pose::compute_pose_trajectory_from_time(traj_points, absolute_times);
   auto distances = detail::compute_cumulative_distances(poses);
-  auto footprints = footprint::compute_footprint_trajectory(poses, vehicle_info);
+  auto footprints = footprint::compute_footprint_trajectory(poses, vehicle_info, global_params);
 
   return TrajectoryData(
     TrajectoryIdentification{"EGO"}, std::move(relative_times), std::move(distances),

--- a/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/trajectory_utils.cpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/trajectory_utils.cpp
@@ -510,7 +510,7 @@ geometry_msgs::msg::Pose interpolate_predicted_path_pose(
 
 TrajectoryData generate_ego_trajectory(
   const geometry_msgs::msg::Twist & initial_twist, double braking_lag, double assumed_acceleration,
-  double max_time, const TrajectoryPoints & traj_points, VehicleInfo & vehicle_info,
+  double max_time, const TrajectoryPoints & traj_points, const VehicleInfo & vehicle_info,
   const GlobalParams & global_params)
 {
   auto [times, distances] = time_distance::compute_motion_profile_1d(
@@ -531,7 +531,7 @@ TrajectoryData generate_ego_trajectory(
 
 TrajectoryData generate_ego_trajectory(
   const TrajectoryPoints & traj_points, const FilterContext & context, double max_time,
-  VehicleInfo & vehicle_info, const GlobalParams & global_params)
+  const VehicleInfo & vehicle_info, const GlobalParams & global_params)
 {
   if (traj_points.empty()) {
     throw std::invalid_argument("points must not be empty");

--- a/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/trajectory_utils.cpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/trajectory_utils.cpp
@@ -307,6 +307,17 @@ std::vector<Point2d> create_base_polygon(const VehicleInfo & vehicle_info)
     Point2d{vehicle_info.min_longitudinal_offset_m, half_width}};
 }
 
+std::vector<Point2d> create_base_polygon(
+  const trajectory::footprint::EgoDimensions & ego_dimensions)
+{
+  const double half_width = ego_dimensions.vehicle_width / 2.0;
+  return {
+    Point2d{ego_dimensions.front_offset, half_width},
+    Point2d{ego_dimensions.front_offset, -half_width},
+    Point2d{-ego_dimensions.rear_overhang, -half_width},
+    Point2d{-ego_dimensions.rear_overhang, half_width}};
+}
+
 Polygon2d to_polygon2d(
   const geometry_msgs::msg::Pose & pose, const autoware_perception_msgs::msg::Shape & shape)
 {
@@ -376,15 +387,8 @@ FootprintTrajectory compute_footprint_trajectory(
 FootprintTrajectory compute_footprint_trajectory(
   const PoseTrajectory & pose_trajectory, const EgoDimensions & ego_dimensions)
 {
-  FootprintTrajectory footprint_trajectory;
-  footprint_trajectory.reserve(pose_trajectory.size());
-
-  for (const auto & pose : pose_trajectory) {
-    footprint_trajectory.push_back(autoware_utils_geometry::to_footprint(
-      pose, ego_dimensions.front_offset, ego_dimensions.rear_overhang,
-      ego_dimensions.vehicle_width));
-  }
-  return footprint_trajectory;
+  return compute_footprint_trajectory(
+    pose_trajectory, geometry::create_base_polygon(ego_dimensions));
 }
 }  // namespace footprint
 

--- a/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/trajectory_utils.cpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/trajectory_utils.cpp
@@ -297,16 +297,6 @@ std::vector<Point2d> create_base_polygon(const autoware_perception_msgs::msg::Sh
   throw std::logic_error("The shape type is not supported in autoware_utils.");
 }
 
-std::vector<Point2d> create_base_polygon(const VehicleInfo & vehicle_info)
-{
-  const double half_width = vehicle_info.vehicle_width_m / 2.0;
-  return {
-    Point2d{vehicle_info.max_longitudinal_offset_m, half_width},
-    Point2d{vehicle_info.max_longitudinal_offset_m, -half_width},
-    Point2d{vehicle_info.min_longitudinal_offset_m, -half_width},
-    Point2d{vehicle_info.min_longitudinal_offset_m, half_width}};
-}
-
 std::vector<Point2d> create_base_polygon(
   const trajectory::footprint::EgoDimensions & ego_dimensions)
 {

--- a/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/trajectory_utils.hpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/trajectory_utils.hpp
@@ -357,12 +357,12 @@ geometry_msgs::msg::Pose interpolate_predicted_path_pose(
 
 TrajectoryData generate_ego_trajectory(
   const geometry_msgs::msg::Twist & initial_twist, double braking_lag, double assumed_acceleration,
-  double max_time, const TrajectoryPoints & traj_points, VehicleInfo & vehicle_info,
+  double max_time, const TrajectoryPoints & traj_points, const VehicleInfo & vehicle_info,
   const GlobalParams & global_params);
 
 TrajectoryData generate_ego_trajectory(
   const TrajectoryPoints & traj_points, const FilterContext & context, double max_time,
-  VehicleInfo & vehicle_info, const GlobalParams & global_params);
+  const VehicleInfo & vehicle_info, const GlobalParams & global_params);
 
 TrajectoryData generate_predicted_path_trajectory(
   const autoware_perception_msgs::msg::PredictedObject & predicted_object, double braking_lag,

--- a/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/trajectory_utils.hpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/trajectory_utils.hpp
@@ -330,13 +330,19 @@ namespace autoware::trajectory_validator::plugin::safety::trajectory
 {
 namespace footprint
 {
+struct EgoDimensions
+{
+  double front_offset{0.0};
+  double rear_overhang{0.0};
+  double vehicle_width{0.0};
+};
+
 FootprintTrajectory compute_footprint_trajectory(
   const PoseTrajectory & pose_trajectory,
   const autoware_perception_msgs::msg::Shape & object_shape);
 
 FootprintTrajectory compute_footprint_trajectory(
-  const PoseTrajectory & pose_trajectory, const VehicleInfo & vehicle_info,
-  const GlobalParams & global_params);
+  const PoseTrajectory & pose_trajectory, const EgoDimensions & ego_dimensions);
 }  // namespace footprint
 
 namespace detail
@@ -357,12 +363,12 @@ geometry_msgs::msg::Pose interpolate_predicted_path_pose(
 
 TrajectoryData generate_ego_trajectory(
   const geometry_msgs::msg::Twist & initial_twist, double braking_lag, double assumed_acceleration,
-  double max_time, const TrajectoryPoints & traj_points, const VehicleInfo & vehicle_info,
-  const GlobalParams & global_params);
+  double max_time, const TrajectoryPoints & traj_points,
+  const footprint::EgoDimensions & ego_dimensions, double time_resolution);
 
 TrajectoryData generate_ego_trajectory(
   const TrajectoryPoints & traj_points, const FilterContext & context, double max_time,
-  const VehicleInfo & vehicle_info, const GlobalParams & global_params);
+  const footprint::EgoDimensions & ego_dimensions, double time_resolution);
 
 TrajectoryData generate_predicted_path_trajectory(
   const autoware_perception_msgs::msg::PredictedObject & predicted_object, double braking_lag,

--- a/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/trajectory_utils.hpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/trajectory_utils.hpp
@@ -363,12 +363,12 @@ geometry_msgs::msg::Pose interpolate_predicted_path_pose(
 
 TrajectoryData generate_ego_trajectory(
   const geometry_msgs::msg::Twist & initial_twist, double braking_lag, double assumed_acceleration,
-  double max_time, const TrajectoryPoints & traj_points,
-  const footprint::EgoDimensions & ego_dimensions, double time_resolution);
+  double max_time, double time_resolution, const TrajectoryPoints & traj_points,
+  const footprint::EgoDimensions & ego_dimensions);
 
 TrajectoryData generate_ego_trajectory(
   const TrajectoryPoints & traj_points, const FilterContext & context, double max_time,
-  const footprint::EgoDimensions & ego_dimensions, double time_resolution);
+  double time_resolution, const footprint::EgoDimensions & ego_dimensions);
 
 TrajectoryData generate_predicted_path_trajectory(
   const autoware_perception_msgs::msg::PredictedObject & predicted_object, double braking_lag,

--- a/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/trajectory_utils.hpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/trajectory_utils.hpp
@@ -335,7 +335,8 @@ FootprintTrajectory compute_footprint_trajectory(
   const autoware_perception_msgs::msg::Shape & object_shape);
 
 FootprintTrajectory compute_footprint_trajectory(
-  const PoseTrajectory & pose_trajectory, const VehicleInfo & vehicle_info);
+  const PoseTrajectory & pose_trajectory, const VehicleInfo & vehicle_info,
+  const GlobalParams & global_params);
 }  // namespace footprint
 
 namespace detail
@@ -356,12 +357,12 @@ geometry_msgs::msg::Pose interpolate_predicted_path_pose(
 
 TrajectoryData generate_ego_trajectory(
   const geometry_msgs::msg::Twist & initial_twist, double braking_lag, double assumed_acceleration,
-  double max_time, double time_resolution, const TrajectoryPoints & traj_points,
-  VehicleInfo & vehicle_info);
+  double max_time, const TrajectoryPoints & traj_points, VehicleInfo & vehicle_info,
+  const GlobalParams & global_params);
 
 TrajectoryData generate_ego_trajectory(
   const TrajectoryPoints & traj_points, const FilterContext & context, double max_time,
-  double time_resolution, VehicleInfo & vehicle_info);
+  VehicleInfo & vehicle_info, const GlobalParams & global_params);
 
 TrajectoryData generate_predicted_path_trajectory(
   const autoware_perception_msgs::msg::PredictedObject & predicted_object, double braking_lag,

--- a/planning/autoware_trajectory_validator/test/plugins/collision_check_filter/test_trajectory_utilities.cpp
+++ b/planning/autoware_trajectory_validator/test/plugins/collision_check_filter/test_trajectory_utilities.cpp
@@ -323,7 +323,8 @@ TEST(TrajectoryUtilitiesTest, ComputeFootprintTrajectoryForVehicleMatchesUtility
   const PoseTrajectory poses = {create_pose(1.0, 2.0, 0.0)};
   const auto vehicle_info = create_vehicle_info();
 
-  const auto footprints = trajectory::footprint::compute_footprint_trajectory(poses, vehicle_info);
+  const auto footprints =
+    trajectory::footprint::compute_footprint_trajectory(poses, vehicle_info, GlobalParams{});
 
   EXPECT_TRUE(std::holds_alternative<QuadTrajectory>(footprints));
   ASSERT_EQ(footprint_count(footprints), 1u);
@@ -332,6 +333,27 @@ TEST(TrajectoryUtilitiesTest, ComputeFootprintTrajectoryForVehicleMatchesUtility
     autoware_utils_geometry::to_footprint(
       poses.front(), vehicle_info.max_longitudinal_offset_m,
       -vehicle_info.min_longitudinal_offset_m, vehicle_info.vehicle_width_m));
+}
+
+TEST(TrajectoryUtilitiesTest, ComputeFootprintTrajectoryForVehicleAppliesGlobalMargins)
+{
+  const PoseTrajectory poses = {create_pose(1.0, 2.0, 0.0)};
+  const auto vehicle_info = create_vehicle_info();
+
+  GlobalParams global_params;
+  global_params.ego_footprint_margin.lateral = 0.3;
+  global_params.ego_footprint_margin.front = 0.7;
+  global_params.ego_footprint_margin.rear = 0.5;
+
+  const auto footprints =
+    trajectory::footprint::compute_footprint_trajectory(poses, vehicle_info, global_params);
+
+  ASSERT_EQ(footprints.size(), 1u);
+  expect_same_polygon(
+    footprints.front(),
+    autoware_utils_geometry::to_footprint(
+      poses.front(), vehicle_info.max_longitudinal_offset_m + 0.7,
+      -vehicle_info.min_longitudinal_offset_m + 0.5, vehicle_info.vehicle_width_m + 0.6));
 }
 
 TEST(TrajectoryUtilitiesTest, ObjectIdentificationClassificationConstructorSetsDefaults)
@@ -374,7 +396,7 @@ TEST(TrajectoryUtilitiesTest, GenerateEgoTrajectoryBuildsConsistentTrajectoryDat
   const auto initial_twist = create_twist(2.0);
 
   const auto trajectory_data = trajectory::generate_ego_trajectory(
-    initial_twist, 0.0, 0.0, 1.05, kDefaultTimeResolution, traj_points, vehicle_info);
+    initial_twist, 0.0, 0.0, 1.05, traj_points, vehicle_info, GlobalParams{});
 
   ASSERT_EQ(trajectory_data.getObjectIdentification().classification, "EGO");
   ASSERT_TRUE(trajectory_data.getObjectIdentification().trajectory_type.empty());
@@ -397,8 +419,8 @@ TEST(TrajectoryUtilitiesTest, GenerateTimedEgoTrajectoryProjectsCurrentPoseOntoT
   const auto odometry = create_odometry(create_pose(5.0, 1.0, 0.0));
   const auto context = create_filter_context(odometry);
 
-  const auto trajectory_data = trajectory::generate_ego_trajectory(
-    traj_points, context, 0.25, kDefaultTimeResolution, vehicle_info);
+  const auto trajectory_data =
+    trajectory::generate_ego_trajectory(traj_points, context, 0.25, vehicle_info, GlobalParams{});
 
   ASSERT_EQ(trajectory_data.getObjectIdentification().classification, "EGO");
   ASSERT_EQ(trajectory_data.size(), 3u);
@@ -424,8 +446,8 @@ TEST(TrajectoryUtilitiesTest, GenerateTimedEgoTrajectoryAllowsExtrapolationBefor
 
   const double projected_time =
     trajectory::detail::project_current_pose_on_trajectory(traj_points, odometry->pose.pose);
-  const auto trajectory_data = trajectory::generate_ego_trajectory(
-    traj_points, context, 0.25, kDefaultTimeResolution, vehicle_info);
+  const auto trajectory_data =
+    trajectory::generate_ego_trajectory(traj_points, context, 0.25, vehicle_info, GlobalParams{});
 
   EXPECT_NEAR(projected_time, -0.5, 1e-6);
   ASSERT_EQ(trajectory_data.size(), 3u);
@@ -446,8 +468,8 @@ TEST(TrajectoryUtilitiesTest, GenerateTimedEgoTrajectoryWithSinglePointReturnsSi
 
   const double projected_time =
     trajectory::detail::project_current_pose_on_trajectory(traj_points, odometry->pose.pose);
-  const auto trajectory_data = trajectory::generate_ego_trajectory(
-    traj_points, context, 1.0, kDefaultTimeResolution, vehicle_info);
+  const auto trajectory_data =
+    trajectory::generate_ego_trajectory(traj_points, context, 1.0, vehicle_info, GlobalParams{});
 
   EXPECT_NEAR(projected_time, 1.0, 1e-6);
   ASSERT_EQ(trajectory_data.size(), 1u);
@@ -467,8 +489,8 @@ TEST(TrajectoryUtilitiesTest, GenerateTimedEgoTrajectoryHandlesNonUniformTimeAnd
 
   const double projected_time =
     trajectory::detail::project_current_pose_on_trajectory(traj_points, odometry->pose.pose);
-  const auto trajectory_data = trajectory::generate_ego_trajectory(
-    traj_points, context, 0.25, kDefaultTimeResolution, vehicle_info);
+  const auto trajectory_data =
+    trajectory::generate_ego_trajectory(traj_points, context, 0.25, vehicle_info, GlobalParams{});
 
   EXPECT_NEAR(projected_time, 0.9, 1e-6);
 

--- a/planning/autoware_trajectory_validator/test/plugins/collision_check_filter/test_trajectory_utilities.cpp
+++ b/planning/autoware_trajectory_validator/test/plugins/collision_check_filter/test_trajectory_utilities.cpp
@@ -322,9 +322,12 @@ TEST(TrajectoryUtilitiesTest, ComputeFootprintTrajectoryForVehicleMatchesUtility
 {
   const PoseTrajectory poses = {create_pose(1.0, 2.0, 0.0)};
   const auto vehicle_info = create_vehicle_info();
+  const trajectory::footprint::EgoDimensions ego_dimensions{
+    vehicle_info.max_longitudinal_offset_m, -vehicle_info.min_longitudinal_offset_m,
+    vehicle_info.vehicle_width_m};
 
   const auto footprints =
-    trajectory::footprint::compute_footprint_trajectory(poses, vehicle_info, GlobalParams{});
+    trajectory::footprint::compute_footprint_trajectory(poses, ego_dimensions);
 
   EXPECT_TRUE(std::holds_alternative<QuadTrajectory>(footprints));
   ASSERT_EQ(footprint_count(footprints), 1u);
@@ -335,18 +338,16 @@ TEST(TrajectoryUtilitiesTest, ComputeFootprintTrajectoryForVehicleMatchesUtility
       -vehicle_info.min_longitudinal_offset_m, vehicle_info.vehicle_width_m));
 }
 
-TEST(TrajectoryUtilitiesTest, ComputeFootprintTrajectoryForVehicleAppliesGlobalMargins)
+TEST(TrajectoryUtilitiesTest, ComputeFootprintTrajectoryForVehicleAppliesSpecifiedDimensions)
 {
   const PoseTrajectory poses = {create_pose(1.0, 2.0, 0.0)};
   const auto vehicle_info = create_vehicle_info();
-
-  GlobalParams global_params;
-  global_params.ego_footprint_margin.lateral = 0.3;
-  global_params.ego_footprint_margin.front = 0.7;
-  global_params.ego_footprint_margin.rear = 0.5;
+  const trajectory::footprint::EgoDimensions ego_dimensions{
+    vehicle_info.max_longitudinal_offset_m + 0.7, -vehicle_info.min_longitudinal_offset_m + 0.5,
+    vehicle_info.vehicle_width_m + 0.6};
 
   const auto footprints =
-    trajectory::footprint::compute_footprint_trajectory(poses, vehicle_info, global_params);
+    trajectory::footprint::compute_footprint_trajectory(poses, ego_dimensions);
 
   ASSERT_EQ(footprints.size(), 1u);
   expect_same_polygon(
@@ -394,9 +395,12 @@ TEST(TrajectoryUtilitiesTest, GenerateEgoTrajectoryBuildsConsistentTrajectoryDat
   auto vehicle_info = create_vehicle_info();
   const auto traj_points = create_straight_trajectory_points({0.0, 10.0, 20.0});
   const auto initial_twist = create_twist(2.0);
+  const trajectory::footprint::EgoDimensions ego_dimensions{
+    vehicle_info.max_longitudinal_offset_m, -vehicle_info.min_longitudinal_offset_m,
+    vehicle_info.vehicle_width_m};
 
   const auto trajectory_data = trajectory::generate_ego_trajectory(
-    initial_twist, 0.0, 0.0, 1.05, traj_points, vehicle_info, GlobalParams{});
+    initial_twist, 0.0, 0.0, 1.05, traj_points, ego_dimensions, GlobalParams{}.time_resolution);
 
   ASSERT_EQ(trajectory_data.getObjectIdentification().classification, "EGO");
   ASSERT_TRUE(trajectory_data.getObjectIdentification().trajectory_type.empty());
@@ -418,9 +422,12 @@ TEST(TrajectoryUtilitiesTest, GenerateTimedEgoTrajectoryProjectsCurrentPoseOntoT
     create_straight_timed_trajectory_points({0.0, 10.0, 20.0}, {0.0, 1.0, 2.0});
   const auto odometry = create_odometry(create_pose(5.0, 1.0, 0.0));
   const auto context = create_filter_context(odometry);
+  const trajectory::footprint::EgoDimensions ego_dimensions{
+    vehicle_info.max_longitudinal_offset_m, -vehicle_info.min_longitudinal_offset_m,
+    vehicle_info.vehicle_width_m};
 
-  const auto trajectory_data =
-    trajectory::generate_ego_trajectory(traj_points, context, 0.25, vehicle_info, GlobalParams{});
+  const auto trajectory_data = trajectory::generate_ego_trajectory(
+    traj_points, context, 0.25, ego_dimensions, GlobalParams{}.time_resolution);
 
   ASSERT_EQ(trajectory_data.getObjectIdentification().classification, "EGO");
   ASSERT_EQ(trajectory_data.size(), 3u);
@@ -443,11 +450,14 @@ TEST(TrajectoryUtilitiesTest, GenerateTimedEgoTrajectoryAllowsExtrapolationBefor
     create_straight_timed_trajectory_points({0.0, 10.0, 20.0}, {0.0, 1.0, 2.0});
   const auto odometry = create_odometry(create_pose(-5.0, 0.0, 0.0));
   const auto context = create_filter_context(odometry);
+  const trajectory::footprint::EgoDimensions ego_dimensions{
+    vehicle_info.max_longitudinal_offset_m, -vehicle_info.min_longitudinal_offset_m,
+    vehicle_info.vehicle_width_m};
 
   const double projected_time =
     trajectory::detail::project_current_pose_on_trajectory(traj_points, odometry->pose.pose);
-  const auto trajectory_data =
-    trajectory::generate_ego_trajectory(traj_points, context, 0.25, vehicle_info, GlobalParams{});
+  const auto trajectory_data = trajectory::generate_ego_trajectory(
+    traj_points, context, 0.25, ego_dimensions, GlobalParams{}.time_resolution);
 
   EXPECT_NEAR(projected_time, -0.5, 1e-6);
   ASSERT_EQ(trajectory_data.size(), 3u);
@@ -465,11 +475,14 @@ TEST(TrajectoryUtilitiesTest, GenerateTimedEgoTrajectoryWithSinglePointReturnsSi
   const auto traj_points = create_straight_timed_trajectory_points({3.0}, {1.0});
   const auto odometry = create_odometry(create_pose(8.0, 1.0, 0.0));
   const auto context = create_filter_context(odometry);
+  const trajectory::footprint::EgoDimensions ego_dimensions{
+    vehicle_info.max_longitudinal_offset_m, -vehicle_info.min_longitudinal_offset_m,
+    vehicle_info.vehicle_width_m};
 
   const double projected_time =
     trajectory::detail::project_current_pose_on_trajectory(traj_points, odometry->pose.pose);
-  const auto trajectory_data =
-    trajectory::generate_ego_trajectory(traj_points, context, 1.0, vehicle_info, GlobalParams{});
+  const auto trajectory_data = trajectory::generate_ego_trajectory(
+    traj_points, context, 1.0, ego_dimensions, GlobalParams{}.time_resolution);
 
   EXPECT_NEAR(projected_time, 1.0, 1e-6);
   ASSERT_EQ(trajectory_data.size(), 1u);
@@ -486,11 +499,14 @@ TEST(TrajectoryUtilitiesTest, GenerateTimedEgoTrajectoryHandlesNonUniformTimeAnd
     create_straight_timed_trajectory_points({0.0, 3.0, 9.0}, {0.0, 0.3, 1.5});
   const auto odometry = create_odometry(create_pose(6.0, 0.5, 0.0));
   const auto context = create_filter_context(odometry);
+  const trajectory::footprint::EgoDimensions ego_dimensions{
+    vehicle_info.max_longitudinal_offset_m, -vehicle_info.min_longitudinal_offset_m,
+    vehicle_info.vehicle_width_m};
 
   const double projected_time =
     trajectory::detail::project_current_pose_on_trajectory(traj_points, odometry->pose.pose);
-  const auto trajectory_data =
-    trajectory::generate_ego_trajectory(traj_points, context, 0.25, vehicle_info, GlobalParams{});
+  const auto trajectory_data = trajectory::generate_ego_trajectory(
+    traj_points, context, 0.25, ego_dimensions, GlobalParams{}.time_resolution);
 
   EXPECT_NEAR(projected_time, 0.9, 1e-6);
 

--- a/planning/autoware_trajectory_validator/test/plugins/collision_check_filter/test_trajectory_utilities.cpp
+++ b/planning/autoware_trajectory_validator/test/plugins/collision_check_filter/test_trajectory_utilities.cpp
@@ -349,9 +349,10 @@ TEST(TrajectoryUtilitiesTest, ComputeFootprintTrajectoryForVehicleAppliesSpecifi
   const auto footprints =
     trajectory::footprint::compute_footprint_trajectory(poses, ego_dimensions);
 
-  ASSERT_EQ(footprints.size(), 1u);
+  EXPECT_TRUE(std::holds_alternative<QuadTrajectory>(footprints));
+  ASSERT_EQ(footprint_count(footprints), 1u);
   expect_same_polygon(
-    footprints.front(),
+    footprint_to_polygon2d(footprints, 0U),
     autoware_utils_geometry::to_footprint(
       poses.front(), vehicle_info.max_longitudinal_offset_m + 0.7,
       -vehicle_info.min_longitudinal_offset_m + 0.5, vehicle_info.vehicle_width_m + 0.6));

--- a/planning/autoware_trajectory_validator/test/plugins/collision_check_filter/test_trajectory_utilities.cpp
+++ b/planning/autoware_trajectory_validator/test/plugins/collision_check_filter/test_trajectory_utilities.cpp
@@ -401,7 +401,7 @@ TEST(TrajectoryUtilitiesTest, GenerateEgoTrajectoryBuildsConsistentTrajectoryDat
     vehicle_info.vehicle_width_m};
 
   const auto trajectory_data = trajectory::generate_ego_trajectory(
-    initial_twist, 0.0, 0.0, 1.05, traj_points, ego_dimensions, GlobalParams{}.time_resolution);
+    initial_twist, 0.0, 0.0, 1.05, GlobalParams{}.time_resolution, traj_points, ego_dimensions);
 
   ASSERT_EQ(trajectory_data.getObjectIdentification().classification, "EGO");
   ASSERT_TRUE(trajectory_data.getObjectIdentification().trajectory_type.empty());
@@ -428,7 +428,7 @@ TEST(TrajectoryUtilitiesTest, GenerateTimedEgoTrajectoryProjectsCurrentPoseOntoT
     vehicle_info.vehicle_width_m};
 
   const auto trajectory_data = trajectory::generate_ego_trajectory(
-    traj_points, context, 0.25, ego_dimensions, GlobalParams{}.time_resolution);
+    traj_points, context, 0.25, GlobalParams{}.time_resolution, ego_dimensions);
 
   ASSERT_EQ(trajectory_data.getObjectIdentification().classification, "EGO");
   ASSERT_EQ(trajectory_data.size(), 3u);
@@ -458,7 +458,7 @@ TEST(TrajectoryUtilitiesTest, GenerateTimedEgoTrajectoryAllowsExtrapolationBefor
   const double projected_time =
     trajectory::detail::project_current_pose_on_trajectory(traj_points, odometry->pose.pose);
   const auto trajectory_data = trajectory::generate_ego_trajectory(
-    traj_points, context, 0.25, ego_dimensions, GlobalParams{}.time_resolution);
+    traj_points, context, 0.25, GlobalParams{}.time_resolution, ego_dimensions);
 
   EXPECT_NEAR(projected_time, -0.5, 1e-6);
   ASSERT_EQ(trajectory_data.size(), 3u);
@@ -483,7 +483,7 @@ TEST(TrajectoryUtilitiesTest, GenerateTimedEgoTrajectoryWithSinglePointReturnsSi
   const double projected_time =
     trajectory::detail::project_current_pose_on_trajectory(traj_points, odometry->pose.pose);
   const auto trajectory_data = trajectory::generate_ego_trajectory(
-    traj_points, context, 1.0, ego_dimensions, GlobalParams{}.time_resolution);
+    traj_points, context, 1.0, GlobalParams{}.time_resolution, ego_dimensions);
 
   EXPECT_NEAR(projected_time, 1.0, 1e-6);
   ASSERT_EQ(trajectory_data.size(), 1u);
@@ -507,7 +507,7 @@ TEST(TrajectoryUtilitiesTest, GenerateTimedEgoTrajectoryHandlesNonUniformTimeAnd
   const double projected_time =
     trajectory::detail::project_current_pose_on_trajectory(traj_points, odometry->pose.pose);
   const auto trajectory_data = trajectory::generate_ego_trajectory(
-    traj_points, context, 0.25, ego_dimensions, GlobalParams{}.time_resolution);
+    traj_points, context, 0.25, GlobalParams{}.time_resolution, ego_dimensions);
 
   EXPECT_NEAR(projected_time, 0.9, 1e-6);
 


### PR DESCRIPTION
This change adds configurable ego footprint margins to trajectory_validator collision checks, allowing the ego polygon used for safety validation to be expanded independently in the lateral, front, and rear directions. The new margin parameters are wired through the collision check configuration and applied consistently when generating ego footprints for trajectory-based collision assessment, making it possible to tune conservativeness around the vehicle shape without changing the underlying vehicle dimensions.