### PR TITLE
feat(traffic_light_filter): add grace periods and hysteresis

### DIFF
--- a/planning/autoware_trajectory_validator/TrafficLightFilter.md
+++ b/planning/autoware_trajectory_validator/TrafficLightFilter.md
@@ -4,35 +4,46 @@
 
 This filter rejects trajectories if they are found to run through a red or amber traffic light. It ensures that the planned motion adheres to traffic signals by validating that the vehicle does not cross stop lines when the signal is prohibitive, while accounting for the "dilemma zone" during amber lights and allowing for a configurable stopping margin.
 
+Additionally, this filter includes signal stability filtering to prevent reacting to flickering or transient signal detections, and amber hysteresis tracking to ensure consistent rejection once an amber light has been deemed "stoppable."
+
 ## Algorithm Overview
 
 The filter decides whether to reject a trajectory based on the following steps:
 
-1. **Trajectory Pre-processing**:
+1. **Signal Pre-filtering (Stability)**:
+   - Tracks the duration each traffic light has been in its current state.
+   - If the ego vehicle is moving ($v \ge v_{stopped\_threshold}$):
+     - A RED signal is ignored (treated as inactive) until it has been stable for `stable_duration_threshold_red`.
+     - An AMBER signal is ignored until it has been stable for `stable_duration_threshold_amber`.
+   - If the ego vehicle is stopped ($v < v_{stopped\_threshold}$), signals are used immediately to allow for responsive departures.
+2. **Trajectory Pre-processing**:
    - Filters out points behind the ego vehicle.
    - Trims the trajectory at the first point where velocity is zero or negative (stop point).
    - Captures this stop point if it exists within the checked range.
    - Extends the trajectory's visual representation by the vehicle's longitudinal offset (front of the vehicle) to ensure the front bumper is checked against stop lines.
-2. **Stop Line Identification**:
+3. **Stop Line Identification**:
    - Uses the **Route** to map traffic light signals to lanelets and filters out signals that do not apply to the current route.
    - For each relevant traffic light, it verifies if the signal is a stop signal for the associated lanelet.
    - Retrieves red and amber stop lines for these relevant signals.
    - If `treat_amber_light_as_red_light` is enabled, all amber stop lines are treated as red stop lines.
-3. **Red Light Validation**:
+4. **Red Light Validation**:
    - If the trajectory intersects a red stop line:
      - If a stop point exists and its distance to the stop line is within `stop_overshoot_margin`, the trajectory is accepted (considered as "stopped at the line").
      - Otherwise, the trajectory is rejected.
-4. **Amber Light Validation**:
+5. **Amber Light Validation**:
    - If the trajectory crosses an amber stop line:
      - If a stop point exists and its distance to the stop line is within `stop_overshoot_margin`, the trajectory is accepted.
