### PR TITLE
Feat/trajectory validator collision edge filtering

### DIFF
--- a/planning/autoware_trajectory_validator/config/trajectory_validator.param.yaml
+++ b/planning/autoware_trajectory_validator/config/trajectory_validator.param.yaml
@@ -31,6 +31,10 @@
           lateral: 0.0
           front: 0.0
           rear: 0.0
+        collision_detection_target_edges:
+          front: true
+          side: true
+          rear: true
         warn_threshold:
           ego_acceleration: -2.0
         error_threshold:
@@ -48,6 +52,10 @@
           lateral: 0.0
           front: 0.0
           rear: 0.0
+        collision_detection_target_edges:
+          front: true
+          side: true
+          rear: true
         ego_assumed_acceleration: -4.0
         warn_threshold:
           ego_first_passing_time_gap: 1.0

--- a/planning/autoware_trajectory_validator/config/trajectory_validator.param.yaml
+++ b/planning/autoware_trajectory_validator/config/trajectory_validator.param.yaml
@@ -18,6 +18,10 @@
     collision_check:
       global_setting:
         time_resolution: 0.1
+        ego_footprint_margin:
+          lateral: 0.0
+          front: 0.0
+          rear: 0.0
       drac:
         enable_assessment:
           # default value is true.

--- a/planning/autoware_trajectory_validator/config/trajectory_validator.param.yaml
+++ b/planning/autoware_trajectory_validator/config/trajectory_validator.param.yaml
@@ -18,10 +18,6 @@
     collision_check:
       global_setting:
         time_resolution: 0.1
-        ego_footprint_margin:
-          lateral: 0.0
-          front: 0.0
-          rear: 0.0
       drac:
         enable_assessment:
           # default value is true.
@@ -31,6 +27,10 @@
           constant_curvature: true
           diffusion_based: true
         ego_total_braking_delay: 0.4
+        ego_footprint_margin:
+          lateral: 0.0
+          front: 0.0
+          rear: 0.0
         warn_threshold:
           ego_acceleration: -2.0
         error_threshold:
@@ -44,6 +44,10 @@
           constant_curvature: true
           diffusion_based: true
         ego_total_braking_delay: 0.4
+        ego_footprint_margin:
+          lateral: 0.0
+          front: 0.0
+          rear: 0.0
         ego_assumed_acceleration: -4.0
         warn_threshold:
           ego_first_passing_time_gap: 1.0
@@ -57,6 +61,10 @@
           unknown: false
         stop_distance_margin: 2.0
         ego_total_braking_delay: 0.4
+        ego_footprint_margin:
+          lateral: 0.0
+          front: 0.0
+          rear: 0.0
         object_assumed_acceleration: -4.0
         error_threshold:
           ego_acceleration: -4.0

--- a/planning/autoware_trajectory_validator/param/parameter_struct.yaml
+++ b/planning/autoware_trajectory_validator/param/parameter_struct.yaml
@@ -115,6 +115,22 @@ validator:
           default_value: 0.0
           description: rear margin added to the ego footprint for DRAC assessment
           read_only: false
+      collision_detection_target_edges:
+        front:
+          type: bool
+          default_value: true
+          description: reject DRAC trajectories when the ego front edge collides with an object
+          read_only: false
+        side:
+          type: bool
+          default_value: true
+          description: reject DRAC trajectories when either ego side edge collides with an object
+          read_only: false
+        rear:
+          type: bool
+          default_value: true
+          description: reject DRAC trajectories when the ego rear edge collides with an object
+          read_only: false
       warn_threshold:
         ego_acceleration:
           type: double
@@ -184,6 +200,22 @@ validator:
           type: double
           default_value: 0.0
           description: rear margin added to the ego footprint for PET assessment
+          read_only: false
+      collision_detection_target_edges:
+        front:
+          type: bool
+          default_value: true
+          description: reject PET trajectories when the ego front edge collides with an object
+          read_only: false
+        side:
+          type: bool
+          default_value: true
+          description: reject PET trajectories when either ego side edge collides with an object
+          read_only: false
+        rear:
+          type: bool
+          default_value: true
+          description: reject PET trajectories when the ego rear edge collides with an object
           read_only: false
       ego_assumed_acceleration:
         type: double

--- a/planning/autoware_trajectory_validator/param/parameter_struct.yaml
+++ b/planning/autoware_trajectory_validator/param/parameter_struct.yaml
@@ -57,22 +57,6 @@ validator:
         default_value: 0.1
         description: sampling interval used in collision check trajectory generation
         read_only: false
-      ego_footprint_margin:
-        lateral:
-          type: double
-          default_value: 0.0
-          description: lateral margin added to both sides of the ego footprint for collision checks
-          read_only: false
-        front:
-          type: double
-          default_value: 0.0
-          description: front margin added to the ego footprint for collision checks
-          read_only: false
-        rear:
-          type: double
-          default_value: 0.0
-          description: rear margin added to the ego footprint for collision checks
-          read_only: false
     drac:
       enable_assessment:
         base:
@@ -115,6 +99,22 @@ validator:
         default_value: 0.4
         description: Total ego braking delay for DRAC assessment
         read_only: false
+      ego_footprint_margin:
+        lateral:
+          type: double
+          default_value: 0.0
+          description: lateral margin added to both sides of the ego footprint for DRAC assessment
+          read_only: false
+        front:
+          type: double
+          default_value: 0.0
+          description: front margin added to the ego footprint for DRAC assessment
+          read_only: false
+        rear:
+          type: double
+          default_value: 0.0
+          description: rear margin added to the ego footprint for DRAC assessment
+          read_only: false
       warn_threshold:
         ego_acceleration:
           type: double
@@ -169,6 +169,22 @@ validator:
         default_value: 0.4
         description: Total ego braking delay for PET assessment
         read_only: false
+      ego_footprint_margin:
+        lateral:
+          type: double
+          default_value: 0.0
+          description: lateral margin added to both sides of the ego footprint for PET assessment
+          read_only: false
+        front:
+          type: double
+          default_value: 0.0
+          description: front margin added to the ego footprint for PET assessment
+          read_only: false
+        rear:
+          type: double
+          default_value: 0.0
+          description: rear margin added to the ego footprint for PET assessment
+          read_only: false
       ego_assumed_acceleration:
         type: double
         default_value: -5.0
@@ -227,6 +243,22 @@ validator:
         default_value: 0.4
         description: Total ego braking delay for RSS calculation
         read_only: false
+      ego_footprint_margin:
+        lateral:
+          type: double
+          default_value: 0.0
+          description: lateral margin added to both sides of the ego footprint for RSS assessment
+          read_only: false
+        front:
+          type: double
+          default_value: 0.0
+          description: front margin added to the ego footprint for RSS assessment
+          read_only: false
+        rear:
+          type: double
+          default_value: 0.0
+          description: rear margin added to the ego footprint for RSS assessment
+          read_only: false
       object_assumed_acceleration:
         type: double
         default_value: -1.0

--- a/planning/autoware_trajectory_validator/param/parameter_struct.yaml
+++ b/planning/autoware_trajectory_validator/param/parameter_struct.yaml
@@ -57,6 +57,22 @@ validator:
         default_value: 0.1
         description: sampling interval used in collision check trajectory generation
         read_only: false
+      ego_footprint_margin:
+        lateral:
+          type: double
+          default_value: 0.0
+          description: lateral margin added to both sides of the ego footprint for collision checks
+          read_only: false
+        front:
+          type: double
+          default_value: 0.0
+          description: front margin added to the ego footprint for collision checks
+          read_only: false
+        rear:
+          type: double
+          default_value: 0.0
+          description: rear margin added to the ego footprint for collision checks
+          read_only: false
     drac:
       enable_assessment:
         base:

--- a/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/assessment.cpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/assessment.cpp
@@ -163,8 +163,8 @@ std::optional<CollisionDetail> find_collision_timing(
 
 PetArtifact assess_planned_speed_collision_timing(
   const TrajectoryPoints & traj_points, const FilterContext & context,
-  const PetParamMap & pet_param_map, const GlobalParams & global_params, VehicleInfo & vehicle_info,
-  const std::vector<TrajectoryData> & object_trajectories)
+  const PetParamMap & pet_param_map, const GlobalParams & global_params,
+  const VehicleInfo & vehicle_info, const std::vector<TrajectoryData> & object_trajectories)
 {
   // todo (takagi): ego_trajectory options can not set for each object type because cache structure
   // is not implemented yet.
@@ -204,7 +204,7 @@ PetArtifact assess_planned_speed_collision_timing(
 
 DracArtifact assess_drac(
   const TrajectoryPoints & traj_points, const FilterContext & context,
-  const DracParamMap & drac_param_map, VehicleInfo & vehicle_info,
+  const DracParamMap & drac_param_map, const VehicleInfo & vehicle_info,
   const std::vector<TrajectoryData> & object_trajectories, const GlobalParams & global_params)
 {
   const double ego_time_horizon = rclcpp::Duration(traj_points.back().time_from_start).seconds();
@@ -364,7 +364,7 @@ std::vector<TrajectoryData> generate_object_trajectories(
 std::pair<PetArtifact, DracArtifact> assess(
   const TrajectoryPoints & traj_points, const FilterContext & context,
   const PetParamMap & pet_param_map, const DracParamMap & drac_param_map,
-  const GlobalParams & global_params, VehicleInfo & vehicle_info)
+  const GlobalParams & global_params, const VehicleInfo & vehicle_info)
 {
   const double required_time_horizon =
     rclcpp::Duration(traj_points.back().time_from_start).seconds();
@@ -413,7 +413,7 @@ std::optional<double> compute_distance_to_collision(
 
 TrajectoryData generate_rss_ego_trajectory(
   const TrajectoryPoints & traj_points, const FilterContext & context,
-  const GlobalParams & global_params, VehicleInfo & vehicle_info)
+  const GlobalParams & global_params, const VehicleInfo & vehicle_info)
 {
   const double ego_time_horizon_for_rss =
     rclcpp::Duration(traj_points.back().time_from_start).seconds();
@@ -453,7 +453,8 @@ RssDetail assess_required_acceleration(
 
 RssArtifact assess(
   const TrajectoryPoints & traj_points, const FilterContext & context,
-  const RssParamMap & rss_param_map, const GlobalParams & global_params, VehicleInfo & vehicle_info)
+  const RssParamMap & rss_param_map, const GlobalParams & global_params,
+  const VehicleInfo & vehicle_info)
 {
   if (!context.predicted_objects || context.predicted_objects->objects.empty()) {
     return {};

--- a/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/assessment.cpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/assessment.cpp
@@ -163,7 +163,7 @@ std::optional<CollisionDetail> find_collision_timing(
 
 PetArtifact assess_planned_speed_collision_timing(
   const TrajectoryPoints & traj_points, const FilterContext & context,
-  const PetParamMap & pet_param_map, double time_resolution, VehicleInfo & vehicle_info,
+  const PetParamMap & pet_param_map, const GlobalParams & global_params, VehicleInfo & vehicle_info,
   const std::vector<TrajectoryData> & object_trajectories)
 {
   // todo (takagi): ego_trajectory options can not set for each object type because cache structure
@@ -173,7 +173,7 @@ PetArtifact assess_planned_speed_collision_timing(
                                             -ego_pet_params.ego_assumed_acceleration +
                                           ego_pet_params.ego_total_braking_delay;
   auto ego_trajectory = trajectory::generate_ego_trajectory(
-    traj_points, context, ego_time_horizon_for_pet, time_resolution, vehicle_info);
+    traj_points, context, ego_time_horizon_for_pet, vehicle_info, global_params);
 
   std::vector<CollisionEvaluation> collision_evaluations{};
   for (const auto & object_trajectory : object_trajectories) {
@@ -186,7 +186,7 @@ PetArtifact assess_planned_speed_collision_timing(
     }
 
     auto collision = find_collision_timing(
-      ego_trajectory, object_trajectory, pet_params.warn_threshold, time_resolution);
+      ego_trajectory, object_trajectory, pet_params.warn_threshold, global_params.time_resolution);
 
     if (collision.has_value()) {
       const auto risk_level =
@@ -223,15 +223,15 @@ DracArtifact assess_drac(
     const auto ego_deceleration_trajectory = [&]() {
       if (ego_dec == 0.0) {
         return trajectory::generate_ego_trajectory(
-          traj_points, context, ego_time_horizon, global_params.time_resolution, vehicle_info);
+          traj_points, context, ego_time_horizon, vehicle_info, global_params);
       } else if (ego_dec > default_max_ego_deceleration - 1e-3) {
         return trajectory::generate_ego_trajectory(
-          context.odometry->twist.twist, 0.0, -ego_dec, ego_time_horizon,
-          global_params.time_resolution, traj_points, vehicle_info);
+          context.odometry->twist.twist, 0.0, -ego_dec, ego_time_horizon, traj_points, vehicle_info,
+          global_params);
       }
       return trajectory::generate_ego_trajectory(
         context.odometry->twist.twist, ego_drac_params.ego_total_braking_delay, -ego_dec,
-        ego_time_horizon, global_params.time_resolution, traj_points, vehicle_info);
+        ego_time_horizon, traj_points, vehicle_info, global_params);
     }();
 
     std::vector<CollisionEvaluation> collision_evaluations{};
@@ -374,7 +374,7 @@ std::pair<PetArtifact, DracArtifact> assess(
 
   PetArtifact pet_artifact{};
   pet_artifact = assess_planned_speed_collision_timing(
-    traj_points, context, pet_param_map, global_params.time_resolution, vehicle_info,
+    traj_points, context, pet_param_map, global_params, vehicle_info,
     nominal_speed_object_trajectories);
 
   DracArtifact drac_artifact{};
@@ -412,14 +412,14 @@ std::optional<double> compute_distance_to_collision(
 }
 
 TrajectoryData generate_rss_ego_trajectory(
-  const TrajectoryPoints & traj_points, const FilterContext & context, double time_resolution,
-  VehicleInfo & vehicle_info)
+  const TrajectoryPoints & traj_points, const FilterContext & context,
+  const GlobalParams & global_params, VehicleInfo & vehicle_info)
 {
   const double ego_time_horizon_for_rss =
     rclcpp::Duration(traj_points.back().time_from_start).seconds();
 
   return trajectory::generate_ego_trajectory(
-    traj_points, context, ego_time_horizon_for_rss, time_resolution, vehicle_info);
+    traj_points, context, ego_time_horizon_for_rss, vehicle_info, global_params);
 }
 
 RssDetail assess_required_acceleration(
@@ -453,14 +453,14 @@ RssDetail assess_required_acceleration(
 
 RssArtifact assess(
   const TrajectoryPoints & traj_points, const FilterContext & context,
-  const RssParamMap & rss_param_map, double time_resolution, VehicleInfo & vehicle_info)
+  const RssParamMap & rss_param_map, const GlobalParams & global_params, VehicleInfo & vehicle_info)
 {
   if (!context.predicted_objects || context.predicted_objects->objects.empty()) {
     return {};
   }
 
   const auto ego_trajectory =
-    generate_rss_ego_trajectory(traj_points, context, time_resolution, vehicle_info);
+    generate_rss_ego_trajectory(traj_points, context, global_params, vehicle_info);
 
   std::vector<RssEvaluation> rss_evaluations{};
   rss_evaluations.reserve(context.predicted_objects->objects.size());

--- a/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/assessment.cpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/assessment.cpp
@@ -66,12 +66,12 @@ RiskLevel to_drac_risk_level(const std::optional<double> & acc, const DracParams
 }
 
 trajectory::footprint::EgoDimensions make_ego_dimensions(
-  const VehicleInfo & vehicle_info, const GlobalParams & global_params)
+  const VehicleInfo & vehicle_info, const EgoFootprintMargin & ego_footprint_margin)
 {
   return trajectory::footprint::EgoDimensions{
-    vehicle_info.max_longitudinal_offset_m + global_params.ego_footprint_margin.front,
-    -vehicle_info.min_longitudinal_offset_m + global_params.ego_footprint_margin.rear,
-    vehicle_info.vehicle_width_m + 2.0 * global_params.ego_footprint_margin.lateral};
+    vehicle_info.max_longitudinal_offset_m + ego_footprint_margin.front,
+    -vehicle_info.min_longitudinal_offset_m + ego_footprint_margin.rear,
+    vehicle_info.vehicle_width_m + 2.0 * ego_footprint_margin.lateral};
 }
 
 std::optional<CollisionDetail> find_collision_timing(
@@ -178,8 +178,8 @@ PetArtifact assess_planned_speed_collision_timing(
   // todo (takagi): ego_trajectory options can not set for each object type because cache structure
   // is not implemented yet.
   const auto & ego_pet_params = pet_param_map.at(kCollisionCheckParamBaseKey);
-  const auto ego_dimensions =
-    collision_timing_assessment::make_ego_dimensions(vehicle_info, global_params);
+  const auto ego_dimensions = collision_timing_assessment::make_ego_dimensions(
+    vehicle_info, ego_pet_params.ego_footprint_margin);
   const double ego_time_horizon_for_pet = std::abs(context.odometry->twist.twist.linear.x) * 0.5 /
                                             -ego_pet_params.ego_assumed_acceleration +
                                           ego_pet_params.ego_total_braking_delay;
@@ -223,7 +223,8 @@ DracArtifact assess_drac(
   // todo (takagi): ego_trajectory options can not set for each object type because cache structure
   // is not implemented yet.
   const auto & ego_drac_params = drac_param_map.at(kCollisionCheckParamBaseKey);
-  const auto ego_dimensions = make_ego_dimensions(vehicle_info, global_params);
+  const auto ego_dimensions =
+    make_ego_dimensions(vehicle_info, ego_drac_params.ego_footprint_margin);
   constexpr double default_ego_deceleration_step = 1.0;
   constexpr double default_max_ego_deceleration = 6.0;
   constexpr PetThreshold error_pet_th{0.6, 0.3};
@@ -424,13 +425,13 @@ std::optional<double> compute_distance_to_collision(
 }
 
 TrajectoryData generate_rss_ego_trajectory(
-  const TrajectoryPoints & traj_points, const FilterContext & context,
+  const TrajectoryPoints & traj_points, const FilterContext & context, const RssParams & rss_params,
   const GlobalParams & global_params, const VehicleInfo & vehicle_info)
 {
   const double ego_time_horizon_for_rss =
     rclcpp::Duration(traj_points.back().time_from_start).seconds();
   const auto ego_dimensions =
-    collision_timing_assessment::make_ego_dimensions(vehicle_info, global_params);
+    collision_timing_assessment::make_ego_dimensions(vehicle_info, rss_params.ego_footprint_margin);
 
   return trajectory::generate_ego_trajectory(
     traj_points, context, ego_time_horizon_for_rss, ego_dimensions, global_params.time_resolution);
@@ -474,8 +475,9 @@ RssArtifact assess(
     return {};
   }
 
+  const auto & ego_rss_params = rss_param_map.at(kCollisionCheckParamBaseKey);
   const auto ego_trajectory =
-    generate_rss_ego_trajectory(traj_points, context, global_params, vehicle_info);
+    generate_rss_ego_trajectory(traj_points, context, ego_rss_params, global_params, vehicle_info);
 
   std::vector<RssEvaluation> rss_evaluations{};
   rss_evaluations.reserve(context.predicted_objects->objects.size());

--- a/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/assessment.cpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/assessment.cpp
@@ -14,9 +14,12 @@
 
 #include "assessment.hpp"
 
+#include <autoware_utils/geometry/geometry.hpp>
+
 #include <boost/geometry.hpp>
 
 #include <algorithm>
+#include <array>
 #include <cmath>
 #include <limits>
 #include <optional>
@@ -74,9 +77,99 @@ trajectory::footprint::EgoDimensions make_ego_dimensions(
     vehicle_info.vehicle_width_m + 2.0 * ego_footprint_margin.lateral};
 }
 
+bool has_enabled_collision_edge(
+  const EgoFootprintEdgeIntersections & edges,
+  const CollisionDetectionTargetEdges & collision_detection_target_edges)
+{
+  return (collision_detection_target_edges.front && edges.front) ||
+         (collision_detection_target_edges.side && (edges.left || edges.right)) ||
+         (collision_detection_target_edges.rear && edges.rear);
+}
+
+constexpr double kCollisionTimeRefinementPrecision = 0.01;
+
+struct CandidateFinding
+{
+  double ref_time;
+  double ttc{0.0};
+  double pet{0.0};
+  IndexRange ref_index_range{0U, 0U};
+  TimeRange test_time_range{0.0, 0.0};
+  Polygon2d ego_polygon_at_first_collision;
+  Polygon2d object_polygon_at_first_collision;
+  EgoFootprintEdgeIntersections ego_collision_edges_at_first_collision;
+};
+
+std::optional<CandidateFinding> evaluate_collision_sample(
+  const TrajectoryData & ref_trajectory, const TrajectoryData & test_trajectory,
+  const double ref_time, const double test_time,
+  const CollisionDetectionTargetEdges & collision_detection_target_edges)
+{
+  const auto ego_footprint = ref_trajectory.interpolate_footprint_at_time(ref_time);
+  const auto object_footprint = test_trajectory.interpolate_footprint_at_time(test_time);
+  if (!boost::geometry::intersects(ego_footprint, object_footprint)) {
+    return std::nullopt;
+  }
+
+  const auto edge_intersections =
+    geometry::intersecting_ego_footprint_edges(ego_footprint, object_footprint);
+  if (!has_enabled_collision_edge(edge_intersections, collision_detection_target_edges)) {
+    return std::nullopt;
+  }
+
+  return CandidateFinding{
+    ref_time, 0.0, 0.0, {0U, 0U}, {0.0, 0.0}, ego_footprint, object_footprint, edge_intersections};
+}
+
+std::optional<CandidateFinding> find_first_collision_in_interval(
+  const TrajectoryData & ref_trajectory, const TrajectoryData & test_trajectory,
+  const TimeRange & time_range,
+  const CollisionDetectionTargetEdges & collision_detection_target_edges)
+{
+  const auto ref_envelope = ref_trajectory.get_precise_envelope(time_range);
+  const auto test_envelope = test_trajectory.get_precise_envelope(time_range);
+  if (!boost::geometry::intersects(ref_envelope, test_envelope)) {
+    return std::nullopt;
+  }
+
+  const auto ref_hull = ref_trajectory.get_precise_convex(time_range);
+  const auto test_hull = test_trajectory.get_precise_convex(time_range);
+  if (!geometry::intersects_sat(ref_hull, test_hull)) {
+    return std::nullopt;
+  }
+
+  if (time_range.second - time_range.first <= kCollisionTimeRefinementPrecision) {
+    constexpr std::array<double, 5> sample_ratios{{0.0, 0.25, 0.5, 0.75, 1.0}};
+    for (const double ratio : sample_ratios) {
+      const double ref_time = time_range.first + (time_range.second - time_range.first) * ratio;
+      const double test_time = time_range.first + (time_range.second - time_range.first) * ratio;
+      const auto collision = evaluate_collision_sample(
+        ref_trajectory, test_trajectory, ref_time, test_time, collision_detection_target_edges);
+      if (collision.has_value()) {
+        return collision;
+      }
+    }
+    return std::nullopt;
+  }
+
+  const double mid_time = 0.5 * (time_range.first + time_range.second);
+
+  if (const auto first_half_collision = find_first_collision_in_interval(
+        ref_trajectory, test_trajectory, TimeRange{time_range.first, mid_time},
+        collision_detection_target_edges);
+      first_half_collision.has_value()) {
+    return first_half_collision;
+  }
+
+  return find_first_collision_in_interval(
+    ref_trajectory, test_trajectory, TimeRange{mid_time, time_range.second},
+    collision_detection_target_edges);
+}
+
 std::optional<CollisionDetail> find_collision_timing(
   const TrajectoryData & ref_trajectory, const TrajectoryData & test_trajectory,
-  PetThreshold pet_find_range, double time_resolution)
+  PetThreshold pet_find_range, double time_resolution,
+  const CollisionDetectionTargetEdges & collision_detection_target_edges)
 {
   const double max_pet_threshold = std::max(
     pet_find_range.ego_first_passing_time_gap, pet_find_range.object_first_passing_time_gap);
@@ -90,14 +183,6 @@ std::optional<CollisionDetail> find_collision_timing(
     return std::nullopt;
   }
 
-  struct CandidateFinding
-  {
-    double ttc;
-    double pet;
-    IndexRange ref_index_range;
-    TimeRange test_time_range;
-  };
-
   const auto make_finding = [&](const CandidateFinding & candidate) -> CollisionDetail {
     return CollisionDetail{
       test_trajectory.getObjectIdentification(),
@@ -106,7 +191,10 @@ std::optional<CollisionDetail> find_collision_timing(
       ref_trajectory.getPoses(),
       test_trajectory.getPoses(),
       ref_trajectory.get_or_compute_convex(candidate.ref_index_range),
-      test_trajectory.get_or_compute_convex(candidate.test_time_range)};
+      test_trajectory.get_or_compute_convex(candidate.test_time_range),
+      candidate.ego_polygon_at_first_collision,
+      candidate.object_polygon_at_first_collision,
+      candidate.ego_collision_edges_at_first_collision};
   };
 
   std::optional<CandidateFinding> candidate_finding{};
@@ -130,32 +218,54 @@ std::optional<CollisionDetail> find_collision_timing(
       continue;
     }
 
-    const auto has_intersects = [&](const TimeRange & time_range) -> bool {
+    const auto has_intersects =
+      [&](const TimeRange & time_range) -> std::optional<CandidateFinding> {
       if (!boost::geometry::intersects(
             ref_envelope, test_trajectory.get_or_compute_envelope(time_range))) {
-        return false;
+        return std::nullopt;
       }
 
-      return geometry::intersects_sat(
-        ref_convex, test_trajectory.get_or_compute_convex(time_range));
+      const auto & test_convex = test_trajectory.get_or_compute_convex(time_range);
+      if (!geometry::intersects_sat(ref_convex, test_convex)) {
+        return std::nullopt;
+      }
+
+      const auto precise_collision = find_first_collision_in_interval(
+        ref_trajectory, test_trajectory, time_range, collision_detection_target_edges);
+      if (!precise_collision.has_value()) {
+        return std::nullopt;
+      }
+
+      return precise_collision;
     };
 
     for (double pet_range = 0.0; pet_range < current_pet_limit; pet_range += time_resolution) {
       const TimeRange test_time_range_before{ref_start_time - pet_range, ref_end_time - pet_range};
-      const bool has_intersects_before = has_intersects(test_time_range_before);
+      const auto edge_intersections_before = has_intersects(test_time_range_before);
 
       const TimeRange test_time_range_after{ref_start_time + pet_range, ref_end_time + pet_range};
-      const bool has_intersects_after = has_intersects(test_time_range_after);
+      const auto edge_intersections_after = has_intersects(test_time_range_after);
 
-      if (!has_intersects_before && !has_intersects_after) {
+      if (!edge_intersections_before.has_value() && !edge_intersections_after.has_value()) {
         continue;
       }
 
+      const bool has_intersects_before = edge_intersections_before.has_value();
       const double pet = has_intersects_before ? -pet_range : pet_range;
       const TimeRange test_time_range =
         has_intersects_before ? test_time_range_before : test_time_range_after;
+      const auto collision = has_intersects_before ? edge_intersections_before.value()
+                                                   : edge_intersections_after.value();
 
-      candidate_finding = CandidateFinding{ref_start_time, pet, ref_index_range, test_time_range};
+      candidate_finding = CandidateFinding{
+        collision.ref_time,
+        collision.ref_time,
+        pet,
+        ref_index_range,
+        test_time_range,
+        collision.ego_polygon_at_first_collision,
+        collision.object_polygon_at_first_collision,
+        collision.ego_collision_edges_at_first_collision};
       break;
     }
     if (candidate_finding.has_value() && candidate_finding->pet == 0.0) {
@@ -197,7 +307,8 @@ PetArtifact assess_planned_speed_collision_timing(
     }
 
     auto collision = find_collision_timing(
-      ego_trajectory, object_trajectory, pet_params.warn_threshold, global_params.time_resolution);
+      ego_trajectory, object_trajectory, pet_params.warn_threshold, global_params.time_resolution,
+      pet_params.collision_detection_target_edges);
 
     if (collision.has_value()) {
       const auto risk_level =
@@ -259,8 +370,8 @@ DracArtifact assess_drac(
 
       constexpr double drac_params_collision_time_threshold = 1.0;
       auto finding_nominal_object_motion = find_collision_timing(
-        ego_deceleration_trajectory, object_trajectory, error_pet_th,
-        global_params.time_resolution);
+        ego_deceleration_trajectory, object_trajectory, error_pet_th, global_params.time_resolution,
+        drac_params.collision_detection_target_edges);
 
       const RiskLevel nominal_motion_risk_level =
         finding_nominal_object_motion.has_value()
@@ -279,7 +390,7 @@ DracArtifact assess_drac(
 
       auto finding_dec_object_motion = find_collision_timing(
         ego_deceleration_trajectory, object_deceleration_trajectory, error_pet_th,
-        global_params.time_resolution);
+        global_params.time_resolution, drac_params.collision_detection_target_edges);
 
       const RiskLevel dec_motion_risk_level =
         finding_dec_object_motion.has_value()

--- a/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/assessment.cpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/assessment.cpp
@@ -65,6 +65,15 @@ RiskLevel to_drac_risk_level(const std::optional<double> & acc, const DracParams
   return RiskLevel::SAFE;
 }
 
+trajectory::footprint::EgoDimensions make_ego_dimensions(
+  const VehicleInfo & vehicle_info, const GlobalParams & global_params)
+{
+  return trajectory::footprint::EgoDimensions{
+    vehicle_info.max_longitudinal_offset_m + global_params.ego_footprint_margin.front,
+    -vehicle_info.min_longitudinal_offset_m + global_params.ego_footprint_margin.rear,
+    vehicle_info.vehicle_width_m + 2.0 * global_params.ego_footprint_margin.lateral};
+}
+
 std::optional<CollisionDetail> find_collision_timing(
   const TrajectoryData & ref_trajectory, const TrajectoryData & test_trajectory,
   PetThreshold pet_find_range, double time_resolution)
@@ -169,11 +178,13 @@ PetArtifact assess_planned_speed_collision_timing(
   // todo (takagi): ego_trajectory options can not set for each object type because cache structure
   // is not implemented yet.
   const auto & ego_pet_params = pet_param_map.at(kCollisionCheckParamBaseKey);
+  const auto ego_dimensions =
+    collision_timing_assessment::make_ego_dimensions(vehicle_info, global_params);
   const double ego_time_horizon_for_pet = std::abs(context.odometry->twist.twist.linear.x) * 0.5 /
                                             -ego_pet_params.ego_assumed_acceleration +
                                           ego_pet_params.ego_total_braking_delay;
   auto ego_trajectory = trajectory::generate_ego_trajectory(
-    traj_points, context, ego_time_horizon_for_pet, vehicle_info, global_params);
+    traj_points, context, ego_time_horizon_for_pet, ego_dimensions, global_params.time_resolution);
 
   std::vector<CollisionEvaluation> collision_evaluations{};
   for (const auto & object_trajectory : object_trajectories) {
@@ -212,6 +223,7 @@ DracArtifact assess_drac(
   // todo (takagi): ego_trajectory options can not set for each object type because cache structure
   // is not implemented yet.
   const auto & ego_drac_params = drac_param_map.at(kCollisionCheckParamBaseKey);
+  const auto ego_dimensions = make_ego_dimensions(vehicle_info, global_params);
   constexpr double default_ego_deceleration_step = 1.0;
   constexpr double default_max_ego_deceleration = 6.0;
   constexpr PetThreshold error_pet_th{0.6, 0.3};
@@ -223,15 +235,15 @@ DracArtifact assess_drac(
     const auto ego_deceleration_trajectory = [&]() {
       if (ego_dec == 0.0) {
         return trajectory::generate_ego_trajectory(
-          traj_points, context, ego_time_horizon, vehicle_info, global_params);
+          traj_points, context, ego_time_horizon, ego_dimensions, global_params.time_resolution);
       } else if (ego_dec > default_max_ego_deceleration - 1e-3) {
         return trajectory::generate_ego_trajectory(
-          context.odometry->twist.twist, 0.0, -ego_dec, ego_time_horizon, traj_points, vehicle_info,
-          global_params);
+          context.odometry->twist.twist, 0.0, -ego_dec, ego_time_horizon, traj_points,
+          ego_dimensions, global_params.time_resolution);
       }
       return trajectory::generate_ego_trajectory(
         context.odometry->twist.twist, ego_drac_params.ego_total_braking_delay, -ego_dec,
-        ego_time_horizon, traj_points, vehicle_info, global_params);
+        ego_time_horizon, traj_points, ego_dimensions, global_params.time_resolution);
     }();
 
     std::vector<CollisionEvaluation> collision_evaluations{};
@@ -417,9 +429,11 @@ TrajectoryData generate_rss_ego_trajectory(
 {
   const double ego_time_horizon_for_rss =
     rclcpp::Duration(traj_points.back().time_from_start).seconds();
+  const auto ego_dimensions =
+    collision_timing_assessment::make_ego_dimensions(vehicle_info, global_params);
 
   return trajectory::generate_ego_trajectory(
-    traj_points, context, ego_time_horizon_for_rss, vehicle_info, global_params);
+    traj_points, context, ego_time_horizon_for_rss, ego_dimensions, global_params.time_resolution);
 }
 
 RssDetail assess_required_acceleration(

--- a/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/assessment.hpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/assessment.hpp
@@ -76,7 +76,8 @@ std::optional<double> compute_distance_to_collision(
 
 RssArtifact assess(
   const TrajectoryPoints & traj_points, const FilterContext & context,
-  const RssParamMap & rss_param_map, double time_resolution, VehicleInfo & vehicle_info);
+  const RssParamMap & rss_param_map, const GlobalParams & global_params,
+  VehicleInfo & vehicle_info);
 }  // namespace autoware::trajectory_validator::plugin::safety::rss_deceleration
 
 #endif  // FILTERS__SAFETY__COLLISION_CHECK_FILTER__ASSESSMENT_HPP_

--- a/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/assessment.hpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/assessment.hpp
@@ -38,7 +38,7 @@ std::vector<TrajectoryData> generate_object_trajectories(
 std::pair<PetArtifact, DracArtifact> assess(
   const TrajectoryPoints & traj_points, const FilterContext & context,
   const PetParamMap & pet_param_map, const DracParamMap & drac_param_map,
-  const GlobalParams & global_params, VehicleInfo & vehicle_info);
+  const GlobalParams & global_params, const VehicleInfo & vehicle_info);
 }  // namespace autoware::trajectory_validator::plugin::safety::collision_timing_assessment
 
 namespace autoware::trajectory_validator::plugin::safety::rss_deceleration
@@ -77,7 +77,7 @@ std::optional<double> compute_distance_to_collision(
 RssArtifact assess(
   const TrajectoryPoints & traj_points, const FilterContext & context,
   const RssParamMap & rss_param_map, const GlobalParams & global_params,
-  VehicleInfo & vehicle_info);
+  const VehicleInfo & vehicle_info);
 }  // namespace autoware::trajectory_validator::plugin::safety::rss_deceleration
 
 #endif  // FILTERS__SAFETY__COLLISION_CHECK_FILTER__ASSESSMENT_HPP_

--- a/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/collision_check_filter.cpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/collision_check_filter.cpp
@@ -149,7 +149,7 @@ CollisionCheckFilter::result_t CollisionCheckFilter::is_feasible(
   const auto [pet_artifact, drac_artifact] = collision_timing_assessment::assess(
     traj_points, context, pet_param_map_, drac_param_map_, global_params_, *vehicle_info_ptr_);
   const auto rss_artifact = rss_deceleration::assess(
-    traj_points, context, rss_param_map_, global_params_.time_resolution, *vehicle_info_ptr_);
+    traj_points, context, rss_param_map_, global_params_, *vehicle_info_ptr_);
 
   auto planning_factors = reporter::process_collision_artifacts(
     *context.odometry, pet_artifact, pet_continuous_times_, drac_artifact, drac_continuous_times_,

--- a/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/parameter.hpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/parameter.hpp
@@ -111,12 +111,23 @@ OutT extract_labeled_param(const ParamStruct & params_struct, const std::string_
 
 struct GlobalParams
 {
+  struct EgoFootprintMargin
+  {
+    double lateral{0.0};
+    double front{0.0};
+    double rear{0.0};
+  };
+
   double time_resolution{0.1};
+  EgoFootprintMargin ego_footprint_margin{};
 
   GlobalParams() = default;
   explicit GlobalParams(const validator::Params::CollisionCheck::GlobalSetting & params)
   {
     time_resolution = params.time_resolution;
+    ego_footprint_margin.lateral = params.ego_footprint_margin.lateral;
+    ego_footprint_margin.front = params.ego_footprint_margin.front;
+    ego_footprint_margin.rear = params.ego_footprint_margin.rear;
   }
 };
 

--- a/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/parameter.hpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/parameter.hpp
@@ -109,25 +109,21 @@ OutT extract_labeled_param(const ParamStruct & params_struct, const std::string_
   }
 }
 
+struct EgoFootprintMargin
+{
+  double lateral{0.0};
+  double front{0.0};
+  double rear{0.0};
+};
+
 struct GlobalParams
 {
-  struct EgoFootprintMargin
-  {
-    double lateral{0.0};
-    double front{0.0};
-    double rear{0.0};
-  };
-
   double time_resolution{0.1};
-  EgoFootprintMargin ego_footprint_margin{};
 
   GlobalParams() = default;
   explicit GlobalParams(const validator::Params::CollisionCheck::GlobalSetting & params)
   {
     time_resolution = params.time_resolution;
-    ego_footprint_margin.lateral = params.ego_footprint_margin.lateral;
-    ego_footprint_margin.front = params.ego_footprint_margin.front;
-    ego_footprint_margin.rear = params.ego_footprint_margin.rear;
   }
 };
 
@@ -165,6 +161,9 @@ struct DracParams
       enable_assessment &&
       extract_labeled_param<bool>(drac.assessment_trajectories.diffusion_based, key);
     ego_total_braking_delay = extract_labeled_param<double>(drac.ego_total_braking_delay, key);
+    ego_footprint_margin.lateral = drac.ego_footprint_margin.lateral;
+    ego_footprint_margin.front = drac.ego_footprint_margin.front;
+    ego_footprint_margin.rear = drac.ego_footprint_margin.rear;
     warn_threshold.ego_acceleration =
       extract_labeled_param<double>(drac.warn_threshold.ego_acceleration, key);
     error_threshold.ego_acceleration =
@@ -174,6 +173,7 @@ struct DracParams
   bool enable_assessment{false};
   AssessmentTrajectories assessment_trajectories{};
   double ego_total_braking_delay{0.4};
+  EgoFootprintMargin ego_footprint_margin{};
   Threshold warn_threshold{-2.0};
   Threshold error_threshold{};
 };
@@ -183,6 +183,7 @@ struct PetParams
   bool enable_assessment{true};
   AssessmentTrajectories assessment_trajectories{};
   double ego_total_braking_delay{0.4};
+  EgoFootprintMargin ego_footprint_margin{};
   double ego_assumed_acceleration{-5.0};
   PetThreshold warn_threshold{};
   PetThreshold error_threshold{0.6, 0.3};
@@ -201,6 +202,9 @@ struct PetParams
       enable_assessment &&
       extract_labeled_param<bool>(pet.assessment_trajectories.diffusion_based, key);
     ego_total_braking_delay = extract_labeled_param<double>(pet.ego_total_braking_delay, key);
+    ego_footprint_margin.lateral = pet.ego_footprint_margin.lateral;
+    ego_footprint_margin.front = pet.ego_footprint_margin.front;
+    ego_footprint_margin.rear = pet.ego_footprint_margin.rear;
     ego_assumed_acceleration = extract_labeled_param<double>(pet.ego_assumed_acceleration, key);
 
     warn_threshold.ego_first_passing_time_gap =
@@ -228,6 +232,9 @@ struct RssParams
     enable_assessment = extract_labeled_param<bool>(rss.enable_assessment, key);
     stop_distance_margin = extract_labeled_param<double>(rss.stop_distance_margin, key);
     ego_total_braking_delay = extract_labeled_param<double>(rss.ego_total_braking_delay, key);
+    ego_footprint_margin.lateral = rss.ego_footprint_margin.lateral;
+    ego_footprint_margin.front = rss.ego_footprint_margin.front;
+    ego_footprint_margin.rear = rss.ego_footprint_margin.rear;
     object_assumed_acceleration =
       extract_labeled_param<double>(rss.object_assumed_acceleration, key);
     error_threshold.ego_acceleration =
@@ -237,6 +244,7 @@ struct RssParams
   bool enable_assessment{true};
   double stop_distance_margin{2.0};
   double ego_total_braking_delay{0.4};
+  EgoFootprintMargin ego_footprint_margin{};
   double object_assumed_acceleration{-1.0};
   ErrorThreshold error_threshold{};
 };

--- a/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/parameter.hpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/parameter.hpp
@@ -116,6 +116,13 @@ struct EgoFootprintMargin
   double rear{0.0};
 };
 
+struct CollisionDetectionTargetEdges
+{
+  bool front{true};
+  bool side{true};
+  bool rear{true};
+};
+
 struct GlobalParams
 {
   double time_resolution{0.1};
@@ -164,6 +171,9 @@ struct DracParams
     ego_footprint_margin.lateral = drac.ego_footprint_margin.lateral;
     ego_footprint_margin.front = drac.ego_footprint_margin.front;
     ego_footprint_margin.rear = drac.ego_footprint_margin.rear;
+    collision_detection_target_edges.front = drac.collision_detection_target_edges.front;
+    collision_detection_target_edges.side = drac.collision_detection_target_edges.side;
+    collision_detection_target_edges.rear = drac.collision_detection_target_edges.rear;
     warn_threshold.ego_acceleration =
       extract_labeled_param<double>(drac.warn_threshold.ego_acceleration, key);
     error_threshold.ego_acceleration =
@@ -174,6 +184,7 @@ struct DracParams
   AssessmentTrajectories assessment_trajectories{};
   double ego_total_braking_delay{0.4};
   EgoFootprintMargin ego_footprint_margin{};
+  CollisionDetectionTargetEdges collision_detection_target_edges{};
   Threshold warn_threshold{-2.0};
   Threshold error_threshold{};
 };
@@ -184,6 +195,7 @@ struct PetParams
   AssessmentTrajectories assessment_trajectories{};
   double ego_total_braking_delay{0.4};
   EgoFootprintMargin ego_footprint_margin{};
+  CollisionDetectionTargetEdges collision_detection_target_edges{};
   double ego_assumed_acceleration{-5.0};
   PetThreshold warn_threshold{};
   PetThreshold error_threshold{0.6, 0.3};
@@ -205,6 +217,9 @@ struct PetParams
     ego_footprint_margin.lateral = pet.ego_footprint_margin.lateral;
     ego_footprint_margin.front = pet.ego_footprint_margin.front;
     ego_footprint_margin.rear = pet.ego_footprint_margin.rear;
+    collision_detection_target_edges.front = pet.collision_detection_target_edges.front;
+    collision_detection_target_edges.side = pet.collision_detection_target_edges.side;
+    collision_detection_target_edges.rear = pet.collision_detection_target_edges.rear;
     ego_assumed_acceleration = extract_labeled_param<double>(pet.ego_assumed_acceleration, key);
 
     warn_threshold.ego_first_passing_time_gap =

--- a/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/reporter.cpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/reporter.cpp
@@ -36,6 +36,34 @@ namespace
 {
 using autoware_trajectory_validator::msg::MetricReport;
 
+std::string to_string(const EgoFootprintEdgeIntersections & edges)
+{
+  std::vector<std::string> edge_names;
+  if (edges.front) {
+    edge_names.push_back("front");
+  }
+  if (edges.right) {
+    edge_names.push_back("right");
+  }
+  if (edges.rear) {
+    edge_names.push_back("rear");
+  }
+  if (edges.left) {
+    edge_names.push_back("left");
+  }
+
+  if (edge_names.empty()) {
+    return "none";
+  }
+
+  std::string out = edge_names.front();
+  for (size_t i = 1; i < edge_names.size(); ++i) {
+    out += ",";
+    out += edge_names.at(i);
+  }
+  return out;
+}
+
 struct VisualizationData
 {
   std::string error_msg{};
@@ -147,15 +175,18 @@ void process_pet_artifacts(
     }
 
     const auto finding_msg = fmt::format(
-      "PET collision, classification: {}, ID: {}, PET: {}, TTC: {}, duration: {}, stamp: {}.{};",
+      "PET collision, classification: {}, ID: {}, PET: {}, TTC: {}, first edges: {}, duration: "
+      "{}, stamp: {}.{};",
       obj_id.classification, obj_id.trajectory_id_string(), timing.pet, timing.ttc,
+      to_string(timing.ego_collision_edges_at_first_collision),
       pet_continuous_times.get_time(obj_id.trajectory_id_string()), obj_id.stamp.sec,
       obj_id.stamp.nanosec);
     log_messages += finding_msg;
     reporter::append_text_marker_message(marker_messages, finding_msg);
     reporter::add_debug_markers(
       debug_markers, current_time, "planned_speed_collision", obj_id.trajectory_id_string(),
-      timing.ego_trajectory, timing.object_trajectory, timing.ego_hull, timing.object_hull);
+      timing.ego_trajectory, timing.object_trajectory, timing.ego_hull, timing.object_hull,
+      timing.ego_polygon_at_first_collision, timing.object_polygon_at_first_collision);
     if (is_error) {
       add_collision_planning_factor(
         time_resolution, odometry.header.stamp, odometry.pose.pose, timing, "PET",
@@ -192,18 +223,20 @@ void process_drac_artifacts(
 
     const auto finding_msg = fmt::format(
       "DRAC collision, classification: {}, ID: {}, PET: {}, TTC: {}, DRAC: {}, duration: {}, "
-      "stamp: {}.{};",
+      "first edges: {}, stamp: {}.{};",
       obj_id.classification, obj_id.trajectory_id_string(), timing.pet, timing.ttc,
       drac_artifact.required_acceleration.has_value()
         ? std::to_string(drac_artifact.required_acceleration.value())
         : "Cant be avoided",
-      drac_continuous_times.get_time(obj_id.trajectory_id_string()), obj_id.stamp.sec,
+      drac_continuous_times.get_time(obj_id.trajectory_id_string()),
+      to_string(timing.ego_collision_edges_at_first_collision), obj_id.stamp.sec,
       obj_id.stamp.nanosec);
     log_messages += finding_msg;
     reporter::append_text_marker_message(marker_messages, finding_msg);
     reporter::add_debug_markers(
       debug_markers, current_time, "drac_collision", obj_id.trajectory_id_string(),
-      timing.ego_trajectory, timing.object_trajectory, timing.ego_hull, timing.object_hull);
+      timing.ego_trajectory, timing.object_trajectory, timing.ego_hull, timing.object_hull,
+      timing.ego_polygon_at_first_collision, timing.object_polygon_at_first_collision);
     if (has_error) {
       add_collision_planning_factor(
         time_resolution, odometry.header.stamp, odometry.pose.pose, timing, "DRAC",
@@ -280,7 +313,8 @@ void add_debug_markers(
   visualization_msgs::msg::MarkerArray & debug_markers, const rclcpp::Time & stamp,
   const std::string & ns, const std::string & trajectory_id, const PoseTrajectory & ego_trajectory,
   const PoseTrajectory & object_trajectory, const Polygon2d & ego_hull,
-  const Polygon2d & object_hull)
+  const Polygon2d & object_hull, const Polygon2d & ego_polygon_at_first_collision,
+  const Polygon2d & object_polygon_at_first_collision)
 {
   int id = next_marker_id(debug_markers);
   const auto trajectory_color = resolve_trajectory_color(trajectory_id);
@@ -351,6 +385,8 @@ void add_debug_markers(
 
   add_poly_marker(ego_hull, "ego_worst_pet", 0.0F, 0.0F, 1.0F);
   add_poly_marker(object_hull, "obj_worst_pet", 1.0F, 0.0F, 0.0F);
+  add_poly_marker(ego_polygon_at_first_collision, "ego_first_collision", 0.0F, 0.6F, 1.0F);
+  add_poly_marker(object_polygon_at_first_collision, "obj_first_collision", 1.0F, 0.3F, 0.3F);
   add_trajectory_marker(ego_trajectory, "ego_trajectory", 1.0F, 1.0F, 1.0F, 0.9F);
   add_trajectory_marker(
     object_trajectory, "object_trajectory", trajectory_color.r, trajectory_color.g,

--- a/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/reporter.hpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/reporter.hpp
@@ -74,7 +74,8 @@ void add_debug_markers(
   visualization_msgs::msg::MarkerArray & debug_markers, const rclcpp::Time & stamp,
   const std::string & ns, const std::string & trajectory_id, const PoseTrajectory & ego_trajectory,
   const PoseTrajectory & object_trajectory, const Polygon2d & ego_hull,
-  const Polygon2d & object_hull);
+  const Polygon2d & object_hull, const Polygon2d & ego_polygon_at_first_collision,
+  const Polygon2d & object_polygon_at_first_collision);
 
 void add_error_text_marker(
   visualization_msgs::msg::MarkerArray & debug_markers, const rclcpp::Time & stamp,

--- a/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/trajectory_utils.cpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/trajectory_utils.cpp
@@ -374,22 +374,15 @@ FootprintTrajectory compute_footprint_trajectory(
 }
 
 FootprintTrajectory compute_footprint_trajectory(
-  const PoseTrajectory & pose_trajectory, const VehicleInfo & vehicle_info,
-  const GlobalParams & global_params)
+  const PoseTrajectory & pose_trajectory, const EgoDimensions & ego_dimensions)
 {
   FootprintTrajectory footprint_trajectory;
   footprint_trajectory.reserve(pose_trajectory.size());
 
-  const double front_offset =
-    vehicle_info.max_longitudinal_offset_m + global_params.ego_footprint_margin.front;
-  const double rear_overhang =
-    -vehicle_info.min_longitudinal_offset_m + global_params.ego_footprint_margin.rear;
-  const double vehicle_width =
-    vehicle_info.vehicle_width_m + 2.0 * global_params.ego_footprint_margin.lateral;
-
   for (const auto & pose : pose_trajectory) {
-    footprint_trajectory.push_back(
-      autoware_utils_geometry::to_footprint(pose, front_offset, rear_overhang, vehicle_width));
+    footprint_trajectory.push_back(autoware_utils_geometry::to_footprint(
+      pose, ego_dimensions.front_offset, ego_dimensions.rear_overhang,
+      ego_dimensions.vehicle_width));
   }
   return footprint_trajectory;
 }
@@ -510,11 +503,11 @@ geometry_msgs::msg::Pose interpolate_predicted_path_pose(
 
 TrajectoryData generate_ego_trajectory(
   const geometry_msgs::msg::Twist & initial_twist, double braking_lag, double assumed_acceleration,
-  double max_time, const TrajectoryPoints & traj_points, const VehicleInfo & vehicle_info,
-  const GlobalParams & global_params)
+  double max_time, const TrajectoryPoints & traj_points,
+  const footprint::EgoDimensions & ego_dimensions, double time_resolution)
 {
   auto [times, distances] = time_distance::compute_motion_profile_1d(
-    initial_twist, braking_lag, assumed_acceleration, 0.0, max_time, global_params.time_resolution);
+    initial_twist, braking_lag, assumed_acceleration, 0.0, max_time, time_resolution);
 
   double distance_offset =
     autoware::motion_utils::calcSignedArcLength(traj_points, traj_points.front().pose.position, 0);
@@ -522,7 +515,7 @@ TrajectoryData generate_ego_trajectory(
     val += distance_offset;
   }
   auto poses = pose::compute_pose_trajectory(traj_points, distances);
-  auto footprints = footprint::compute_footprint_trajectory(poses, vehicle_info, global_params);
+  auto footprints = footprint::compute_footprint_trajectory(poses, ego_dimensions);
 
   return TrajectoryData(
     TrajectoryIdentification{"EGO"}, std::move(times), std::move(distances), std::move(poses),
@@ -531,7 +524,7 @@ TrajectoryData generate_ego_trajectory(
 
 TrajectoryData generate_ego_trajectory(
   const TrajectoryPoints & traj_points, const FilterContext & context, double max_time,
-  const VehicleInfo & vehicle_info, const GlobalParams & global_params)
+  const footprint::EgoDimensions & ego_dimensions, double time_resolution)
 {
   if (traj_points.empty()) {
     throw std::invalid_argument("points must not be empty");
@@ -544,18 +537,16 @@ TrajectoryData generate_ego_trajectory(
 
   TimeTrajectory relative_times{0.0};
   TimeTrajectory absolute_times{start_time};
-  for (double sample_time = global_params.time_resolution; start_time + sample_time < end_time;
+  for (double sample_time = time_resolution; start_time + sample_time < end_time;
        sample_time =
-         std::floor(
-           (sample_time + global_params.time_resolution + 1e-6) / global_params.time_resolution) *
-         global_params.time_resolution) {
+         std::floor((sample_time + time_resolution + 1e-6) / time_resolution) * time_resolution) {
     relative_times.push_back(sample_time);
     absolute_times.push_back(start_time + sample_time);
   }
 
   auto poses = pose::compute_pose_trajectory_from_time(traj_points, absolute_times);
   auto distances = detail::compute_cumulative_distances(poses);
-  auto footprints = footprint::compute_footprint_trajectory(poses, vehicle_info, global_params);
+  auto footprints = footprint::compute_footprint_trajectory(poses, ego_dimensions);
 
   return TrajectoryData(
     TrajectoryIdentification{"EGO"}, std::move(relative_times), std::move(distances),

--- a/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/trajectory_utils.cpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/trajectory_utils.cpp
@@ -374,9 +374,24 @@ FootprintTrajectory compute_footprint_trajectory(
 }
 
 FootprintTrajectory compute_footprint_trajectory(
-  const PoseTrajectory & pose_trajectory, const VehicleInfo & vehicle_info)
+  const PoseTrajectory & pose_trajectory, const VehicleInfo & vehicle_info,
+  const GlobalParams & global_params)
 {
-  return compute_footprint_trajectory(pose_trajectory, geometry::create_base_polygon(vehicle_info));
+  FootprintTrajectory footprint_trajectory;
+  footprint_trajectory.reserve(pose_trajectory.size());
+
+  const double front_offset =
+    vehicle_info.max_longitudinal_offset_m + global_params.ego_footprint_margin.front;
+  const double rear_overhang =
+    -vehicle_info.min_longitudinal_offset_m + global_params.ego_footprint_margin.rear;
+  const double vehicle_width =
+    vehicle_info.vehicle_width_m + 2.0 * global_params.ego_footprint_margin.lateral;
+
+  for (const auto & pose : pose_trajectory) {
+    footprint_trajectory.push_back(
+      autoware_utils_geometry::to_footprint(pose, front_offset, rear_overhang, vehicle_width));
+  }
+  return footprint_trajectory;
 }
 }  // namespace footprint
 
@@ -495,11 +510,11 @@ geometry_msgs::msg::Pose interpolate_predicted_path_pose(
 
 TrajectoryData generate_ego_trajectory(
   const geometry_msgs::msg::Twist & initial_twist, double braking_lag, double assumed_acceleration,
-  double max_time, double time_resolution, const TrajectoryPoints & traj_points,
-  VehicleInfo & vehicle_info)
+  double max_time, const TrajectoryPoints & traj_points, VehicleInfo & vehicle_info,
+  const GlobalParams & global_params)
 {
   auto [times, distances] = time_distance::compute_motion_profile_1d(
-    initial_twist, braking_lag, assumed_acceleration, 0.0, max_time, time_resolution);
+    initial_twist, braking_lag, assumed_acceleration, 0.0, max_time, global_params.time_resolution);
 
   double distance_offset =
     autoware::motion_utils::calcSignedArcLength(traj_points, traj_points.front().pose.position, 0);
@@ -507,7 +522,7 @@ TrajectoryData generate_ego_trajectory(
     val += distance_offset;
   }
   auto poses = pose::compute_pose_trajectory(traj_points, distances);
-  auto footprints = footprint::compute_footprint_trajectory(poses, vehicle_info);
+  auto footprints = footprint::compute_footprint_trajectory(poses, vehicle_info, global_params);
 
   return TrajectoryData(
     TrajectoryIdentification{"EGO"}, std::move(times), std::move(distances), std::move(poses),
@@ -516,7 +531,7 @@ TrajectoryData generate_ego_trajectory(
 
 TrajectoryData generate_ego_trajectory(
   const TrajectoryPoints & traj_points, const FilterContext & context, double max_time,
-  double time_resolution, VehicleInfo & vehicle_info)
+  VehicleInfo & vehicle_info, const GlobalParams & global_params)
 {
   if (traj_points.empty()) {
     throw std::invalid_argument("points must not be empty");
@@ -529,16 +544,18 @@ TrajectoryData generate_ego_trajectory(
 
   TimeTrajectory relative_times{0.0};
   TimeTrajectory absolute_times{start_time};
-  for (double sample_time = time_resolution; start_time + sample_time < end_time;
+  for (double sample_time = global_params.time_resolution; start_time + sample_time < end_time;
        sample_time =
-         std::floor((sample_time + time_resolution + 1e-6) / time_resolution) * time_resolution) {
+         std::floor(
+           (sample_time + global_params.time_resolution + 1e-6) / global_params.time_resolution) *
+         global_params.time_resolution) {
     relative_times.push_back(sample_time);
     absolute_times.push_back(start_time + sample_time);
   }
 
   auto poses = pose::compute_pose_trajectory_from_time(traj_points, absolute_times);
   auto distances = detail::compute_cumulative_distances(poses);
-  auto footprints = footprint::compute_footprint_trajectory(poses, vehicle_info);
+  auto footprints = footprint::compute_footprint_trajectory(poses, vehicle_info, global_params);
 
   return TrajectoryData(
     TrajectoryIdentification{"EGO"}, std::move(relative_times), std::move(distances),

--- a/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/trajectory_utils.cpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/trajectory_utils.cpp
@@ -510,7 +510,7 @@ geometry_msgs::msg::Pose interpolate_predicted_path_pose(
 
 TrajectoryData generate_ego_trajectory(
   const geometry_msgs::msg::Twist & initial_twist, double braking_lag, double assumed_acceleration,
-  double max_time, const TrajectoryPoints & traj_points, VehicleInfo & vehicle_info,
+  double max_time, const TrajectoryPoints & traj_points, const VehicleInfo & vehicle_info,
   const GlobalParams & global_params)
 {
   auto [times, distances] = time_distance::compute_motion_profile_1d(
@@ -531,7 +531,7 @@ TrajectoryData generate_ego_trajectory(
 
 TrajectoryData generate_ego_trajectory(
   const TrajectoryPoints & traj_points, const FilterContext & context, double max_time,
-  VehicleInfo & vehicle_info, const GlobalParams & global_params)
+  const VehicleInfo & vehicle_info, const GlobalParams & global_params)
 {
   if (traj_points.empty()) {
     throw std::invalid_argument("points must not be empty");

--- a/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/trajectory_utils.cpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/trajectory_utils.cpp
@@ -308,21 +308,49 @@ std::vector<Point2d> create_base_polygon(
     Point2d{-ego_dimensions.rear_overhang, half_width}};
 }
 
-Polygon2d to_polygon2d(
-  const geometry_msgs::msg::Pose & pose, const autoware_perception_msgs::msg::Shape & shape)
+Polygon2d to_polygon2d(const geometry_msgs::msg::Pose & pose, const BaseFootprint & base_polygon)
 {
   const auto iso = pose_to_isometry(pose);
-  const auto points = create_base_polygon(shape);
 
   Polygon2d polygon;
-  polygon.outer().reserve(points.size() + 1U);
-  for (const auto & point : points) {
+  polygon.outer().reserve(base_polygon.size() + 1U);
+  for (const auto & point : base_polygon) {
     polygon.outer().push_back(transform_point(iso, point));
   }
   if (!polygon.outer().empty()) {
     polygon.outer().push_back(polygon.outer().front());
   }
   return polygon;
+}
+
+Polygon2d to_polygon2d(
+  const geometry_msgs::msg::Pose & pose, const autoware_perception_msgs::msg::Shape & shape)
+{
+  return to_polygon2d(pose, create_base_polygon(shape));
+}
+
+EgoFootprintEdgeIntersections intersecting_ego_footprint_edges(
+  const Polygon2d & ego_footprint, const Polygon2d & object_polygon)
+{
+  EgoFootprintEdgeIntersections edges;
+
+  constexpr size_t rectangle_closed_ring_size = 5U;
+  if (ego_footprint.outer().size() < rectangle_closed_ring_size) {
+    return edges;
+  }
+
+  using Segment2d = boost::geometry::model::segment<Point2d>;
+  const auto & ring = ego_footprint.outer();
+  const auto intersects_object = [&](const size_t start_index, const size_t end_index) {
+    return boost::geometry::intersects(
+      Segment2d{ring.at(start_index), ring.at(end_index)}, object_polygon);
+  };
+
+  edges.front = intersects_object(0U, 1U);
+  edges.right = intersects_object(1U, 2U);
+  edges.rear = intersects_object(2U, 3U);
+  edges.left = intersects_object(3U, 0U);
+  return edges;
 }
 }  // namespace autoware::trajectory_validator::plugin::safety::geometry
 
@@ -494,7 +522,18 @@ geometry_msgs::msg::Pose interpolate_predicted_path_pose(
     predicted_path.path.at(index), predicted_path.path.at(next_index), ratio, false);
 }
 }  // namespace detail
+}  // namespace autoware::trajectory_validator::plugin::safety::trajectory
 
+namespace autoware::trajectory_validator::plugin::safety
+{
+Polygon2d TrajectoryData::interpolate_footprint_at_time(const double t) const
+{
+  return geometry::to_polygon2d(interpolate_pose_at_time(t), base_footprint_);
+}
+}  // namespace autoware::trajectory_validator::plugin::safety
+
+namespace autoware::trajectory_validator::plugin::safety::trajectory
+{
 TrajectoryData generate_ego_trajectory(
   const geometry_msgs::msg::Twist & initial_twist, double braking_lag, double assumed_acceleration,
   double max_time, const TrajectoryPoints & traj_points,
@@ -509,11 +548,12 @@ TrajectoryData generate_ego_trajectory(
     val += distance_offset;
   }
   auto poses = pose::compute_pose_trajectory(traj_points, distances);
-  auto footprints = footprint::compute_footprint_trajectory(poses, ego_dimensions);
+  auto base_footprint = geometry::create_base_polygon(ego_dimensions);
+  auto footprints = footprint::compute_footprint_trajectory(poses, base_footprint);
 
   return TrajectoryData(
     TrajectoryIdentification{"EGO"}, std::move(times), std::move(distances), std::move(poses),
-    std::move(footprints));
+    std::move(base_footprint), std::move(footprints));
 }
 
 TrajectoryData generate_ego_trajectory(
@@ -540,11 +580,12 @@ TrajectoryData generate_ego_trajectory(
 
   auto poses = pose::compute_pose_trajectory_from_time(traj_points, absolute_times);
   auto distances = detail::compute_cumulative_distances(poses);
-  auto footprints = footprint::compute_footprint_trajectory(poses, ego_dimensions);
+  auto base_footprint = geometry::create_base_polygon(ego_dimensions);
+  auto footprints = footprint::compute_footprint_trajectory(poses, base_footprint);
 
   return TrajectoryData(
     TrajectoryIdentification{"EGO"}, std::move(relative_times), std::move(distances),
-    std::move(poses), std::move(footprints));
+    std::move(poses), std::move(base_footprint), std::move(footprints));
 }
 
 TrajectoryData generate_predicted_path_trajectory(
@@ -565,12 +606,14 @@ TrajectoryData generate_predicted_path_trajectory(
     time_resolution);
 
   auto poses = pose::compute_pose_trajectory(most_confident_path_it->path, distances);
-  auto footprints = footprint::compute_footprint_trajectory(poses, predicted_object.shape);
+  auto base_footprint = geometry::create_base_polygon(predicted_object.shape);
+  auto footprints = footprint::compute_footprint_trajectory(poses, base_footprint);
 
   return TrajectoryData(
     TrajectoryIdentification{
       predicted_object, stamp, "map_based_predicted_path", assumed_acceleration},
-    std::move(times), std::move(distances), std::move(poses), std::move(footprints));
+    std::move(times), std::move(distances), std::move(poses), std::move(base_footprint),
+    std::move(footprints));
 }
 
 TrajectoryData generate_diffusion_based_trajectory(
@@ -604,11 +647,13 @@ TrajectoryData generate_diffusion_based_trajectory(
       autoware_utils_geometry::calc_distance2d(poses.at(i - 1).position, poses.at(i).position));
   }
 
-  auto footprints = footprint::compute_footprint_trajectory(poses, predicted_object.shape);
+  auto base_footprint = geometry::create_base_polygon(predicted_object.shape);
+  auto footprints = footprint::compute_footprint_trajectory(poses, base_footprint);
 
   return TrajectoryData(
     TrajectoryIdentification{predicted_object, stamp, "diffusion_based_trajectory", 0.0},
-    std::move(times), std::move(distances), std::move(poses), std::move(footprints));
+    std::move(times), std::move(distances), std::move(poses), std::move(base_footprint),
+    std::move(footprints));
 }
 
 TrajectoryData generate_constant_curvature_trajectory(
@@ -623,12 +668,14 @@ TrajectoryData generate_constant_curvature_trajectory(
   auto poses = pose::constant_curvature_predictor::compute(
     predicted_object.kinematics.initial_pose_with_covariance.pose,
     predicted_object.kinematics.initial_twist_with_covariance.twist, distances);
-  auto footprints = footprint::compute_footprint_trajectory(poses, predicted_object.shape);
+  auto base_footprint = geometry::create_base_polygon(predicted_object.shape);
+  auto footprints = footprint::compute_footprint_trajectory(poses, base_footprint);
 
   return TrajectoryData(
     TrajectoryIdentification{
       predicted_object, stamp, "constant_curvature_path", assumed_acceleration},
-    std::move(times), std::move(distances), std::move(poses), std::move(footprints));
+    std::move(times), std::move(distances), std::move(poses), std::move(base_footprint),
+    std::move(footprints));
 }
 
 TrajectoryData generate_object_trajectory(

--- a/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/trajectory_utils.cpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/trajectory_utils.cpp
@@ -307,6 +307,17 @@ std::vector<Point2d> create_base_polygon(const VehicleInfo & vehicle_info)
     Point2d{vehicle_info.min_longitudinal_offset_m, half_width}};
 }
 
+std::vector<Point2d> create_base_polygon(
+  const trajectory::footprint::EgoDimensions & ego_dimensions)
+{
+  const double half_width = ego_dimensions.vehicle_width / 2.0;
+  return {
+    Point2d{ego_dimensions.front_offset, half_width},
+    Point2d{ego_dimensions.front_offset, -half_width},
+    Point2d{-ego_dimensions.rear_overhang, -half_width},
+    Point2d{-ego_dimensions.rear_overhang, half_width}};
+}
+
 Polygon2d to_polygon2d(
   const geometry_msgs::msg::Pose & pose, const autoware_perception_msgs::msg::Shape & shape)
 {
@@ -376,15 +387,8 @@ FootprintTrajectory compute_footprint_trajectory(
 FootprintTrajectory compute_footprint_trajectory(
   const PoseTrajectory & pose_trajectory, const EgoDimensions & ego_dimensions)
 {
-  FootprintTrajectory footprint_trajectory;
-  footprint_trajectory.reserve(pose_trajectory.size());
-
-  for (const auto & pose : pose_trajectory) {
-    footprint_trajectory.push_back(autoware_utils_geometry::to_footprint(
-      pose, ego_dimensions.front_offset, ego_dimensions.rear_overhang,
-      ego_dimensions.vehicle_width));
-  }
-  return footprint_trajectory;
+  return compute_footprint_trajectory(
+    pose_trajectory, geometry::create_base_polygon(ego_dimensions));
 }
 }  // namespace footprint
 

--- a/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/trajectory_utils.cpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/trajectory_utils.cpp
@@ -297,16 +297,6 @@ std::vector<Point2d> create_base_polygon(const autoware_perception_msgs::msg::Sh
   throw std::logic_error("The shape type is not supported in autoware_utils.");
 }
 
-std::vector<Point2d> create_base_polygon(const VehicleInfo & vehicle_info)
-{
-  const double half_width = vehicle_info.vehicle_width_m / 2.0;
-  return {
-    Point2d{vehicle_info.max_longitudinal_offset_m, half_width},
-    Point2d{vehicle_info.max_longitudinal_offset_m, -half_width},
-    Point2d{vehicle_info.min_longitudinal_offset_m, -half_width},
-    Point2d{vehicle_info.min_longitudinal_offset_m, half_width}};
-}
-
 std::vector<Point2d> create_base_polygon(
   const trajectory::footprint::EgoDimensions & ego_dimensions)
 {

--- a/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/trajectory_utils.hpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/trajectory_utils.hpp
@@ -357,12 +357,12 @@ geometry_msgs::msg::Pose interpolate_predicted_path_pose(
 
 TrajectoryData generate_ego_trajectory(
   const geometry_msgs::msg::Twist & initial_twist, double braking_lag, double assumed_acceleration,
-  double max_time, const TrajectoryPoints & traj_points, VehicleInfo & vehicle_info,
+  double max_time, const TrajectoryPoints & traj_points, const VehicleInfo & vehicle_info,
   const GlobalParams & global_params);
 
 TrajectoryData generate_ego_trajectory(
   const TrajectoryPoints & traj_points, const FilterContext & context, double max_time,
-  VehicleInfo & vehicle_info, const GlobalParams & global_params);
+  const VehicleInfo & vehicle_info, const GlobalParams & global_params);
 
 TrajectoryData generate_predicted_path_trajectory(
   const autoware_perception_msgs::msg::PredictedObject & predicted_object, double braking_lag,

--- a/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/trajectory_utils.hpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/trajectory_utils.hpp
@@ -21,6 +21,7 @@
 #include <autoware/motion_utils/trajectory/interpolation.hpp>
 #include <autoware/motion_utils/trajectory/trajectory.hpp>
 #include <autoware/universe_utils/geometry/geometry.hpp>
+#include <autoware_utils/geometry/geometry.hpp>
 #include <rclcpp/duration.hpp>
 
 #include <geometry_msgs/msg/pose.hpp>
@@ -36,7 +37,6 @@
 
 namespace autoware::trajectory_validator::plugin::safety
 {
-
 using IndexRange = std::pair<size_t, size_t>;
 using TimeRange = std::pair<double, double>;
 
@@ -46,6 +46,7 @@ using PoseTrajectory = std::vector<geometry_msgs::msg::Pose>;
 using QuadTrajectory = std::vector<std::array<Point2d, 4>>;
 using NgonTrajectory = std::vector<std::vector<Point2d>>;
 using FootprintTrajectory = std::variant<QuadTrajectory, NgonTrajectory>;
+using BaseFootprint = std::vector<Point2d>;
 
 class TrajectoryData
 {
@@ -54,10 +55,12 @@ private:
   TimeTrajectory times_;
   TravelDistanceTrajectory distances_;
   PoseTrajectory poses_;
+  BaseFootprint base_footprint_;
   FootprintTrajectory footprints_;
   mutable std::map<IndexRange, Box2d> envelope_cache_;
   mutable std::map<IndexRange, Polygon2d> convex_cache_;
 
+public:
   size_t get_same_or_earlier_time_index(const double t) const
   {
     const auto it = std::upper_bound(times_.begin(), times_.end(), t + TIME_INDEX_EPSILON);
@@ -70,6 +73,25 @@ private:
     const auto it = std::lower_bound(times_.begin(), times_.end(), t - TIME_INDEX_EPSILON);
     if (it == times_.end()) return times_.size() - 1;
     return std::distance(times_.begin(), it);
+  }
+
+  geometry_msgs::msg::Pose interpolate_pose_at_time(const double t) const
+  {
+    if (poses_.size() == 1 || t <= times_.front()) {
+      return poses_.front();
+    }
+    if (t >= times_.back()) {
+      return poses_.back();
+    }
+
+    const size_t upper_index = get_same_or_later_time_index(t);
+    const size_t lower_index = get_same_or_earlier_time_index(t);
+    const double lower_time = times_.at(lower_index);
+    const double upper_time = times_.at(upper_index);
+    const double duration = upper_time - lower_time;
+    const double ratio = duration > TIME_INDEX_EPSILON ? (t - lower_time) / duration : 0.0;
+    return autoware_utils::calc_interpolated_pose(
+      poses_.at(lower_index), poses_.at(upper_index), ratio, false);
   }
 
   IndexRange resolve_covering_index_range(const TimeRange & key_time) const
@@ -125,11 +147,13 @@ private:
 public:
   TrajectoryData(
     TrajectoryIdentification trajectory_identification, TimeTrajectory times,
-    TravelDistanceTrajectory distances, PoseTrajectory poses, FootprintTrajectory footprints)
+    TravelDistanceTrajectory distances, PoseTrajectory poses, BaseFootprint base_footprint,
+    FootprintTrajectory footprints)
   : identification_(std::move(trajectory_identification)),
     times_(std::move(times)),
     distances_(std::move(distances)),
     poses_(std::move(poses)),
+    base_footprint_(std::move(base_footprint)),
     footprints_(std::move(footprints))
   {
     if (times_.empty()) {
@@ -144,6 +168,11 @@ public:
     if (times_.size() != poses_.size()) {
       throw std::invalid_argument(
         "Trajectory sizes mismatch (times vs poses) classification: " +
+        identification_.classification);
+    }
+    if (base_footprint_.empty()) {
+      throw std::invalid_argument(
+        "Trajectory base footprint must not be empty classification: " +
         identification_.classification);
     }
     const auto footprint_size =
@@ -161,9 +190,60 @@ public:
   const TimeTrajectory & getTimes() const { return times_; }
   const TravelDistanceTrajectory & getDistances() const { return distances_; }
   const PoseTrajectory & getPoses() const { return poses_; }
+  const BaseFootprint & getBaseFootprint() const { return base_footprint_; }
   const FootprintTrajectory & getFootprints() const { return footprints_; }
 
   size_t size() const { return times_.size(); }
+
+  Polygon2d interpolate_footprint_at_time(const double t) const;
+
+  Box2d get_precise_envelope(const TimeRange & key_time) const
+  {
+    assert(key_time.first <= key_time.second);
+
+    Box2d box;
+    boost::geometry::assign_inverse(box);
+
+    const auto expand_points = [&](const auto & points) {
+      for (const auto & pt : points) {
+        boost::geometry::expand(box, pt);
+      }
+    };
+
+    const auto start_footprint = interpolate_footprint_at_time(key_time.first);
+    expand_points(start_footprint.outer());
+
+    const auto end_footprint = interpolate_footprint_at_time(key_time.second);
+    expand_points(end_footprint.outer());
+
+    return box;
+  }
+
+  Polygon2d get_precise_convex(const TimeRange & key_time) const
+  {
+    assert(key_time.first <= key_time.second);
+
+    MultiPoint2d all_points;
+    const auto append_points = [&](const auto & points) {
+      const size_t point_count =
+        points.empty() ? 0U : points.size() - (points.size() > 1U ? 1U : 0U);
+      all_points.reserve(all_points.size() + point_count);
+      for (size_t i = 0; i < point_count; ++i) {
+        all_points.push_back(points[i]);
+      }
+    };
+
+    const auto start_footprint = interpolate_footprint_at_time(key_time.first);
+    append_points(start_footprint.outer());
+
+    const auto end_footprint = interpolate_footprint_at_time(key_time.second);
+    append_points(end_footprint.outer());
+
+    Polygon2d hull;
+    hull.outer().reserve(all_points.size());
+    boost::geometry::convex_hull(all_points, hull);
+    return hull;
+  }
 
   const Box2d & get_or_compute_envelope(const IndexRange & key) const
   {
@@ -322,8 +402,13 @@ bool intersects_sat(const ConvexPolygon & poly_a, const ConvexPolygon & poly_b)
          !detail::has_separating_axis(ring_b, ring_a, ring_b);
 }
 
+Polygon2d to_polygon2d(const geometry_msgs::msg::Pose & pose, const BaseFootprint & base_polygon);
+
 Polygon2d to_polygon2d(
   const geometry_msgs::msg::Pose & pose, const autoware_perception_msgs::msg::Shape & shape);
+
+EgoFootprintEdgeIntersections intersecting_ego_footprint_edges(
+  const Polygon2d & ego_footprint, const Polygon2d & object_polygon);
 }  // namespace autoware::trajectory_validator::plugin::safety::geometry
 
 namespace autoware::trajectory_validator::plugin::safety::trajectory

--- a/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/trajectory_utils.hpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/trajectory_utils.hpp
@@ -330,13 +330,19 @@ namespace autoware::trajectory_validator::plugin::safety::trajectory
 {
 namespace footprint
 {
+struct EgoDimensions
+{
+  double front_offset{0.0};
+  double rear_overhang{0.0};
+  double vehicle_width{0.0};
+};
+
 FootprintTrajectory compute_footprint_trajectory(
   const PoseTrajectory & pose_trajectory,
   const autoware_perception_msgs::msg::Shape & object_shape);
 
 FootprintTrajectory compute_footprint_trajectory(
-  const PoseTrajectory & pose_trajectory, const VehicleInfo & vehicle_info,
-  const GlobalParams & global_params);
+  const PoseTrajectory & pose_trajectory, const EgoDimensions & ego_dimensions);
 }  // namespace footprint
 
 namespace detail
@@ -357,12 +363,12 @@ geometry_msgs::msg::Pose interpolate_predicted_path_pose(
 
 TrajectoryData generate_ego_trajectory(
   const geometry_msgs::msg::Twist & initial_twist, double braking_lag, double assumed_acceleration,
-  double max_time, const TrajectoryPoints & traj_points, const VehicleInfo & vehicle_info,
-  const GlobalParams & global_params);
+  double max_time, const TrajectoryPoints & traj_points,
+  const footprint::EgoDimensions & ego_dimensions, double time_resolution);
 
 TrajectoryData generate_ego_trajectory(
   const TrajectoryPoints & traj_points, const FilterContext & context, double max_time,
-  const VehicleInfo & vehicle_info, const GlobalParams & global_params);
+  const footprint::EgoDimensions & ego_dimensions, double time_resolution);
 
 TrajectoryData generate_predicted_path_trajectory(
   const autoware_perception_msgs::msg::PredictedObject & predicted_object, double braking_lag,

--- a/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/trajectory_utils.hpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/trajectory_utils.hpp
@@ -335,7 +335,8 @@ FootprintTrajectory compute_footprint_trajectory(
   const autoware_perception_msgs::msg::Shape & object_shape);
 
 FootprintTrajectory compute_footprint_trajectory(
-  const PoseTrajectory & pose_trajectory, const VehicleInfo & vehicle_info);
+  const PoseTrajectory & pose_trajectory, const VehicleInfo & vehicle_info,
+  const GlobalParams & global_params);
 }  // namespace footprint
 
 namespace detail
@@ -356,12 +357,12 @@ geometry_msgs::msg::Pose interpolate_predicted_path_pose(
 
 TrajectoryData generate_ego_trajectory(
   const geometry_msgs::msg::Twist & initial_twist, double braking_lag, double assumed_acceleration,
-  double max_time, double time_resolution, const TrajectoryPoints & traj_points,
-  VehicleInfo & vehicle_info);
+  double max_time, const TrajectoryPoints & traj_points, VehicleInfo & vehicle_info,
+  const GlobalParams & global_params);
 
 TrajectoryData generate_ego_trajectory(
   const TrajectoryPoints & traj_points, const FilterContext & context, double max_time,
-  double time_resolution, VehicleInfo & vehicle_info);
+  VehicleInfo & vehicle_info, const GlobalParams & global_params);
 
 TrajectoryData generate_predicted_path_trajectory(
   const autoware_perception_msgs::msg::PredictedObject & predicted_object, double braking_lag,

--- a/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/types.hpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/types.hpp
@@ -75,6 +75,26 @@ struct TrajectoryIdentification
 };
 
 enum class RiskLevel { SAFE, WARN, ERROR };
+
+struct EgoFootprintEdgeIntersections
+{
+  bool front{false};
+  bool right{false};
+  bool rear{false};
+  bool left{false};
+
+  bool any() const { return front || right || rear || left; }
+
+  EgoFootprintEdgeIntersections & operator|=(const EgoFootprintEdgeIntersections & other)
+  {
+    front = front || other.front;
+    right = right || other.right;
+    rear = rear || other.rear;
+    left = left || other.left;
+    return *this;
+  }
+};
+
 struct CollisionDetail
 {
   TrajectoryIdentification object_identification;
@@ -84,6 +104,9 @@ struct CollisionDetail
   std::vector<geometry_msgs::msg::Pose> object_trajectory;
   Polygon2d ego_hull;
   Polygon2d object_hull;
+  Polygon2d ego_polygon_at_first_collision;
+  Polygon2d object_polygon_at_first_collision;
+  EgoFootprintEdgeIntersections ego_collision_edges_at_first_collision{};
 };
 
 struct CollisionEvaluation

--- a/planning/autoware_trajectory_validator/test/plugins/collision_check_filter/test_geometry.cpp
+++ b/planning/autoware_trajectory_validator/test/plugins/collision_check_filter/test_geometry.cpp
@@ -214,5 +214,27 @@ TEST(GeometryTest, IntersectsSatMatchesBoostForPointContactAndNearPointCases)
   expect_both_outcomes_covered("point boundary shifts", saw_intersection, saw_separation);
 }
 
+TEST(GeometryTest, IntersectingEgoFootprintEdgesReportsExpectedSides)
+{
+  Polygon2d ego_poly;
+  ego_poly.outer() = {
+    Point2d(2.0, 1.0), Point2d(2.0, -1.0), Point2d(0.0, -1.0), Point2d(0.0, 1.0),
+    Point2d(2.0, 1.0)};
+
+  const auto front_object = create_rect_poly(1.8, -0.2, 2.2, 0.2);
+  const auto front_edges = intersecting_ego_footprint_edges(ego_poly, front_object);
+  EXPECT_TRUE(front_edges.front);
+  EXPECT_FALSE(front_edges.right);
+  EXPECT_FALSE(front_edges.rear);
+  EXPECT_FALSE(front_edges.left);
+
+  const auto front_left_object = create_rect_poly(1.8, 0.8, 2.2, 1.2);
+  const auto front_left_edges = intersecting_ego_footprint_edges(ego_poly, front_left_object);
+  EXPECT_TRUE(front_left_edges.front);
+  EXPECT_FALSE(front_left_edges.right);
+  EXPECT_FALSE(front_left_edges.rear);
+  EXPECT_TRUE(front_left_edges.left);
+}
+
 }  // namespace
 }  // namespace autoware::trajectory_validator::plugin::safety::geometry

--- a/planning/autoware_trajectory_validator/test/plugins/collision_check_filter/test_trajectory_utilities.cpp
+++ b/planning/autoware_trajectory_validator/test/plugins/collision_check_filter/test_trajectory_utilities.cpp
@@ -323,7 +323,8 @@ TEST(TrajectoryUtilitiesTest, ComputeFootprintTrajectoryForVehicleMatchesUtility
   const PoseTrajectory poses = {create_pose(1.0, 2.0, 0.0)};
   const auto vehicle_info = create_vehicle_info();
 
-  const auto footprints = trajectory::footprint::compute_footprint_trajectory(poses, vehicle_info);
+  const auto footprints =
+    trajectory::footprint::compute_footprint_trajectory(poses, vehicle_info, GlobalParams{});
 
   EXPECT_TRUE(std::holds_alternative<QuadTrajectory>(footprints));
   ASSERT_EQ(footprint_count(footprints), 1u);
@@ -332,6 +333,27 @@ TEST(TrajectoryUtilitiesTest, ComputeFootprintTrajectoryForVehicleMatchesUtility
     autoware_utils_geometry::to_footprint(
       poses.front(), vehicle_info.max_longitudinal_offset_m,
       -vehicle_info.min_longitudinal_offset_m, vehicle_info.vehicle_width_m));
+}
+
+TEST(TrajectoryUtilitiesTest, ComputeFootprintTrajectoryForVehicleAppliesGlobalMargins)
+{
+  const PoseTrajectory poses = {create_pose(1.0, 2.0, 0.0)};
+  const auto vehicle_info = create_vehicle_info();
+
+  GlobalParams global_params;
+  global_params.ego_footprint_margin.lateral = 0.3;
+  global_params.ego_footprint_margin.front = 0.7;
+  global_params.ego_footprint_margin.rear = 0.5;
+
+  const auto footprints =
+    trajectory::footprint::compute_footprint_trajectory(poses, vehicle_info, global_params);
+
+  ASSERT_EQ(footprints.size(), 1u);
+  expect_same_polygon(
+    footprints.front(),
+    autoware_utils_geometry::to_footprint(
+      poses.front(), vehicle_info.max_longitudinal_offset_m + 0.7,
+      -vehicle_info.min_longitudinal_offset_m + 0.5, vehicle_info.vehicle_width_m + 0.6));
 }
 
 TEST(TrajectoryUtilitiesTest, ObjectIdentificationClassificationConstructorSetsDefaults)
@@ -374,7 +396,7 @@ TEST(TrajectoryUtilitiesTest, GenerateEgoTrajectoryBuildsConsistentTrajectoryDat
   const auto initial_twist = create_twist(2.0);
 
   const auto trajectory_data = trajectory::generate_ego_trajectory(
-    initial_twist, 0.0, 0.0, 1.05, kDefaultTimeResolution, traj_points, vehicle_info);
+    initial_twist, 0.0, 0.0, 1.05, traj_points, vehicle_info, GlobalParams{});
 
   ASSERT_EQ(trajectory_data.getObjectIdentification().classification, "EGO");
   ASSERT_TRUE(trajectory_data.getObjectIdentification().trajectory_type.empty());
@@ -397,8 +419,8 @@ TEST(TrajectoryUtilitiesTest, GenerateTimedEgoTrajectoryProjectsCurrentPoseOntoT
   const auto odometry = create_odometry(create_pose(5.0, 1.0, 0.0));
   const auto context = create_filter_context(odometry);
 
-  const auto trajectory_data = trajectory::generate_ego_trajectory(
-    traj_points, context, 0.25, kDefaultTimeResolution, vehicle_info);
+  const auto trajectory_data =
+    trajectory::generate_ego_trajectory(traj_points, context, 0.25, vehicle_info, GlobalParams{});
 
   ASSERT_EQ(trajectory_data.getObjectIdentification().classification, "EGO");
   ASSERT_EQ(trajectory_data.size(), 3u);
@@ -424,8 +446,8 @@ TEST(TrajectoryUtilitiesTest, GenerateTimedEgoTrajectoryAllowsExtrapolationBefor
 
   const double projected_time =
     trajectory::detail::project_current_pose_on_trajectory(traj_points, odometry->pose.pose);
-  const auto trajectory_data = trajectory::generate_ego_trajectory(
-    traj_points, context, 0.25, kDefaultTimeResolution, vehicle_info);
+  const auto trajectory_data =
+    trajectory::generate_ego_trajectory(traj_points, context, 0.25, vehicle_info, GlobalParams{});
 
   EXPECT_NEAR(projected_time, -0.5, 1e-6);
   ASSERT_EQ(trajectory_data.size(), 3u);
@@ -446,8 +468,8 @@ TEST(TrajectoryUtilitiesTest, GenerateTimedEgoTrajectoryWithSinglePointReturnsSi
 
   const double projected_time =
     trajectory::detail::project_current_pose_on_trajectory(traj_points, odometry->pose.pose);
-  const auto trajectory_data = trajectory::generate_ego_trajectory(
-    traj_points, context, 1.0, kDefaultTimeResolution, vehicle_info);
+  const auto trajectory_data =
+    trajectory::generate_ego_trajectory(traj_points, context, 1.0, vehicle_info, GlobalParams{});
 
   EXPECT_NEAR(projected_time, 1.0, 1e-6);
   ASSERT_EQ(trajectory_data.size(), 1u);
@@ -467,8 +489,8 @@ TEST(TrajectoryUtilitiesTest, GenerateTimedEgoTrajectoryHandlesNonUniformTimeAnd
 
   const double projected_time =
     trajectory::detail::project_current_pose_on_trajectory(traj_points, odometry->pose.pose);
-  const auto trajectory_data = trajectory::generate_ego_trajectory(
-    traj_points, context, 0.25, kDefaultTimeResolution, vehicle_info);
+  const auto trajectory_data =
+    trajectory::generate_ego_trajectory(traj_points, context, 0.25, vehicle_info, GlobalParams{});
 
   EXPECT_NEAR(projected_time, 0.9, 1e-6);
 

--- a/planning/autoware_trajectory_validator/test/plugins/collision_check_filter/test_trajectory_utilities.cpp
+++ b/planning/autoware_trajectory_validator/test/plugins/collision_check_filter/test_trajectory_utilities.cpp
@@ -322,9 +322,12 @@ TEST(TrajectoryUtilitiesTest, ComputeFootprintTrajectoryForVehicleMatchesUtility
 {
   const PoseTrajectory poses = {create_pose(1.0, 2.0, 0.0)};
   const auto vehicle_info = create_vehicle_info();
+  const trajectory::footprint::EgoDimensions ego_dimensions{
+    vehicle_info.max_longitudinal_offset_m, -vehicle_info.min_longitudinal_offset_m,
+    vehicle_info.vehicle_width_m};
 
   const auto footprints =
-    trajectory::footprint::compute_footprint_trajectory(poses, vehicle_info, GlobalParams{});
+    trajectory::footprint::compute_footprint_trajectory(poses, ego_dimensions);
 
   EXPECT_TRUE(std::holds_alternative<QuadTrajectory>(footprints));
   ASSERT_EQ(footprint_count(footprints), 1u);
@@ -335,18 +338,16 @@ TEST(TrajectoryUtilitiesTest, ComputeFootprintTrajectoryForVehicleMatchesUtility
       -vehicle_info.min_longitudinal_offset_m, vehicle_info.vehicle_width_m));
 }
 
-TEST(TrajectoryUtilitiesTest, ComputeFootprintTrajectoryForVehicleAppliesGlobalMargins)
+TEST(TrajectoryUtilitiesTest, ComputeFootprintTrajectoryForVehicleAppliesSpecifiedDimensions)
 {
   const PoseTrajectory poses = {create_pose(1.0, 2.0, 0.0)};
   const auto vehicle_info = create_vehicle_info();
-
-  GlobalParams global_params;
-  global_params.ego_footprint_margin.lateral = 0.3;
-  global_params.ego_footprint_margin.front = 0.7;
-  global_params.ego_footprint_margin.rear = 0.5;
+  const trajectory::footprint::EgoDimensions ego_dimensions{
+    vehicle_info.max_longitudinal_offset_m + 0.7, -vehicle_info.min_longitudinal_offset_m + 0.5,
+    vehicle_info.vehicle_width_m + 0.6};
 
   const auto footprints =
-    trajectory::footprint::compute_footprint_trajectory(poses, vehicle_info, global_params);
+    trajectory::footprint::compute_footprint_trajectory(poses, ego_dimensions);
 
   ASSERT_EQ(footprints.size(), 1u);
   expect_same_polygon(
@@ -394,9 +395,12 @@ TEST(TrajectoryUtilitiesTest, GenerateEgoTrajectoryBuildsConsistentTrajectoryDat
   auto vehicle_info = create_vehicle_info();
   const auto traj_points = create_straight_trajectory_points({0.0, 10.0, 20.0});
   const auto initial_twist = create_twist(2.0);
+  const trajectory::footprint::EgoDimensions ego_dimensions{
+    vehicle_info.max_longitudinal_offset_m, -vehicle_info.min_longitudinal_offset_m,
+    vehicle_info.vehicle_width_m};
 
   const auto trajectory_data = trajectory::generate_ego_trajectory(
-    initial_twist, 0.0, 0.0, 1.05, traj_points, vehicle_info, GlobalParams{});
+    initial_twist, 0.0, 0.0, 1.05, traj_points, ego_dimensions, GlobalParams{}.time_resolution);
 
   ASSERT_EQ(trajectory_data.getObjectIdentification().classification, "EGO");
   ASSERT_TRUE(trajectory_data.getObjectIdentification().trajectory_type.empty());
@@ -418,9 +422,12 @@ TEST(TrajectoryUtilitiesTest, GenerateTimedEgoTrajectoryProjectsCurrentPoseOntoT
     create_straight_timed_trajectory_points({0.0, 10.0, 20.0}, {0.0, 1.0, 2.0});
   const auto odometry = create_odometry(create_pose(5.0, 1.0, 0.0));
   const auto context = create_filter_context(odometry);
+  const trajectory::footprint::EgoDimensions ego_dimensions{
+    vehicle_info.max_longitudinal_offset_m, -vehicle_info.min_longitudinal_offset_m,
+    vehicle_info.vehicle_width_m};
 
-  const auto trajectory_data =
-    trajectory::generate_ego_trajectory(traj_points, context, 0.25, vehicle_info, GlobalParams{});
+  const auto trajectory_data = trajectory::generate_ego_trajectory(
+    traj_points, context, 0.25, ego_dimensions, GlobalParams{}.time_resolution);
 
   ASSERT_EQ(trajectory_data.getObjectIdentification().classification, "EGO");
   ASSERT_EQ(trajectory_data.size(), 3u);
@@ -443,11 +450,14 @@ TEST(TrajectoryUtilitiesTest, GenerateTimedEgoTrajectoryAllowsExtrapolationBefor
     create_straight_timed_trajectory_points({0.0, 10.0, 20.0}, {0.0, 1.0, 2.0});
   const auto odometry = create_odometry(create_pose(-5.0, 0.0, 0.0));
   const auto context = create_filter_context(odometry);
+  const trajectory::footprint::EgoDimensions ego_dimensions{
+    vehicle_info.max_longitudinal_offset_m, -vehicle_info.min_longitudinal_offset_m,
+    vehicle_info.vehicle_width_m};
 
   const double projected_time =
     trajectory::detail::project_current_pose_on_trajectory(traj_points, odometry->pose.pose);
-  const auto trajectory_data =
-    trajectory::generate_ego_trajectory(traj_points, context, 0.25, vehicle_info, GlobalParams{});
+  const auto trajectory_data = trajectory::generate_ego_trajectory(
+    traj_points, context, 0.25, ego_dimensions, GlobalParams{}.time_resolution);
 
   EXPECT_NEAR(projected_time, -0.5, 1e-6);
   ASSERT_EQ(trajectory_data.size(), 3u);
@@ -465,11 +475,14 @@ TEST(TrajectoryUtilitiesTest, GenerateTimedEgoTrajectoryWithSinglePointReturnsSi
   const auto traj_points = create_straight_timed_trajectory_points({3.0}, {1.0});
   const auto odometry = create_odometry(create_pose(8.0, 1.0, 0.0));
   const auto context = create_filter_context(odometry);
+  const trajectory::footprint::EgoDimensions ego_dimensions{
+    vehicle_info.max_longitudinal_offset_m, -vehicle_info.min_longitudinal_offset_m,
+    vehicle_info.vehicle_width_m};
 
   const double projected_time =
     trajectory::detail::project_current_pose_on_trajectory(traj_points, odometry->pose.pose);
-  const auto trajectory_data =
-    trajectory::generate_ego_trajectory(traj_points, context, 1.0, vehicle_info, GlobalParams{});
+  const auto trajectory_data = trajectory::generate_ego_trajectory(
+    traj_points, context, 1.0, ego_dimensions, GlobalParams{}.time_resolution);
 
   EXPECT_NEAR(projected_time, 1.0, 1e-6);
   ASSERT_EQ(trajectory_data.size(), 1u);
@@ -486,11 +499,14 @@ TEST(TrajectoryUtilitiesTest, GenerateTimedEgoTrajectoryHandlesNonUniformTimeAnd
     create_straight_timed_trajectory_points({0.0, 3.0, 9.0}, {0.0, 0.3, 1.5});
   const auto odometry = create_odometry(create_pose(6.0, 0.5, 0.0));
   const auto context = create_filter_context(odometry);
+  const trajectory::footprint::EgoDimensions ego_dimensions{
+    vehicle_info.max_longitudinal_offset_m, -vehicle_info.min_longitudinal_offset_m,
+    vehicle_info.vehicle_width_m};
 
   const double projected_time =
     trajectory::detail::project_current_pose_on_trajectory(traj_points, odometry->pose.pose);
-  const auto trajectory_data =
-    trajectory::generate_ego_trajectory(traj_points, context, 0.25, vehicle_info, GlobalParams{});
+  const auto trajectory_data = trajectory::generate_ego_trajectory(
+    traj_points, context, 0.25, ego_dimensions, GlobalParams{}.time_resolution);
 
   EXPECT_NEAR(projected_time, 0.9, 1e-6);
 

--- a/planning/autoware_trajectory_validator/test/plugins/collision_check_filter/test_trajectory_utilities.cpp
+++ b/planning/autoware_trajectory_validator/test/plugins/collision_check_filter/test_trajectory_utilities.cpp
@@ -349,9 +349,10 @@ TEST(TrajectoryUtilitiesTest, ComputeFootprintTrajectoryForVehicleAppliesSpecifi
   const auto footprints =
     trajectory::footprint::compute_footprint_trajectory(poses, ego_dimensions);
 
-  ASSERT_EQ(footprints.size(), 1u);
+  EXPECT_TRUE(std::holds_alternative<QuadTrajectory>(footprints));
+  ASSERT_EQ(footprint_count(footprints), 1u);
   expect_same_polygon(
-    footprints.front(),
+    footprint_to_polygon2d(footprints, 0U),
     autoware_utils_geometry::to_footprint(
       poses.front(), vehicle_info.max_longitudinal_offset_m + 0.7,
       -vehicle_info.min_longitudinal_offset_m + 0.5, vehicle_info.vehicle_width_m + 0.6));


### PR DESCRIPTION
### fd3af20d06 feat(trajectory_validator): add precise footprint trajectory utilities

TrajectoryData と footprint 周りの基盤整理です。各 trajectory が base footprint を保持し、任意時刻の pose 補間から footprint を再構成できるようにしました。あわせて、2 時刻間の正確な envelope / convex を扱うための utility と、ego footprint のどの辺が衝突したかを判定する共通処理を追加しています。

### 373ba6b3c7 feat(trajectory_validator): support per-assessment collision edge filtering

PET/DRAC の collision 判定で、ego footprint の front / side / rear のどの衝突を有効とみなすかを assessment ごとに切り替えられるようにした変更です。assessment.cpp では粗い hull 判定の後に補間 footprint を使った精密な first collision 判定を行い、その衝突 edge 情報を PET/DRAC の判定に反映するようにしています。