### PR TITLE
fix(trajectory_validator): runtime error caused by uninitialized instance

### DIFF
--- a/planning/autoware_trajectory_validator/src/trajectory_validator_node.cpp
+++ b/planning/autoware_trajectory_validator/src/trajectory_validator_node.cpp
@@ -85,6 +85,8 @@ void TrajectoryValidator::publishers()
   pub_validation_reports_ = std::make_shared<autoware_utils_debug::DebugPublisher>(this, "~/debug");
   pub_debug_ = std::make_shared<autoware_utils_debug::DebugPublisher>(this, "~/debug");
 
+  pseudo_emergency_stop_handler_ = std::make_unique<PseudoEmergencyStopHandler>(*this);
+
   planning_factor_interface_ =
     std::make_unique<autoware::planning_factor_interface::PlanningFactorInterface>(
       this, "trajectory_validator");


### PR DESCRIPTION
https://github.com/tier4/autoware_universe/pull/2845 をv0.64/e2eに移植したときの移植漏れを修正します

## How to Test
psimで動作するようになったことを確認