+     - If the signal ID is currently in the **Amber Hysteresis** state (was rejected within the last `amber_rejection_hysteresis_duration` and ego is not stopped), the trajectory is rejected.
      - Otherwise, the filter calculates the distance to the intersection and the time at which the ego vehicle is expected to cross it.
      - It then applies the [Amber Light Logic](#amber-light-logic) to determine if the crossing is permissible.
+     - If rejected, the signal ID is added to the hysteresis history.
 
 ### Decision Flow
 
 ```mermaid
 graph TD
-    A[Start: Trajectory Validation] --> B[Pre-process Trajectory & Capture Stop Point]
+    A[Start: Trajectory Validation] --> AS[Signal Stability Filter]
+    AS --> B[Pre-process Trajectory & Capture Stop Point]
     B --> C{Intersects Red Stop Line?}
     C -- Yes --> C1{Stopped within margin?}
     C1 -- No --> D[Reject: crosses red light]
@@ -41,11 +52,13 @@ graph TD
     E -- No --> F[Accept Trajectory]
     E -- Yes --> E1{Stopped within margin?}
     E1 -- Yes --> F
-    E1 -- No --> G{Treat Amber as Red?}
+    E1 -- No --> E2{In Amber Hysteresis?}
+    E2 -- Yes --> D
+    E2 -- No --> G{Treat Amber as Red?}
     G -- Yes --> D
     G -- No --> H[Calculate Distance and Time to Stop Line]
     H --> I{Can safely stop before line?}
-    I -- Yes --> J[Reject: crosses amber light]
+    I -- Yes --> J[Reject: crosses amber light & Update Hysteresis]
     I -- No --> K{Can cross within time limit?}
     K -- Yes --> F
     K -- No --> J
@@ -70,6 +83,7 @@ The filter utilizes the following data from the `FilterContext`:
 - **Traffic Light Signals**: Provides the current state (color) of traffic light groups.
 - **Route**: Used to map traffic light signals to lanelets and filter those that are relevant to the vehicle's path.
 - **Vehicle Info**: Used to account for the vehicle's dimensions (longitudinal offset) when checking for stop line intersections.
+- **Odometry**: Provides the current velocity to determine if ego is stopped and to calculate stopping distances.
 
 ### Parameters
 
@@ -81,5 +95,9 @@ The filter utilizes the following data from the `FilterContext`:
 | `traffic_light.crossing_time_limit`                          | double | 2.75    | [s] Maximum time allowed for the ego vehicle to cross the stop line after an amber light appears.                 |
 | `traffic_light.treat_amber_light_as_red_light`               | bool   | true    | When true, amber lights are treated identically to red lights (rejection on intersection regardless of distance). |
 | `traffic_light.stop_overshoot_margin`                        | double | 0.5     | [m] Maximum distance between the stop line and the trajectory stop point to consider the trajectory feasible.     |
+| `traffic_light.stable_duration_threshold_red`                | double | 0.0     | [s] Minimum duration a RED light must be seen before it is considered active (only when ego is moving).           |
+| `traffic_light.stable_duration_threshold_amber`              | double | 0.0     | [s] Minimum duration an AMBER light must be seen before it is considered active (only when ego is moving).        |
+| `traffic_light.amber_rejection_hysteresis_duration`          | double | 0.0     | [s] Duration to persist an amber rejection state to prevent "flipping" due to minor velocity/distance changes.    |
+| `traffic_light.ego_stopped_velocity_threshold`               | double | 0.01    | [m/s] Velocity threshold below which stability and hysteresis filters are bypassed.                               |
 | `traffic_light.checked_trajectory_length.deceleration_limit` | double | 2.0     | [m/s²] Deceleration limit used to calculate the maximum trajectory length to check for traffic lights.            |
 | `traffic_light.checked_trajectory_length.jerk_limit`         | double | 4.0     | [m/s³] Jerk limit used to calculate the maximum trajectory length to check for traffic lights.                    |

--- a/planning/autoware_trajectory_validator/include/autoware/trajectory_validator/filters/traffic_rule/traffic_light_compliance_checker.hpp
+++ b/planning/autoware_trajectory_validator/include/autoware/trajectory_validator/filters/traffic_rule/traffic_light_compliance_checker.hpp
@@ -42,6 +42,14 @@ struct Inputs
   autoware_perception_msgs::msg::TrafficLightGroupArray signals;
   double current_velocity;
   double current_acceleration;
+  std::vector<int64_t> force_reject_amber_ids;
+};
+
+/// @brief information about a stop line and its associated traffic light
+struct StopLineInfo
+{
+  lanelet::BasicLineString2d line;
+  int64_t traffic_light_id;
 };
 
 /// @brief type of traffic light violation
@@ -52,6 +60,7 @@ struct Violation
 {
   ViolationType type;
   lanelet::BasicLineString2d stop_line;
+  int64_t traffic_light_id;
 };
 
 /// @brief result of compliance check
@@ -69,6 +78,10 @@ struct Parameters
   double crossing_time_limit;
   bool treat_amber_light_as_red_light;
   double stop_overshoot_margin;
+  double stable_duration_threshold_red;
+  double stable_duration_threshold_amber;
+  double amber_rejection_hysteresis_duration;
+  double ego_stopped_velocity_threshold;
   struct CheckedTrajectoryLength
   {
     double deceleration_limit;
@@ -103,9 +116,7 @@ public:
 
 private:
   /// @brief return the red and amber stop lines related to the given traffic light groups
-  [[nodiscard]] std::pair<
-    std::vector<lanelet::BasicLineString2d>, std::vector<lanelet::BasicLineString2d>>
-  get_stop_lines(
+  [[nodiscard]] std::pair<std::vector<StopLineInfo>, std::vector<StopLineInfo>> get_stop_lines(
     const lanelet::LaneletMap & lanelet_map,
     const autoware_planning_msgs::msg::LaneletRoute & route,
     const autoware_perception_msgs::msg::TrafficLightGroupArray & traffic_lights) const;

--- a/planning/autoware_trajectory_validator/include/autoware/trajectory_validator/filters/traffic_rule/traffic_light_filter.hpp
+++ b/planning/autoware_trajectory_validator/include/autoware/trajectory_validator/filters/traffic_rule/traffic_light_filter.hpp
@@ -24,6 +24,7 @@
 
 #include <memory>
 #include <unordered_map>
+#include <vector>
 
 namespace autoware::trajectory_validator::plugin::traffic_rule
 {
@@ -43,6 +44,7 @@ private:
   {
     autoware_perception_msgs::msg::TrafficLightGroup msg;
     rclcpp::Time first_seen_time;
+    rclcpp::Time last_seen_time;
   };
 
   std::unique_ptr<traffic_light_filter::TrafficLightComplianceChecker> checker_;
@@ -50,6 +52,15 @@ private:
 
   std::unordered_map<int64_t, SignalStateHistory> signal_history_;
   std::unordered_map<int64_t, rclcpp::Time> amber_rejection_history_;
+
+  autoware_perception_msgs::msg::TrafficLightGroupArray filter_signals(
+    const autoware_perception_msgs::msg::TrafficLightGroupArray & signals,
+    const rclcpp::Time & current_time, bool is_ego_stopped);
+
+  std::vector<int64_t> get_force_reject_amber_ids(
+    const rclcpp::Time & current_time, bool is_ego_stopped) const;
+
+  void cleanup_history(const rclcpp::Time & current_time);
 };
 
 }  // namespace autoware::trajectory_validator::plugin::traffic_rule

--- a/planning/autoware_trajectory_validator/include/autoware/trajectory_validator/filters/traffic_rule/traffic_light_filter.hpp
+++ b/planning/autoware_trajectory_validator/include/autoware/trajectory_validator/filters/traffic_rule/traffic_light_filter.hpp
@@ -23,8 +23,7 @@
 #include <lanelet2_core/Forward.h>
 
 #include <memory>
-#include <string>
-#include <vector>
+#include <unordered_map>
 
 namespace autoware::trajectory_validator::plugin::traffic_rule
 {
@@ -40,8 +39,17 @@ public:
   void set_vehicle_info(const VehicleInfo & vehicle_info) final;
 
 private:
+  struct SignalStateHistory
+  {
+    autoware_perception_msgs::msg::TrafficLightGroup msg;
+    rclcpp::Time first_seen_time;
+  };
+
   std::unique_ptr<traffic_light_filter::TrafficLightComplianceChecker> checker_;
   validator::Params::TrafficLight params_;
+
+  std::unordered_map<int64_t, SignalStateHistory> signal_history_;
+  std::unordered_map<int64_t, rclcpp::Time> amber_rejection_history_;
 };
 
 }  // namespace autoware::trajectory_validator::plugin::traffic_rule

--- a/planning/autoware_trajectory_validator/param/parameter_struct.yaml
+++ b/planning/autoware_trajectory_validator/param/parameter_struct.yaml
@@ -254,6 +254,26 @@ validator:
       default_value: 0.5
       description: Maximum distance between the stop line and the trajectory stop point to consider the trajectory feasible (m)
       read_only: false
+    stable_duration_threshold_red:
+      type: double
+      default_value: 0.0
+      description: Stability duration for RED signals (seconds)
+      read_only: false
+    stable_duration_threshold_amber:
+      type: double
+      default_value: 0.0
+      description: Stability duration for AMBER signals (seconds)
+      read_only: false
+    amber_rejection_hysteresis_duration:
+      type: double
+      default_value: 0.0
+      description: Hysteresis duration to persist an AMBER rejection (seconds)
+      read_only: false
+    ego_stopped_velocity_threshold:
+      type: double
+      default_value: 0.01
+      description: Velocity below which ego is considered fully stopped (m/s)
+      read_only: false
     checked_trajectory_length:
       deceleration_limit:
         type: double

--- a/planning/autoware_trajectory_validator/src/filters/traffic_rule/traffic_light_compliance_checker.cpp
+++ b/planning/autoware_trajectory_validator/src/filters/traffic_rule/traffic_light_compliance_checker.cpp
@@ -34,16 +34,16 @@
 
 namespace
 {
+using autoware::trajectory_validator::traffic_light_filter::StopLineInfo;
+
 /// @brief get stop lines where ego need to stop, and their corresponding signals from the given
 /// traffic light groups
-std::vector<std::pair<lanelet::BasicLineString2d, autoware_perception_msgs::msg::TrafficLightGroup>>
+std::vector<std::pair<StopLineInfo, autoware_perception_msgs::msg::TrafficLightGroup>>
 collect_stop_lines(
   const lanelet::LaneletMap & lanelet_map, const autoware_planning_msgs::msg::LaneletRoute & route,
   const std::vector<autoware_perception_msgs::msg::TrafficLightGroup> & traffic_light_groups)
 {
-  std::vector<
-    std::pair<lanelet::BasicLineString2d, autoware_perception_msgs::msg::TrafficLightGroup>>
-    stop_lines;
+  std::vector<std::pair<StopLineInfo, autoware_perception_msgs::msg::TrafficLightGroup>> stop_lines;
   std::unordered_map<lanelet::Id, lanelet::Id> route_lanelet_id_per_traffic_light_id;
   for (const auto & segment : route.segments) {
     for (const auto & tl : lanelet_map.laneletLayer.get(segment.preferred_primitive.id)
@@ -74,7 +74,10 @@ collect_stop_lines(
       continue;
     }
     stop_lines.emplace_back(
-      lanelet::utils::to2D(traffic_light->stopLine()->basicLineString()), signal);
+      StopLineInfo{
+        lanelet::utils::to2D(traffic_light->stopLine()->basicLineString()),
+        signal.traffic_light_group_id},
+      signal);
   }
   return stop_lines;
 }
@@ -155,11 +158,12 @@ tl::expected<ComplianceResult, std::string> TrafficLightComplianceChecker::check
 
   // Check for red light crossings
   for (const auto & red_stop_line : red_stop_lines) {
-    if (boost::geometry::intersects(trajectory_ls, red_stop_line)) {
-      if (is_stop_point_within_margin_from_stop_line(stop_point, red_stop_line)) {
+    if (boost::geometry::intersects(trajectory_ls, red_stop_line.line)) {
+      if (is_stop_point_within_margin_from_stop_line(stop_point, red_stop_line.line)) {
         continue;
       }
-      result.violations.push_back({ViolationType::RED_LIGHT, red_stop_line});
+      result.violations.push_back(
+        {ViolationType::RED_LIGHT, red_stop_line.line, red_stop_line.traffic_light_id});
     }
   }
 
@@ -171,7 +175,7 @@ tl::expected<ComplianceResult, std::string> TrafficLightComplianceChecker::check
       lanelet::BasicPoints2d intersection_points;
       const lanelet::BasicLineString2d segment{trajectory_ls[i], trajectory_ls[i + 1]};
       const auto segment_length = static_cast<double>(boost::geometry::length(segment));
-      boost::geometry::intersection(segment, amber_stop_line, intersection_points);
+      boost::geometry::intersection(segment, amber_stop_line.line, intersection_points);
       if (!intersection_points.empty()) {
         const auto distance_to_intersection =
           boost::geometry::distance(segment.front(), intersection_points.front());
@@ -188,13 +192,24 @@ tl::expected<ComplianceResult, std::string> TrafficLightComplianceChecker::check
     const auto current_velocity = trajectory.front().longitudinal_velocity_mps;
     const auto current_acceleration = trajectory.front().acceleration_mps2;
     if (amber_stop_line_crossing_time) {
-      if (is_stop_point_within_margin_from_stop_line(stop_point, amber_stop_line)) {
+      if (is_stop_point_within_margin_from_stop_line(stop_point, amber_stop_line.line)) {
         continue;
       }
-      if (!can_pass_amber_light(
-            distance_to_stop_line, current_velocity, current_acceleration,
-            *amber_stop_line_crossing_time)) {
-        result.violations.push_back({ViolationType::AMBER_LIGHT, amber_stop_line});
+
+      bool is_force_reject = false;
+      if (
+        std::find(
+          input.force_reject_amber_ids.begin(), input.force_reject_amber_ids.end(),
+          amber_stop_line.traffic_light_id) != input.force_reject_amber_ids.end()) {
+        is_force_reject = true;
+      }
+
+      if (
+        is_force_reject || !can_pass_amber_light(
+                             distance_to_stop_line, current_velocity, current_acceleration,
+                             *amber_stop_line_crossing_time)) {
+        result.violations.push_back(
+          {ViolationType::AMBER_LIGHT, amber_stop_line.line, amber_stop_line.traffic_light_id});
       }
     }
   }
@@ -202,24 +217,24 @@ tl::expected<ComplianceResult, std::string> TrafficLightComplianceChecker::check
   return result;
 }
 
-std::pair<std::vector<lanelet::BasicLineString2d>, std::vector<lanelet::BasicLineString2d>>
+std::pair<std::vector<StopLineInfo>, std::vector<StopLineInfo>>
 TrafficLightComplianceChecker::get_stop_lines(
   const lanelet::LaneletMap & lanelet_map, const autoware_planning_msgs::msg::LaneletRoute & route,
   const autoware_perception_msgs::msg::TrafficLightGroupArray & traffic_lights) const
 {
-  std::vector<lanelet::BasicLineString2d> red_stop_lines;
-  std::vector<lanelet::BasicLineString2d> amber_stop_lines;
-  for (const auto & [stop_line, signal] :
+  std::vector<StopLineInfo> red_stop_lines;
+  std::vector<StopLineInfo> amber_stop_lines;
+  for (const auto & [stop_line_info, signal] :
        collect_stop_lines(lanelet_map, route, traffic_lights.traffic_light_groups)) {
     if (autoware::traffic_light_utils::hasTrafficLightShapeAndColor(
           signal.elements, autoware_perception_msgs::msg::TrafficLightElement::CIRCLE,
           autoware_perception_msgs::msg::TrafficLightElement::RED)) {
-      red_stop_lines.push_back(stop_line);
+      red_stop_lines.push_back(stop_line_info);
     }
     if (autoware::traffic_light_utils::hasTrafficLightShapeAndColor(
           signal.elements, autoware_perception_msgs::msg::TrafficLightElement::CIRCLE,
           autoware_perception_msgs::msg::TrafficLightElement::AMBER)) {
-      amber_stop_lines.push_back(stop_line);
+      amber_stop_lines.push_back(stop_line_info);
     }
   }
   if (params_.treat_amber_light_as_red_light) {

--- a/planning/autoware_trajectory_validator/src/filters/traffic_rule/traffic_light_filter.cpp
+++ b/planning/autoware_trajectory_validator/src/filters/traffic_rule/traffic_light_filter.cpp
@@ -17,6 +17,8 @@
 #include <autoware/traffic_light_utils/traffic_light_utils.hpp>
 #include <rclcpp/logging.hpp>
 
+#include <algorithm>
+#include <cmath>
 #include <memory>
 #include <string>
 #include <utility>
@@ -70,6 +72,30 @@ autoware::trajectory_validator::traffic_light_filter::Parameters to_checker_para
   p.checked_trajectory_length.jerk_limit = params.checked_trajectory_length.jerk_limit;
   return p;
 }
+
+bool is_equal(
+  const autoware_perception_msgs::msg::TrafficLightElement & a,
+  const autoware_perception_msgs::msg::TrafficLightElement & b)
+{
+  return a.color == b.color && a.shape == b.shape && a.status == b.status;
+}
+
+bool is_equal(
+  const std::vector<autoware_perception_msgs::msg::TrafficLightElement> & a,
+  const std::vector<autoware_perception_msgs::msg::TrafficLightElement> & b)
+{
+  if (a.size() != b.size()) {
+    return false;
+  }
+
+  for (size_t i = 0; i < a.size(); ++i) {
+    if (!is_equal(a[i], b[i])) {
+      return false;
+    }
+  }
+
+  return true;
+}
 }  // namespace
 
 namespace autoware::trajectory_validator::plugin::traffic_rule
@@ -110,48 +136,11 @@ TrafficLightFilter::result_t TrafficLightFilter::is_feasible(
   const bool is_ego_stopped = std::abs(velocity) < params_.ego_stopped_velocity_threshold;
 
   // Signal Stability Filter
-  autoware_perception_msgs::msg::TrafficLightGroupArray filtered_signals;
-  filtered_signals.stamp = context.traffic_light_signals->stamp;
-
-  for (const auto & signal : context.traffic_light_signals->traffic_light_groups) {
-    const auto id = signal.traffic_light_group_id;
-    if (signal_history_.find(id) == signal_history_.end()) {
-      signal_history_[id] = {signal, current_time};
-    } else {
-      if (signal_history_[id].msg.elements != signal.elements) {
-        signal_history_[id].first_seen_time = current_time;
-        signal_history_[id].msg = signal;
-      }
-    }
-
-    auto filtered_signal = signal;
-    if (!is_ego_stopped) {
-      const auto state_duration = (current_time - signal_history_[id].first_seen_time).seconds();
-      bool is_red = autoware::traffic_light_utils::hasTrafficLightShapeAndColor(
-        signal.elements, autoware_perception_msgs::msg::TrafficLightElement::CIRCLE,
-        autoware_perception_msgs::msg::TrafficLightElement::RED);
-      bool is_amber = autoware::traffic_light_utils::hasTrafficLightShapeAndColor(
-        signal.elements, autoware_perception_msgs::msg::TrafficLightElement::CIRCLE,
-        autoware_perception_msgs::msg::TrafficLightElement::AMBER);
-
-      if (is_red && state_duration < params_.stable_duration_threshold_red) {
-        filtered_signal.elements.clear();
-      } else if (is_amber && state_duration < params_.stable_duration_threshold_amber) {
-        filtered_signal.elements.clear();
-      }
-    }
-    filtered_signals.traffic_light_groups.push_back(filtered_signal);
-  }
+  const auto filtered_signals =
+    filter_signals(*context.traffic_light_signals, current_time, is_ego_stopped);
 
   // Amber Hysteresis Tracking
-  std::vector<int64_t> force_reject_amber_ids;
-  if (!is_ego_stopped) {
-    for (const auto & [id, rejected_time] : amber_rejection_history_) {
-      if ((current_time - rejected_time).seconds() <= params_.amber_rejection_hysteresis_duration) {
-        force_reject_amber_ids.push_back(id);
-      }
-    }
-  }
+  const auto force_reject_amber_ids = get_force_reject_amber_ids(current_time, is_ego_stopped);
 
   const traffic_light_filter::Inputs inputs{
     traj_points,
@@ -175,18 +164,17 @@ TrafficLightFilter::result_t TrafficLightFilter::is_feasible(
       is_crossing_red = true;
     } else if (violation.type == traffic_light_filter::ViolationType::AMBER_LIGHT) {
       is_crossing_amber = true;
-      amber_rejection_history_[violation.traffic_light_id] = current_time;
+      if (
+        std::find(
+          force_reject_amber_ids.begin(), force_reject_amber_ids.end(),
+          violation.traffic_light_id) == force_reject_amber_ids.end()) {
+        amber_rejection_history_[violation.traffic_light_id] = current_time;
+      }
     }
   }
 
   // Memory Management
-  for (auto it = amber_rejection_history_.begin(); it != amber_rejection_history_.end();) {
-    if ((current_time - it->second).seconds() > 2.0 * params_.amber_rejection_hysteresis_duration) {
-      it = amber_rejection_history_.erase(it);
-    } else {
-      ++it;
-    }
-  }
+  cleanup_history(current_time);
 
   std::vector<MetricReport> metrics;
   metrics.push_back(
@@ -208,6 +196,82 @@ TrafficLightFilter::result_t TrafficLightFilter::is_feasible(
   const bool is_feasible = !is_crossing_red && !is_crossing_amber;
 
   return ValidationResult{is_feasible, std::move(metrics)};
+}
+
+autoware_perception_msgs::msg::TrafficLightGroupArray TrafficLightFilter::filter_signals(
+  const autoware_perception_msgs::msg::TrafficLightGroupArray & signals,
+  const rclcpp::Time & current_time, bool is_ego_stopped)
+{
+  autoware_perception_msgs::msg::TrafficLightGroupArray filtered_signals;
+  filtered_signals.stamp = signals.stamp;
+
+  for (const auto & signal : signals.traffic_light_groups) {
+    const auto id = signal.traffic_light_group_id;
+    if (signal_history_.find(id) == signal_history_.end()) {
+      signal_history_[id] = {signal, current_time, current_time};
+    } else {
+      if (!is_equal(signal_history_[id].msg.elements, signal.elements)) {
+        signal_history_[id].first_seen_time = current_time;
+        signal_history_[id].msg = signal;
+      }
+      signal_history_[id].last_seen_time = current_time;
+    }
+
+    auto filtered_signal = signal;
+    if (!is_ego_stopped) {
+      const auto state_duration = (current_time - signal_history_[id].first_seen_time).seconds();
+      const bool is_red = autoware::traffic_light_utils::hasTrafficLightShapeAndColor(
+        signal.elements, autoware_perception_msgs::msg::TrafficLightElement::CIRCLE,
+        autoware_perception_msgs::msg::TrafficLightElement::RED);
+      const bool is_amber = autoware::traffic_light_utils::hasTrafficLightShapeAndColor(
+        signal.elements, autoware_perception_msgs::msg::TrafficLightElement::CIRCLE,
+        autoware_perception_msgs::msg::TrafficLightElement::AMBER);
+
+      if (is_red && state_duration < params_.stable_duration_threshold_red) {
+        filtered_signal.elements.clear();
+      } else if (is_amber && state_duration < params_.stable_duration_threshold_amber) {
+        filtered_signal.elements.clear();
+      }
+    }
+    filtered_signals.traffic_light_groups.push_back(filtered_signal);
+  }
+
+  return filtered_signals;
+}
+
+std::vector<int64_t> TrafficLightFilter::get_force_reject_amber_ids(
+  const rclcpp::Time & current_time, bool is_ego_stopped) const
+{
+  std::vector<int64_t> force_reject_amber_ids;
+  if (!is_ego_stopped) {
+    for (const auto & [id, rejected_time] : amber_rejection_history_) {
+      if ((current_time - rejected_time).seconds() <= params_.amber_rejection_hysteresis_duration) {
+        force_reject_amber_ids.push_back(id);
+      }
+    }
+  }
+  return force_reject_amber_ids;
+}
+
+void TrafficLightFilter::cleanup_history(const rclcpp::Time & current_time)
+{
+  for (auto it = amber_rejection_history_.begin(); it != amber_rejection_history_.end();) {
+    if ((current_time - it->second).seconds() > 2.0 * params_.amber_rejection_hysteresis_duration) {
+      it = amber_rejection_history_.erase(it);
+    } else {
+      ++it;
+    }
+  }
+
+  const double max_stable_duration =
+    std::max(params_.stable_duration_threshold_red, params_.stable_duration_threshold_amber);
+  for (auto it = signal_history_.begin(); it != signal_history_.end();) {
+    if ((current_time - it->second.last_seen_time).seconds() > max_stable_duration) {
+      it = signal_history_.erase(it);
+    } else {
+      ++it;
+    }
+  }
 }
 }  // namespace autoware::trajectory_validator::plugin::traffic_rule
 

--- a/planning/autoware_trajectory_validator/src/filters/traffic_rule/traffic_light_filter.cpp
+++ b/planning/autoware_trajectory_validator/src/filters/traffic_rule/traffic_light_filter.cpp
@@ -218,20 +218,22 @@ autoware_perception_msgs::msg::TrafficLightGroupArray TrafficLightFilter::filter
     }
 
     auto filtered_signal = signal;
-    if (!is_ego_stopped) {
-      const auto state_duration = (current_time - signal_history_[id].first_seen_time).seconds();
-      const bool is_red = autoware::traffic_light_utils::hasTrafficLightShapeAndColor(
-        signal.elements, autoware_perception_msgs::msg::TrafficLightElement::CIRCLE,
-        autoware_perception_msgs::msg::TrafficLightElement::RED);
-      const bool is_amber = autoware::traffic_light_utils::hasTrafficLightShapeAndColor(
-        signal.elements, autoware_perception_msgs::msg::TrafficLightElement::CIRCLE,
-        autoware_perception_msgs::msg::TrafficLightElement::AMBER);
+    if (is_ego_stopped) {
+      filtered_signals.traffic_light_groups.push_back(filtered_signal);
+      continue;
+    }
+    const auto state_duration = (current_time - signal_history_[id].first_seen_time).seconds();
+    const bool is_red = autoware::traffic_light_utils::hasTrafficLightShapeAndColor(
+      signal.elements, autoware_perception_msgs::msg::TrafficLightElement::CIRCLE,
+      autoware_perception_msgs::msg::TrafficLightElement::RED);
+    const bool is_amber = autoware::traffic_light_utils::hasTrafficLightShapeAndColor(
+      signal.elements, autoware_perception_msgs::msg::TrafficLightElement::CIRCLE,
+      autoware_perception_msgs::msg::TrafficLightElement::AMBER);
 
-      if (is_red && state_duration < params_.stable_duration_threshold_red) {
-        filtered_signal.elements.clear();
-      } else if (is_amber && state_duration < params_.stable_duration_threshold_amber) {
-        filtered_signal.elements.clear();
-      }
+    if (is_red && state_duration < params_.stable_duration_threshold_red) {
+      filtered_signal.elements.clear();
+    } else if (is_amber && state_duration < params_.stable_duration_threshold_amber) {
+      filtered_signal.elements.clear();
     }
     filtered_signals.traffic_light_groups.push_back(filtered_signal);
   }
@@ -243,11 +245,12 @@ std::vector<int64_t> TrafficLightFilter::get_force_reject_amber_ids(
   const rclcpp::Time & current_time, bool is_ego_stopped) const
 {
   std::vector<int64_t> force_reject_amber_ids;
-  if (!is_ego_stopped) {
-    for (const auto & [id, rejected_time] : amber_rejection_history_) {
-      if ((current_time - rejected_time).seconds() <= params_.amber_rejection_hysteresis_duration) {
-        force_reject_amber_ids.push_back(id);
-      }
+  if (is_ego_stopped) {
+    return force_reject_amber_ids;
+  }
+  for (const auto & [id, rejected_time] : amber_rejection_history_) {
+    if ((current_time - rejected_time).seconds() <= params_.amber_rejection_hysteresis_duration) {
+      force_reject_amber_ids.push_back(id);
     }
   }
   return force_reject_amber_ids;

--- a/planning/autoware_trajectory_validator/src/filters/traffic_rule/traffic_light_filter.cpp
+++ b/planning/autoware_trajectory_validator/src/filters/traffic_rule/traffic_light_filter.cpp
@@ -259,7 +259,7 @@ std::vector<int64_t> TrafficLightFilter::get_force_reject_amber_ids(
 void TrafficLightFilter::cleanup_history(const rclcpp::Time & current_time)
 {
   for (auto it = amber_rejection_history_.begin(); it != amber_rejection_history_.end();) {
-    if ((current_time - it->second).seconds() > 2.0 * params_.amber_rejection_hysteresis_duration) {
+    if ((current_time - it->second).seconds() > params_.amber_rejection_hysteresis_duration) {
       it = amber_rejection_history_.erase(it);
     } else {
       ++it;

--- a/planning/autoware_trajectory_validator/src/filters/traffic_rule/traffic_light_filter.cpp
+++ b/planning/autoware_trajectory_validator/src/filters/traffic_rule/traffic_light_filter.cpp
@@ -14,6 +14,7 @@
 
 #include "autoware/trajectory_validator/filters/traffic_rule/traffic_light_filter.hpp"
 
+#include <autoware/traffic_light_utils/traffic_light_utils.hpp>
 #include <rclcpp/logging.hpp>
 
 #include <memory>
@@ -60,6 +61,10 @@ autoware::trajectory_validator::traffic_light_filter::Parameters to_checker_para
   p.crossing_time_limit = params.crossing_time_limit;
   p.treat_amber_light_as_red_light = params.treat_amber_light_as_red_light;
   p.stop_overshoot_margin = params.stop_overshoot_margin;
+  p.stable_duration_threshold_red = params.stable_duration_threshold_red;
+  p.stable_duration_threshold_amber = params.stable_duration_threshold_amber;
+  p.amber_rejection_hysteresis_duration = params.amber_rejection_hysteresis_duration;
+  p.ego_stopped_velocity_threshold = params.ego_stopped_velocity_threshold;
   p.checked_trajectory_length.deceleration_limit =
     params.checked_trajectory_length.deceleration_limit;
   p.checked_trajectory_length.jerk_limit = params.checked_trajectory_length.jerk_limit;
@@ -100,13 +105,62 @@ TrafficLightFilter::result_t TrafficLightFilter::is_feasible(
     return tl::make_unexpected("Compliance checker is not initialized.");
   }
 
+  const auto current_time = rclcpp::Time(context.odometry->header.stamp);
+  const auto velocity = context.odometry->twist.twist.linear.x;
+  const bool is_ego_stopped = std::abs(velocity) < params_.ego_stopped_velocity_threshold;
+
+  // Signal Stability Filter
+  autoware_perception_msgs::msg::TrafficLightGroupArray filtered_signals;
+  filtered_signals.stamp = context.traffic_light_signals->stamp;
+
+  for (const auto & signal : context.traffic_light_signals->traffic_light_groups) {
+    const auto id = signal.traffic_light_group_id;
+    if (signal_history_.find(id) == signal_history_.end()) {
+      signal_history_[id] = {signal, current_time};
+    } else {
+      if (signal_history_[id].msg.elements != signal.elements) {
+        signal_history_[id].first_seen_time = current_time;
+        signal_history_[id].msg = signal;
+      }
+    }
+
+    auto filtered_signal = signal;
+    if (!is_ego_stopped) {
+      const auto state_duration = (current_time - signal_history_[id].first_seen_time).seconds();
+      bool is_red = autoware::traffic_light_utils::hasTrafficLightShapeAndColor(
+        signal.elements, autoware_perception_msgs::msg::TrafficLightElement::CIRCLE,
+        autoware_perception_msgs::msg::TrafficLightElement::RED);
+      bool is_amber = autoware::traffic_light_utils::hasTrafficLightShapeAndColor(
+        signal.elements, autoware_perception_msgs::msg::TrafficLightElement::CIRCLE,
+        autoware_perception_msgs::msg::TrafficLightElement::AMBER);
+
+      if (is_red && state_duration < params_.stable_duration_threshold_red) {
+        filtered_signal.elements.clear();
+      } else if (is_amber && state_duration < params_.stable_duration_threshold_amber) {
+        filtered_signal.elements.clear();
+      }
+    }
+    filtered_signals.traffic_light_groups.push_back(filtered_signal);
+  }
+
+  // Amber Hysteresis Tracking
+  std::vector<int64_t> force_reject_amber_ids;
+  if (!is_ego_stopped) {
+    for (const auto & [id, rejected_time] : amber_rejection_history_) {
+      if ((current_time - rejected_time).seconds() <= params_.amber_rejection_hysteresis_duration) {
+        force_reject_amber_ids.push_back(id);
+      }
+    }
+  }
+
   const traffic_light_filter::Inputs inputs{
     traj_points,
     context.lanelet_map,
     *context.route,
-    *context.traffic_light_signals,
+    filtered_signals,
     context.odometry->twist.twist.linear.x,
-    context.acceleration->accel.accel.linear.x};
+    context.acceleration->accel.accel.linear.x,
+    force_reject_amber_ids};
 
   const auto result = checker_->check(inputs);
   if (!result) {
@@ -121,6 +175,16 @@ TrafficLightFilter::result_t TrafficLightFilter::is_feasible(
       is_crossing_red = true;
     } else if (violation.type == traffic_light_filter::ViolationType::AMBER_LIGHT) {
       is_crossing_amber = true;
+      amber_rejection_history_[violation.traffic_light_id] = current_time;
+    }
+  }
+
+  // Memory Management
+  for (auto it = amber_rejection_history_.begin(); it != amber_rejection_history_.end();) {
+    if ((current_time - it->second).seconds() > 2.0 * params_.amber_rejection_hysteresis_duration) {
+      it = amber_rejection_history_.erase(it);
+    } else {
+      ++it;
     }
   }
 

--- a/planning/autoware_trajectory_validator/src/filters/traffic_rule/traffic_light_filter.cpp
+++ b/planning/autoware_trajectory_validator/src/filters/traffic_rule/traffic_light_filter.cpp
@@ -266,10 +266,13 @@ void TrafficLightFilter::cleanup_history(const rclcpp::Time & current_time)
     }
   }
 
-  const double max_stable_duration =
-    std::max(params_.stable_duration_threshold_red, params_.stable_duration_threshold_amber);
   for (auto it = signal_history_.begin(); it != signal_history_.end();) {
-    if ((current_time - it->second.last_seen_time).seconds() > max_stable_duration) {
+    const auto stable_duration =
+      autoware::traffic_light_utils::hasTrafficLightColor(
+        it->second.msg.elements, autoware_perception_msgs::msg::TrafficLightElement::RED)
+        ? params_.stable_duration_threshold_red
+        : params_.stable_duration_threshold_amber;
+    if ((current_time - it->second.last_seen_time).seconds() > stable_duration) {
       it = signal_history_.erase(it);
     } else {
       ++it;

--- a/planning/autoware_trajectory_validator/test/plugins/test_traffic_light_filter.cpp
+++ b/planning/autoware_trajectory_validator/test/plugins/test_traffic_light_filter.cpp
@@ -27,6 +27,7 @@
 
 #include <algorithm>
 #include <memory>
+#include <string>
 #include <vector>
 
 using autoware::trajectory_validator::FilterContext;
@@ -170,6 +171,15 @@ protected:
     return points;
   }
 
+  void expect_feasibility(
+    const std::vector<TrajectoryPoint> & points, const bool expected_feasible,
+    const std::string & message = "")
+  {
+    const auto res = filter_->is_feasible(points, context_);
+    ASSERT_TRUE(res.has_value()) << "is_feasible should not return an error";
+    EXPECT_EQ(res->is_feasible, expected_feasible) << message;
+  }
+
   std::shared_ptr<TrafficLightFilter> filter_;
   std::shared_ptr<rclcpp::Node> node_;
   FilterContext context_;
@@ -180,10 +190,9 @@ TEST_F(TrafficLightFilterTest, IsFeasibleEmptyInput)
   std::vector<TrajectoryPoint> points;
   create_and_set_map(0, 0);
   set_traffic_light_signal(0, TrafficLightElement::RED);
-  const auto res = filter_->is_feasible(points, context_);
-  ASSERT_TRUE(res.has_value());
-  EXPECT_TRUE(res->is_feasible)
-    << "Empty trajectory should always be feasible (cannot cross a traffic light if empty)";
+  expect_feasibility(
+    points, true,
+    "Empty trajectory should always be feasible (cannot cross a traffic light if empty)");
 }
 
 TEST_F(TrafficLightFilterTest, IsInfeasibleWithoutMapAndSignals)
@@ -234,9 +243,7 @@ TEST_F(TrafficLightFilterTest, IsInfeasibleWithRedLightIntersection)
   // Trajectory crossing stop line (0 -> 10)
   auto points = create_trajectory(0.0, 10.0);
 
-  const auto res = filter_->is_feasible(points, context_);
-  ASSERT_TRUE(res.has_value());
-  EXPECT_FALSE(res->is_feasible) << "Should return false when crossing red light stop line";
+  expect_feasibility(points, false, "Should return false when crossing red light stop line");
 }
 
 TEST_F(TrafficLightFilterTest, IsFeasibleWithGreenLight)
@@ -250,9 +257,7 @@ TEST_F(TrafficLightFilterTest, IsFeasibleWithGreenLight)
   // Trajectory crossing stop line (0 -> 10)
   auto points = create_trajectory(0.0, 10.0);
 
-  const auto res = filter_->is_feasible(points, context_);
-  ASSERT_TRUE(res.has_value());
-  EXPECT_TRUE(res->is_feasible) << "Should return true for green light";
+  expect_feasibility(points, true, "Should return true for green light");
 }
 
 TEST_F(TrafficLightFilterTest, IsFeasibleWithRedLightNoIntersection)
@@ -266,9 +271,7 @@ TEST_F(TrafficLightFilterTest, IsFeasibleWithRedLightNoIntersection)
   // Trajectory stops before stop line (0 -> 4)
   auto points = create_trajectory(0.0, 4.0);
 
-  const auto res = filter_->is_feasible(points, context_);
-  ASSERT_TRUE(res.has_value());
-  EXPECT_TRUE(res->is_feasible) << "Should return true if red light is not crossed";
+  expect_feasibility(points, true, "Should return true if red light is not crossed");
 }
 
 TEST_F(TrafficLightFilterTest, IsInfeasibleWithFrontOverhang)
@@ -286,9 +289,7 @@ TEST_F(TrafficLightFilterTest, IsInfeasibleWithFrontOverhang)
   vehicle_info.max_longitudinal_offset_m = 2.0;
   filter_->set_vehicle_info(vehicle_info);
 
-  const auto res = filter_->is_feasible(points, context_);
-  ASSERT_TRUE(res.has_value());
-  EXPECT_FALSE(res->is_feasible) << "Should return false when crossing red light stop line";
+  expect_feasibility(points, false, "Should return false when crossing red light stop line");
 }
 
 TEST_F(TrafficLightFilterTest, IsInfeasibleWithAmberLightCanStop)
@@ -307,9 +308,7 @@ TEST_F(TrafficLightFilterTest, IsInfeasibleWithAmberLightCanStop)
 
   auto points = create_trajectory(0.0, 30.0, 5.0);
 
-  const auto res = filter_->is_feasible(points, context_);
-  ASSERT_TRUE(res.has_value());
-  EXPECT_FALSE(res->is_feasible) << "Should return false if amber light can be stopped";
+  expect_feasibility(points, false, "Should return false if amber light can be stopped");
 }
 
 TEST_F(TrafficLightFilterTest, IsFeasibleWithAmberLightCannotStop)
@@ -331,10 +330,8 @@ TEST_F(TrafficLightFilterTest, IsFeasibleWithAmberLightCannotStop)
 
   auto points = create_trajectory(0.0, 10.0, 10.0);
 
-  const auto res = filter_->is_feasible(points, context_);
-  ASSERT_TRUE(res.has_value());
-  EXPECT_TRUE(res->is_feasible)
-    << "Should return true if amber light cannot be stopped but is reachable";
+  expect_feasibility(
+    points, true, "Should return true if amber light cannot be stopped but is reachable");
 }
 
 TEST_F(TrafficLightFilterTest, IsInfeasibleWithAmberLightCanStopAndCannotPass)
@@ -362,9 +359,7 @@ TEST_F(TrafficLightFilterTest, IsInfeasibleWithAmberLightCanStopAndCannotPass)
 
   auto points = create_trajectory(0.0, 200.0, 10.0);
 
-  const auto res = filter_->is_feasible(points, context_);
-  ASSERT_TRUE(res.has_value());
-  EXPECT_FALSE(res->is_feasible) << "Should return false if ego can stop but cannot pass";
+  expect_feasibility(points, false, "Should return false if ego can stop but cannot pass");
 }
 
 TEST_F(TrafficLightFilterTest, IsInfeasibleWithAmberLightAsRedLight)
@@ -392,10 +387,9 @@ TEST_F(TrafficLightFilterTest, IsInfeasibleWithAmberLightAsRedLight)
   // it should be rejected because it's treated as red.
   auto points = create_trajectory(0.0, 10.0, 10.0);
 
-  const auto res = filter_->is_feasible(points, context_);
-  ASSERT_TRUE(res.has_value());
-  EXPECT_FALSE(res->is_feasible)
-    << "Should return false for amber light when treat_amber_light_as_red_light is true";
+  expect_feasibility(
+    points, false,
+    "Should return false for amber light when treat_amber_light_as_red_light is true");
 }
 
 TEST_F(TrafficLightFilterTest, IsFeasibleWithStabilityFiltering)
@@ -421,11 +415,7 @@ TEST_F(TrafficLightFilterTest, IsFeasibleWithStabilityFiltering)
   // Set initial state to GREEN
   set_traffic_light_signal(light_id, TrafficLightElement::GREEN);
   auto points = create_trajectory(0.0, 10.0);
-  {
-    const auto res = filter_->is_feasible(points, context_);
-    ASSERT_TRUE(res.has_value());
-    EXPECT_TRUE(res->is_feasible);
-  }
+  expect_feasibility(points, true);
 
   // Switch to RED at t=0
   set_traffic_light_signal(light_id, TrafficLightElement::RED);
@@ -434,31 +424,19 @@ TEST_F(TrafficLightFilterTest, IsFeasibleWithStabilityFiltering)
   context_.odometry = std::make_shared<nav_msgs::msg::Odometry>(odometry);
 
   // Immediately check, should be feasible because of stability threshold
-  {
-    const auto res = filter_->is_feasible(points, context_);
-    ASSERT_TRUE(res.has_value());
-    EXPECT_TRUE(res->is_feasible) << "Should be feasible because signal is not stable yet";
-  }
+  expect_feasibility(points, true, "Should be feasible because signal is not stable yet");
 
   // Advance time by 0.5s (less than 1s threshold)
   odometry.header.stamp =
     rclcpp::Time(context_.odometry->header.stamp) + rclcpp::Duration::from_seconds(0.5);
   context_.odometry = std::make_shared<nav_msgs::msg::Odometry>(odometry);
-  {
-    const auto res = filter_->is_feasible(points, context_);
-    ASSERT_TRUE(res.has_value());
-    EXPECT_TRUE(res->is_feasible) << "Should still be feasible after 0.5s";
-  }
+  expect_feasibility(points, true, "Should still be feasible after 0.5s");
 
   // Advance time by another 0.6s (total 1.1s > 1s threshold)
   odometry.header.stamp =
     rclcpp::Time(context_.odometry->header.stamp) + rclcpp::Duration::from_seconds(0.6);
   context_.odometry = std::make_shared<nav_msgs::msg::Odometry>(odometry);
-  {
-    const auto res = filter_->is_feasible(points, context_);
-    ASSERT_TRUE(res.has_value());
-    EXPECT_FALSE(res->is_feasible) << "Should be infeasible after stability threshold is exceeded";
-  }
+  expect_feasibility(points, false, "Should be infeasible after stability threshold is exceeded");
 }
 
 TEST_F(TrafficLightFilterTest, IsFeasibleWithAmberHysteresis)
@@ -484,9 +462,7 @@ TEST_F(TrafficLightFilterTest, IsFeasibleWithAmberHysteresis)
   auto points = create_trajectory(0.0, 30.0, 5.0);
 
   // First check: should be infeasible (can stop for amber)
-  const auto res1 = filter_->is_feasible(points, context_);
-  ASSERT_TRUE(res1.has_value());
-  EXPECT_FALSE(res1->is_feasible);
+  expect_feasibility(points, false);
 
   // Advance time by 1s (less than 2s hysteresis)
   nav_msgs::msg::Odometry odometry = *context_.odometry;
@@ -496,18 +472,14 @@ TEST_F(TrafficLightFilterTest, IsFeasibleWithAmberHysteresis)
   // Move ego closer to 5m from stop line. Now cannot stop (5m away at 10m/s)
   auto points2 = create_trajectory(15.0, 30.0, 10.0);
 
-  const auto res2 = filter_->is_feasible(points2, context_);
-  ASSERT_TRUE(res2.has_value());
-  EXPECT_FALSE(res2->is_feasible) << "Should be infeasible due to amber hysteresis";
+  expect_feasibility(points2, false, "Should be infeasible due to amber hysteresis");
 
   // Advance time by another 1.1s (total 2.1s > 2s hysteresis)
   odometry.header.stamp = rclcpp::Time(odometry.header.stamp) + rclcpp::Duration::from_seconds(1.1);
   context_.odometry = std::make_shared<nav_msgs::msg::Odometry>(odometry);
 
   // Now it should be feasible if it cannot stop
-  const auto res3 = filter_->is_feasible(points2, context_);
-  ASSERT_TRUE(res3.has_value());
-  EXPECT_TRUE(res3->is_feasible) << "Should be feasible after hysteresis duration";
+  expect_feasibility(points2, true, "Should be feasible after hysteresis duration");
 }
 
 TEST_F(TrafficLightFilterTest, IsFeasibleWithSignalHistoryCleanup)
@@ -528,11 +500,7 @@ TEST_F(TrafficLightFilterTest, IsFeasibleWithSignalHistoryCleanup)
 
   // 1. Send RED signal
   set_traffic_light_signal(light_id, TrafficLightElement::RED);
-  {
-    const auto res = filter_->is_feasible(points, context_);
-    ASSERT_TRUE(res.has_value());
-    EXPECT_TRUE(res->is_feasible);
-  }
+  expect_feasibility(points, true);
 
   // 2. Stop sending signal for 2.0s
   context_.traffic_light_signals = std::make_shared<TrafficLightGroupArray>();
@@ -541,19 +509,11 @@ TEST_F(TrafficLightFilterTest, IsFeasibleWithSignalHistoryCleanup)
   context_.odometry = std::make_shared<nav_msgs::msg::Odometry>(odometry);
 
   // Trigger cleanup
-  {
-    const auto res = filter_->is_feasible(points, context_);
-    ASSERT_TRUE(res.has_value());
-    EXPECT_TRUE(res->is_feasible);
-  }
+  expect_feasibility(points, true);
 
   // 3. Send RED signal again. It should be treated as new (not stable yet).
   set_traffic_light_signal(light_id, TrafficLightElement::RED);
-  {
-    const auto res = filter_->is_feasible(points, context_);
-    ASSERT_TRUE(res.has_value());
-    EXPECT_TRUE(res->is_feasible) << "Should be feasible because history was cleaned up";
-  }
+  expect_feasibility(points, true, "Should be feasible because history was cleaned up");
 }
 
 TEST_F(TrafficLightFilterTest, IsFeasibleWithSignalStateChange)
@@ -574,46 +534,26 @@ TEST_F(TrafficLightFilterTest, IsFeasibleWithSignalStateChange)
 
   // 1. Send AMBER signal
   set_traffic_light_signal(light_id, TrafficLightElement::AMBER);
-  {
-    const auto res = filter_->is_feasible(points, context_);
-    ASSERT_TRUE(res.has_value());
-    EXPECT_TRUE(res->is_feasible);
-  }
+  expect_feasibility(points, true);
 
   // 2. Advance 0.5s, still AMBER
   nav_msgs::msg::Odometry odometry = *context_.odometry;
   odometry.header.stamp = rclcpp::Time(odometry.header.stamp) + rclcpp::Duration::from_seconds(0.5);
   context_.odometry = std::make_shared<nav_msgs::msg::Odometry>(odometry);
-  {
-    const auto res = filter_->is_feasible(points, context_);
-    ASSERT_TRUE(res.has_value());
-    EXPECT_TRUE(res->is_feasible);
-  }
+  expect_feasibility(points, true);
 
   // 3. Switch to RED
   set_traffic_light_signal(light_id, TrafficLightElement::RED);
   // Stability timer should reset.
-  {
-    const auto res = filter_->is_feasible(points, context_);
-    ASSERT_TRUE(res.has_value());
-    EXPECT_TRUE(res->is_feasible) << "Should be feasible after state change";
-  }
+  expect_feasibility(points, true, "Should be feasible after state change");
 
   // 4. Advance another 0.6s (total from AMBER start is 1.1s, but from RED start is 0.6s)
   odometry.header.stamp = rclcpp::Time(odometry.header.stamp) + rclcpp::Duration::from_seconds(0.6);
   context_.odometry = std::make_shared<nav_msgs::msg::Odometry>(odometry);
-  {
-    const auto res = filter_->is_feasible(points, context_);
-    ASSERT_TRUE(res.has_value());
-    EXPECT_TRUE(res->is_feasible) << "Should still be feasible (0.6s < 1.0s)";
-  }
+  expect_feasibility(points, true, "Should still be feasible (0.6s < 1.0s)");
 
   // 5. Advance another 0.5s (total from RED start is 1.1s > 1.0s duration threshold)
   odometry.header.stamp = rclcpp::Time(odometry.header.stamp) + rclcpp::Duration::from_seconds(0.5);
   context_.odometry = std::make_shared<nav_msgs::msg::Odometry>(odometry);
-  {
-    const auto res = filter_->is_feasible(points, context_);
-    ASSERT_TRUE(res.has_value());
-    EXPECT_FALSE(res->is_feasible) << "Should be unfeasible (stable RED signal)";
-  }
+  expect_feasibility(points, false, "Should be unfeasible (stable RED signal)");
 }

--- a/planning/autoware_trajectory_validator/test/plugins/test_traffic_light_filter.cpp
+++ b/planning/autoware_trajectory_validator/test/plugins/test_traffic_light_filter.cpp
@@ -180,7 +180,9 @@ TEST_F(TrafficLightFilterTest, IsFeasibleEmptyInput)
   std::vector<TrajectoryPoint> points;
   create_and_set_map(0, 0);
   set_traffic_light_signal(0, TrafficLightElement::RED);
-  EXPECT_TRUE(filter_->is_feasible(points, context_))
+  const auto res = filter_->is_feasible(points, context_);
+  ASSERT_TRUE(res.has_value());
+  EXPECT_TRUE(res->is_feasible)
     << "Empty trajectory should always be feasible (cannot cross a traffic light if empty)";
 }
 
@@ -248,7 +250,9 @@ TEST_F(TrafficLightFilterTest, IsFeasibleWithGreenLight)
   // Trajectory crossing stop line (0 -> 10)
   auto points = create_trajectory(0.0, 10.0);
 
-  EXPECT_TRUE(filter_->is_feasible(points, context_)) << "Should return true for green light";
+  const auto res = filter_->is_feasible(points, context_);
+  ASSERT_TRUE(res.has_value());
+  EXPECT_TRUE(res->is_feasible) << "Should return true for green light";
 }
 
 TEST_F(TrafficLightFilterTest, IsFeasibleWithRedLightNoIntersection)
@@ -262,8 +266,9 @@ TEST_F(TrafficLightFilterTest, IsFeasibleWithRedLightNoIntersection)
   // Trajectory stops before stop line (0 -> 4)
   auto points = create_trajectory(0.0, 4.0);
 
-  EXPECT_TRUE(filter_->is_feasible(points, context_))
-    << "Should return true if red light is not crossed";
+  const auto res = filter_->is_feasible(points, context_);
+  ASSERT_TRUE(res.has_value());
+  EXPECT_TRUE(res->is_feasible) << "Should return true if red light is not crossed";
 }
 
 TEST_F(TrafficLightFilterTest, IsInfeasibleWithFrontOverhang)
@@ -326,7 +331,9 @@ TEST_F(TrafficLightFilterTest, IsFeasibleWithAmberLightCannotStop)
 
   auto points = create_trajectory(0.0, 10.0, 10.0);
 
-  EXPECT_TRUE(filter_->is_feasible(points, context_))
+  const auto res = filter_->is_feasible(points, context_);
+  ASSERT_TRUE(res.has_value());
+  EXPECT_TRUE(res->is_feasible)
     << "Should return true if amber light cannot be stopped but is reachable";
 }
 
@@ -414,7 +421,11 @@ TEST_F(TrafficLightFilterTest, IsFeasibleWithStabilityFiltering)
   // Set initial state to GREEN
   set_traffic_light_signal(light_id, TrafficLightElement::GREEN);
   auto points = create_trajectory(0.0, 10.0);
-  EXPECT_TRUE(filter_->is_feasible(points, context_));
+  {
+    const auto res = filter_->is_feasible(points, context_);
+    ASSERT_TRUE(res.has_value());
+    EXPECT_TRUE(res->is_feasible);
+  }
 
   // Switch to RED at t=0
   set_traffic_light_signal(light_id, TrafficLightElement::RED);
@@ -423,20 +434,186 @@ TEST_F(TrafficLightFilterTest, IsFeasibleWithStabilityFiltering)
   context_.odometry = std::make_shared<nav_msgs::msg::Odometry>(odometry);
 
   // Immediately check, should be feasible because of stability threshold
-  EXPECT_TRUE(filter_->is_feasible(points, context_))
-    << "Should be feasible because signal is not stable yet";
+  {
+    const auto res = filter_->is_feasible(points, context_);
+    ASSERT_TRUE(res.has_value());
+    EXPECT_TRUE(res->is_feasible) << "Should be feasible because signal is not stable yet";
+  }
 
   // Advance time by 0.5s (less than 1s threshold)
   odometry.header.stamp =
     rclcpp::Time(context_.odometry->header.stamp) + rclcpp::Duration::from_seconds(0.5);
   context_.odometry = std::make_shared<nav_msgs::msg::Odometry>(odometry);
-  EXPECT_TRUE(filter_->is_feasible(points, context_)) << "Should still be feasible after 0.5s";
+  {
+    const auto res = filter_->is_feasible(points, context_);
+    ASSERT_TRUE(res.has_value());
+    EXPECT_TRUE(res->is_feasible) << "Should still be feasible after 0.5s";
+  }
 
   // Advance time by another 0.6s (total 1.1s > 1s threshold)
   odometry.header.stamp =
     rclcpp::Time(context_.odometry->header.stamp) + rclcpp::Duration::from_seconds(0.6);
   context_.odometry = std::make_shared<nav_msgs::msg::Odometry>(odometry);
-  const auto res = filter_->is_feasible(points, context_);
-  ASSERT_TRUE(res.has_value());
-  EXPECT_FALSE(res->is_feasible) << "Should be infeasible after stability threshold is exceeded";
+  {
+    const auto res = filter_->is_feasible(points, context_);
+    ASSERT_TRUE(res.has_value());
+    EXPECT_FALSE(res->is_feasible) << "Should be infeasible after stability threshold is exceeded";
+  }
+}
+
+TEST_F(TrafficLightFilterTest, IsFeasibleWithAmberHysteresis)
+{
+  const lanelet::Id light_id = 500;
+  const double stop_x = 20.0;
+
+  create_and_set_map(light_id, stop_x);
+
+  validator::Params params;
+  params.traffic_light.deceleration_limit = 2.8;
+  params.traffic_light.delay_response_time = 0.5;
+  params.traffic_light.crossing_time_limit = 2.75;
+  params.traffic_light.treat_amber_light_as_red_light = false;
+  params.traffic_light.amber_rejection_hysteresis_duration = 2.0;  // 2 seconds hysteresis
+  params.traffic_light.ego_stopped_velocity_threshold = 0.01;
+  params.traffic_light.checked_trajectory_length.deceleration_limit = 999.9;
+  params.traffic_light.checked_trajectory_length.jerk_limit = 999.9;
+  filter_->update_parameters(params);
+
+  // Ego at 0m, velocity 5m/s. Stoppable.
+  set_traffic_light_signal(light_id, TrafficLightElement::AMBER);
+  auto points = create_trajectory(0.0, 30.0, 5.0);
+
+  // First check: should be infeasible (can stop for amber)
+  const auto res1 = filter_->is_feasible(points, context_);
+  ASSERT_TRUE(res1.has_value());
+  EXPECT_FALSE(res1->is_feasible);
+
+  // Advance time by 1s (less than 2s hysteresis)
+  nav_msgs::msg::Odometry odometry = *context_.odometry;
+  odometry.header.stamp = rclcpp::Time(odometry.header.stamp) + rclcpp::Duration::from_seconds(1.0);
+  context_.odometry = std::make_shared<nav_msgs::msg::Odometry>(odometry);
+
+  // Move ego closer to 5m from stop line. Now cannot stop (5m away at 10m/s)
+  auto points2 = create_trajectory(15.0, 30.0, 10.0);
+
+  const auto res2 = filter_->is_feasible(points2, context_);
+  ASSERT_TRUE(res2.has_value());
+  EXPECT_FALSE(res2->is_feasible) << "Should be infeasible due to amber hysteresis";
+
+  // Advance time by another 1.1s (total 2.1s > 2s hysteresis)
+  odometry.header.stamp = rclcpp::Time(odometry.header.stamp) + rclcpp::Duration::from_seconds(1.1);
+  context_.odometry = std::make_shared<nav_msgs::msg::Odometry>(odometry);
+
+  // Now it should be feasible if it cannot stop
+  const auto res3 = filter_->is_feasible(points2, context_);
+  ASSERT_TRUE(res3.has_value());
+  EXPECT_TRUE(res3->is_feasible) << "Should be feasible after hysteresis duration";
+}
+
+TEST_F(TrafficLightFilterTest, IsFeasibleWithSignalHistoryCleanup)
+{
+  const lanelet::Id light_id = 600;
+  const double stop_x = 5.0;
+  create_and_set_map(light_id, stop_x);
+
+  validator::Params params;
+  params.traffic_light.stable_duration_threshold_red = 1.0;
+  params.traffic_light.stable_duration_threshold_amber = 1.0;
+  params.traffic_light.ego_stopped_velocity_threshold = 0.01;
+  params.traffic_light.checked_trajectory_length.deceleration_limit = 999.9;
+  params.traffic_light.checked_trajectory_length.jerk_limit = 999.9;
+  filter_->update_parameters(params);
+
+  auto points = create_trajectory(0.0, 10.0);
+
+  // 1. Send RED signal
+  set_traffic_light_signal(light_id, TrafficLightElement::RED);
+  {
+    const auto res = filter_->is_feasible(points, context_);
+    ASSERT_TRUE(res.has_value());
+    EXPECT_TRUE(res->is_feasible);
+  }
+
+  // 2. Stop sending signal for 2.0s
+  context_.traffic_light_signals = std::make_shared<TrafficLightGroupArray>();
+  nav_msgs::msg::Odometry odometry = *context_.odometry;
+  odometry.header.stamp = rclcpp::Time(odometry.header.stamp) + rclcpp::Duration::from_seconds(2.0);
+  context_.odometry = std::make_shared<nav_msgs::msg::Odometry>(odometry);
+
+  // Trigger cleanup
+  {
+    const auto res = filter_->is_feasible(points, context_);
+    ASSERT_TRUE(res.has_value());
+    EXPECT_TRUE(res->is_feasible);
+  }
+
+  // 3. Send RED signal again. It should be treated as new (not stable yet).
+  set_traffic_light_signal(light_id, TrafficLightElement::RED);
+  {
+    const auto res = filter_->is_feasible(points, context_);
+    ASSERT_TRUE(res.has_value());
+    EXPECT_TRUE(res->is_feasible) << "Should be feasible because history was cleaned up";
+  }
+}
+
+TEST_F(TrafficLightFilterTest, IsFeasibleWithSignalStateChange)
+{
+  const lanelet::Id light_id = 700;
+  const double stop_x = 5.0;
+  create_and_set_map(light_id, stop_x);
+
+  validator::Params params;
+  params.traffic_light.stable_duration_threshold_red = 1.0;
+  params.traffic_light.stable_duration_threshold_amber = 1.0;
+  params.traffic_light.ego_stopped_velocity_threshold = 0.01;
+  params.traffic_light.checked_trajectory_length.deceleration_limit = 999.9;
+  params.traffic_light.checked_trajectory_length.jerk_limit = 999.9;
+  filter_->update_parameters(params);
+
+  auto points = create_trajectory(0.0, 10.0);
+
+  // 1. Send AMBER signal
+  set_traffic_light_signal(light_id, TrafficLightElement::AMBER);
+  {
+    const auto res = filter_->is_feasible(points, context_);
+    ASSERT_TRUE(res.has_value());
+    EXPECT_TRUE(res->is_feasible);
+  }
+
+  // 2. Advance 0.5s, still AMBER
+  nav_msgs::msg::Odometry odometry = *context_.odometry;
+  odometry.header.stamp = rclcpp::Time(odometry.header.stamp) + rclcpp::Duration::from_seconds(0.5);
+  context_.odometry = std::make_shared<nav_msgs::msg::Odometry>(odometry);
+  {
+    const auto res = filter_->is_feasible(points, context_);
+    ASSERT_TRUE(res.has_value());
+    EXPECT_TRUE(res->is_feasible);
+  }
+
+  // 3. Switch to RED
+  set_traffic_light_signal(light_id, TrafficLightElement::RED);
+  // Stability timer should reset.
+  {
+    const auto res = filter_->is_feasible(points, context_);
+    ASSERT_TRUE(res.has_value());
+    EXPECT_TRUE(res->is_feasible) << "Should be feasible after state change";
+  }
+
+  // 4. Advance another 0.6s (total from AMBER start is 1.1s, but from RED start is 0.6s)
+  odometry.header.stamp = rclcpp::Time(odometry.header.stamp) + rclcpp::Duration::from_seconds(0.6);
+  context_.odometry = std::make_shared<nav_msgs::msg::Odometry>(odometry);
+  {
+    const auto res = filter_->is_feasible(points, context_);
+    ASSERT_TRUE(res.has_value());
+    EXPECT_TRUE(res->is_feasible) << "Should still be feasible (0.6s < 1.0s)";
+  }
+
+  // 5. Advance another 0.5s (total from RED start is 1.1s > 1.0s duration threshold)
+  odometry.header.stamp = rclcpp::Time(odometry.header.stamp) + rclcpp::Duration::from_seconds(0.5);
+  context_.odometry = std::make_shared<nav_msgs::msg::Odometry>(odometry);
+  {
+    const auto res = filter_->is_feasible(points, context_);
+    ASSERT_TRUE(res.has_value());
+    EXPECT_FALSE(res->is_feasible) << "Should be unfeasible (stable RED signal)";
+  }
 }

--- a/planning/autoware_trajectory_validator/test/plugins/test_traffic_light_filter.cpp
+++ b/planning/autoware_trajectory_validator/test/plugins/test_traffic_light_filter.cpp
@@ -56,6 +56,10 @@ protected:
     node_->declare_parameter("traffic_light.delay_response_time", 0.5);
     node_->declare_parameter("traffic_light.crossing_time_limit", 2.75);
     node_->declare_parameter("traffic_light.treat_amber_light_as_red_light", false);
+    node_->declare_parameter("traffic_light.stable_duration_threshold_red", 0.0);
+    node_->declare_parameter("traffic_light.stable_duration_threshold_amber", 0.0);
+    node_->declare_parameter("traffic_light.amber_rejection_hysteresis_duration", 0.0);
+    node_->declare_parameter("traffic_light.ego_stopped_velocity_threshold", 0.01);
     node_->declare_parameter("traffic_light.checked_trajectory_length.deceleration_limit", 999.9);
     node_->declare_parameter("traffic_light.checked_trajectory_length.jerk_limit", 999.9);
 
@@ -65,6 +69,10 @@ protected:
     params.traffic_light.delay_response_time = 0.5;
     params.traffic_light.crossing_time_limit = 2.75;
     params.traffic_light.treat_amber_light_as_red_light = false;
+    params.traffic_light.stable_duration_threshold_red = 0.0;
+    params.traffic_light.stable_duration_threshold_amber = 0.0;
+    params.traffic_light.amber_rejection_hysteresis_duration = 0.0;
+    params.traffic_light.ego_stopped_velocity_threshold = 0.01;
     params.traffic_light.checked_trajectory_length.deceleration_limit = 999.9;
     params.traffic_light.checked_trajectory_length.jerk_limit = 999.9;
     filter_->update_parameters(params);
@@ -75,6 +83,7 @@ protected:
     acceleration->accel.accel.linear.x = 0.0f;
     context_.acceleration = acceleration;
     auto odometry = std::make_shared<nav_msgs::msg::Odometry>();
+    odometry->header.stamp = node_->now();
     odometry->twist.twist.linear.x = 5.0f;
     context_.odometry = odometry;
   }
@@ -364,6 +373,12 @@ TEST_F(TrafficLightFilterTest, IsInfeasibleWithAmberLightAsRedLight)
   params.traffic_light.delay_response_time = 0.5;
   params.traffic_light.crossing_time_limit = 2.75;
   params.traffic_light.treat_amber_light_as_red_light = true;
+  params.traffic_light.stable_duration_threshold_red = 0.0;
+  params.traffic_light.stable_duration_threshold_amber = 0.0;
+  params.traffic_light.amber_rejection_hysteresis_duration = 0.0;
+  params.traffic_light.ego_stopped_velocity_threshold = 0.01;
+  params.traffic_light.checked_trajectory_length.deceleration_limit = 999.9;
+  params.traffic_light.checked_trajectory_length.jerk_limit = 999.9;
   filter_->update_parameters(params);
 
   // Even if it's NOT stoppable (ego at 0m, velocity 10m/s, stop at 5m),
@@ -376,8 +391,52 @@ TEST_F(TrafficLightFilterTest, IsInfeasibleWithAmberLightAsRedLight)
     << "Should return false for amber light when treat_amber_light_as_red_light is true";
 }
 
-int main(int argc, char ** argv)
+TEST_F(TrafficLightFilterTest, IsFeasibleWithStabilityFiltering)
 {
-  testing::InitGoogleTest(&argc, argv);
-  return RUN_ALL_TESTS();
+  const lanelet::Id light_id = 400;
+  const double stop_x = 5.0;
+
+  create_and_set_map(light_id, stop_x);
+
+  validator::Params params;
+  params.traffic_light.deceleration_limit = 2.8;
+  params.traffic_light.delay_response_time = 0.5;
+  params.traffic_light.crossing_time_limit = 2.75;
+  params.traffic_light.treat_amber_light_as_red_light = false;
+  params.traffic_light.stable_duration_threshold_red = 1.0;  // 1 second stability
+  params.traffic_light.stable_duration_threshold_amber = 1.0;
+  params.traffic_light.amber_rejection_hysteresis_duration = 0.0;
+  params.traffic_light.ego_stopped_velocity_threshold = 0.01;
+  params.traffic_light.checked_trajectory_length.deceleration_limit = 999.9;
+  params.traffic_light.checked_trajectory_length.jerk_limit = 999.9;
+  filter_->update_parameters(params);
+
+  // Set initial state to GREEN
+  set_traffic_light_signal(light_id, TrafficLightElement::GREEN);
+  auto points = create_trajectory(0.0, 10.0);
+  EXPECT_TRUE(filter_->is_feasible(points, context_));
+
+  // Switch to RED at t=0
+  set_traffic_light_signal(light_id, TrafficLightElement::RED);
+  nav_msgs::msg::Odometry odometry = *context_.odometry;
+  odometry.header.stamp = node_->now();
+  context_.odometry = std::make_shared<nav_msgs::msg::Odometry>(odometry);
+
+  // Immediately check, should be feasible because of stability threshold
+  EXPECT_TRUE(filter_->is_feasible(points, context_))
+    << "Should be feasible because signal is not stable yet";
+
+  // Advance time by 0.5s (less than 1s threshold)
+  odometry.header.stamp =
+    rclcpp::Time(context_.odometry->header.stamp) + rclcpp::Duration::from_seconds(0.5);
+  context_.odometry = std::make_shared<nav_msgs::msg::Odometry>(odometry);
+  EXPECT_TRUE(filter_->is_feasible(points, context_)) << "Should still be feasible after 0.5s";
+
+  // Advance time by another 0.6s (total 1.1s > 1s threshold)
+  odometry.header.stamp =
+    rclcpp::Time(context_.odometry->header.stamp) + rclcpp::Duration::from_seconds(0.6);
+  context_.odometry = std::make_shared<nav_msgs::msg::Odometry>(odometry);
+  const auto res = filter_->is_feasible(points, context_);
+  ASSERT_TRUE(res.has_value());
+  EXPECT_FALSE(res->is_feasible) << "Should be infeasible after stability threshold is exceeded";
 }


### PR DESCRIPTION
## Description
This PR refactors the `TrafficLightFilter` and `TrafficLightComplianceChecker` to introduce advanced features for handling signal flickering and inconsistent rejections in the "dilemma zone."

### Feature 1: Signal Stability Filtering
Requires a signal state (RED or AMBER) to be stable for a configurable duration before the filter reacts to it. This prevents "phantom stops" caused by transient perception errors.

### Feature 2: Amber Rejection Hysteresis
Once a trajectory is rejected for an AMBER light (stoppable case), the rejection is persisted for a short duration. This prevents the decision from "flipping" back to feasible due to minor changes in ego state while within the dilemma zone.

https://tier4.atlassian.net/browse/T4DEV-52028

Requires https://github.com/tier4/autoware_launch.x2/pull/2294


## Effects on system behavior

Improves the consistency of traffic light compliance behavior. The vehicle is less likely to exhibit jittery braking behavior in response to flickering signal detections or when approaching the limit of its stopping capability at an amber light.


### ROS Parameter Changes

| Parameter Name | Default Value | Update Description |
| -------------- | ------------- | ------------------ |
| `traffic_light.stable_duration_threshold_red` | `0.0` | [s] Minimum duration RED must be seen before activation. |
| `traffic_light.stable_duration_threshold_amber` | `0.0` | [s] Minimum duration AMBER must be seen before activation. |
| `traffic_light.amber_rejection_hysteresis_duration` | `0.0` | [s] Duration to persist an amber rejection. |
| `traffic_light.ego_stopped_velocity_threshold` | `0.01` | [m/s] Velocity below which filters are bypassed. |
