### PR TITLE
fix(polar_voxel_outlier_filter): revert delete force_update() PR

### DIFF
--- a/sensing/autoware_pointcloud_preprocessor/src/outlier_filter/polar_voxel_outlier_filter_node.cpp
+++ b/sensing/autoware_pointcloud_preprocessor/src/outlier_filter/polar_voxel_outlier_filter_node.cpp
@@ -428,6 +428,9 @@ void PolarVoxelOutlierFilterComponent::publish_diagnostics(
   // Publish metrics
   publish_visibility_metric();
   publish_filter_ratio_metric();
+
+  // Update diagnostics
+  updater_.force_update();
 }
 
 void PolarVoxelOutlierFilterComponent::calculate_visibility_metric(


### PR DESCRIPTION
Reverts tier4/autoware_universe#2647

該当PRを取り込んた後、DLRがダウングレード発生しました。
チケットにも結果を添付したが、Revertした後、シナリオがPASSした。

[チケット](https://tier4.atlassian.net/browse/T4DEV-53778)
[Revert後のシナリオ結果](https://evaluation.tier4.jp/evaluation/reports/cef63ee0-2ffb-55d6-91b5-f1188453fe78/tests/b72d2feb-e549-5acc-a042-f5cf8238eb13?project_id=x2_dev)
