### PR TITLE
fix(obstacle_stop): always process objects/pointcloud

### DIFF
--- a/planning/autoware_trajectory_modifier/launch/trajectory_modifier.launch.xml
+++ b/planning/autoware_trajectory_modifier/launch/trajectory_modifier.launch.xml
@@ -3,16 +3,16 @@
   <arg name="input_candidate_trajectories" default="/planning/diffusion_planner/candidate_trajectories"/>
   <arg name="input_odometry" default="/localization/kinematic_state"/>
   <arg name="input_acceleration" default="/localization/acceleration"/>
-  <arg name="input_objects_topic_name" default="/perception/object_recognition/objects"/>
-  <arg name="input_pointcloud_topic_name" default="/perception/obstacle_segmentation/pointcloud"/>
+  <arg name="input_objects" default="/perception/object_recognition/objects"/>
+  <arg name="input_pointcloud" default="/perception/obstacle_segmentation/pointcloud"/>
   <arg name="output_candidate_trajectories" default="~/output/candidate_trajectories"/>
 
   <node_container pkg="rclcpp_components" exec="component_container" name="trajectory_modifier_container" namespace="">
     <composable_node pkg="autoware_glog_component" plugin="autoware::glog_component::GlogComponent" name="glog_component" namespace=""/>
     <composable_node pkg="autoware_trajectory_modifier" plugin="autoware::trajectory_modifier::TrajectoryModifier" name="trajectory_modifier" namespace="">
       <param from="$(var trajectory_modifier_param_path)"/>
-      <remap from="~/input/objects" to="$(var input_objects_topic_name)"/>
-      <remap from="~/input/pointcloud" to="$(var input_pointcloud_topic_name)"/>
+      <remap from="~/input/objects" to="$(var input_objects)"/>
+      <remap from="~/input/pointcloud" to="$(var input_pointcloud)"/>
       <remap from="~/input/candidate_trajectories" to="$(var input_candidate_trajectories)"/>
       <remap from="~/input/odometry" to="$(var input_odometry)"/>
       <remap from="~/input/acceleration" to="$(var input_acceleration)"/>

--- a/planning/autoware_trajectory_modifier/src/trajectory_modifier_plugins/obstacle_stop.cpp
+++ b/planning/autoware_trajectory_modifier/src/trajectory_modifier_plugins/obstacle_stop.cpp
@@ -368,8 +368,8 @@ std::optional<CollisionPoint> ObstacleStop::check_predicted_objects(
 {
   autoware_utils_debug::ScopedTimeTrack st(
     "ObstacleStop::check_predicted_objects", *get_time_keeper());
-  if (!params_.use_objects || !input.predicted_objects || input.predicted_objects->objects.empty())
-    return std::nullopt;
+  if (!params_.use_objects || !input.predicted_objects) return std::nullopt;
+
   debug_data_.filtered_objects = *input.predicted_objects;
 
   object_filter_->filter_objects(debug_data_.filtered_objects);
@@ -402,11 +402,7 @@ std::optional<CollisionPoint> ObstacleStop::check_pointcloud(
   const TrajectoryPoints & traj_points, const InputData & input)
 {
   autoware_utils_debug::ScopedTimeTrack st("ObstacleStop::check_pointcloud", *get_time_keeper());
-  if (
-    !params_.use_pointcloud || !input.obstacle_pointcloud ||
-    input.obstacle_pointcloud->data.empty()) {
-    return std::nullopt;
-  }
+  if (!params_.use_pointcloud || !input.obstacle_pointcloud) return std::nullopt;
 
   PointCloud::Ptr filtered_pointcloud(new PointCloud);
   pcl::fromROSMsg(*input.obstacle_pointcloud, *filtered_pointcloud);


### PR DESCRIPTION
- always process input objects/pointcloud, even if data is empty
- change arg names in trajectory_modifier launch file