### PR TITLE
fix(trajectroy_validator): fix rss sign

### DIFF
--- a/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/assessment.cpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/assessment.cpp
@@ -422,7 +422,7 @@ TrajectoryData generate_rss_ego_trajectory(
     traj_points, context, ego_time_horizon_for_rss, time_resolution, vehicle_info);
 }
 
-RssDetail assess_required_deceleration(
+RssDetail assess_required_acceleration(
   const TrajectoryData & ego_trajectory, const geometry_msgs::msg::Twist & ego_twist,
   const autoware_perception_msgs::msg::PredictedObject & object, const RssParams & rss_params,
   const builtin_interfaces::msg::Time & stamp)
@@ -448,7 +448,7 @@ RssDetail assess_required_deceleration(
                                          ? std::numeric_limits<double>::infinity()
                                          : ego_long_vel * ego_long_vel * 0.5 / safe_distance;
 
-  return RssDetail{TrajectoryIdentification{object, stamp}, required_deceleration};
+  return RssDetail{TrajectoryIdentification{object, stamp}, -required_deceleration};
 }
 
 RssArtifact assess(
@@ -470,7 +470,7 @@ RssArtifact assess(
     if (!rss_params.enable_assessment) {
       continue;
     }
-    const auto rss_detail = assess_required_deceleration(
+    const auto rss_detail = assess_required_acceleration(
       ego_trajectory, context.odometry->twist.twist, object, rss_params,
       context.predicted_objects->header.stamp);
     const auto risk_level =


### PR DESCRIPTION

インターフェイス型RssDetailに対して、誤った符号の値をいれてしまったいたので、修正します。
関数間で受け渡す加速度値は全て符号付きの値にするという方針に基づくものです。

```
struct RssDetail
{
  TrajectoryIdentification object_identification;
  double rss_acceleration;
};

```


<img width="2407" height="1397" alt="image" src="https://github.com/user-attachments/assets/dabfd2fe-399d-45cb-a96d-cfcaa576f393" />

evaluatorは回していません。

