### PR TITLE
feat(trajectory_validator): reduce malloc

### DIFF
--- a/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/trajectory_utils.cpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/trajectory_utils.cpp
@@ -271,33 +271,23 @@ Point2d transform_point(const Eigen::Isometry2d & transform, const Point2d & poi
   return Point2d{transformed.x(), transformed.y()};
 }
 
-BaseFootprint create_base_polygon(const autoware_perception_msgs::msg::Shape & shape)
+std::vector<Point2d> create_base_polygon(const autoware_perception_msgs::msg::Shape & shape)
 {
   if (shape.type == autoware_perception_msgs::msg::Shape::BOUNDING_BOX) {
     const double half_x = shape.dimensions.x / 2.0;
     const double half_y = shape.dimensions.y / 2.0;
 
-    return QuadFootprint{
+    return {
       Point2d{half_x, half_y}, Point2d{half_x, -half_y}, Point2d{-half_x, -half_y},
       Point2d{-half_x, half_y}};
-  }
-
-  if (shape.type == autoware_perception_msgs::msg::Shape::CYLINDER) {
+  } else if (shape.type == autoware_perception_msgs::msg::Shape::CYLINDER) {
     const double radius = shape.dimensions.x / 2.0;
-    constexpr int circle_discrete_num = 6;
 
-    NgonFootprint polygon;
-    polygon.reserve(circle_discrete_num);
-    for (int i = 0; i < circle_discrete_num; ++i) {
-      const double theta =
-        -1.0 * (static_cast<double>(i) / static_cast<double>(circle_discrete_num)) * 2.0 * M_PI;
-      polygon.push_back(Point2d{std::cos(theta) * radius, std::sin(theta) * radius});
-    }
-    return polygon;
-  }
-
-  if (shape.type == autoware_perception_msgs::msg::Shape::POLYGON) {
-    NgonFootprint polygon;
+    return {
+      Point2d{radius, radius}, Point2d{radius, -radius}, Point2d{-radius, -radius},
+      Point2d{-radius, radius}};
+  } else if (shape.type == autoware_perception_msgs::msg::Shape::POLYGON) {
+    std::vector<Point2d> polygon;
     polygon.reserve(shape.footprint.points.size());
     for (const auto & point : shape.footprint.points) {
       polygon.push_back(Point2d{point.x, point.y});
@@ -307,65 +297,40 @@ BaseFootprint create_base_polygon(const autoware_perception_msgs::msg::Shape & s
       shape.footprint.points.front().y == shape.footprint.points.back().y) {
       polygon.pop_back();
     }
-    if (polygon.size() == 4U) {
-      return QuadFootprint{polygon[0], polygon[1], polygon[2], polygon[3]};
-    }
     return polygon;
   }
 
   throw std::logic_error("The shape type is not supported in autoware_utils.");
 }
 
-QuadFootprint create_base_quad(const VehicleInfo & vehicle_info)
+std::vector<Point2d> create_base_polygon(const VehicleInfo & vehicle_info)
 {
   const double half_width = vehicle_info.vehicle_width_m / 2.0;
-  return QuadFootprint{
+  // DO NOT change the order of the points and number of points.
+  return {
     Point2d{vehicle_info.max_longitudinal_offset_m, half_width},
     Point2d{vehicle_info.max_longitudinal_offset_m, -half_width},
     Point2d{vehicle_info.min_longitudinal_offset_m, -half_width},
     Point2d{vehicle_info.min_longitudinal_offset_m, half_width}};
 }
 
-NgonFootprint transform_footprint(const Eigen::Isometry2d & transform, const NgonFootprint & points)
-{
-  NgonFootprint polygon;
-  for (const auto & point : points) {
-    polygon.push_back(transform_point(transform, point));
-  }
-  return polygon;
-}
-
-QuadFootprint transform_footprint(const Eigen::Isometry2d & transform, const QuadFootprint & points)
-{
-  QuadFootprint polygon;
-  for (size_t i = 0; i < points.size(); ++i) {
-    polygon[i] = transform_point(transform, points[i]);
-  }
-  return polygon;
-}
-
-template <typename Points>
-Polygon2d to_closed_polygon2d(const Eigen::Isometry2d & transform, const Points & points)
-{
-  Polygon2d polygon;
-  polygon.outer().reserve(points.size() + 1U);
-  for (const auto & point : points) {
-    polygon.outer().push_back(transform_point(transform, point));
-  }
-  if (!polygon.outer().empty()) {
-    polygon.outer().push_back(polygon.outer().front());
-  }
-  return polygon;
-}
 }  // namespace detail
 
 Polygon2d to_polygon2d(
   const geometry_msgs::msg::Pose & pose, const autoware_perception_msgs::msg::Shape & shape)
 {
-  const auto transform = detail::pose_to_isometry(pose);
-  return std::visit(
-    [&](const auto & base_polygon) { return detail::to_closed_polygon2d(transform, base_polygon); },
-    detail::create_base_polygon(shape));
+  const auto iso = detail::pose_to_isometry(pose);
+  const auto points = detail::create_base_polygon(shape);
+
+  Polygon2d polygon;
+  polygon.outer().reserve(points.size() + 1U);
+  for (const auto & point : points) {
+    polygon.outer().push_back(detail::transform_point(iso, point));
+  }
+  if (!polygon.outer().empty()) {
+    polygon.outer().push_back(polygon.outer().front());
+  }
+  return polygon;
 }
 }  // namespace autoware::trajectory_validator::plugin::safety::geometry
 
@@ -374,37 +339,58 @@ namespace autoware::trajectory_validator::plugin::safety::trajectory
 namespace footprint
 {
 FootprintTrajectory compute_footprint_trajectory(
+  const PoseTrajectory & pose_trajectory, const std::vector<Point2d> & base_poly)
+{
+  auto transform_point = [](const auto & transform, const Point2d & pt) {
+    const Eigen::Vector2d p = transform * Eigen::Vector2d{pt.x(), pt.y()};
+    return Point2d{p.x(), p.y()};
+  };
+
+  if (base_poly.size() == 4) {
+    QuadTrajectory trajectory;
+    trajectory.reserve(pose_trajectory.size());
+
+    for (const auto & pose : pose_trajectory) {
+      const auto iso = geometry::detail::pose_to_isometry(pose);
+
+      trajectory.push_back(
+        std::array<Point2d, 4>{
+          transform_point(iso, base_poly[0]), transform_point(iso, base_poly[1]),
+          transform_point(iso, base_poly[2]), transform_point(iso, base_poly[3])});
+    }
+    return trajectory;
+  } else {
+    NgonTrajectory trajectory;
+    trajectory.reserve(pose_trajectory.size());
+
+    for (const auto & pose : pose_trajectory) {
+      const auto iso = geometry::detail::pose_to_isometry(pose);
+
+      std::vector<Point2d> transformed_poly;
+      transformed_poly.reserve(base_poly.size());
+
+      for (const auto & pt : base_poly) {
+        transformed_poly.push_back(transform_point(iso, pt));
+      }
+
+      trajectory.push_back(std::move(transformed_poly));
+    }
+    return trajectory;
+  }
+}
+
+FootprintTrajectory compute_footprint_trajectory(
   const PoseTrajectory & pose_trajectory, const autoware_perception_msgs::msg::Shape & object_shape)
 {
-  return std::visit(
-    [&](const auto & base_footprint) -> FootprintTrajectory {
-      using Footprint = std::decay_t<decltype(base_footprint)>;
-      using Trajectory = std::conditional_t<
-        std::is_same_v<Footprint, QuadFootprint>, QuadTrajectory, NgonTrajectory>;
-      Trajectory footprint_trajectory;
-      footprint_trajectory.reserve(pose_trajectory.size());
-      for (const auto & pose : pose_trajectory) {
-        footprint_trajectory.push_back(
-          geometry::detail::transform_footprint(
-            geometry::detail::pose_to_isometry(pose), base_footprint));
-      }
-      return footprint_trajectory;
-    },
-    geometry::detail::create_base_polygon(object_shape));
+  return compute_footprint_trajectory(
+    pose_trajectory, geometry::detail::create_base_polygon(object_shape));
 }
 
 FootprintTrajectory compute_footprint_trajectory(
   const PoseTrajectory & pose_trajectory, const VehicleInfo & vehicle_info)
 {
-  const auto base_quad = geometry::detail::create_base_quad(vehicle_info);
-  QuadTrajectory footprint_trajectory;
-  footprint_trajectory.reserve(pose_trajectory.size());
-
-  for (const auto & pose : pose_trajectory) {
-    footprint_trajectory.push_back(
-      geometry::detail::transform_footprint(geometry::detail::pose_to_isometry(pose), base_quad));
-  }
-  return footprint_trajectory;
+  return compute_footprint_trajectory(
+    pose_trajectory, geometry::detail::create_base_polygon(vehicle_info));
 }
 }  // namespace footprint
 

--- a/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/trajectory_utils.cpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/trajectory_utils.cpp
@@ -29,6 +29,7 @@
 #include <optional>
 #include <stdexcept>
 #include <string>
+#include <type_traits>
 #include <utility>
 #include <vector>
 
@@ -254,55 +255,117 @@ PoseTrajectory compute_pose_trajectory_from_time(
 
 namespace autoware::trajectory_validator::plugin::safety::geometry
 {
-Polygon2d to_polygon2d(
-  const geometry_msgs::msg::Pose & pose, const autoware_perception_msgs::msg::Shape & shape)
+namespace detail
 {
-  Polygon2d polygon;
-
+Eigen::Isometry2d pose_to_isometry(const geometry_msgs::msg::Pose & pose)
+{
   Eigen::Isometry2d transform = Eigen::Isometry2d::Identity();
   transform.linear() = Eigen::Rotation2Dd(tf2::getYaw(pose.orientation)).toRotationMatrix();
   transform.translation() = Eigen::Vector2d{pose.position.x, pose.position.y};
+  return transform;
+}
 
-  auto append_transformed_point =
-    [&](const Eigen::Isometry2d & current_transform, const double x, const double y) {
-      const Eigen::Vector2d transformed = current_transform * Eigen::Vector2d{x, y};
-      polygon.outer().push_back(Point2d{transformed.x(), transformed.y()});
-    };
+Point2d transform_point(const Eigen::Isometry2d & transform, const Point2d & point)
+{
+  const Eigen::Vector2d transformed = transform * Eigen::Vector2d{point.x(), point.y()};
+  return Point2d{transformed.x(), transformed.y()};
+}
 
+BaseFootprint create_base_polygon(const autoware_perception_msgs::msg::Shape & shape)
+{
   if (shape.type == autoware_perception_msgs::msg::Shape::BOUNDING_BOX) {
     const double half_x = shape.dimensions.x / 2.0;
     const double half_y = shape.dimensions.y / 2.0;
 
-    polygon.outer().reserve(5);
-    append_transformed_point(transform, half_x, half_y);
-    append_transformed_point(transform, half_x, -half_y);
-    append_transformed_point(transform, -half_x, -half_y);
-    append_transformed_point(transform, -half_x, half_y);
-    polygon.outer().push_back(polygon.outer().front());
-  } else if (shape.type == autoware_perception_msgs::msg::Shape::CYLINDER) {
+    return QuadFootprint{
+      Point2d{half_x, half_y}, Point2d{half_x, -half_y}, Point2d{-half_x, -half_y},
+      Point2d{-half_x, half_y}};
+  }
+
+  if (shape.type == autoware_perception_msgs::msg::Shape::CYLINDER) {
     const double radius = shape.dimensions.x / 2.0;
     constexpr int circle_discrete_num = 6;
 
-    polygon.outer().reserve(circle_discrete_num + 1);
+    NgonFootprint polygon;
+    polygon.reserve(circle_discrete_num);
     for (int i = 0; i < circle_discrete_num; ++i) {
       const double theta =
         -1.0 * (static_cast<double>(i) / static_cast<double>(circle_discrete_num)) * 2.0 * M_PI;
-      append_transformed_point(transform, std::cos(theta) * radius, std::sin(theta) * radius);
+      polygon.push_back(Point2d{std::cos(theta) * radius, std::sin(theta) * radius});
     }
-    polygon.outer().push_back(polygon.outer().front());
-  } else if (shape.type == autoware_perception_msgs::msg::Shape::POLYGON) {
-    polygon.outer().reserve(shape.footprint.points.size() + 1);
-    for (const auto & point : shape.footprint.points) {
-      append_transformed_point(transform, point.x, point.y);
-    }
-    if (!polygon.outer().empty()) {
-      polygon.outer().push_back(polygon.outer().front());
-    }
-  } else {
-    throw std::logic_error("The shape type is not supported in autoware_utils.");
+    return polygon;
   }
 
+  if (shape.type == autoware_perception_msgs::msg::Shape::POLYGON) {
+    NgonFootprint polygon;
+    polygon.reserve(shape.footprint.points.size());
+    for (const auto & point : shape.footprint.points) {
+      polygon.push_back(Point2d{point.x, point.y});
+    }
+    if (
+      polygon.size() > 1 && shape.footprint.points.front().x == shape.footprint.points.back().x &&
+      shape.footprint.points.front().y == shape.footprint.points.back().y) {
+      polygon.pop_back();
+    }
+    if (polygon.size() == 4U) {
+      return QuadFootprint{polygon[0], polygon[1], polygon[2], polygon[3]};
+    }
+    return polygon;
+  }
+
+  throw std::logic_error("The shape type is not supported in autoware_utils.");
+}
+
+QuadFootprint create_base_quad(const VehicleInfo & vehicle_info)
+{
+  const double half_width = vehicle_info.vehicle_width_m / 2.0;
+  return QuadFootprint{
+    Point2d{vehicle_info.max_longitudinal_offset_m, half_width},
+    Point2d{vehicle_info.max_longitudinal_offset_m, -half_width},
+    Point2d{vehicle_info.min_longitudinal_offset_m, -half_width},
+    Point2d{vehicle_info.min_longitudinal_offset_m, half_width}};
+}
+
+NgonFootprint transform_footprint(const Eigen::Isometry2d & transform, const NgonFootprint & points)
+{
+  NgonFootprint polygon;
+  for (const auto & point : points) {
+    polygon.push_back(transform_point(transform, point));
+  }
   return polygon;
+}
+
+QuadFootprint transform_footprint(const Eigen::Isometry2d & transform, const QuadFootprint & points)
+{
+  QuadFootprint polygon;
+  for (size_t i = 0; i < points.size(); ++i) {
+    polygon[i] = transform_point(transform, points[i]);
+  }
+  return polygon;
+}
+
+template <typename Points>
+Polygon2d to_closed_polygon2d(const Eigen::Isometry2d & transform, const Points & points)
+{
+  Polygon2d polygon;
+  polygon.outer().reserve(points.size() + 1U);
+  for (const auto & point : points) {
+    polygon.outer().push_back(transform_point(transform, point));
+  }
+  if (!polygon.outer().empty()) {
+    polygon.outer().push_back(polygon.outer().front());
+  }
+  return polygon;
+}
+}  // namespace detail
+
+Polygon2d to_polygon2d(
+  const geometry_msgs::msg::Pose & pose, const autoware_perception_msgs::msg::Shape & shape)
+{
+  const auto transform = detail::pose_to_isometry(pose);
+  return std::visit(
+    [&](const auto & base_polygon) { return detail::to_closed_polygon2d(transform, base_polygon); },
+    detail::create_base_polygon(shape));
 }
 }  // namespace autoware::trajectory_validator::plugin::safety::geometry
 
@@ -313,26 +376,33 @@ namespace footprint
 FootprintTrajectory compute_footprint_trajectory(
   const PoseTrajectory & pose_trajectory, const autoware_perception_msgs::msg::Shape & object_shape)
 {
-  FootprintTrajectory footprint_trajectory;
-  footprint_trajectory.reserve(pose_trajectory.size());
-
-  for (const auto & pose : pose_trajectory) {
-    footprint_trajectory.push_back(geometry::to_polygon2d(pose, object_shape));
-  }
-  return footprint_trajectory;
+  return std::visit(
+    [&](const auto & base_footprint) -> FootprintTrajectory {
+      using Footprint = std::decay_t<decltype(base_footprint)>;
+      using Trajectory = std::conditional_t<
+        std::is_same_v<Footprint, QuadFootprint>, QuadTrajectory, NgonTrajectory>;
+      Trajectory footprint_trajectory;
+      footprint_trajectory.reserve(pose_trajectory.size());
+      for (const auto & pose : pose_trajectory) {
+        footprint_trajectory.push_back(
+          geometry::detail::transform_footprint(
+            geometry::detail::pose_to_isometry(pose), base_footprint));
+      }
+      return footprint_trajectory;
+    },
+    geometry::detail::create_base_polygon(object_shape));
 }
 
 FootprintTrajectory compute_footprint_trajectory(
   const PoseTrajectory & pose_trajectory, const VehicleInfo & vehicle_info)
 {
-  FootprintTrajectory footprint_trajectory;
+  const auto base_quad = geometry::detail::create_base_quad(vehicle_info);
+  QuadTrajectory footprint_trajectory;
   footprint_trajectory.reserve(pose_trajectory.size());
 
   for (const auto & pose : pose_trajectory) {
     footprint_trajectory.push_back(
-      autoware_utils_geometry::to_footprint(
-        pose, vehicle_info.max_longitudinal_offset_m, -vehicle_info.min_longitudinal_offset_m,
-        vehicle_info.vehicle_width_m));
+      geometry::detail::transform_footprint(geometry::detail::pose_to_isometry(pose), base_quad));
   }
   return footprint_trajectory;
 }

--- a/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/trajectory_utils.cpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/trajectory_utils.cpp
@@ -255,8 +255,6 @@ PoseTrajectory compute_pose_trajectory_from_time(
 
 namespace autoware::trajectory_validator::plugin::safety::geometry
 {
-namespace detail
-{
 Eigen::Isometry2d pose_to_isometry(const geometry_msgs::msg::Pose & pose)
 {
   Eigen::Isometry2d transform = Eigen::Isometry2d::Identity();
@@ -292,11 +290,7 @@ std::vector<Point2d> create_base_polygon(const autoware_perception_msgs::msg::Sh
     for (const auto & point : shape.footprint.points) {
       polygon.push_back(Point2d{point.x, point.y});
     }
-    if (
-      polygon.size() > 1 && shape.footprint.points.front().x == shape.footprint.points.back().x &&
-      shape.footprint.points.front().y == shape.footprint.points.back().y) {
-      polygon.pop_back();
-    }
+
     return polygon;
   }
 
@@ -306,7 +300,6 @@ std::vector<Point2d> create_base_polygon(const autoware_perception_msgs::msg::Sh
 std::vector<Point2d> create_base_polygon(const VehicleInfo & vehicle_info)
 {
   const double half_width = vehicle_info.vehicle_width_m / 2.0;
-  // DO NOT change the order of the points and number of points.
   return {
     Point2d{vehicle_info.max_longitudinal_offset_m, half_width},
     Point2d{vehicle_info.max_longitudinal_offset_m, -half_width},
@@ -314,18 +307,16 @@ std::vector<Point2d> create_base_polygon(const VehicleInfo & vehicle_info)
     Point2d{vehicle_info.min_longitudinal_offset_m, half_width}};
 }
 
-}  // namespace detail
-
 Polygon2d to_polygon2d(
   const geometry_msgs::msg::Pose & pose, const autoware_perception_msgs::msg::Shape & shape)
 {
-  const auto iso = detail::pose_to_isometry(pose);
-  const auto points = detail::create_base_polygon(shape);
+  const auto iso = pose_to_isometry(pose);
+  const auto points = create_base_polygon(shape);
 
   Polygon2d polygon;
   polygon.outer().reserve(points.size() + 1U);
   for (const auto & point : points) {
-    polygon.outer().push_back(detail::transform_point(iso, point));
+    polygon.outer().push_back(transform_point(iso, point));
   }
   if (!polygon.outer().empty()) {
     polygon.outer().push_back(polygon.outer().front());
@@ -341,22 +332,19 @@ namespace footprint
 FootprintTrajectory compute_footprint_trajectory(
   const PoseTrajectory & pose_trajectory, const std::vector<Point2d> & base_poly)
 {
-  auto transform_point = [](const auto & transform, const Point2d & pt) {
-    const Eigen::Vector2d p = transform * Eigen::Vector2d{pt.x(), pt.y()};
-    return Point2d{p.x(), p.y()};
-  };
-
   if (base_poly.size() == 4) {
     QuadTrajectory trajectory;
     trajectory.reserve(pose_trajectory.size());
 
     for (const auto & pose : pose_trajectory) {
-      const auto iso = geometry::detail::pose_to_isometry(pose);
+      const auto iso = geometry::pose_to_isometry(pose);
 
       trajectory.push_back(
         std::array<Point2d, 4>{
-          transform_point(iso, base_poly[0]), transform_point(iso, base_poly[1]),
-          transform_point(iso, base_poly[2]), transform_point(iso, base_poly[3])});
+          geometry::transform_point(iso, base_poly[0]),
+          geometry::transform_point(iso, base_poly[1]),
+          geometry::transform_point(iso, base_poly[2]),
+          geometry::transform_point(iso, base_poly[3])});
     }
     return trajectory;
   } else {
@@ -364,13 +352,13 @@ FootprintTrajectory compute_footprint_trajectory(
     trajectory.reserve(pose_trajectory.size());
 
     for (const auto & pose : pose_trajectory) {
-      const auto iso = geometry::detail::pose_to_isometry(pose);
+      const auto iso = geometry::pose_to_isometry(pose);
 
       std::vector<Point2d> transformed_poly;
       transformed_poly.reserve(base_poly.size());
 
       for (const auto & pt : base_poly) {
-        transformed_poly.push_back(transform_point(iso, pt));
+        transformed_poly.push_back(geometry::transform_point(iso, pt));
       }
 
       trajectory.push_back(std::move(transformed_poly));
@@ -382,15 +370,13 @@ FootprintTrajectory compute_footprint_trajectory(
 FootprintTrajectory compute_footprint_trajectory(
   const PoseTrajectory & pose_trajectory, const autoware_perception_msgs::msg::Shape & object_shape)
 {
-  return compute_footprint_trajectory(
-    pose_trajectory, geometry::detail::create_base_polygon(object_shape));
+  return compute_footprint_trajectory(pose_trajectory, geometry::create_base_polygon(object_shape));
 }
 
 FootprintTrajectory compute_footprint_trajectory(
   const PoseTrajectory & pose_trajectory, const VehicleInfo & vehicle_info)
 {
-  return compute_footprint_trajectory(
-    pose_trajectory, geometry::detail::create_base_polygon(vehicle_info));
+  return compute_footprint_trajectory(pose_trajectory, geometry::create_base_polygon(vehicle_info));
 }
 }  // namespace footprint
 

--- a/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/trajectory_utils.hpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/trajectory_utils.hpp
@@ -32,12 +32,20 @@
 #include <map>
 #include <string>
 #include <utility>
+#include <vector>
 
 namespace autoware::trajectory_validator::plugin::safety
 {
 
 using IndexRange = std::pair<size_t, size_t>;
 using TimeRange = std::pair<double, double>;
+
+using TimeTrajectory = std::vector<double>;
+using TravelDistanceTrajectory = std::vector<double>;
+using PoseTrajectory = std::vector<geometry_msgs::msg::Pose>;
+using QuadTrajectory = std::vector<std::array<Point2d, 4>>;
+using NgonTrajectory = std::vector<std::vector<Point2d>>;
+using FootprintTrajectory = std::variant<QuadTrajectory, NgonTrajectory>;
 
 class TrajectoryData
 {

--- a/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/trajectory_utils.hpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/trajectory_utils.hpp
@@ -79,11 +79,15 @@ private:
 
     Box2d box;
     boost::geometry::assign_inverse(box);
-    for (size_t i = key.first; i <= key.second; ++i) {
-      for (const auto & pt : footprints_[i].outer()) {
-        boost::geometry::expand(box, pt);
-      }
-    }
+    std::visit(
+      [&](const auto & polygons) {
+        for (size_t i = key.first; i <= key.second; ++i) {
+          for (const auto & pt : polygons[i]) {
+            boost::geometry::expand(box, pt);
+          }
+        }
+      },
+      footprints_);
     return box;
   }
 
@@ -92,12 +96,21 @@ private:
     assert(key.first <= key.second);
 
     MultiPoint2d all_points;
-    all_points.reserve((key.second - key.first + 1) * 4);
-    for (size_t i = key.first; i <= key.second; ++i) {
-      for (const auto & pt : footprints_[i].outer()) {
-        all_points.push_back(pt);
-      }
-    }
+    std::visit(
+      [&](const auto & polygons) {
+        size_t total_point_count = 0;
+        for (size_t i = key.first; i <= key.second; ++i) {
+          total_point_count += polygons[i].size();
+        }
+
+        all_points.reserve(total_point_count);
+        for (size_t i = key.first; i <= key.second; ++i) {
+          for (const auto & pt : polygons[i]) {
+            all_points.push_back(pt);
+          }
+        }
+      },
+      footprints_);
 
     Polygon2d hull;
     hull.outer().reserve(all_points.size());
@@ -129,7 +142,9 @@ public:
         "Trajectory sizes mismatch (times vs poses) classification: " +
         identification_.classification);
     }
-    if (times_.size() != footprints_.size()) {
+    const auto footprint_size =
+      std::visit([](const auto & polygons) { return polygons.size(); }, footprints_);
+    if (times_.size() != footprint_size) {
       throw std::invalid_argument(
         "Trajectory sizes mismatch (times vs footprints) classification: " +
         identification_.classification);
@@ -164,7 +179,7 @@ public:
 
   const Box2d & get_or_compute_overall_envelope() const
   {
-    return get_or_compute_envelope(IndexRange{0U, footprints_.size() - 1});
+    return get_or_compute_envelope(IndexRange{0U, times_.size() - 1});
   }
 
   const Polygon2d & get_or_compute_convex(const IndexRange & key) const

--- a/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/trajectory_utils.hpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/trajectory_utils.hpp
@@ -98,11 +98,7 @@ private:
     MultiPoint2d all_points;
     std::visit(
       [&](const auto & polygons) {
-        size_t total_point_count = 0;
-        for (size_t i = key.first; i <= key.second; ++i) {
-          total_point_count += polygons[i].size();
-        }
-
+        size_t total_point_count = (key.second - key.first + 1U) * polygons[key.first].size();
         all_points.reserve(total_point_count);
         for (size_t i = key.first; i <= key.second; ++i) {
           for (const auto & pt : polygons[i]) {

--- a/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/types.hpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/types.hpp
@@ -39,14 +39,6 @@ using autoware_utils_geometry::MultiPoint2d;
 using autoware_utils_geometry::Point2d;
 using autoware_utils_geometry::Polygon2d;
 
-using TimeTrajectory = std::vector<double>;
-using TravelDistanceTrajectory = std::vector<double>;
-using PoseTrajectory = std::vector<geometry_msgs::msg::Pose>;
-using QuadTrajectory = std::vector<std::array<Point2d, 4>>;
-using NgonTrajectory = std::vector<std::vector<Point2d>>;
-using FootprintTrajectory = std::variant<QuadTrajectory, NgonTrajectory>;
-using StepPolygonTrajectory = std::vector<Polygon2d>;
-
 static constexpr double TIME_INDEX_EPSILON = 1e-3;
 
 struct TrajectoryIdentification
@@ -88,8 +80,8 @@ struct CollisionDetail
   TrajectoryIdentification object_identification;
   double pet;
   double ttc;
-  PoseTrajectory ego_trajectory;
-  PoseTrajectory object_trajectory;
+  std::vector<geometry_msgs::msg::Pose> ego_trajectory;
+  std::vector<geometry_msgs::msg::Pose> object_trajectory;
   Polygon2d ego_hull;
   Polygon2d object_hull;
 };

--- a/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/types.hpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/types.hpp
@@ -42,11 +42,8 @@ using autoware_utils_geometry::Polygon2d;
 using TimeTrajectory = std::vector<double>;
 using TravelDistanceTrajectory = std::vector<double>;
 using PoseTrajectory = std::vector<geometry_msgs::msg::Pose>;
-using QuadFootprint = std::array<Point2d, 4>;
-using NgonFootprint = std::vector<Point2d>;
-using BaseFootprint = std::variant<QuadFootprint, NgonFootprint>;
-using QuadTrajectory = std::vector<QuadFootprint>;
-using NgonTrajectory = std::vector<NgonFootprint>;
+using QuadTrajectory = std::vector<std::array<Point2d, 4>>;
+using NgonTrajectory = std::vector<std::vector<Point2d>>;
 using FootprintTrajectory = std::variant<QuadTrajectory, NgonTrajectory>;
 using StepPolygonTrajectory = std::vector<Polygon2d>;
 

--- a/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/types.hpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/types.hpp
@@ -25,9 +25,11 @@
 #include <geometry_msgs/msg/pose.hpp>
 #include <unique_identifier_msgs/msg/uuid.hpp>
 
+#include <array>
 #include <optional>
 #include <string>
 #include <utility>
+#include <variant>
 #include <vector>
 
 namespace autoware::trajectory_validator::plugin::safety
@@ -40,7 +42,12 @@ using autoware_utils_geometry::Polygon2d;
 using TimeTrajectory = std::vector<double>;
 using TravelDistanceTrajectory = std::vector<double>;
 using PoseTrajectory = std::vector<geometry_msgs::msg::Pose>;
-using FootprintTrajectory = std::vector<Polygon2d>;
+using QuadFootprint = std::array<Point2d, 4>;
+using NgonFootprint = std::vector<Point2d>;
+using BaseFootprint = std::variant<QuadFootprint, NgonFootprint>;
+using QuadTrajectory = std::vector<QuadFootprint>;
+using NgonTrajectory = std::vector<NgonFootprint>;
+using FootprintTrajectory = std::variant<QuadTrajectory, NgonTrajectory>;
 using StepPolygonTrajectory = std::vector<Polygon2d>;
 
 static constexpr double TIME_INDEX_EPSILON = 1e-3;

--- a/planning/autoware_trajectory_validator/test/plugins/collision_check_filter/test_trajectory_utilities.cpp
+++ b/planning/autoware_trajectory_validator/test/plugins/collision_check_filter/test_trajectory_utilities.cpp
@@ -312,7 +312,7 @@ TEST(TrajectoryUtilitiesTest, ComputeFootprintTrajectoryForCylinderUsesNgonTraje
 
   const auto footprints = trajectory::footprint::compute_footprint_trajectory(poses, shape);
 
-  EXPECT_TRUE(std::holds_alternative<NgonTrajectory>(footprints));
+  EXPECT_TRUE(std::holds_alternative<QuadTrajectory>(footprints));
   ASSERT_EQ(footprint_count(footprints), 1u);
   expect_same_polygon(
     footprint_to_polygon2d(footprints, 0U), geometry::to_polygon2d(poses.front(), shape));

--- a/planning/autoware_trajectory_validator/test/plugins/collision_check_filter/test_trajectory_utilities.cpp
+++ b/planning/autoware_trajectory_validator/test/plugins/collision_check_filter/test_trajectory_utilities.cpp
@@ -129,6 +129,16 @@ autoware_perception_msgs::msg::Shape create_bounding_box_shape(
   return shape;
 }
 
+autoware_perception_msgs::msg::Shape create_cylinder_shape(const double diameter = 2.0)
+{
+  autoware_perception_msgs::msg::Shape shape;
+  shape.type = autoware_perception_msgs::msg::Shape::CYLINDER;
+  shape.dimensions.x = diameter;
+  shape.dimensions.y = diameter;
+  shape.dimensions.z = 1.5;
+  return shape;
+}
+
 autoware_perception_msgs::msg::PredictedPath create_straight_predicted_path(
   const double y, const double confidence, const std::vector<double> & xs)
 {
@@ -176,6 +186,29 @@ void expect_same_polygon(const Polygon2d & actual, const Polygon2d & expected)
     EXPECT_DOUBLE_EQ(actual.outer().at(i).x(), expected.outer().at(i).x());
     EXPECT_DOUBLE_EQ(actual.outer().at(i).y(), expected.outer().at(i).y());
   }
+}
+
+size_t footprint_count(const FootprintTrajectory & footprints)
+{
+  return std::visit([](const auto & polygons) { return polygons.size(); }, footprints);
+}
+
+Polygon2d footprint_to_polygon2d(const FootprintTrajectory & footprints, const size_t index)
+{
+  return std::visit(
+    [&](const auto & polygons) {
+      Polygon2d polygon;
+      const auto & points = polygons.at(index);
+      polygon.outer().reserve(points.size() + 1U);
+      for (const auto & point : points) {
+        polygon.outer().push_back(point);
+      }
+      if (!polygon.outer().empty()) {
+        polygon.outer().push_back(polygon.outer().front());
+      }
+      return polygon;
+    },
+    footprints);
 }
 
 }  // namespace
@@ -265,9 +298,24 @@ TEST(TrajectoryUtilitiesTest, ComputeFootprintTrajectoryForObjectShapeMatchesUti
 
   const auto footprints = trajectory::footprint::compute_footprint_trajectory(poses, shape);
 
-  ASSERT_EQ(footprints.size(), 1u);
+  EXPECT_TRUE(std::holds_alternative<QuadTrajectory>(footprints));
+  ASSERT_EQ(footprint_count(footprints), 1u);
   expect_same_polygon(
-    footprints.front(), autoware_utils_geometry::to_polygon2d(poses.front(), shape));
+    footprint_to_polygon2d(footprints, 0U),
+    autoware_utils_geometry::to_polygon2d(poses.front(), shape));
+}
+
+TEST(TrajectoryUtilitiesTest, ComputeFootprintTrajectoryForCylinderUsesNgonTrajectory)
+{
+  const PoseTrajectory poses = {create_pose(1.0, 2.0, 0.0)};
+  const auto shape = create_cylinder_shape(2.0);
+
+  const auto footprints = trajectory::footprint::compute_footprint_trajectory(poses, shape);
+
+  EXPECT_TRUE(std::holds_alternative<NgonTrajectory>(footprints));
+  ASSERT_EQ(footprint_count(footprints), 1u);
+  expect_same_polygon(
+    footprint_to_polygon2d(footprints, 0U), geometry::to_polygon2d(poses.front(), shape));
 }
 
 TEST(TrajectoryUtilitiesTest, ComputeFootprintTrajectoryForVehicleMatchesUtility)
@@ -277,11 +325,13 @@ TEST(TrajectoryUtilitiesTest, ComputeFootprintTrajectoryForVehicleMatchesUtility
 
   const auto footprints = trajectory::footprint::compute_footprint_trajectory(poses, vehicle_info);
 
-  ASSERT_EQ(footprints.size(), 1u);
+  EXPECT_TRUE(std::holds_alternative<QuadTrajectory>(footprints));
+  ASSERT_EQ(footprint_count(footprints), 1u);
   expect_same_polygon(
-    footprints.front(), autoware_utils_geometry::to_footprint(
-                          poses.front(), vehicle_info.max_longitudinal_offset_m,
-                          -vehicle_info.min_longitudinal_offset_m, vehicle_info.vehicle_width_m));
+    footprint_to_polygon2d(footprints, 0U),
+    autoware_utils_geometry::to_footprint(
+      poses.front(), vehicle_info.max_longitudinal_offset_m,
+      -vehicle_info.min_longitudinal_offset_m, vehicle_info.vehicle_width_m));
 }
 
 TEST(TrajectoryUtilitiesTest, ObjectIdentificationClassificationConstructorSetsDefaults)
@@ -333,7 +383,7 @@ TEST(TrajectoryUtilitiesTest, GenerateEgoTrajectoryBuildsConsistentTrajectoryDat
   EXPECT_NEAR(trajectory_data.getDistances().back(), 2.1, 1e-6);
   EXPECT_NEAR(trajectory_data.getPoses().back().position.x, 2.1, 1e-6);
   expect_same_polygon(
-    trajectory_data.getFootprints().front(),
+    footprint_to_polygon2d(trajectory_data.getFootprints(), 0U),
     autoware_utils_geometry::to_footprint(
       trajectory_data.getPoses().front(), vehicle_info.max_longitudinal_offset_m,
       -vehicle_info.min_longitudinal_offset_m, vehicle_info.vehicle_width_m));


### PR DESCRIPTION
`FootprintTrajectory`が`std::vector<Polygon2d>`、すなわち、`std::vector<std::vector<Point2d>>`であったため、mallocとfreeに多くの計算負荷を要していました。

この解決のため、unknown以外の物体においては、`FootprintTrajectory`が`std::vector<std::array<Point2d, 4>>`として確保されるように変更しました。


おおよそ3割ほど処理負荷が減少しました。

before:
<img width="2619" height="2030" alt="image" src="https://github.com/user-attachments/assets/14799792-3921-4e4d-9f76-77826e2e0c08" />

after:
<img width="2619" height="2030" alt="image" src="https://github.com/user-attachments/assets/89c07c61-e878-475d-bf14-3b2d855d71a9" />

