### PR TITLE
feat(object_merger): add option to keep dimensions in object fusion merger

### DIFF
--- a/perception/autoware_object_merger/config/object_fusion_merger.param.yaml
+++ b/perception/autoware_object_merger/config/object_fusion_merger.param.yaml
@@ -2,3 +2,4 @@
   ros__parameters:
     sync_queue_size: 20
     base_link_frame_id: base_link
+    keep_input_dimensions: false

--- a/perception/autoware_object_merger/docs/object_fusion_merger.md
+++ b/perception/autoware_object_merger/docs/object_fusion_merger.md
@@ -62,9 +62,9 @@ Pose and dimension handling depends on the main shape type and on `keep_input_di
 
 When footprint retention is used, the retained union footprint is generated in the main object's local frame.
 
-- `BOUNDING_BOX`: keep the main x/y dimensions for frame-to-frame stability and store the union convex hull in `shape.footprint`.
-- `CYLINDER`: keep the main diameter for frame-to-frame stability and store the union convex hull in `shape.footprint`.
-- `POLYGON`: build a convex hull from the union footprint points in the main local frame and store it in `shape.footprint`.
+- `BOUNDING_BOX`: keep the main x/y dimensions for frame-to-frame stability and store the grouped union footprint in `shape.footprint`.
+- `CYLINDER`: keep the main diameter for frame-to-frame stability and store the grouped union footprint in `shape.footprint`.
+- `POLYGON`: rebuild the grouped union footprint in the main local frame and store it in `shape.footprint`.
 
 The height dimension is updated so the output encloses the full z-extent of the main object and all grouped sub objects.
 
@@ -72,7 +72,7 @@ The height dimension is updated so the output encloses the full z-extent of the 
 
 - `BOUNDING_BOX` main objects can either grow to the grouped union or keep their original x/y box dimensions, depending on `keep_input_dimensions`.
 - `CYLINDER` main objects can either grow to the grouped union or keep their original x/y diameter, depending on `keep_input_dimensions`.
-- `POLYGON` main objects keep polygon output and rebuild the footprint from the convex hull of the combined main/sub footprint points. Concavities in the original input footprints are not preserved.
+- `POLYGON` main objects keep polygon output and rebuild the footprint from the grouped union polygon in the main local frame.
 - Current generic geometry utilities in Autoware ignore `shape.footprint` for non-`POLYGON` types, so retained footprints on `BOUNDING_BOX` and `CYLINDER` outputs are auxiliary metadata unless downstream components opt in to use them.
 
 ## Association Preconditions
@@ -114,7 +114,7 @@ The current focused test suite covers the following cases:
 - multiple sub objects can expand one main object together
 - `BOUNDING_BOX` main object can retain a larger grouped union footprint from a sub `POLYGON` when `keep_input_dimensions=true`
 - `CYLINDER` main object can retain the grouped union footprint without changing its diameter when `keep_input_dimensions=true`
-- `POLYGON` main object rebuilds its footprint from the union convex hull
+- `POLYGON` main object rebuilds its footprint from the grouped union polygon
 
 ## Known Limits
 

--- a/perception/autoware_object_merger/docs/object_fusion_merger.md
+++ b/perception/autoware_object_merger/docs/object_fusion_merger.md
@@ -3,7 +3,7 @@
 ## Purpose
 
 `object_fusion_merger` groups sub detected objects by footprint overlap with main detected objects and keeps the main stream as the base output.
-For each main object, it expands the main object's shape so that the main region and all uniquely overlapped sub regions are enclosed by the main shape type.
+For each main object, it can either expand the main object's non-polygon shape to enclose the grouped union or preserve the main x/y dimensions and retain the grouped union on `shape.footprint`.
 
 The node is stateless across frames.
 
@@ -36,38 +36,44 @@ The packaged launch file remaps these by default to the following topics:
 4. If the sub object overlaps exactly one main object, add it to that main object's sub group.
 5. If the sub object overlaps multiple main objects, ignore it.
 6. If the sub object overlaps no main objects, publish it on `output/other_objects`.
-7. For each main object, expand its shape to enclose the main object and all grouped sub objects.
+7. For each main object, rebuild the grouped union footprint and update the output shape according to the main shape policy.
 8. Publish all main objects, expanded or unchanged, on `output/objects`.
 
 ## Shape Update Rule
 
-The output object is always based on the main object, but the geometry-related fields can move to fit the covered region.
+The output object is always based on the main object. When non-polygon dimension preservation is enabled, the grouped 2D union footprint is retained on `shape.footprint` for `BOUNDING_BOX` and `CYLINDER` outputs instead of growing their x/y dimensions.
 
 - Orientation is kept from the main object.
 - Twist is kept from the main object.
 - Classification is kept from the main object.
 - Existence probability is kept from the main object.
 
-Pose handling depends on the enclosing shape.
+Pose and dimension handling depends on the main shape type and on `keep_input_dimensions`.
 
-- `BOUNDING_BOX`: x/y center is moved so the box tightly fits the union of the main object and grouped sub objects.
-- `CYLINDER`: x/y center remains the main-object center, while the radius expands to cover the union.
+- Left: expand the output box itself so it encloses the union.
+- Right: keep the box size stable and retain the union footprint in `shape.footprint`.
+
+![Direct box expansion vs retained footprint](./object_fusion_merger_footprint_retention.drawio.svg)
+
+- `BOUNDING_BOX`: with `keep_input_dimensions=false`, x/y center is moved and x/y dimensions are expanded to tightly fit the grouped union. With `true`, x/y pose and x/y dimensions remain those of the main object and the grouped union footprint is stored in the main local frame.
+- `CYLINDER`: with `keep_input_dimensions=false`, diameter expands to cover the grouped union. With `true`, x/y pose and diameter remain those of the main object and the grouped union footprint is stored in the main local frame.
 - `POLYGON`: x/y pose remains the main-object pose and the footprint is rebuilt in the main local frame.
 - For all shape types, the z center and height are updated to fit the full z-range of the main object and grouped sub objects.
 
-The enclosing shape is generated using the main object's shape type.
+When footprint retention is used, the retained union footprint is generated in the main object's local frame.
 
-- `BOUNDING_BOX`: compute the union bounds in the main local frame, shift the box center to the union center, and set dimensions to the exact x/y span.
-- `CYLINDER`: enlarge radius to cover the farthest union point.
-- `POLYGON`: build a convex hull from the union footprint points in the main local frame.
+- `BOUNDING_BOX`: keep the main x/y dimensions for frame-to-frame stability and store the union convex hull in `shape.footprint`.
+- `CYLINDER`: keep the main diameter for frame-to-frame stability and store the union convex hull in `shape.footprint`.
+- `POLYGON`: build a convex hull from the union footprint points in the main local frame and store it in `shape.footprint`.
 
 The height dimension is updated so the output encloses the full z-extent of the main object and all grouped sub objects.
 
 ### Notes Per Shape Type
 
-- `BOUNDING_BOX` main objects remain axis-aligned in the main-object local frame, but the output center is shifted to tightly fit the union instead of expanding symmetrically around the original main pose.
-- `CYLINDER` main objects are expanded isotropically in x/y because the enclosing radius is computed from the farthest union point. The resulting diameter is identical for `dimensions.x` and `dimensions.y`.
+- `BOUNDING_BOX` main objects can either grow to the grouped union or keep their original x/y box dimensions, depending on `keep_input_dimensions`.
+- `CYLINDER` main objects can either grow to the grouped union or keep their original x/y diameter, depending on `keep_input_dimensions`.
 - `POLYGON` main objects keep polygon output and rebuild the footprint from the convex hull of the combined main/sub footprint points. Concavities in the original input footprints are not preserved.
+- Current generic geometry utilities in Autoware ignore `shape.footprint` for non-`POLYGON` types, so retained footprints on `BOUNDING_BOX` and `CYLINDER` outputs are auxiliary metadata unless downstream components opt in to use them.
 
 ## Association Preconditions
 
@@ -85,6 +91,7 @@ Current parameters in `config/object_fusion_merger.param.yaml` are:
 
 - `sync_queue_size`
 - `base_link_frame_id`
+- `keep_input_dimensions`
 
 ## Default Behavior
 
@@ -94,26 +101,29 @@ With the default configuration:
 - unmatched main objects remain in the output
 - sub objects that overlap no main objects are emitted on `output/other_objects`
 - sub objects that overlap multiple main objects are ignored
+- `BOUNDING_BOX` and `CYLINDER` outputs are expanded to enclose the grouped union
+- set `keep_input_dimensions=true` to keep non-polygon x/y dimensions stable and retain the grouped union in `shape.footprint`
 
 ## Test Coverage
 
 The current focused test suite covers the following cases:
 
-- uniquely overlapped `BOUNDING_BOX` pair shifts and expands the main box to fit the union
+- uniquely overlapped `BOUNDING_BOX` pair expands by default
 - unmatched main objects remain in the output and non-overlapping sub objects are published separately
 - sub objects that overlap multiple main objects are ignored
 - multiple sub objects can expand one main object together
-- `BOUNDING_BOX` main object can enclose a larger sub `POLYGON`
-- `CYLINDER` main object expands to cover the union footprint
+- `BOUNDING_BOX` main object can retain a larger grouped union footprint from a sub `POLYGON` when `keep_input_dimensions=true`
+- `CYLINDER` main object can retain the grouped union footprint without changing its diameter when `keep_input_dimensions=true`
 - `POLYGON` main object rebuilds its footprint from the union convex hull
 
 ## Known Limits
 
 - There is no temporal fusion across messages.
 - The node does not maintain track IDs or track existence over time.
-- `CYLINDER` and `POLYGON` keep the main object's x/y pose, so their enclosing geometry can still be conservative compared with a fully re-centered fit.
+- When `keep_input_dimensions=true`, `BOUNDING_BOX` and `CYLINDER` outputs retain expanded footprints as metadata only. Most existing downstream components still interpret these shapes from `dimensions`, not from `shape.footprint`.
+- `POLYGON` outputs keep the main object's x/y pose, so their enclosing geometry can still be conservative compared with a fully re-centered fit.
 - Sub objects that bridge multiple main objects are intentionally ignored rather than split.
 
 ## Intended Usage
 
-This node is intended for cases where the main detector should stay authoritative, while the sub detector is used only to expand the geometric extent of matched objects.
+This node is intended for cases where the main detector should stay authoritative, while the sub detector is used either to enlarge matched non-polygon shapes or, when configured, to retain additional matched footprint extent without destabilizing the main stream's non-polygon box size.

--- a/perception/autoware_object_merger/docs/object_fusion_merger_association_rules.drawio.svg
+++ b/perception/autoware_object_merger/docs/object_fusion_merger_association_rules.drawio.svg
@@ -1,17 +1,17 @@
-<svg host="65bd71144e" xmlns="http://www.w3.org/2000/svg" style="background: transparent; background-color: transparent;" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="1600px" height="1020px" viewBox="-0.5 -0.5 1600 1020" content="&lt;mxfile&gt;&lt;diagram id=&quot;assoc-rules&quot; name=&quot;Page-1&quot;&gt;7V1bc6M4Fv41rpp92CkQVz920p2erppUujY9NY9bAmSsGQweLrnsr19dAIN04mSmBaRDXhIjybb4js7t0xHeOJeHh88lPu6vi4RkG2QlDxvn4wYh27ND9o+3PLYtlu/JlrSkSdt2aril/yPdwLa1oQmpRgProshqehw3xkWek7geteGyLO7Hw3ZFNv7WI06J1nAb40xv/Z0m9b5t9S3r1PELoem++2oLtT0H3I1uG6o9Tor7QZPzaeNclkVRy1eHh0uScfg6YOT7rp7o7WdWkrx+yRuiVL7jDmdNe3ftxOrH7nbZHI/8ZSmwvNjXh4xd2exlVZfFn+SyyIqSteRFzoZd7GiWdU0b5OzcnU1C1q5PrZ3tHSlr8jBoaqf6mRQHUpePbMg9BPMehBi3wk37d59un71oEYDRqGnNbloF5Cb6g935VVPRIr8mZUpK1v+hqoqY4pq1sav/NBlbkCpw7K7+LmBtE85omrPLjOz4J3CEKFt/H9rmA02STLy1yOtWPxy3u24nYLfXA1nYO4QR+U5ZtL1+i3erxI4vLweSCnxAUK4BMVVNBEvqGlMujUIIrBLaTvjfpt4XJa2ZtO7Iz6zhE473XFRN1I/mH8/fEWe4quiOkoR35Rm/44j/QR+FqSjqY0lzPrxgWGX4yD8/Zd9b8TYs5nkYTePnZdeFHerrwN16rocnWQdhqK0D2w6BhYD8718IGUlJnnzFOfcwz5mxsmjyhCQt4riMO4DYzV3c72lNbo845i33zG+N5aPatN0u2YWa3FiPQxwsNFH2dO4BTYK17SIdbBcC20ahKbS/gZr3q+hbdqWjmS3gVpGG7+rSQIAwHAMmUMpC2rsZF34UJG5iQQvf9jziO9rC5yIp2KfTmqPkepMgjyzd+fjh1MB/42v7rAcaO4xFnUCgq4LjuJYbmBGIHfiKRLa6LoBewDUlklvuzOf0AUG823qQKmwvvEvLekYVPEOq4FpL6wIDHlSF23F0tRJNcMPFNYFlKiSZVRfigFhRAsZDnh859jO6gL43PWx7A7S0LgjoQW349HDEAu5TetDUx4YN9DO+diOWVPopf1UMO6/6XOYtK01oqUpja4JDUCjVBcDfL7mbes/z+jmVJkwCEoFKY3thuJtJaWxr8WhKYA9qzW/5AdfxXqhNm62/TGv4J/53Fbpj67EXoDwgFWNAeWJcEXu1CTgKAdbLhlI+xwDbIbCG0+9L1rXhgnc+nDRF8lOc1CIPOK4FlcWXceeBVpyrO5ZOU7nuRLm6lBtk3m6ENNj9MpEUgqocUpKVkBS/iT8KETEwo8aH4MNJhlbKtOooJ4isrMjT7jURHKdqJl+0NDhF+m0/+BIighc+vC42fF/lTnDgbD6U/29yWuRL05wTm1l1Abm65nugkTWl+B/pHU1eEqJ02zUZFVhqFjLxYhKjqSykmo86W4AV02Gyt6Zw+pKzEOBXHAEeSXQtvEzD5+0etzrMX5iJDpSUiCmEJo6pslEhjrVSlBrwgMEAeYCtqajstonsWZE/w4hFXjwbI4bscTzsesCWlAUkNJ6BPZIOeTQr8lfB5dVrQN5VkO/W8hB5BwHIm7I2wsLD/Mtoy/cU/7RbvNfszi6BcImHOxHLJk9B2LW9sAfxdI/h+b7jR9MYrj6qGaaTYI5jSn0+8BIdTYD/7mQyAfwxg4uFVn+z0ALKOo1EUN5YiwLdcziA+TJRWSHwvxEsChxC3bQMy5piqH5H/UwMtZ0yhlotoe8GSAmiAFvkQfUOtqkoSi74tUaxnpLNuT7g0aEo1jflDCT+oEv/2kQZrfY9dUFOWyzcSau+vN7juiMvRG2Y+DLBn3T88tJU8cSuXVUn0LWDFSuGpInWwxSHztJUMTpLFaMnqOJDw+uos478W1gj5qaJQ7WqFeKJp6rpkkKDLN2XXW/kpMCikiYpEYTsPU9RKsJuG9cDyrankC83HXEsTB0VDLEodcWHiKZN0fAKVdVYfpPGUn6bGM2EVJTCUGJe6Ccb80KMOmZUVMSWHH9plduRj/d7UpI3zg1rqwYih6EI0RQ5jH4Qcti2g2XZYfTODo8W7nZZdliUS85LUr6SwDoM3THyEElpA1l+aMrRcOjRGqG3LcUIwQQxsOyNYf+l86Uzon+GI366XjXBwpPLD+QXX3Fdk5LbLx67WuFIQrahtH+rCgjaO4F4ZNsyZZieJpJvBmFYxRLOahB+dalnGyJdo6dJZdqfOKLDxfDqUs+LaTyNB+hcH0RPknqunFW2bdXXA7Sy5+sCMEUro3daWd1o8ZblldGJ21xlDGar5XxwEAaxm+YlsM5QzHlRGDy9BLinh3RAum5uBEai8P9q+AH9i1jixom0Mo1+4hQfp1u2W/mfRZr/EkB14ztncyM3nVWqhj+woKZ5Q3pCht2C/PLOScnmhN6pTcbnKAsABwRQUhbHI0memxtrHk3vVUY1xvbKFRPuQWdAwQO5hsIaZz2MumKsfU+HGibUTSUFzllC3XmCUM+LzXvBNfJ93bA7UxZcO2DyNjRq/cnEpCAnLhvvdrIV552J5uXQX/p0bcBva4ldmwa25dSbpw6kvHE6XBF9YCFN9O6U51GcH4QNV0ulA4jmgFyHKRV5J8PPFb4Fni6OKclwZ61FJhrwWyAJgE4ghqaCqFf07IBZ63W3wQj4sAufnsu+QlOW+mma1TpFUcf+1PQbr89RFWELnMS1wXI3U4qwcpLU7YDsFALpOcaUpbfOO0d6vvQW8slTUqTOuss/XX98oCO0AAcBemZD9RrOah/L4LvjUwBhV9E8V4GAc6bytn3KVVXjx0pPdfskV82P5ROBUplui5PErzM/nrkMF3Lzk+6FuushDdUy3PlZQ/csa+hK1rDdCdjjnjEc1aVvBpsES2rG0uW4EIsIUkmmWEQXNH8DifUkIs7upTE8lkXSxETaRTKwce1YwSbuOjGPqUjVYArCscnpX43kFPmjadOcrwq+dUMhTpINj/c4T8VGzaJWdOaiW4hm9KZ6ZpRYGz8IzagV3c7NM7rvPOO5Uqi5eUZ3rdnMtkPwHM8YTMgzuk/TXZ8Vdx8z9OVTM5l9kTWFYmCXgL3V2FhVDjA2hqy6KQrMXTkFptUJQhwYZJ5McWDuOwf2TJHJ3CSYu24SzEZKkVoIHAoE/UaX5xsSwHOHoEua0hxnG/j482t8rOzc5VnghkowEdPCH3gNZAdfxaPzdqV4ih9P4wi7oUctFbR2OMvE8YBcMGXqc/qYJGM2J0kfDFLEnjcQGeLpzObowKfs1Y9riqSVM3HiR1LaeamZrjw72qW75EDruv2xlHjxg56hvqAm/K2TbQAYApCP+AemmF2efgZK9A1+Tsv59H8=&lt;/diagram&gt;&lt;/mxfile&gt;">
+<svg host="65bd71144e" xmlns="http://www.w3.org/2000/svg" style="background: transparent; background-color: transparent;" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="1601px" height="1020px" viewBox="-0.5 -0.5 1601 1020" content="&lt;mxfile&gt;&lt;diagram id=&quot;assoc-rules&quot; name=&quot;Page-1&quot;&gt;7V1bc6M4Fv41rpp92CkQ98eOu9PTVZNK16an5nFLgIw1g8HDJZf99asLYEDHTmZaQDrkJTFHwkjn6Nw+HeGNtT08fi7wcX+TxyTdICN+3FgfNwgh3zDYP055khQzsFxJSQoaN7QT4Y7+jzTE5sakpjEpBx2rPE8rehwSozzLSFQNaLgo8odht12eDp96xAlRCHcRTlXq7zSu9g3VbSfGG34hNNm3jzZQ03LAbe+GUO5xnD/0SNanjbUt8rySnw6PW5Jy9rWMkfddn2ntRlaQrHrJDWEi77jHad3MrhlY9dROl43xyD8WgpdX++qQsiuTfSyrIv+TbPM0LxglyzPW7WpH07QlbZC1s3cm8RldHVoz2ntSVOSxR2qG+pnkB1IVT6zLA8TmPchi3Ag36e4+TZ99aDgAc6OiFZv0mCG34R9s5td1SfPshhQJKVj7h7LMI4orRmNX/6lTtiDHjGOz+rsMa0g4pUnGLlOy49/AOUTZ+vvQkA80jlNxa55VjX5YdnvdDMBsrnuyMHcII/Kdsmha3YbfjRK3KtyTlOcCgrI1iKmsQ1hSN5hyaeRCYKXQdsL/1tU+L2jFpHVPfmaETzjac1HVYdebfz2/I0pxWdIdJTFvylI+45D/QR+FqcirY0Ez3j1nvErxkX9/wp5bchoW4zwMhvHzsuvC9NV1YAeO7eBJ1oHvK+vANH1gISD3+xdCShKSxV9xxj3Mc2asyOssJnHDcVxELYPY5K4e9rQid0ccccoD81tD+Yxt2m4X73xFbqzFIhYWmihbWveAJuG1aSOV2TbEbBP5urj9DdS8X0XbsisdzWwBg5E0XFuVBgKEYWkwgVIW0t7NuPBDL7ZjA1r4puMQ11IWPhdJzr6dVpxLtjMJ55GhOh/Xn5rx3/javuiBhg5jUSfgqapgWbZhe3oEYnruSCKBqgugF7B1ieSOO/M5fYAX7QIHUoXgytkaxjOq4GhSBdtYWhcY40FVuBtGVyvRBNtfXBNYpkLiWXUh8ogRxmA85LihZT6jC+h708Om1UNL64JgPagNnx6PWLD7lB7U1bFmHd2Ur92QJZVuwj/l/cbrLpd5y0rjG2OlMRXBISiUagPg75fcbbXnef2cSuPHHglBpTEd39/NpDSmsXg0JXgPas1v2QFX0V6oTZOtv0xr+Df+dxW6Y6qxF6A8IBSjQXkiXBJztQk48gHUy4RSPksD2iF4DaffW9a04YK3Ppw0ReJTHNQijziqBJTFl3HrgVacq1uGClPZ9kS5upQbZN5uhTTYfJlIcgFV9iHJUkiKT+KPXEQMzKjxLvhwkqGRMK06ygEiI82zpP1MBMY5NpMvWhocIv227z2EiOCFd6/yDd9XuRcYOBsP5f/rjObZ0jDnxGZ2vIBsVfMd0MjqUvyP9J7GLwlR2u2alApeKhYydiISoaks5DgftQIAFVPZZAa6+PQlYyHArzgEPJJoWniZ+s/bPW51mL/QEx2MUiKmEIo4pspGhTjWClEqjAcMBogDBLqisrs6NGfl/AVELHSi2RAxZA7jYdsBtqQMIKFxNOyRtJxHs3L+2ttevwbO2yPOt2u5z3kLAZzXZW2EhYfxl8GW7yn+abZ4b9jMtkC4xMOdkGWTpyDsxlzYgziqx3Bc13LDaQxXF9X000kwx9GlPh94iY4iwH+3MpmA/RFjFwut/mahBZR1aomgnKEWearnsADzpaOyQvD/VqAocAh12yAsa4qhuh31CzFUMGUMtVpA3/bQKIgCbJED1TuYuqIoueDXGsU6o2zOdgGPDkWxri5nIPkPuvSvdZjSct9BF+S0xcKd9NiXV3tcteCFqA0TDxP4SYsvLw0VT+zax+oEunawYkWTNNF6kGLfWhoqRhehYnQGKj7UvI46bcG/hTVibpjYH1e1QjjxVDVdUmiQpfuy64ycFFhY0DghApB94ClKSdi0cdWDbDsIebtpgWNh6qhAiEWpKz6ENKnzmleojo3lN2ks5dNEbyakvBCGEvNCP0nMctHrmFJREVtw/kur3PR8etiTgrxxbFhZNRA4DEWIusBh9IOAw6bpLYsOo3d0eLBwg2XRYVEuOS9I+UoCa9+3h5yHQEoTyPJ9XY6Gsx6tkfWmMTJCMEAMLHttvP/S+tIZuX8BIz5frxpj4cnlF/KLr7iqSMHtF49dDX8gIVNT2h+MBQTtnUA4smnoMkzngeTbXhhWsoSz7IVfberZhEg36DyoTLsTR7S/GF5d6nk1jadxAJ3rguhJUs+Vo8qmOfb1AKzsuKoAdMHK6B1WHm+0OMviyuiEba4yBjPH5XxwEAahm/olsM5QzHpRGDy9BLinh3RAum5uBAaicP+q+QH9q0jyjQNpRRL+xCE+DrcEgfzPIs1/CUa1/Vtncys3ncdQDX9hQUWzmnSADJuCfHjrpCQ5pvdjkvYxygLAHgAUF/nxSOLnxsbIg+G9yqhG2175yIQ70BlQ8ECuprDGWg+iPjLWrqOyGgbUdSUF1kVA3ToDqGf55r3gGrmuatitKQuuLTB56xu17mRinJMTlo13O0nFWWuieTn0ly5d6+HbSmLXpIFNOfXm3IGUNw6Hj0TvGUgRvT3leRTrB0HDx6XSHgRzQK5Dl4q8g+GXCt88RxXHlGC4tdYiE4XxAZAEQCcQfV1B1Ct6d8Cs9bqBN2C834ZPz2Vfvi5LfR5mNU5R1LE7Nf3G63PGihAAJ3FNsNxNlyKsHCS1W0a2CoHUHGPK0lvrHSO9XHoL+eQpIVJr3eWftjs80NG9uvNZz6ypXsNa7WsZXHt4CsBvK5rnKhCwLlTeNm+5Kiv8VKqpbpfkjvNj+UagRKbb4iTx68yPZy7Dhdz8pHuh9npAw3EZ7vyooX0RNbQlatjsBOxxhxgO6tI3vU2CJTVj6XJcCEUEoSRdKKINmr+exDoQEacP0hgeizyuIyLtIunZuKavQBN3rZiHUOTYYArAsc7oX7XEFPmraZOMrwq+dUMhTJJ1j/Y4S8RGzaJWdOaiWwhmdKZ6Z5RYGz8IzKgU3c6NM9rvOOOlUqi5cUZ7rdlM0HLwEs7oTYgz2ufhrs8jdx8x7su3ZjL7ImsKRcc2AXursfFYOcDYGLLquiAwe+UQmFInCGFgkHnShYHZ7xjYM0Umc4Ng9rpBMBONitR84FAg6DfaPF+TAJ47BF3QhGY43cDHn1/ja2XnLs8CN1S8iZAW/sJrIDv4Kl6dtyvEW/x4GkfYhJ6UVNDY4TQVxwMygZSN39PHJBmxMUn4oJcidriByBBPZzYHBz5lq3pcUyStHIkTP5LSjGuc6cqzo226Sw60qpofS4kWP+jpqwtqwt86CTzAEIB4xD8wxezy9DNQoq33c1rWp/8D&lt;/diagram&gt;&lt;/mxfile&gt;">
     <defs/>
     <g>
         <g>
-            <rect x="0" y="0" width="1600" height="1020" fill="#f4f1e8" stroke="none" pointer-events="all" style="fill: light-dark(rgb(244, 241, 232), rgb(33, 30, 22));"/>
+            <rect x="0" y="-1" width="1600" height="1020" fill="#f4f1e8" stroke="none" pointer-events="all" style="fill: light-dark(rgb(244, 241, 232), rgb(33, 30, 22));"/>
         </g>
         <g>
-            <rect x="60" y="36" width="760" height="40" fill="none" stroke="none" pointer-events="all"/>
+            <rect x="60" y="35" width="760" height="40" fill="none" stroke="none" pointer-events="all"/>
         </g>
         <g>
             <g transform="translate(-0.5 -0.5)">
                 <switch>
                     <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 1px; height: 1px; padding-top: 56px; margin-left: 62px;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 1px; height: 1px; padding-top: 55px; margin-left: 62px;">
                             <div style="box-sizing: border-box; font-size: 0; text-align: left; color: #1f2a2e; ">
                                 <div style="display: inline-block; font-size: 34px; font-family: &quot;Helvetica&quot;; color: light-dark(#1f2a2e, #c3cccf); line-height: 1.2; pointer-events: all; font-weight: bold; white-space: nowrap; ">
                                     ObjectFusionMerger Association Rules
@@ -19,20 +19,20 @@
                             </div>
                         </div>
                     </foreignObject>
-                    <text x="62" y="66" fill="#1f2a2e" font-family="&quot;Helvetica&quot;" font-size="34px" font-weight="bold">
+                    <text x="62" y="65" fill="#1f2a2e" font-family="&quot;Helvetica&quot;" font-size="34px" font-weight="bold">
                         ObjectFusionMerger Association Rules
                     </text>
                 </switch>
             </g>
         </g>
         <g>
-            <rect x="60" y="88" width="1180" height="26" fill="none" stroke="none" pointer-events="all"/>
+            <rect x="60" y="87" width="1180" height="26" fill="none" stroke="none" pointer-events="all"/>
         </g>
         <g>
             <g transform="translate(-0.5 -0.5)">
                 <switch>
                     <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 1px; height: 1px; padding-top: 101px; margin-left: 62px;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 1px; height: 1px; padding-top: 100px; margin-left: 62px;">
                             <div style="box-sizing: border-box; font-size: 0; text-align: left; color: #49545a; ">
                                 <div style="display: inline-block; font-size: 18px; font-family: &quot;Helvetica&quot;; color: light-dark(#49545a, #9fa8ad); line-height: 1.2; pointer-events: all; white-space: nowrap; ">
                                     Main objects are authoritative. Each sub object is classified only by 2D footprint overlap against all main objects.
@@ -40,23 +40,23 @@
                             </div>
                         </div>
                     </foreignObject>
-                    <text x="62" y="106" fill="#49545a" font-family="&quot;Helvetica&quot;" font-size="18px">
+                    <text x="62" y="105" fill="#49545a" font-family="&quot;Helvetica&quot;" font-size="18px">
                         Main objects are authoritative. Each sub object is classified only by 2D footprint overlap against all main objects.
                     </text>
                 </switch>
             </g>
         </g>
         <g>
-            <rect x="60" y="142" width="1480" height="128" rx="15.36" ry="15.36" fill="#fffdf8" stroke="#3e3a34" stroke-width="2" pointer-events="all" style="fill: light-dark(rgb(255, 253, 248), rgb(22, 20, 16)); stroke: light-dark(rgb(62, 58, 52), rgb(189, 186, 181));"/>
+            <rect x="60" y="141" width="1480" height="128" rx="15.36" ry="15.36" fill="#fffdf8" stroke="#3e3a34" stroke-width="2" pointer-events="all" style="fill: light-dark(rgb(255, 253, 248), rgb(22, 20, 16)); stroke: light-dark(rgb(62, 58, 52), rgb(189, 186, 181));"/>
         </g>
         <g>
-            <rect x="90" y="164" width="120" height="30" fill="none" stroke="none" pointer-events="all"/>
+            <rect x="90" y="163" width="120" height="30" fill="none" stroke="none" pointer-events="all"/>
         </g>
         <g>
             <g transform="translate(-0.5 -0.5)">
                 <switch>
                     <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 1px; height: 1px; padding-top: 179px; margin-left: 92px;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 1px; height: 1px; padding-top: 178px; margin-left: 92px;">
                             <div style="box-sizing: border-box; font-size: 0; text-align: left; color: #1f2a2e; ">
                                 <div style="display: inline-block; font-size: 24px; font-family: &quot;Helvetica&quot;; color: light-dark(#1f2a2e, #c3cccf); line-height: 1.2; pointer-events: all; font-weight: bold; white-space: nowrap; ">
                                     Legend
@@ -64,23 +64,23 @@
                             </div>
                         </div>
                     </foreignObject>
-                    <text x="92" y="186" fill="#1f2a2e" font-family="&quot;Helvetica&quot;" font-size="24px" font-weight="bold">
+                    <text x="92" y="185" fill="#1f2a2e" font-family="&quot;Helvetica&quot;" font-size="24px" font-weight="bold">
                         Legend
                     </text>
                 </switch>
             </g>
         </g>
         <g>
-            <rect x="90" y="206" width="68" height="30" rx="3.6" ry="3.6" fill-opacity="0.45" fill="#b7d4d0" stroke="#155e63" stroke-opacity="0.45" stroke-width="4" pointer-events="all" style="fill: light-dark(rgb(183, 212, 208), rgb(41, 66, 63)); stroke: light-dark(rgb(21, 94, 99), rgb(119, 182, 186));"/>
+            <rect x="90" y="205" width="68" height="30" rx="3.6" ry="3.6" fill-opacity="0.45" fill="#b7d4d0" stroke="#155e63" stroke-opacity="0.45" stroke-width="4" pointer-events="all" style="fill: light-dark(rgb(183, 212, 208), rgb(41, 66, 63)); stroke: light-dark(rgb(21, 94, 99), rgb(119, 182, 186));"/>
         </g>
         <g>
-            <rect x="176" y="209" width="180" height="24" fill="none" stroke="none" pointer-events="all"/>
+            <rect x="176" y="208" width="180" height="24" fill="none" stroke="none" pointer-events="all"/>
         </g>
         <g>
             <g transform="translate(-0.5 -0.5)">
                 <switch>
                     <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 1px; height: 1px; padding-top: 221px; margin-left: 178px;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 1px; height: 1px; padding-top: 220px; margin-left: 178px;">
                             <div style="box-sizing: border-box; font-size: 0; text-align: left; color: #334047; ">
                                 <div style="display: inline-block; font-size: 17px; font-family: &quot;Helvetica&quot;; color: light-dark(#334047, #afbac0); line-height: 1.2; pointer-events: all; white-space: nowrap; ">
                                     Main object footprint
@@ -88,23 +88,23 @@
                             </div>
                         </div>
                     </foreignObject>
-                    <text x="178" y="226" fill="#334047" font-family="&quot;Helvetica&quot;" font-size="17px">
+                    <text x="178" y="225" fill="#334047" font-family="&quot;Helvetica&quot;" font-size="17px">
                         Main object footprint
                     </text>
                 </switch>
             </g>
         </g>
         <g>
-            <rect x="400" y="206" width="68" height="30" rx="3.6" ry="3.6" fill-opacity="0.55" fill="#f7cf95" stroke="#9b5c00" stroke-opacity="0.55" stroke-width="4" pointer-events="all" style="fill: light-dark(rgb(247, 207, 149), rgb(86, 52, 2)); stroke: light-dark(rgb(155, 92, 0), rgb(200, 146, 67));"/>
+            <rect x="400" y="205" width="68" height="30" rx="3.6" ry="3.6" fill-opacity="0.55" fill="#f7cf95" stroke="#9b5c00" stroke-opacity="0.55" stroke-width="4" pointer-events="all" style="fill: light-dark(rgb(247, 207, 149), rgb(86, 52, 2)); stroke: light-dark(rgb(155, 92, 0), rgb(200, 146, 67));"/>
         </g>
         <g>
-            <rect x="486" y="209" width="180" height="24" fill="none" stroke="none" pointer-events="all"/>
+            <rect x="486" y="208" width="180" height="24" fill="none" stroke="none" pointer-events="all"/>
         </g>
         <g>
             <g transform="translate(-0.5 -0.5)">
                 <switch>
                     <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 1px; height: 1px; padding-top: 221px; margin-left: 488px;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 1px; height: 1px; padding-top: 220px; margin-left: 488px;">
                             <div style="box-sizing: border-box; font-size: 0; text-align: left; color: #334047; ">
                                 <div style="display: inline-block; font-size: 17px; font-family: &quot;Helvetica&quot;; color: light-dark(#334047, #afbac0); line-height: 1.2; pointer-events: all; white-space: nowrap; ">
                                     Sub object footprint
@@ -112,23 +112,23 @@
                             </div>
                         </div>
                     </foreignObject>
-                    <text x="488" y="226" fill="#334047" font-family="&quot;Helvetica&quot;" font-size="17px">
+                    <text x="488" y="225" fill="#334047" font-family="&quot;Helvetica&quot;" font-size="17px">
                         Sub object footprint
                     </text>
                 </switch>
             </g>
         </g>
         <g>
-            <rect x="720" y="206" width="68" height="30" rx="3.6" ry="3.6" fill-opacity="0.28" fill="#c7e0bd" stroke="#356b31" stroke-opacity="0.28" stroke-width="4" pointer-events="all" style="fill: light-dark(rgb(199, 224, 189), rgb(37, 58, 28)); stroke: light-dark(rgb(53, 107, 49), rgb(125, 172, 122));"/>
+            <rect x="720" y="205" width="68" height="30" rx="3.6" ry="3.6" fill-opacity="0.28" fill="#c7e0bd" stroke="#356b31" stroke-opacity="0.28" stroke-width="4" pointer-events="all" style="fill: light-dark(rgb(199, 224, 189), rgb(37, 58, 28)); stroke: light-dark(rgb(53, 107, 49), rgb(125, 172, 122));"/>
         </g>
         <g>
-            <rect x="806" y="201" width="220" height="42" fill="none" stroke="none" pointer-events="all"/>
+            <rect x="806" y="200" width="220" height="42" fill="none" stroke="none" pointer-events="all"/>
         </g>
         <g>
             <g transform="translate(-0.5 -0.5)">
                 <switch>
                     <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 1px; height: 1px; padding-top: 222px; margin-left: 808px;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 1px; height: 1px; padding-top: 221px; margin-left: 808px;">
                             <div style="box-sizing: border-box; font-size: 0; text-align: left; color: #334047; ">
                                 <div style="display: inline-block; font-size: 17px; font-family: &quot;Helvetica&quot;; color: light-dark(#334047, #afbac0); line-height: 1.2; pointer-events: all; white-space: nowrap; ">
                                     Expanded main output
@@ -138,23 +138,23 @@
                             </div>
                         </div>
                     </foreignObject>
-                    <text x="808" y="227" fill="#334047" font-family="&quot;Helvetica&quot;" font-size="17px">
+                    <text x="808" y="226" fill="#334047" font-family="&quot;Helvetica&quot;" font-size="17px">
                         Expanded main output...
                     </text>
                 </switch>
             </g>
         </g>
         <g>
-            <rect x="1090" y="206" width="68" height="30" rx="3.6" ry="3.6" fill-opacity="0.28" fill="#c8d7eb" stroke="#31588f" stroke-opacity="0.28" stroke-width="4" pointer-events="all" style="fill: light-dark(rgb(200, 215, 235), rgb(42, 55, 72)); stroke: light-dark(rgb(49, 88, 143), rgb(135, 169, 216));"/>
+            <rect x="1090" y="205" width="68" height="30" rx="3.6" ry="3.6" fill-opacity="0.28" fill="#c8d7eb" stroke="#31588f" stroke-opacity="0.28" stroke-width="4" pointer-events="all" style="fill: light-dark(rgb(200, 215, 235), rgb(42, 55, 72)); stroke: light-dark(rgb(49, 88, 143), rgb(135, 169, 216));"/>
         </g>
         <g>
-            <rect x="1176" y="201" width="260" height="42" fill="none" stroke="none" pointer-events="all"/>
+            <rect x="1176" y="200" width="260" height="42" fill="none" stroke="none" pointer-events="all"/>
         </g>
         <g>
             <g transform="translate(-0.5 -0.5)">
                 <switch>
                     <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 1px; height: 1px; padding-top: 222px; margin-left: 1178px;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 1px; height: 1px; padding-top: 221px; margin-left: 1178px;">
                             <div style="box-sizing: border-box; font-size: 0; text-align: left; color: #334047; ">
                                 <div style="display: inline-block; font-size: 17px; font-family: &quot;Helvetica&quot;; color: light-dark(#334047, #afbac0); line-height: 1.2; pointer-events: all; white-space: nowrap; ">
                                     Unmatched sub output
@@ -164,23 +164,23 @@
                             </div>
                         </div>
                     </foreignObject>
-                    <text x="1178" y="227" fill="#334047" font-family="&quot;Helvetica&quot;" font-size="17px">
+                    <text x="1178" y="226" fill="#334047" font-family="&quot;Helvetica&quot;" font-size="17px">
                         Unmatched sub output...
                     </text>
                 </switch>
             </g>
         </g>
         <g>
-            <rect x="60" y="286" width="710" height="336" rx="40.32" ry="40.32" fill="#fffdf8" stroke="#3e3a34" stroke-width="2" pointer-events="all" style="fill: light-dark(rgb(255, 253, 248), rgb(22, 20, 16)); stroke: light-dark(rgb(62, 58, 52), rgb(189, 186, 181));"/>
+            <rect x="60" y="285" width="710" height="336" rx="40.32" ry="40.32" fill="#fffdf8" stroke="#3e3a34" stroke-width="2" pointer-events="all" style="fill: light-dark(rgb(255, 253, 248), rgb(22, 20, 16)); stroke: light-dark(rgb(62, 58, 52), rgb(189, 186, 181));"/>
         </g>
         <g>
-            <rect x="90" y="308" width="440" height="30" fill="none" stroke="none" pointer-events="all"/>
+            <rect x="90" y="307" width="440" height="30" fill="none" stroke="none" pointer-events="all"/>
         </g>
         <g>
             <g transform="translate(-0.5 -0.5)">
                 <switch>
                     <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 1px; height: 1px; padding-top: 323px; margin-left: 92px;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 1px; height: 1px; padding-top: 322px; margin-left: 92px;">
                             <div style="box-sizing: border-box; font-size: 0; text-align: left; color: #1f2a2e; ">
                                 <div style="display: inline-block; font-size: 24px; font-family: &quot;Helvetica&quot;; color: light-dark(#1f2a2e, #c3cccf); line-height: 1.2; pointer-events: all; font-weight: bold; white-space: nowrap; ">
                                     Case 1: sub overlaps exactly one main
@@ -188,20 +188,20 @@
                             </div>
                         </div>
                     </foreignObject>
-                    <text x="92" y="330" fill="#1f2a2e" font-family="&quot;Helvetica&quot;" font-size="24px" font-weight="bold">
+                    <text x="92" y="329" fill="#1f2a2e" font-family="&quot;Helvetica&quot;" font-size="24px" font-weight="bold">
                         Case 1: sub overlaps exactly one main
                     </text>
                 </switch>
             </g>
         </g>
         <g>
-            <rect x="90" y="346" width="560" height="46" fill="none" stroke="none" pointer-events="all"/>
+            <rect x="90" y="345" width="560" height="46" fill="none" stroke="none" pointer-events="all"/>
         </g>
         <g>
             <g transform="translate(-0.5 -0.5)">
                 <switch>
                     <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 1px; height: 1px; padding-top: 369px; margin-left: 92px;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 1px; height: 1px; padding-top: 368px; margin-left: 92px;">
                             <div style="box-sizing: border-box; font-size: 0; text-align: left; color: #334047; ">
                                 <div style="display: inline-block; font-size: 17px; font-family: &quot;Helvetica&quot;; color: light-dark(#334047, #afbac0); line-height: 1.2; pointer-events: all; white-space: nowrap; ">
                                     One or more sub objects may join the same main group as long as each
@@ -211,23 +211,23 @@
                             </div>
                         </div>
                     </foreignObject>
-                    <text x="92" y="374" fill="#334047" font-family="&quot;Helvetica&quot;" font-size="17px">
+                    <text x="92" y="373" fill="#334047" font-family="&quot;Helvetica&quot;" font-size="17px">
                         One or more sub objects may join the same main group as long as ea...
                     </text>
                 </switch>
             </g>
         </g>
         <g>
-            <path d="M 400 492 L 401 492" fill="none" stroke="#d5cec2" stroke-width="2" stroke-miterlimit="10" pointer-events="all" style="stroke: light-dark(rgb(213, 206, 194), rgb(65, 59, 49));"/>
+            <path d="M 400 491 L 401 491" fill="none" stroke="#d5cec2" stroke-width="2" stroke-miterlimit="10" pointer-events="all" style="stroke: light-dark(rgb(213, 206, 194), rgb(65, 59, 49));"/>
         </g>
         <g>
-            <rect x="120" y="404" width="80" height="24" fill="none" stroke="none" pointer-events="all"/>
+            <rect x="120" y="403" width="80" height="24" fill="none" stroke="none" pointer-events="all"/>
         </g>
         <g>
             <g transform="translate(-0.5 -0.5)">
                 <switch>
                     <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 1px; height: 1px; padding-top: 416px; margin-left: 122px;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 1px; height: 1px; padding-top: 415px; margin-left: 122px;">
                             <div style="box-sizing: border-box; font-size: 0; text-align: left; color: #223036; ">
                                 <div style="display: inline-block; font-size: 18px; font-family: &quot;Helvetica&quot;; color: light-dark(#223036, #bcc8cd); line-height: 1.2; pointer-events: all; font-weight: bold; white-space: nowrap; ">
                                     Input
@@ -235,29 +235,29 @@
                             </div>
                         </div>
                     </foreignObject>
-                    <text x="122" y="421" fill="#223036" font-family="&quot;Helvetica&quot;" font-size="18px" font-weight="bold">
+                    <text x="122" y="420" fill="#223036" font-family="&quot;Helvetica&quot;" font-size="18px" font-weight="bold">
                         Input
                     </text>
                 </switch>
             </g>
         </g>
         <g>
-            <rect x="120" y="446" width="180" height="92" rx="11.04" ry="11.04" fill-opacity="0.45" fill="#b7d4d0" stroke="#155e63" stroke-opacity="0.45" stroke-width="4" pointer-events="all" style="fill: light-dark(rgb(183, 212, 208), rgb(41, 66, 63)); stroke: light-dark(rgb(21, 94, 99), rgb(119, 182, 186));"/>
+            <rect x="120" y="445" width="180" height="92" rx="11.04" ry="11.04" fill-opacity="0.45" fill="#b7d4d0" stroke="#155e63" stroke-opacity="0.45" stroke-width="4" pointer-events="all" style="fill: light-dark(rgb(183, 212, 208), rgb(41, 66, 63)); stroke: light-dark(rgb(21, 94, 99), rgb(119, 182, 186));"/>
         </g>
         <g>
-            <rect x="216" y="458" width="108" height="58" rx="6.96" ry="6.96" fill-opacity="0.55" fill="#f7cf95" stroke="#9b5c00" stroke-opacity="0.55" stroke-width="4" pointer-events="all" style="fill: light-dark(rgb(247, 207, 149), rgb(86, 52, 2)); stroke: light-dark(rgb(155, 92, 0), rgb(200, 146, 67));"/>
+            <rect x="216" y="457" width="108" height="58" rx="6.96" ry="6.96" fill-opacity="0.55" fill="#f7cf95" stroke="#9b5c00" stroke-opacity="0.55" stroke-width="4" pointer-events="all" style="fill: light-dark(rgb(247, 207, 149), rgb(86, 52, 2)); stroke: light-dark(rgb(155, 92, 0), rgb(200, 146, 67));"/>
         </g>
         <g>
-            <rect x="246" y="492" width="132" height="54" rx="6.48" ry="6.48" fill-opacity="0.55" fill="#f7cf95" stroke="#9b5c00" stroke-opacity="0.55" stroke-width="4" pointer-events="all" style="fill: light-dark(rgb(247, 207, 149), rgb(86, 52, 2)); stroke: light-dark(rgb(155, 92, 0), rgb(200, 146, 67));"/>
+            <rect x="246" y="491" width="132" height="54" rx="6.48" ry="6.48" fill-opacity="0.55" fill="#f7cf95" stroke="#9b5c00" stroke-opacity="0.55" stroke-width="4" pointer-events="all" style="fill: light-dark(rgb(247, 207, 149), rgb(86, 52, 2)); stroke: light-dark(rgb(155, 92, 0), rgb(200, 146, 67));"/>
         </g>
         <g>
-            <rect x="120" y="560" width="210" height="38" fill="none" stroke="none" pointer-events="all"/>
+            <rect x="120" y="559" width="210" height="38" fill="none" stroke="none" pointer-events="all"/>
         </g>
         <g>
             <g transform="translate(-0.5 -0.5)">
                 <switch>
                     <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 1px; height: 1px; padding-top: 579px; margin-left: 122px;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 1px; height: 1px; padding-top: 578px; margin-left: 122px;">
                             <div style="box-sizing: border-box; font-size: 0; text-align: left; color: #56636b; ">
                                 <div style="display: inline-block; font-size: 15px; font-family: &quot;Helvetica&quot;; color: light-dark(#56636b, #919ca3); line-height: 1.2; pointer-events: all; white-space: nowrap; ">
                                     Each sub overlaps only M1,
@@ -267,20 +267,20 @@
                             </div>
                         </div>
                     </foreignObject>
-                    <text x="122" y="584" fill="#56636b" font-family="&quot;Helvetica&quot;" font-size="15px">
+                    <text x="122" y="583" fill="#56636b" font-family="&quot;Helvetica&quot;" font-size="15px">
                         Each sub overlaps only M1,...
                     </text>
                 </switch>
             </g>
         </g>
         <g>
-            <rect x="405" y="476" width="38" height="40" fill="none" stroke="none" pointer-events="all"/>
+            <rect x="405" y="475" width="38" height="40" fill="none" stroke="none" pointer-events="all"/>
         </g>
         <g>
             <g transform="translate(-0.5 -0.5)">
                 <switch>
                     <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 496px; margin-left: 424px;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 495px; margin-left: 424px;">
                             <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #3e3a34; ">
                                 <div style="display: inline-block; font-size: 34px; font-family: &quot;Helvetica&quot;; color: light-dark(#3e3a34, #bdbab5); line-height: 1.2; pointer-events: all; white-space: nowrap; ">
                                     -&gt;
@@ -288,20 +288,20 @@
                             </div>
                         </div>
                     </foreignObject>
-                    <text x="424" y="506" fill="#3e3a34" font-family="&quot;Helvetica&quot;" font-size="34px" text-anchor="middle">
+                    <text x="424" y="505" fill="#3e3a34" font-family="&quot;Helvetica&quot;" font-size="34px" text-anchor="middle">
                         -&gt;
                     </text>
                 </switch>
             </g>
         </g>
         <g>
-            <rect x="480" y="404" width="90" height="24" fill="none" stroke="none" pointer-events="all"/>
+            <rect x="480" y="403" width="90" height="24" fill="none" stroke="none" pointer-events="all"/>
         </g>
         <g>
             <g transform="translate(-0.5 -0.5)">
                 <switch>
                     <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 1px; height: 1px; padding-top: 416px; margin-left: 482px;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 1px; height: 1px; padding-top: 415px; margin-left: 482px;">
                             <div style="box-sizing: border-box; font-size: 0; text-align: left; color: #223036; ">
                                 <div style="display: inline-block; font-size: 18px; font-family: &quot;Helvetica&quot;; color: light-dark(#223036, #bcc8cd); line-height: 1.2; pointer-events: all; font-weight: bold; white-space: nowrap; ">
                                     Output
@@ -309,26 +309,26 @@
                             </div>
                         </div>
                     </foreignObject>
-                    <text x="482" y="421" fill="#223036" font-family="&quot;Helvetica&quot;" font-size="18px" font-weight="bold">
+                    <text x="482" y="420" fill="#223036" font-family="&quot;Helvetica&quot;" font-size="18px" font-weight="bold">
                         Output
                     </text>
                 </switch>
             </g>
         </g>
         <g>
-            <rect x="472" y="440" width="250" height="112" rx="13.44" ry="13.44" fill-opacity="0.28" fill="#c7e0bd" stroke="#356b31" stroke-opacity="0.28" stroke-width="4" pointer-events="all" style="fill: light-dark(rgb(199, 224, 189), rgb(37, 58, 28)); stroke: light-dark(rgb(53, 107, 49), rgb(125, 172, 122));"/>
+            <rect x="472" y="439" width="250" height="112" rx="13.44" ry="13.44" fill-opacity="0.28" fill="#c7e0bd" stroke="#356b31" stroke-opacity="0.28" stroke-width="4" pointer-events="all" style="fill: light-dark(rgb(199, 224, 189), rgb(37, 58, 28)); stroke: light-dark(rgb(53, 107, 49), rgb(125, 172, 122));"/>
         </g>
         <g>
-            <rect x="500" y="462" width="180" height="68" rx="8.16" ry="8.16" fill-opacity="0.45" fill="#b7d4d0" stroke="#155e63" stroke-opacity="0.45" stroke-width="4" pointer-events="all" style="fill: light-dark(rgb(183, 212, 208), rgb(41, 66, 63)); stroke: light-dark(rgb(21, 94, 99), rgb(119, 182, 186));"/>
+            <rect x="500" y="461" width="180" height="68" rx="8.16" ry="8.16" fill-opacity="0.45" fill="#b7d4d0" stroke="#155e63" stroke-opacity="0.45" stroke-width="4" pointer-events="all" style="fill: light-dark(rgb(183, 212, 208), rgb(41, 66, 63)); stroke: light-dark(rgb(21, 94, 99), rgb(119, 182, 186));"/>
         </g>
         <g>
-            <rect x="472" y="560" width="220" height="38" fill="none" stroke="none" pointer-events="all"/>
+            <rect x="472" y="559" width="220" height="38" fill="none" stroke="none" pointer-events="all"/>
         </g>
         <g>
             <g transform="translate(-0.5 -0.5)">
                 <switch>
                     <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 1px; height: 1px; padding-top: 579px; margin-left: 474px;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 1px; height: 1px; padding-top: 578px; margin-left: 474px;">
                             <div style="box-sizing: border-box; font-size: 0; text-align: left; color: #56636b; ">
                                 <div style="display: inline-block; font-size: 15px; font-family: &quot;Helvetica&quot;; color: light-dark(#56636b, #919ca3); line-height: 1.2; pointer-events: all; white-space: nowrap; ">
                                     Publish one expanded M1
@@ -338,23 +338,23 @@
                             </div>
                         </div>
                     </foreignObject>
-                    <text x="474" y="584" fill="#56636b" font-family="&quot;Helvetica&quot;" font-size="15px">
+                    <text x="474" y="583" fill="#56636b" font-family="&quot;Helvetica&quot;" font-size="15px">
                         Publish one expanded M1...
                     </text>
                 </switch>
             </g>
         </g>
         <g>
-            <rect x="830" y="286" width="710" height="336" rx="40.32" ry="40.32" fill="#fffdf8" stroke="#3e3a34" stroke-width="2" pointer-events="all" style="fill: light-dark(rgb(255, 253, 248), rgb(22, 20, 16)); stroke: light-dark(rgb(62, 58, 52), rgb(189, 186, 181));"/>
+            <rect x="830" y="285" width="710" height="336" rx="40.32" ry="40.32" fill="#fffdf8" stroke="#3e3a34" stroke-width="2" pointer-events="all" style="fill: light-dark(rgb(255, 253, 248), rgb(22, 20, 16)); stroke: light-dark(rgb(62, 58, 52), rgb(189, 186, 181));"/>
         </g>
         <g>
-            <rect x="860" y="308" width="420" height="30" fill="none" stroke="none" pointer-events="all"/>
+            <rect x="860" y="307" width="420" height="30" fill="none" stroke="none" pointer-events="all"/>
         </g>
         <g>
             <g transform="translate(-0.5 -0.5)">
                 <switch>
                     <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 1px; height: 1px; padding-top: 323px; margin-left: 862px;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 1px; height: 1px; padding-top: 322px; margin-left: 862px;">
                             <div style="box-sizing: border-box; font-size: 0; text-align: left; color: #1f2a2e; ">
                                 <div style="display: inline-block; font-size: 24px; font-family: &quot;Helvetica&quot;; color: light-dark(#1f2a2e, #c3cccf); line-height: 1.2; pointer-events: all; font-weight: bold; white-space: nowrap; ">
                                     Case 2: sub overlaps multiple mains
@@ -362,20 +362,20 @@
                             </div>
                         </div>
                     </foreignObject>
-                    <text x="862" y="330" fill="#1f2a2e" font-family="&quot;Helvetica&quot;" font-size="24px" font-weight="bold">
+                    <text x="862" y="329" fill="#1f2a2e" font-family="&quot;Helvetica&quot;" font-size="24px" font-weight="bold">
                         Case 2: sub overlaps multiple mains
                     </text>
                 </switch>
             </g>
         </g>
         <g>
-            <rect x="860" y="346" width="590" height="46" fill="none" stroke="none" pointer-events="all"/>
+            <rect x="860" y="345" width="590" height="46" fill="none" stroke="none" pointer-events="all"/>
         </g>
         <g>
             <g transform="translate(-0.5 -0.5)">
                 <switch>
                     <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 1px; height: 1px; padding-top: 369px; margin-left: 862px;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 1px; height: 1px; padding-top: 368px; margin-left: 862px;">
                             <div style="box-sizing: border-box; font-size: 0; text-align: left; color: #334047; ">
                                 <div style="display: inline-block; font-size: 17px; font-family: &quot;Helvetica&quot;; color: light-dark(#334047, #afbac0); line-height: 1.2; pointer-events: all; white-space: nowrap; ">
                                     If one sub bridges two separate main objects, the grouping is ambiguous.
@@ -385,23 +385,23 @@
                             </div>
                         </div>
                     </foreignObject>
-                    <text x="862" y="374" fill="#334047" font-family="&quot;Helvetica&quot;" font-size="17px">
+                    <text x="862" y="373" fill="#334047" font-family="&quot;Helvetica&quot;" font-size="17px">
                         If one sub bridges two separate main objects, the grouping is ambiguo...
                     </text>
                 </switch>
             </g>
         </g>
         <g>
-            <path d="M 1170 492 L 1171 492" fill="none" stroke="#d5cec2" stroke-width="2" stroke-miterlimit="10" pointer-events="all" style="stroke: light-dark(rgb(213, 206, 194), rgb(65, 59, 49));"/>
+            <path d="M 1170 491 L 1171 491" fill="none" stroke="#d5cec2" stroke-width="2" stroke-miterlimit="10" pointer-events="all" style="stroke: light-dark(rgb(213, 206, 194), rgb(65, 59, 49));"/>
         </g>
         <g>
-            <rect x="890" y="404" width="80" height="24" fill="none" stroke="none" pointer-events="all"/>
+            <rect x="890" y="403" width="80" height="24" fill="none" stroke="none" pointer-events="all"/>
         </g>
         <g>
             <g transform="translate(-0.5 -0.5)">
                 <switch>
                     <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 1px; height: 1px; padding-top: 416px; margin-left: 892px;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 1px; height: 1px; padding-top: 415px; margin-left: 892px;">
                             <div style="box-sizing: border-box; font-size: 0; text-align: left; color: #223036; ">
                                 <div style="display: inline-block; font-size: 18px; font-family: &quot;Helvetica&quot;; color: light-dark(#223036, #bcc8cd); line-height: 1.2; pointer-events: all; font-weight: bold; white-space: nowrap; ">
                                     Input
@@ -409,29 +409,29 @@
                             </div>
                         </div>
                     </foreignObject>
-                    <text x="892" y="421" fill="#223036" font-family="&quot;Helvetica&quot;" font-size="18px" font-weight="bold">
+                    <text x="892" y="420" fill="#223036" font-family="&quot;Helvetica&quot;" font-size="18px" font-weight="bold">
                         Input
                     </text>
                 </switch>
             </g>
         </g>
         <g>
-            <rect x="884" y="458" width="118" height="80" rx="9.6" ry="9.6" fill-opacity="0.45" fill="#b7d4d0" stroke="#155e63" stroke-opacity="0.45" stroke-width="4" pointer-events="all" style="fill: light-dark(rgb(183, 212, 208), rgb(41, 66, 63)); stroke: light-dark(rgb(21, 94, 99), rgb(119, 182, 186));"/>
+            <rect x="884" y="457" width="118" height="80" rx="9.6" ry="9.6" fill-opacity="0.45" fill="#b7d4d0" stroke="#155e63" stroke-opacity="0.45" stroke-width="4" pointer-events="all" style="fill: light-dark(rgb(183, 212, 208), rgb(41, 66, 63)); stroke: light-dark(rgb(21, 94, 99), rgb(119, 182, 186));"/>
         </g>
         <g>
-            <rect x="1070" y="458" width="100" height="80" rx="9.6" ry="9.6" fill-opacity="0.45" fill="#b7d4d0" stroke="#155e63" stroke-opacity="0.45" stroke-width="4" pointer-events="all" style="fill: light-dark(rgb(183, 212, 208), rgb(41, 66, 63)); stroke: light-dark(rgb(21, 94, 99), rgb(119, 182, 186));"/>
+            <rect x="1070" y="457" width="100" height="80" rx="9.6" ry="9.6" fill-opacity="0.45" fill="#b7d4d0" stroke="#155e63" stroke-opacity="0.45" stroke-width="4" pointer-events="all" style="fill: light-dark(rgb(183, 212, 208), rgb(41, 66, 63)); stroke: light-dark(rgb(21, 94, 99), rgb(119, 182, 186));"/>
         </g>
         <g>
-            <rect x="970" y="446" width="132" height="104" rx="12.48" ry="12.48" fill-opacity="0.18" fill="#f7cf95" stroke="#9b5c00" stroke-opacity="0.18" stroke-width="4" stroke-dasharray="40 32" pointer-events="all" style="fill: light-dark(rgb(247, 207, 149), rgb(86, 52, 2)); stroke: light-dark(rgb(155, 92, 0), rgb(200, 146, 67));"/>
+            <rect x="970" y="445" width="132" height="104" rx="12.48" ry="12.48" fill-opacity="0.18" fill="#f7cf95" stroke="#9b5c00" stroke-opacity="0.18" stroke-width="4" stroke-dasharray="40 32" pointer-events="all" style="fill: light-dark(rgb(247, 207, 149), rgb(86, 52, 2)); stroke: light-dark(rgb(155, 92, 0), rgb(200, 146, 67));"/>
         </g>
         <g>
-            <rect x="890" y="558" width="230" height="38" fill="none" stroke="none" pointer-events="all"/>
+            <rect x="890" y="557" width="230" height="38" fill="none" stroke="none" pointer-events="all"/>
         </g>
         <g>
             <g transform="translate(-0.5 -0.5)">
                 <switch>
                     <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 1px; height: 1px; padding-top: 577px; margin-left: 892px;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 1px; height: 1px; padding-top: 576px; margin-left: 892px;">
                             <div style="box-sizing: border-box; font-size: 0; text-align: left; color: #56636B; ">
                                 <div style="display: inline-block; font-size: 15px; font-family: &quot;Helvetica&quot;; color: light-dark(#56636B, #919ca3); line-height: 1.2; pointer-events: all; white-space: nowrap; ">
                                     One sub spans separated M1 and M2,
@@ -441,20 +441,20 @@
                             </div>
                         </div>
                     </foreignObject>
-                    <text x="892" y="582" fill="#56636B" font-family="&quot;Helvetica&quot;" font-size="15px">
+                    <text x="892" y="581" fill="#56636B" font-family="&quot;Helvetica&quot;" font-size="15px">
                         One sub spans separated M1 and...
                     </text>
                 </switch>
             </g>
         </g>
         <g>
-            <rect x="1190" y="476" width="56" height="40" fill="none" stroke="none" pointer-events="all"/>
+            <rect x="1190" y="475" width="56" height="40" fill="none" stroke="none" pointer-events="all"/>
         </g>
         <g>
             <g transform="translate(-0.5 -0.5)">
                 <switch>
                     <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 496px; margin-left: 1218px;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 495px; margin-left: 1218px;">
                             <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #3e3a34; ">
                                 <div style="display: inline-block; font-size: 34px; font-family: &quot;Helvetica&quot;; color: light-dark(#3e3a34, #bdbab5); line-height: 1.2; pointer-events: all; white-space: nowrap; ">
                                     -&gt;
@@ -462,20 +462,20 @@
                             </div>
                         </div>
                     </foreignObject>
-                    <text x="1218" y="506" fill="#3e3a34" font-family="&quot;Helvetica&quot;" font-size="34px" text-anchor="middle">
+                    <text x="1218" y="505" fill="#3e3a34" font-family="&quot;Helvetica&quot;" font-size="34px" text-anchor="middle">
                         -&gt;
                     </text>
                 </switch>
             </g>
         </g>
         <g>
-            <rect x="1250" y="404" width="90" height="24" fill="none" stroke="none" pointer-events="all"/>
+            <rect x="1250" y="403" width="90" height="24" fill="none" stroke="none" pointer-events="all"/>
         </g>
         <g>
             <g transform="translate(-0.5 -0.5)">
                 <switch>
                     <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 1px; height: 1px; padding-top: 416px; margin-left: 1252px;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 1px; height: 1px; padding-top: 415px; margin-left: 1252px;">
                             <div style="box-sizing: border-box; font-size: 0; text-align: left; color: #223036; ">
                                 <div style="display: inline-block; font-size: 18px; font-family: &quot;Helvetica&quot;; color: light-dark(#223036, #bcc8cd); line-height: 1.2; pointer-events: all; font-weight: bold; white-space: nowrap; ">
                                     Output
@@ -483,26 +483,26 @@
                             </div>
                         </div>
                     </foreignObject>
-                    <text x="1252" y="421" fill="#223036" font-family="&quot;Helvetica&quot;" font-size="18px" font-weight="bold">
+                    <text x="1252" y="420" fill="#223036" font-family="&quot;Helvetica&quot;" font-size="18px" font-weight="bold">
                         Output
                     </text>
                 </switch>
             </g>
         </g>
         <g>
-            <rect x="1260" y="458" width="110" height="64" rx="7.68" ry="7.68" fill-opacity="0.45" fill="#b7d4d0" stroke="#155e63" stroke-opacity="0.45" stroke-width="4" pointer-events="all" style="fill: light-dark(rgb(183, 212, 208), rgb(41, 66, 63)); stroke: light-dark(rgb(21, 94, 99), rgb(119, 182, 186));"/>
+            <rect x="1260" y="457" width="110" height="64" rx="7.68" ry="7.68" fill-opacity="0.45" fill="#b7d4d0" stroke="#155e63" stroke-opacity="0.45" stroke-width="4" pointer-events="all" style="fill: light-dark(rgb(183, 212, 208), rgb(41, 66, 63)); stroke: light-dark(rgb(21, 94, 99), rgb(119, 182, 186));"/>
         </g>
         <g>
-            <rect x="1384" y="458" width="110" height="64" rx="7.68" ry="7.68" fill-opacity="0.45" fill="#b7d4d0" stroke="#155e63" stroke-opacity="0.45" stroke-width="4" pointer-events="all" style="fill: light-dark(rgb(183, 212, 208), rgb(41, 66, 63)); stroke: light-dark(rgb(21, 94, 99), rgb(119, 182, 186));"/>
+            <rect x="1384" y="457" width="110" height="64" rx="7.68" ry="7.68" fill-opacity="0.45" fill="#b7d4d0" stroke="#155e63" stroke-opacity="0.45" stroke-width="4" pointer-events="all" style="fill: light-dark(rgb(183, 212, 208), rgb(41, 66, 63)); stroke: light-dark(rgb(21, 94, 99), rgb(119, 182, 186));"/>
         </g>
         <g>
-            <rect x="1250" y="564" width="180" height="18" fill="none" stroke="none" pointer-events="all"/>
+            <rect x="1250" y="563" width="180" height="18" fill="none" stroke="none" pointer-events="all"/>
         </g>
         <g>
             <g transform="translate(-0.5 -0.5)">
                 <switch>
                     <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 1px; height: 1px; padding-top: 573px; margin-left: 1252px;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 1px; height: 1px; padding-top: 572px; margin-left: 1252px;">
                             <div style="box-sizing: border-box; font-size: 0; text-align: left; color: #56636b; ">
                                 <div style="display: inline-block; font-size: 15px; font-family: &quot;Helvetica&quot;; color: light-dark(#56636b, #919ca3); line-height: 1.2; pointer-events: all; white-space: nowrap; ">
                                     <font style="color: light-dark(rgb(86, 99, 107), rgb(145, 156, 163));">
@@ -517,23 +517,23 @@
                             </div>
                         </div>
                     </foreignObject>
-                    <text x="1252" y="578" fill="#56636b" font-family="&quot;Helvetica&quot;" font-size="15px">
+                    <text x="1252" y="577" fill="#56636b" font-family="&quot;Helvetica&quot;" font-size="15px">
                         Only main objects contin...
                     </text>
                 </switch>
             </g>
         </g>
         <g>
-            <rect x="60" y="654" width="710" height="304" rx="36.48" ry="36.48" fill="#fffdf8" stroke="#3e3a34" stroke-width="2" pointer-events="all" style="fill: light-dark(rgb(255, 253, 248), rgb(22, 20, 16)); stroke: light-dark(rgb(62, 58, 52), rgb(189, 186, 181));"/>
+            <rect x="60" y="653" width="710" height="304" rx="36.48" ry="36.48" fill="#fffdf8" stroke="#3e3a34" stroke-width="2" pointer-events="all" style="fill: light-dark(rgb(255, 253, 248), rgb(22, 20, 16)); stroke: light-dark(rgb(62, 58, 52), rgb(189, 186, 181));"/>
         </g>
         <g>
-            <rect x="90" y="668" width="340" height="30" fill="none" stroke="none" pointer-events="all"/>
+            <rect x="90" y="667" width="340" height="30" fill="none" stroke="none" pointer-events="all"/>
         </g>
         <g>
             <g transform="translate(-0.5 -0.5)">
                 <switch>
                     <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 1px; height: 1px; padding-top: 683px; margin-left: 92px;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 1px; height: 1px; padding-top: 682px; margin-left: 92px;">
                             <div style="box-sizing: border-box; font-size: 0; text-align: left; color: #1f2a2e; ">
                                 <div style="display: inline-block; font-size: 24px; font-family: &quot;Helvetica&quot;; color: light-dark(#1f2a2e, #c3cccf); line-height: 1.2; pointer-events: all; font-weight: bold; white-space: nowrap; ">
                                     Case 3: sub overlaps no main
@@ -541,20 +541,20 @@
                             </div>
                         </div>
                     </foreignObject>
-                    <text x="92" y="690" fill="#1f2a2e" font-family="&quot;Helvetica&quot;" font-size="24px" font-weight="bold">
+                    <text x="92" y="689" fill="#1f2a2e" font-family="&quot;Helvetica&quot;" font-size="24px" font-weight="bold">
                         Case 3: sub overlaps no main
                     </text>
                 </switch>
             </g>
         </g>
         <g>
-            <rect x="90" y="702" width="460" height="42" fill="none" stroke="none" pointer-events="all"/>
+            <rect x="90" y="701" width="460" height="42" fill="none" stroke="none" pointer-events="all"/>
         </g>
         <g>
             <g transform="translate(-0.5 -0.5)">
                 <switch>
                     <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 1px; height: 1px; padding-top: 723px; margin-left: 92px;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 1px; height: 1px; padding-top: 722px; margin-left: 92px;">
                             <div style="box-sizing: border-box; font-size: 0; text-align: left; color: #334047; ">
                                 <div style="display: inline-block; font-size: 17px; font-family: &quot;Helvetica&quot;; color: light-dark(#334047, #afbac0); line-height: 1.2; pointer-events: all; white-space: nowrap; ">
                                     The sub object does not affect any main. It is published
@@ -564,23 +564,23 @@
                             </div>
                         </div>
                     </foreignObject>
-                    <text x="92" y="728" fill="#334047" font-family="&quot;Helvetica&quot;" font-size="17px">
+                    <text x="92" y="727" fill="#334047" font-family="&quot;Helvetica&quot;" font-size="17px">
                         The sub object does not affect any main. It is publish...
                     </text>
                 </switch>
             </g>
         </g>
         <g>
-            <path d="M 400 836 L 401 836" fill="none" stroke="#d5cec2" stroke-width="2" stroke-miterlimit="10" pointer-events="all" style="stroke: light-dark(rgb(213, 206, 194), rgb(65, 59, 49));"/>
+            <path d="M 400 835 L 401 835" fill="none" stroke="#d5cec2" stroke-width="2" stroke-miterlimit="10" pointer-events="all" style="stroke: light-dark(rgb(213, 206, 194), rgb(65, 59, 49));"/>
         </g>
         <g>
-            <rect x="120" y="756" width="80" height="24" fill="none" stroke="none" pointer-events="all"/>
+            <rect x="120" y="755" width="80" height="24" fill="none" stroke="none" pointer-events="all"/>
         </g>
         <g>
             <g transform="translate(-0.5 -0.5)">
                 <switch>
                     <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 1px; height: 1px; padding-top: 768px; margin-left: 122px;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 1px; height: 1px; padding-top: 767px; margin-left: 122px;">
                             <div style="box-sizing: border-box; font-size: 0; text-align: left; color: #223036; ">
                                 <div style="display: inline-block; font-size: 18px; font-family: &quot;Helvetica&quot;; color: light-dark(#223036, #bcc8cd); line-height: 1.2; pointer-events: all; font-weight: bold; white-space: nowrap; ">
                                     Input
@@ -588,26 +588,26 @@
                             </div>
                         </div>
                     </foreignObject>
-                    <text x="122" y="773" fill="#223036" font-family="&quot;Helvetica&quot;" font-size="18px" font-weight="bold">
+                    <text x="122" y="772" fill="#223036" font-family="&quot;Helvetica&quot;" font-size="18px" font-weight="bold">
                         Input
                     </text>
                 </switch>
             </g>
         </g>
         <g>
-            <rect x="120" y="798" width="168" height="88" rx="10.56" ry="10.56" fill-opacity="0.45" fill="#b7d4d0" stroke="#155e63" stroke-opacity="0.45" stroke-width="4" pointer-events="all" style="fill: light-dark(rgb(183, 212, 208), rgb(41, 66, 63)); stroke: light-dark(rgb(21, 94, 99), rgb(119, 182, 186));"/>
+            <rect x="120" y="797" width="168" height="88" rx="10.56" ry="10.56" fill-opacity="0.45" fill="#b7d4d0" stroke="#155e63" stroke-opacity="0.45" stroke-width="4" pointer-events="all" style="fill: light-dark(rgb(183, 212, 208), rgb(41, 66, 63)); stroke: light-dark(rgb(21, 94, 99), rgb(119, 182, 186));"/>
         </g>
         <g>
-            <rect x="297" y="810" width="110" height="82" rx="9.84" ry="9.84" fill-opacity="0.55" fill="#f7cf95" stroke="#9b5c00" stroke-opacity="0.55" stroke-width="4" pointer-events="all" style="fill: light-dark(rgb(247, 207, 149), rgb(86, 52, 2)); stroke: light-dark(rgb(155, 92, 0), rgb(200, 146, 67));"/>
+            <rect x="297" y="809" width="110" height="82" rx="9.84" ry="9.84" fill-opacity="0.55" fill="#f7cf95" stroke="#9b5c00" stroke-opacity="0.55" stroke-width="4" pointer-events="all" style="fill: light-dark(rgb(247, 207, 149), rgb(86, 52, 2)); stroke: light-dark(rgb(155, 92, 0), rgb(200, 146, 67));"/>
         </g>
         <g>
-            <rect x="120" y="906" width="150" height="18" fill="none" stroke="none" pointer-events="all"/>
+            <rect x="120" y="905" width="150" height="18" fill="none" stroke="none" pointer-events="all"/>
         </g>
         <g>
             <g transform="translate(-0.5 -0.5)">
                 <switch>
                     <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 1px; height: 1px; padding-top: 915px; margin-left: 122px;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 1px; height: 1px; padding-top: 914px; margin-left: 122px;">
                             <div style="box-sizing: border-box; font-size: 0; text-align: left; color: #56636b; ">
                                 <div style="display: inline-block; font-size: 15px; font-family: &quot;Helvetica&quot;; color: light-dark(#56636b, #919ca3); line-height: 1.2; pointer-events: all; white-space: nowrap; ">
                                     0 overlapped mains
@@ -615,20 +615,20 @@
                             </div>
                         </div>
                     </foreignObject>
-                    <text x="122" y="920" fill="#56636b" font-family="&quot;Helvetica&quot;" font-size="15px">
+                    <text x="122" y="919" fill="#56636b" font-family="&quot;Helvetica&quot;" font-size="15px">
                         0 overlapped mains
                     </text>
                 </switch>
             </g>
         </g>
         <g>
-            <rect x="418" y="824" width="38" height="40" fill="none" stroke="none" pointer-events="all"/>
+            <rect x="418" y="823" width="38" height="40" fill="none" stroke="none" pointer-events="all"/>
         </g>
         <g>
             <g transform="translate(-0.5 -0.5)">
                 <switch>
                     <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 844px; margin-left: 437px;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 843px; margin-left: 437px;">
                             <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #3e3a34; ">
                                 <div style="display: inline-block; font-size: 34px; font-family: &quot;Helvetica&quot;; color: light-dark(#3e3a34, #bdbab5); line-height: 1.2; pointer-events: all; white-space: nowrap; ">
                                     -&gt;
@@ -636,20 +636,20 @@
                             </div>
                         </div>
                     </foreignObject>
-                    <text x="437" y="854" fill="#3e3a34" font-family="&quot;Helvetica&quot;" font-size="34px" text-anchor="middle">
+                    <text x="437" y="853" fill="#3e3a34" font-family="&quot;Helvetica&quot;" font-size="34px" text-anchor="middle">
                         -&gt;
                     </text>
                 </switch>
             </g>
         </g>
         <g>
-            <rect x="480" y="756" width="90" height="24" fill="none" stroke="none" pointer-events="all"/>
+            <rect x="480" y="755" width="90" height="24" fill="none" stroke="none" pointer-events="all"/>
         </g>
         <g>
             <g transform="translate(-0.5 -0.5)">
                 <switch>
                     <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 1px; height: 1px; padding-top: 768px; margin-left: 482px;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 1px; height: 1px; padding-top: 767px; margin-left: 482px;">
                             <div style="box-sizing: border-box; font-size: 0; text-align: left; color: #223036; ">
                                 <div style="display: inline-block; font-size: 18px; font-family: &quot;Helvetica&quot;; color: light-dark(#223036, #bcc8cd); line-height: 1.2; pointer-events: all; font-weight: bold; white-space: nowrap; ">
                                     Output
@@ -657,26 +657,26 @@
                             </div>
                         </div>
                     </foreignObject>
-                    <text x="482" y="773" fill="#223036" font-family="&quot;Helvetica&quot;" font-size="18px" font-weight="bold">
+                    <text x="482" y="772" fill="#223036" font-family="&quot;Helvetica&quot;" font-size="18px" font-weight="bold">
                         Output
                     </text>
                 </switch>
             </g>
         </g>
         <g>
-            <rect x="466" y="800" width="168" height="86" rx="10.32" ry="10.32" fill-opacity="0.45" fill="#b7d4d0" stroke="#155e63" stroke-opacity="0.45" stroke-width="4" pointer-events="all" style="fill: light-dark(rgb(183, 212, 208), rgb(41, 66, 63)); stroke: light-dark(rgb(21, 94, 99), rgb(119, 182, 186));"/>
+            <rect x="466" y="799" width="168" height="86" rx="10.32" ry="10.32" fill-opacity="0.45" fill="#b7d4d0" stroke="#155e63" stroke-opacity="0.45" stroke-width="4" pointer-events="all" style="fill: light-dark(rgb(183, 212, 208), rgb(41, 66, 63)); stroke: light-dark(rgb(21, 94, 99), rgb(119, 182, 186));"/>
         </g>
         <g>
-            <rect x="645" y="812" width="118" height="80" rx="9.6" ry="9.6" fill-opacity="0.28" fill="#c8d7eb" stroke="#31588f" stroke-opacity="0.28" stroke-width="4" pointer-events="all" style="fill: light-dark(rgb(200, 215, 235), rgb(42, 55, 72)); stroke: light-dark(rgb(49, 88, 143), rgb(135, 169, 216));"/>
+            <rect x="645" y="811" width="118" height="80" rx="9.6" ry="9.6" fill-opacity="0.28" fill="#c8d7eb" stroke="#31588f" stroke-opacity="0.28" stroke-width="4" pointer-events="all" style="fill: light-dark(rgb(200, 215, 235), rgb(42, 55, 72)); stroke: light-dark(rgb(49, 88, 143), rgb(135, 169, 216));"/>
         </g>
         <g>
-            <rect x="472" y="906" width="230" height="38" fill="none" stroke="none" pointer-events="all"/>
+            <rect x="472" y="905" width="230" height="38" fill="none" stroke="none" pointer-events="all"/>
         </g>
         <g>
             <g transform="translate(-0.5 -0.5)">
                 <switch>
                     <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 1px; height: 1px; padding-top: 925px; margin-left: 474px;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 1px; height: 1px; padding-top: 924px; margin-left: 474px;">
                             <div style="box-sizing: border-box; font-size: 0; text-align: left; color: #56636b; ">
                                 <div style="display: inline-block; font-size: 15px; font-family: &quot;Helvetica&quot;; color: light-dark(#56636b, #919ca3); line-height: 1.2; pointer-events: all; white-space: nowrap; ">
                                     Main stays on output/objects.
@@ -686,23 +686,23 @@
                             </div>
                         </div>
                     </foreignObject>
-                    <text x="474" y="930" fill="#56636b" font-family="&quot;Helvetica&quot;" font-size="15px">
+                    <text x="474" y="929" fill="#56636b" font-family="&quot;Helvetica&quot;" font-size="15px">
                         Main stays on output/objects....
                     </text>
                 </switch>
             </g>
         </g>
         <g>
-            <rect x="830" y="654" width="710" height="304" rx="36.48" ry="36.48" fill="#fffdf8" stroke="#3e3a34" stroke-width="2" pointer-events="all" style="fill: light-dark(rgb(255, 253, 248), rgb(22, 20, 16)); stroke: light-dark(rgb(62, 58, 52), rgb(189, 186, 181));"/>
+            <rect x="830" y="653" width="710" height="304" rx="36.48" ry="36.48" fill="#fffdf8" stroke="#3e3a34" stroke-width="2" pointer-events="all" style="fill: light-dark(rgb(255, 253, 248), rgb(22, 20, 16)); stroke: light-dark(rgb(62, 58, 52), rgb(189, 186, 181));"/>
         </g>
         <g>
-            <rect x="860" y="668" width="460" height="30" fill="none" stroke="none" pointer-events="all"/>
+            <rect x="860" y="667" width="460" height="30" fill="none" stroke="none" pointer-events="all"/>
         </g>
         <g>
             <g transform="translate(-0.5 -0.5)">
                 <switch>
                     <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 1px; height: 1px; padding-top: 683px; margin-left: 862px;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 1px; height: 1px; padding-top: 682px; margin-left: 862px;">
                             <div style="box-sizing: border-box; font-size: 0; text-align: left; color: #1f2a2e; ">
                                 <div style="display: inline-block; font-size: 24px; font-family: &quot;Helvetica&quot;; color: light-dark(#1f2a2e, #c3cccf); line-height: 1.2; pointer-events: all; font-weight: bold; white-space: nowrap; ">
                                     Case 4: main has no grouped sub objects
@@ -710,20 +710,20 @@
                             </div>
                         </div>
                     </foreignObject>
-                    <text x="862" y="690" fill="#1f2a2e" font-family="&quot;Helvetica&quot;" font-size="24px" font-weight="bold">
+                    <text x="862" y="689" fill="#1f2a2e" font-family="&quot;Helvetica&quot;" font-size="24px" font-weight="bold">
                         Case 4: main has no grouped sub objects
                     </text>
                 </switch>
             </g>
         </g>
         <g>
-            <rect x="860" y="702" width="520" height="42" fill="none" stroke="none" pointer-events="all"/>
+            <rect x="860" y="701" width="520" height="42" fill="none" stroke="none" pointer-events="all"/>
         </g>
         <g>
             <g transform="translate(-0.5 -0.5)">
                 <switch>
                     <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 1px; height: 1px; padding-top: 723px; margin-left: 862px;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 1px; height: 1px; padding-top: 722px; margin-left: 862px;">
                             <div style="box-sizing: border-box; font-size: 0; text-align: left; color: #334047; ">
                                 <div style="display: inline-block; font-size: 17px; font-family: &quot;Helvetica&quot;; color: light-dark(#334047, #afbac0); line-height: 1.2; pointer-events: all; white-space: nowrap; ">
                                     A main object always produces one output object. If no sub object
@@ -733,23 +733,23 @@
                             </div>
                         </div>
                     </foreignObject>
-                    <text x="862" y="728" fill="#334047" font-family="&quot;Helvetica&quot;" font-size="17px">
+                    <text x="862" y="727" fill="#334047" font-family="&quot;Helvetica&quot;" font-size="17px">
                         A main object always produces one output object. If no sub ob...
                     </text>
                 </switch>
             </g>
         </g>
         <g>
-            <path d="M 1170 836 L 1171 836" fill="none" stroke="#d5cec2" stroke-width="2" stroke-miterlimit="10" pointer-events="all" style="stroke: light-dark(rgb(213, 206, 194), rgb(65, 59, 49));"/>
+            <path d="M 1170 835 L 1171 835" fill="none" stroke="#d5cec2" stroke-width="2" stroke-miterlimit="10" pointer-events="all" style="stroke: light-dark(rgb(213, 206, 194), rgb(65, 59, 49));"/>
         </g>
         <g>
-            <rect x="890" y="756" width="80" height="24" fill="none" stroke="none" pointer-events="all"/>
+            <rect x="890" y="755" width="80" height="24" fill="none" stroke="none" pointer-events="all"/>
         </g>
         <g>
             <g transform="translate(-0.5 -0.5)">
                 <switch>
                     <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 1px; height: 1px; padding-top: 768px; margin-left: 892px;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 1px; height: 1px; padding-top: 767px; margin-left: 892px;">
                             <div style="box-sizing: border-box; font-size: 0; text-align: left; color: #223036; ">
                                 <div style="display: inline-block; font-size: 18px; font-family: &quot;Helvetica&quot;; color: light-dark(#223036, #bcc8cd); line-height: 1.2; pointer-events: all; font-weight: bold; white-space: nowrap; ">
                                     Input
@@ -757,23 +757,23 @@
                             </div>
                         </div>
                     </foreignObject>
-                    <text x="892" y="773" fill="#223036" font-family="&quot;Helvetica&quot;" font-size="18px" font-weight="bold">
+                    <text x="892" y="772" fill="#223036" font-family="&quot;Helvetica&quot;" font-size="18px" font-weight="bold">
                         Input
                     </text>
                 </switch>
             </g>
         </g>
         <g>
-            <rect x="924" y="798" width="178" height="88" rx="10.56" ry="10.56" fill-opacity="0.45" fill="#b7d4d0" stroke="#155e63" stroke-opacity="0.45" stroke-width="4" pointer-events="all" style="fill: light-dark(rgb(183, 212, 208), rgb(41, 66, 63)); stroke: light-dark(rgb(21, 94, 99), rgb(119, 182, 186));"/>
+            <rect x="924" y="797" width="178" height="88" rx="10.56" ry="10.56" fill-opacity="0.45" fill="#b7d4d0" stroke="#155e63" stroke-opacity="0.45" stroke-width="4" pointer-events="all" style="fill: light-dark(rgb(183, 212, 208), rgb(41, 66, 63)); stroke: light-dark(rgb(21, 94, 99), rgb(119, 182, 186));"/>
         </g>
         <g>
-            <rect x="890" y="906" width="220" height="18" fill="none" stroke="none" pointer-events="all"/>
+            <rect x="890" y="905" width="220" height="18" fill="none" stroke="none" pointer-events="all"/>
         </g>
         <g>
             <g transform="translate(-0.5 -0.5)">
                 <switch>
                     <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 1px; height: 1px; padding-top: 915px; margin-left: 892px;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 1px; height: 1px; padding-top: 914px; margin-left: 892px;">
                             <div style="box-sizing: border-box; font-size: 0; text-align: left; color: #56636b; ">
                                 <div style="display: inline-block; font-size: 15px; font-family: &quot;Helvetica&quot;; color: light-dark(#56636b, #919ca3); line-height: 1.2; pointer-events: all; white-space: nowrap; ">
                                     Grouped sub count for M1 = 0
@@ -781,20 +781,20 @@
                             </div>
                         </div>
                     </foreignObject>
-                    <text x="892" y="920" fill="#56636b" font-family="&quot;Helvetica&quot;" font-size="15px">
+                    <text x="892" y="919" fill="#56636b" font-family="&quot;Helvetica&quot;" font-size="15px">
                         Grouped sub count for M1 = 0
                     </text>
                 </switch>
             </g>
         </g>
         <g>
-            <rect x="1190" y="824" width="80" height="40" fill="none" stroke="none" pointer-events="all"/>
+            <rect x="1190" y="823" width="80" height="40" fill="none" stroke="none" pointer-events="all"/>
         </g>
         <g>
             <g transform="translate(-0.5 -0.5)">
                 <switch>
                     <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 844px; margin-left: 1230px;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe center; width: 1px; height: 1px; padding-top: 843px; margin-left: 1230px;">
                             <div style="box-sizing: border-box; font-size: 0; text-align: center; color: #3e3a34; ">
                                 <div style="display: inline-block; font-size: 34px; font-family: &quot;Helvetica&quot;; color: light-dark(#3e3a34, #bdbab5); line-height: 1.2; pointer-events: all; white-space: nowrap; ">
                                     -&gt;
@@ -802,20 +802,20 @@
                             </div>
                         </div>
                     </foreignObject>
-                    <text x="1230" y="854" fill="#3e3a34" font-family="&quot;Helvetica&quot;" font-size="34px" text-anchor="middle">
+                    <text x="1230" y="853" fill="#3e3a34" font-family="&quot;Helvetica&quot;" font-size="34px" text-anchor="middle">
                         -&gt;
                     </text>
                 </switch>
             </g>
         </g>
         <g>
-            <rect x="1250" y="756" width="90" height="24" fill="none" stroke="none" pointer-events="all"/>
+            <rect x="1250" y="755" width="90" height="24" fill="none" stroke="none" pointer-events="all"/>
         </g>
         <g>
             <g transform="translate(-0.5 -0.5)">
                 <switch>
                     <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 1px; height: 1px; padding-top: 768px; margin-left: 1252px;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 1px; height: 1px; padding-top: 767px; margin-left: 1252px;">
                             <div style="box-sizing: border-box; font-size: 0; text-align: left; color: #223036; ">
                                 <div style="display: inline-block; font-size: 18px; font-family: &quot;Helvetica&quot;; color: light-dark(#223036, #bcc8cd); line-height: 1.2; pointer-events: all; font-weight: bold; white-space: nowrap; ">
                                     Output
@@ -823,23 +823,23 @@
                             </div>
                         </div>
                     </foreignObject>
-                    <text x="1252" y="773" fill="#223036" font-family="&quot;Helvetica&quot;" font-size="18px" font-weight="bold">
+                    <text x="1252" y="772" fill="#223036" font-family="&quot;Helvetica&quot;" font-size="18px" font-weight="bold">
                         Output
                     </text>
                 </switch>
             </g>
         </g>
         <g>
-            <rect x="1284" y="808" width="178" height="72" rx="8.64" ry="8.64" fill-opacity="0.45" fill="#b7d4d0" stroke="#155e63" stroke-opacity="0.45" stroke-width="4" pointer-events="all" style="fill: light-dark(rgb(183, 212, 208), rgb(41, 66, 63)); stroke: light-dark(rgb(21, 94, 99), rgb(119, 182, 186));"/>
+            <rect x="1284" y="807" width="178" height="72" rx="8.64" ry="8.64" fill-opacity="0.45" fill="#b7d4d0" stroke="#155e63" stroke-opacity="0.45" stroke-width="4" pointer-events="all" style="fill: light-dark(rgb(183, 212, 208), rgb(41, 66, 63)); stroke: light-dark(rgb(21, 94, 99), rgb(119, 182, 186));"/>
         </g>
         <g>
-            <rect x="1250" y="906" width="170" height="38" fill="none" stroke="none" pointer-events="all"/>
+            <rect x="1250" y="905" width="170" height="38" fill="none" stroke="none" pointer-events="all"/>
         </g>
         <g>
             <g transform="translate(-0.5 -0.5)">
                 <switch>
                     <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 1px; height: 1px; padding-top: 925px; margin-left: 1252px;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 1px; height: 1px; padding-top: 924px; margin-left: 1252px;">
                             <div style="box-sizing: border-box; font-size: 0; text-align: left; color: #56636b; ">
                                 <div style="display: inline-block; font-size: 15px; font-family: &quot;Helvetica&quot;; color: light-dark(#56636b, #919ca3); line-height: 1.2; pointer-events: all; white-space: nowrap; ">
                                     Publish original M1
@@ -849,20 +849,20 @@
                             </div>
                         </div>
                     </foreignObject>
-                    <text x="1252" y="930" fill="#56636b" font-family="&quot;Helvetica&quot;" font-size="15px">
+                    <text x="1252" y="929" fill="#56636b" font-family="&quot;Helvetica&quot;" font-size="15px">
                         Publish original M1...
                     </text>
                 </switch>
             </g>
         </g>
         <g>
-            <rect x="60" y="978" width="1460" height="24" fill="none" stroke="none" pointer-events="all"/>
+            <rect x="60" y="977" width="1460" height="24" fill="none" stroke="none" pointer-events="all"/>
         </g>
         <g>
             <g transform="translate(-0.5 -0.5)">
                 <switch>
                     <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
-                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 1px; height: 1px; padding-top: 990px; margin-left: 62px;">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 1px; height: 1px; padding-top: 989px; margin-left: 62px;">
                             <div style="box-sizing: border-box; font-size: 0; text-align: left; color: #49545a; ">
                                 <div style="display: inline-block; font-size: 18px; font-family: &quot;Helvetica&quot;; color: light-dark(#49545a, #9fa8ad); line-height: 1.2; pointer-events: all; white-space: nowrap; ">
                                     Per frame, every sub object falls into exactly one outcome: uniquely grouped, ignored as ambiguous, or published as other. Every main object is always emitted once.
@@ -870,7 +870,7 @@
                             </div>
                         </div>
                     </foreignObject>
-                    <text x="62" y="995" fill="#49545a" font-family="&quot;Helvetica&quot;" font-size="18px">
+                    <text x="62" y="994" fill="#49545a" font-family="&quot;Helvetica&quot;" font-size="18px">
                         Per frame, every sub object falls into exactly one outcome: uniquely grouped, ignored as ambiguous, or published as other. Every main object is always emitted onc...
                     </text>
                 </switch>

--- a/perception/autoware_object_merger/docs/object_fusion_merger_footprint_retention.drawio.svg
+++ b/perception/autoware_object_merger/docs/object_fusion_merger_footprint_retention.drawio.svg
@@ -1,0 +1,521 @@
+<svg host="65bd71144e" xmlns="http://www.w3.org/2000/svg" style="background: transparent; background-color: transparent;" xmlns:xlink="http://www.w3.org/1999/xlink" version="1.1" width="1711px" height="770px" viewBox="-0.5 -0.5 1711 770" content="&lt;mxfile&gt;&lt;diagram id=&quot;footprint-retention&quot; name=&quot;Page-1&quot;&gt;7VzZcqM4FP0aV808TAoEAvyYpZep6q6kJl3Vj10ChM00RowQWebrRwu75NhJg51J/GRzJYR0z910hL1wLjcPnygq1l9JjLMFsOKHhXO1AABAz+IfQvKoJLblQSVZ0TSuZZ3gNv0XNx1raZXGuBx0ZIRkLC2GwojkOY7YQIYoJffDbgnJhk8t0AprgtsIZbr0exqzdS317V7DZ5yu1s2jLVDPfIOa3rWgXKOY3PdEzoeFc0kJYerb5uESZ0J9jWLUfR+3tLYToDhn+9wQrtQddyir6tXVE2OPzXL5HAvxlUpdXiRpll2SjFDZ6iRuYuOAy0tGyU/ctOQk5/dc6POpp3iHKcMPPVE9v0+YbDCjj7xLax61ru5Nul739Oz7dU9UA7xqB+tUwL/UWjBrhKWML3yslOvwb776j1WZkvwrpitMefsNJYxKEb/4jPI4S3OuT+u6YFxWaorkCxYKXLMNf/iVvU1nfQXXIpSlq5xfZjgRIwjlpdwez2vxJo3jTN5Kclb7i+M21/UE7Pq6h52dAAR+Faam1a4tp4EN6rAtGyj7qLkTgFZWoRm3b2ss3S4VEBEJIv9CsZCUIm7I9hCV4oNUrKjYmQATU9y28sF/tLem4i4klEWyx5VEPuHeWtCUaw5cisY8FmPl2WM7ghpYPriguORKRkxZTbRG+QqXZ8e1FTvQbcNdQhciLr9fpwzfFigSPe95SJ/HXoDJze3AYDDA+3WDyfAK5/EFedgd/iip8hjHNQqIRrXSvC266UE2DpVJEid6qOQtDnaQdFjV0mQVMJWqraGqoaer2jWp2gbBVLr+ZvTPL7LtuNYPDh0p3ZHl+4EOBzCg4UwQKRUYX2VAPJzlh37sxlYtv+Z3pUws3oUmZ7AhxJ7TtnTdIdQ8REAXo3LdzlJc3CDGMBVwc8Va3lSoDZ3IAXq88oK5QfsmHGMMnELTCkU0s0KcEJm8kroyOWpi8XVXchzXcv1pQAFNfHoCFHtpyiHuVKjcVuFuT2pK6DV+QKJocC4KTFP+REw76U0jAs/PLH6ULKHmX9DoX8sQRpZl8C/f7F8T4OS6I5wsoBeHng6TN5nzcJiMvnPbL+6MNd1b9h/o7fafFoR5/OfDQ4FkljlgOop8bIWx5i6O0V0c6IWOfVB3WYJj55oGFaPPdJB1O5uwKaXfqqvYlrWHr9iz+spfmPFUv4+vzJ1wcBBCD2keBJ6XcALL6EFPFHRi02gFEyHa+kublQyFuGXws+nSUoOo0c86uK0qT99TXrIdf3cEnM3ZIlRi+51yA65B0b5J0W3HX9a0mRm4IVkaiYlyZZ3zjzilqkhT2xwsctDxNzjH5g7c5roHl2Mq2KYoDSRaV7iMbA2t72sswtNPjIsfac5Lgh8xTy0SIPHABGWCYRX06IgRVWimrMRZshAHPuJ0BniZACBO7/jXFZOqU6KSoz6A2/unEmclF5HSt7AUugp/g7Z6mueqT9/+XY1Sd2/GLYmcEhJTkTnzrJv3GZ/Zx8fW9CSfi/MoI2XHDW/6W2/F/JZiQ9jbSsjQfdYsgA+p1jBcFxcPVvtqg/tcbPDYroOlXvG6hlTsTkAGS7v+U1jtFxSKw8qRccumI2MS7I4zwsmdqdguf4gHNFDG/pzp91oGCDMe13XweE+AQNfdCYjxsGQqQKQTnHjjF3jSsMDyTOdcJuSWYErkTjTlHlgBzxs6WWA4KDNtCIOpqiuJ1SUqWFvZbuP5F+DCUGy8lv2hp0dD6HmOF07kVN4wPfnNYXJ/e+iawuFUTnUu3iPa7VF8i696OldRhsoyjYYYdKHSMvlAEAfQ9zRzd3TXantu1S6OB2816brt6Q4aVNfIKM4QS+/wYHCTPusn3BBpju1RgDWKh+7oiLkkFY1wfVeHijYQtN2nB2KIrjDTBpLwtst+bkVyYFpgGqZ6C882R1myNPA0luFkx7amKtwVLqf8tgdaPADvRGve/HZRZRlmOn/wx1P7byTPs6siRqzhvl9z2d+64QSIuXAYLX3ga4g5prfqpuNBJWLAiFhRhVkqi+imKulRJRHhy+zesVvxoFj0uey3XJ9osEGowzZnfQLeCX0dBMemr8EO+hrUpKQ8y1m8upOcQxPYy9Frn0YC25mRwAYvIrAZrQb89YD3LRl6LNVnKEzBQxvhLXlYFjNS14ptVtPBeSaK3V50VS8q0+4EUQpViu2ZniWXMVhTRrjJCAOlaIO389ZHDd9HYKg1ww1czXCNDDWcqNAFJ4Z6gMfoxAAafm8wJ0MNTgz1+Mx+tCGHrqMhMidFDU4U9Utd6cgUNThR1Pu/hjbewx+aowYnjno/r3KGCergHDU4cdSDwffnqG3t0O6lJLUNgoOy1OD0imj7imip/Nw6s22bpziwDKDlux7wlhOFYrAcWgn0DeS3ycPtyTazqtD8f9Y8y9lOJXgpeuyK5nQq8Zxf1h27pHnRsYSgfSThon7EHR+5nNlju9eCO0n0s/Y4mjD9jHWy/d5TRxMGmrX3s390h9JMkXVbiLG3XJnq0JmOJ4w/+3p+eOSX3d+ZqKqm+1sY58N/&lt;/diagram&gt;&lt;/mxfile&gt;">
+    <defs/>
+    <g>
+        <g>
+            <rect x="0" y="0" width="1711" height="770" fill="#f4f1e8" stroke="none" pointer-events="all" style="fill: light-dark(rgb(244, 241, 232), rgb(33, 30, 22));"/>
+        </g>
+        <g>
+            <rect x="112" y="50" width="900" height="40" fill="none" stroke="none" pointer-events="all"/>
+        </g>
+        <g>
+            <g transform="translate(-0.5 -0.5)">
+                <switch>
+                    <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 1px; height: 1px; padding-top: 70px; margin-left: 114px;">
+                            <div style="box-sizing: border-box; font-size: 0; text-align: left; color: #1f2a2e; ">
+                                <div style="display: inline-block; font-size: 34px; font-family: &quot;Helvetica&quot;; color: light-dark(#1f2a2e, #c3cccf); line-height: 1.2; pointer-events: all; font-weight: bold; white-space: nowrap; ">
+                                    ObjectFusionMerger Protrusion Handling Options
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text x="114" y="80" fill="#1f2a2e" font-family="&quot;Helvetica&quot;" font-size="34px" font-weight="bold">
+                        ObjectFusionMerger Protrusion Handling Options
+                    </text>
+                </switch>
+            </g>
+        </g>
+        <g>
+            <rect x="112" y="100" width="1180" height="26" fill="none" stroke="none" pointer-events="all"/>
+        </g>
+        <g>
+            <g transform="translate(-0.5 -0.5)">
+                <switch>
+                    <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 1178px; height: 1px; padding-top: 113px; margin-left: 114px;">
+                            <div style="box-sizing: border-box; font-size: 0; text-align: left; color: #49545a; ">
+                                <div style="display: inline-block; font-size: 18px; font-family: &quot;Helvetica&quot;; color: light-dark(#49545a, #9fa8ad); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
+                                    The main object remains the base output. Here the sub_object is a polygon footprint, and only the output representation changes.
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text x="114" y="118" fill="#49545a" font-family="&quot;Helvetica&quot;" font-size="18px">
+                        The main object remains the base output. Here the sub_object is a polygon footprint, and only the output representation changes.
+                    </text>
+                </switch>
+            </g>
+        </g>
+        <g>
+            <rect x="110" y="156" width="1480" height="128" rx="7.68" ry="7.68" fill="#fffdf8" stroke="#3e3a34" stroke-width="2" pointer-events="all" style="fill: light-dark(rgb(255, 253, 248), rgb(22, 20, 16)); stroke: light-dark(rgb(62, 58, 52), rgb(189, 186, 181));"/>
+        </g>
+        <g>
+            <rect x="142" y="178" width="120" height="30" fill="none" stroke="none" pointer-events="all"/>
+        </g>
+        <g>
+            <g transform="translate(-0.5 -0.5)">
+                <switch>
+                    <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 1px; height: 1px; padding-top: 193px; margin-left: 144px;">
+                            <div style="box-sizing: border-box; font-size: 0; text-align: left; color: #1f2a2e; ">
+                                <div style="display: inline-block; font-size: 24px; font-family: &quot;Helvetica&quot;; color: light-dark(#1f2a2e, #c3cccf); line-height: 1.2; pointer-events: all; font-weight: bold; white-space: nowrap; ">
+                                    Legend
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text x="144" y="200" fill="#1f2a2e" font-family="&quot;Helvetica&quot;" font-size="24px" font-weight="bold">
+                        Legend
+                    </text>
+                </switch>
+            </g>
+        </g>
+        <g>
+            <rect x="140" y="220" width="68" height="30" rx="1.8" ry="1.8" fill-opacity="0.45" fill="#b7d4d0" stroke="#155e63" stroke-opacity="0.55" stroke-width="4" stroke-dasharray="32 24" pointer-events="all" style="fill: light-dark(rgb(183, 212, 208), rgb(41, 66, 63)); stroke: light-dark(rgb(21, 94, 99), rgb(119, 182, 186));"/>
+        </g>
+        <g>
+            <rect x="228" y="220" width="190" height="24" fill="none" stroke="none" pointer-events="all"/>
+        </g>
+        <g>
+            <g transform="translate(-0.5 -0.5)">
+                <switch>
+                    <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 1px; height: 1px; padding-top: 232px; margin-left: 230px;">
+                            <div style="box-sizing: border-box; font-size: 0; text-align: left; color: #334047; ">
+                                <div style="display: inline-block; font-size: 17px; font-family: &quot;Helvetica&quot;; color: light-dark(#334047, #afbac0); line-height: 1.2; pointer-events: all; white-space: nowrap; ">
+                                    Main box before fusion
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text x="230" y="237" fill="#334047" font-family="&quot;Helvetica&quot;" font-size="17px">
+                        Main box before fusion
+                    </text>
+                </switch>
+            </g>
+        </g>
+        <g>
+            <path d="M 472 202 L 520 202 L 544 232 L 520 262 L 472 262 L 448 232 Z" fill-opacity="0.55" fill="#f7cf95" stroke="#9b5c00" stroke-opacity="0.75" stroke-width="4" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(247, 207, 149), rgb(86, 52, 2)); stroke: light-dark(rgb(155, 92, 0), rgb(200, 146, 67));"/>
+        </g>
+        <g>
+            <rect x="568" y="220" width="260" height="24" fill="none" stroke="none" pointer-events="all"/>
+        </g>
+        <g>
+            <g transform="translate(-0.5 -0.5)">
+                <switch>
+                    <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 1px; height: 1px; padding-top: 232px; margin-left: 570px;">
+                            <div style="box-sizing: border-box; font-size: 0; text-align: left; color: #334047; ">
+                                <div style="display: inline-block; font-size: 17px; font-family: &quot;Helvetica&quot;; color: light-dark(#334047, #afbac0); line-height: 1.2; pointer-events: all; white-space: nowrap; ">
+                                    Sub_object polygon footprint
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text x="570" y="237" fill="#334047" font-family="&quot;Helvetica&quot;" font-size="17px">
+                        Sub_object polygon footprint
+                    </text>
+                </switch>
+            </g>
+        </g>
+        <g>
+            <rect x="920" y="220" width="68" height="30" rx="1.8" ry="1.8" fill-opacity="0.35" fill="#c7e0bd" stroke="#356b31" stroke-opacity="0.75" stroke-width="4" pointer-events="all" style="fill: light-dark(rgb(199, 224, 189), rgb(37, 58, 28)); stroke: light-dark(rgb(53, 107, 49), rgb(125, 172, 122));"/>
+        </g>
+        <g>
+            <rect x="1008" y="220" width="210" height="24" fill="none" stroke="none" pointer-events="all"/>
+        </g>
+        <g>
+            <g transform="translate(-0.5 -0.5)">
+                <switch>
+                    <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 1px; height: 1px; padding-top: 232px; margin-left: 1010px;">
+                            <div style="box-sizing: border-box; font-size: 0; text-align: left; color: #334047; ">
+                                <div style="display: inline-block; font-size: 17px; font-family: &quot;Helvetica&quot;; color: light-dark(#334047, #afbac0); line-height: 1.2; pointer-events: all; white-space: nowrap; ">
+                                    Expanded output box
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text x="1010" y="237" fill="#334047" font-family="&quot;Helvetica&quot;" font-size="17px">
+                        Expanded output box
+                    </text>
+                </switch>
+            </g>
+        </g>
+        <g>
+            <path d="M 1257 208 L 1311 208 L 1338 238 L 1311 268 L 1257 268 L 1230 238 Z" fill-opacity="0.25" fill="#e8b56a" stroke="#9b5c00" stroke-opacity="0.8" stroke-width="4" stroke-miterlimit="10" stroke-dasharray="48 32" pointer-events="all" style="fill: light-dark(rgb(232, 181, 106), rgb(115, 72, 7)); stroke: light-dark(rgb(155, 92, 0), rgb(200, 146, 67));"/>
+        </g>
+        <g>
+            <rect x="1370" y="220" width="210" height="24" fill="none" stroke="none" pointer-events="all"/>
+        </g>
+        <g>
+            <g transform="translate(-0.5 -0.5)">
+                <switch>
+                    <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 1px; height: 1px; padding-top: 232px; margin-left: 1372px;">
+                            <div style="box-sizing: border-box; font-size: 0; text-align: left; color: #334047; ">
+                                <div style="display: inline-block; font-size: 17px; font-family: &quot;Helvetica&quot;; color: light-dark(#334047, #afbac0); line-height: 1.2; pointer-events: all; white-space: nowrap; ">
+                                    Retained union footprint
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text x="1372" y="237" fill="#334047" font-family="&quot;Helvetica&quot;" font-size="17px">
+                        Retained union footprint
+                    </text>
+                </switch>
+            </g>
+        </g>
+        <g>
+            <rect x="110" y="320" width="710" height="420" rx="25.2" ry="25.2" fill="#fffdf8" stroke="#3e3a34" stroke-width="2" pointer-events="all" style="fill: light-dark(rgb(255, 253, 248), rgb(22, 20, 16)); stroke: light-dark(rgb(62, 58, 52), rgb(189, 186, 181));"/>
+        </g>
+        <g>
+            <rect x="142" y="342" width="360" height="30" fill="none" stroke="none" pointer-events="all"/>
+        </g>
+        <g>
+            <g transform="translate(-0.5 -0.5)">
+                <switch>
+                    <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 1px; height: 1px; padding-top: 357px; margin-left: 144px;">
+                            <div style="box-sizing: border-box; font-size: 0; text-align: left; color: #1f2a2e; ">
+                                <div style="display: inline-block; font-size: 24px; font-family: &quot;Helvetica&quot;; color: light-dark(#1f2a2e, #c3cccf); line-height: 1.2; pointer-events: all; font-weight: bold; white-space: nowrap; ">
+                                    Policy 1: direct box expansion
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text x="144" y="364" fill="#1f2a2e" font-family="&quot;Helvetica&quot;" font-size="24px" font-weight="bold">
+                        Policy 1: direct box expansion
+                    </text>
+                </switch>
+            </g>
+        </g>
+        <g>
+            <rect x="142" y="389" width="648" height="46" fill="none" stroke="none" pointer-events="all"/>
+        </g>
+        <g>
+            <g transform="translate(-0.5 -0.5)">
+                <switch>
+                    <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 646px; height: 1px; padding-top: 412px; margin-left: 144px;">
+                            <div style="box-sizing: border-box; font-size: 0; text-align: left; color: #334047; ">
+                                <div style="display: inline-block; font-size: 17px; font-family: &quot;Helvetica&quot;; color: light-dark(#334047, #afbac0); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
+                                    When keep_input_dimensions=false, the output box itself grows
+                                    <div>
+                                        <span style="color: light-dark(rgb(51, 64, 71), rgb(175, 186, 192));">
+                                            so that shape.dimensions.x/y directly enclose the main box and sub polygon union.
+                                        </span>
+                                    </div>
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text x="144" y="417" fill="#334047" font-family="&quot;Helvetica&quot;" font-size="17px">
+                        When keep_input_dimensions=false, the output box itself grows...
+                    </text>
+                </switch>
+            </g>
+        </g>
+        <g>
+            <rect x="172" y="456" width="70" height="24" fill="none" stroke="none" pointer-events="all"/>
+        </g>
+        <g>
+            <g transform="translate(-0.5 -0.5)">
+                <switch>
+                    <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 1px; height: 1px; padding-top: 468px; margin-left: 174px;">
+                            <div style="box-sizing: border-box; font-size: 0; text-align: left; color: #223036; ">
+                                <div style="display: inline-block; font-size: 18px; font-family: &quot;Helvetica&quot;; color: light-dark(#223036, #bcc8cd); line-height: 1.2; pointer-events: all; font-weight: bold; white-space: nowrap; ">
+                                    Input
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text x="174" y="473" fill="#223036" font-family="&quot;Helvetica&quot;" font-size="18px" font-weight="bold">
+                        Input
+                    </text>
+                </switch>
+            </g>
+        </g>
+        <g>
+            <rect x="544" y="456" width="80" height="24" fill="none" stroke="none" pointer-events="all"/>
+        </g>
+        <g>
+            <g transform="translate(-0.5 -0.5)">
+                <switch>
+                    <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 1px; height: 1px; padding-top: 468px; margin-left: 546px;">
+                            <div style="box-sizing: border-box; font-size: 0; text-align: left; color: #223036; ">
+                                <div style="display: inline-block; font-size: 18px; font-family: &quot;Helvetica&quot;; color: light-dark(#223036, #bcc8cd); line-height: 1.2; pointer-events: all; font-weight: bold; white-space: nowrap; ">
+                                    Output
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text x="546" y="473" fill="#223036" font-family="&quot;Helvetica&quot;" font-size="18px" font-weight="bold">
+                        Output
+                    </text>
+                </switch>
+            </g>
+        </g>
+        <g>
+            <rect x="170" y="500" width="180" height="92" rx="5.52" ry="5.52" fill-opacity="0.45" fill="#b7d4d0" stroke="#155e63" stroke-opacity="0.55" stroke-width="4" stroke-dasharray="32 24" pointer-events="all" style="fill: light-dark(rgb(183, 212, 208), rgb(41, 66, 63)); stroke: light-dark(rgb(21, 94, 99), rgb(119, 182, 186));"/>
+        </g>
+        <g>
+            <path d="M 293 486 L 347 486 L 374 526 L 347 566 L 293 566 L 266 526 Z" fill-opacity="0.55" fill="#f7cf95" stroke="#9b5c00" stroke-opacity="0.75" stroke-width="4" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(247, 207, 149), rgb(86, 52, 2)); stroke: light-dark(rgb(155, 92, 0), rgb(200, 146, 67));"/>
+        </g>
+        <g>
+            <rect x="162" y="612" width="240" height="22" fill="none" stroke="none" pointer-events="all"/>
+        </g>
+        <g>
+            <g transform="translate(-0.5 -0.5)">
+                <switch>
+                    <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 1px; height: 1px; padding-top: 623px; margin-left: 164px;">
+                            <div style="box-sizing: border-box; font-size: 0; text-align: left; color: #56636b; ">
+                                <div style="display: inline-block; font-size: 16px; font-family: &quot;Helvetica&quot;; color: light-dark(#56636b, #919ca3); line-height: 1.2; pointer-events: all; white-space: nowrap; ">
+                                    Main box + sub polygon footprint
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text x="164" y="628" fill="#56636b" font-family="&quot;Helvetica&quot;" font-size="16px">
+                        Main box + sub polygon footpri...
+                    </text>
+                </switch>
+            </g>
+        </g>
+        <g>
+            <path d="M 400 548 L 503.9 548" fill="none" stroke="#8d8576" stroke-width="3" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(141, 133, 118), rgb(129, 122, 109));"/>
+            <path d="M 510.65 548 L 501.65 552.5 L 503.9 548 L 501.65 543.5 Z" fill="#8d8576" stroke="#8d8576" stroke-width="3" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(141, 133, 118), rgb(129, 122, 109)); stroke: light-dark(rgb(141, 133, 118), rgb(129, 122, 109));"/>
+        </g>
+        <g>
+            <rect x="544" y="490" width="206" height="106" rx="6.36" ry="6.36" fill-opacity="0.35" fill="#c7e0bd" stroke="#356b31" stroke-opacity="0.8" stroke-width="4" pointer-events="all" style="fill: light-dark(rgb(199, 224, 189), rgb(37, 58, 28)); stroke: light-dark(rgb(53, 107, 49), rgb(125, 172, 122));"/>
+        </g>
+        <g>
+            <path d="M 663 490 L 717 490 L 744 530 L 717 570 L 663 570 L 636 530 Z" fill-opacity="0.55" fill="#f7cf95" stroke="#9b5c00" stroke-opacity="0.75" stroke-width="4" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(247, 207, 149), rgb(86, 52, 2)); stroke: light-dark(rgb(155, 92, 0), rgb(200, 146, 67));"/>
+        </g>
+        <g>
+            <rect x="450" y="627" width="300" height="24" fill="none" stroke="none" pointer-events="all"/>
+        </g>
+        <g>
+            <g transform="translate(-0.5 -0.5)">
+                <switch>
+                    <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 1px; height: 1px; padding-top: 639px; margin-left: 452px;">
+                            <div style="box-sizing: border-box; font-size: 0; text-align: left; color: #356b31; ">
+                                <div style="display: inline-block; font-size: 18px; font-family: &quot;Helvetica&quot;; color: light-dark(#356b31, #7dac7a); line-height: 1.2; pointer-events: all; font-weight: bold; white-space: nowrap; ">
+                                    - shape.dimensions.x/y are updated
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text x="452" y="644" fill="#356b31" font-family="&quot;Helvetica&quot;" font-size="18px" font-weight="bold">
+                        - shape.dimensions.x/y are updated
+                    </text>
+                </switch>
+            </g>
+        </g>
+        <g>
+            <rect x="450" y="655" width="340" height="22" fill="none" stroke="none" pointer-events="all"/>
+        </g>
+        <g>
+            <g transform="translate(-0.5 -0.5)">
+                <switch>
+                    <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 1px; height: 1px; padding-top: 666px; margin-left: 452px;">
+                            <div style="box-sizing: border-box; font-size: 0; text-align: left; color: #56636b; ">
+                                <div style="display: inline-block; font-size: 16px; font-family: &quot;Helvetica&quot;; color: light-dark(#56636b, #919ca3); line-height: 1.2; pointer-events: all; white-space: nowrap; ">
+                                    - published box directly covers the grouped union
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text x="452" y="671" fill="#56636b" font-family="&quot;Helvetica&quot;" font-size="16px">
+                        - published box directly covers the groupe...
+                    </text>
+                </switch>
+            </g>
+        </g>
+        <g>
+            <rect x="880" y="320" width="710" height="420" rx="25.2" ry="25.2" fill="#fffdf8" stroke="#3e3a34" stroke-width="2" pointer-events="all" style="fill: light-dark(rgb(255, 253, 248), rgb(22, 20, 16)); stroke: light-dark(rgb(62, 58, 52), rgb(189, 186, 181));"/>
+        </g>
+        <g>
+            <rect x="912" y="342" width="330" height="30" fill="none" stroke="none" pointer-events="all"/>
+        </g>
+        <g>
+            <g transform="translate(-0.5 -0.5)">
+                <switch>
+                    <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 1px; height: 1px; padding-top: 357px; margin-left: 914px;">
+                            <div style="box-sizing: border-box; font-size: 0; text-align: left; color: #1f2a2e; ">
+                                <div style="display: inline-block; font-size: 24px; font-family: &quot;Helvetica&quot;; color: light-dark(#1f2a2e, #c3cccf); line-height: 1.2; pointer-events: all; font-weight: bold; white-space: nowrap; ">
+                                    Policy 2: retain union footprint
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text x="914" y="364" fill="#1f2a2e" font-family="&quot;Helvetica&quot;" font-size="24px" font-weight="bold">
+                        Policy 2: retain union footp...
+                    </text>
+                </switch>
+            </g>
+        </g>
+        <g>
+            <rect x="912" y="384" width="648" height="56" fill="none" stroke="none" pointer-events="all"/>
+        </g>
+        <g>
+            <g transform="translate(-0.5 -0.5)">
+                <switch>
+                    <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 646px; height: 1px; padding-top: 412px; margin-left: 914px;">
+                            <div style="box-sizing: border-box; font-size: 0; text-align: left; color: #334047; ">
+                                <div style="display: inline-block; font-size: 17px; font-family: &quot;Helvetica&quot;; color: light-dark(#334047, #afbac0); line-height: 1.2; pointer-events: all; white-space: normal; word-wrap: normal; ">
+                                    When keep_input_dimensions=true, the main box stays stable
+                                    <span style="color: light-dark(rgb(51, 64, 71), rgb(175, 186, 192));">
+                                        and the enlarged union is retained on shape.footprint in the main local frame.
+                                    </span>
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text x="914" y="417" fill="#334047" font-family="&quot;Helvetica&quot;" font-size="17px">
+                        When keep_input_dimensions=true, the main box stays stable and the enlarged...
+                    </text>
+                </switch>
+            </g>
+        </g>
+        <g>
+            <rect x="942" y="450" width="70" height="24" fill="none" stroke="none" pointer-events="all"/>
+        </g>
+        <g>
+            <g transform="translate(-0.5 -0.5)">
+                <switch>
+                    <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 1px; height: 1px; padding-top: 462px; margin-left: 944px;">
+                            <div style="box-sizing: border-box; font-size: 0; text-align: left; color: #223036; ">
+                                <div style="display: inline-block; font-size: 18px; font-family: &quot;Helvetica&quot;; color: light-dark(#223036, #bcc8cd); line-height: 1.2; pointer-events: all; font-weight: bold; white-space: nowrap; ">
+                                    Input
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text x="944" y="467" fill="#223036" font-family="&quot;Helvetica&quot;" font-size="18px" font-weight="bold">
+                        Input
+                    </text>
+                </switch>
+            </g>
+        </g>
+        <g>
+            <rect x="1314" y="443" width="80" height="24" fill="none" stroke="none" pointer-events="all"/>
+        </g>
+        <g>
+            <g transform="translate(-0.5 -0.5)">
+                <switch>
+                    <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 1px; height: 1px; padding-top: 455px; margin-left: 1316px;">
+                            <div style="box-sizing: border-box; font-size: 0; text-align: left; color: #223036; ">
+                                <div style="display: inline-block; font-size: 18px; font-family: &quot;Helvetica&quot;; color: light-dark(#223036, #bcc8cd); line-height: 1.2; pointer-events: all; font-weight: bold; white-space: nowrap; ">
+                                    Output
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text x="1316" y="460" fill="#223036" font-family="&quot;Helvetica&quot;" font-size="18px" font-weight="bold">
+                        Output
+                    </text>
+                </switch>
+            </g>
+        </g>
+        <g>
+            <rect x="940" y="500" width="180" height="92" rx="5.52" ry="5.52" fill-opacity="0.45" fill="#b7d4d0" stroke="#155e63" stroke-opacity="0.55" stroke-width="4" stroke-dasharray="32 24" pointer-events="all" style="fill: light-dark(rgb(183, 212, 208), rgb(41, 66, 63)); stroke: light-dark(rgb(21, 94, 99), rgb(119, 182, 186));"/>
+        </g>
+        <g>
+            <path d="M 1063 486 L 1117 486 L 1144 526 L 1117 566 L 1063 566 L 1036 526 Z" fill-opacity="0.55" fill="#f7cf95" stroke="#9b5c00" stroke-opacity="0.75" stroke-width="4" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(247, 207, 149), rgb(86, 52, 2)); stroke: light-dark(rgb(155, 92, 0), rgb(200, 146, 67));"/>
+        </g>
+        <g>
+            <rect x="932" y="612" width="240" height="22" fill="none" stroke="none" pointer-events="all"/>
+        </g>
+        <g>
+            <g transform="translate(-0.5 -0.5)">
+                <switch>
+                    <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 1px; height: 1px; padding-top: 623px; margin-left: 934px;">
+                            <div style="box-sizing: border-box; font-size: 0; text-align: left; color: #56636b; ">
+                                <div style="display: inline-block; font-size: 16px; font-family: &quot;Helvetica&quot;; color: light-dark(#56636b, #919ca3); line-height: 1.2; pointer-events: all; white-space: nowrap; ">
+                                    Main box + sub polygon footprint
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text x="934" y="628" fill="#56636b" font-family="&quot;Helvetica&quot;" font-size="16px">
+                        Main box + sub polygon footpri...
+                    </text>
+                </switch>
+            </g>
+        </g>
+        <g>
+            <path d="M 1170 548 L 1273.9 548" fill="none" stroke="#8d8576" stroke-width="3" stroke-miterlimit="10" pointer-events="stroke" style="stroke: light-dark(rgb(141, 133, 118), rgb(129, 122, 109));"/>
+            <path d="M 1280.65 548 L 1271.65 552.5 L 1273.9 548 L 1271.65 543.5 Z" fill="#8d8576" stroke="#8d8576" stroke-width="3" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(141, 133, 118), rgb(129, 122, 109)); stroke: light-dark(rgb(141, 133, 118), rgb(129, 122, 109));"/>
+        </g>
+        <g>
+            <path d="M 1316.87 470 L 1503.13 470 L 1530 535 L 1503.13 600 L 1316.87 600 L 1290 535 Z" fill-opacity="0.25" fill="#e8b56a" stroke="#9b5c00" stroke-opacity="0.8" stroke-width="4" stroke-miterlimit="10" stroke-dasharray="48 32" pointer-events="all" style="fill: light-dark(rgb(232, 181, 106), rgb(115, 72, 7)); stroke: light-dark(rgb(155, 92, 0), rgb(200, 146, 67));"/>
+        </g>
+        <g>
+            <rect x="1310" y="500" width="180" height="92" rx="5.52" ry="5.52" fill-opacity="0.45" fill="#b7d4d0" stroke="#155e63" stroke-opacity="0.9" stroke-width="4" pointer-events="all" style="fill: light-dark(rgb(183, 212, 208), rgb(41, 66, 63)); stroke: light-dark(rgb(21, 94, 99), rgb(119, 182, 186));"/>
+        </g>
+        <g>
+            <path d="M 1433 486 L 1487 486 L 1514 526 L 1487 566 L 1433 566 L 1406 526 Z" fill-opacity="0.55" fill="#f7cf95" stroke="#9b5c00" stroke-opacity="0.75" stroke-width="4" stroke-miterlimit="10" pointer-events="all" style="fill: light-dark(rgb(247, 207, 149), rgb(86, 52, 2)); stroke: light-dark(rgb(155, 92, 0), rgb(200, 146, 67));"/>
+        </g>
+        <g>
+            <rect x="1200" y="627" width="320" height="24" fill="none" stroke="none" pointer-events="all"/>
+        </g>
+        <g>
+            <g transform="translate(-0.5 -0.5)">
+                <switch>
+                    <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 1px; height: 1px; padding-top: 639px; margin-left: 1202px;">
+                            <div style="box-sizing: border-box; font-size: 0; text-align: left; color: #9b5c00; ">
+                                <div style="display: inline-block; font-size: 18px; font-family: &quot;Helvetica&quot;; color: light-dark(#9b5c00, #c89243); line-height: 1.2; pointer-events: all; font-weight: bold; white-space: nowrap; ">
+                                    - shape.dimensions.x/y stay unchanged
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text x="1202" y="644" fill="#9b5c00" font-family="&quot;Helvetica&quot;" font-size="18px" font-weight="bold">
+                        - shape.dimensions.x/y stay unchanged
+                    </text>
+                </switch>
+            </g>
+        </g>
+        <g>
+            <rect x="1200" y="655" width="360" height="22" fill="none" stroke="none" pointer-events="all"/>
+        </g>
+        <g>
+            <g transform="translate(-0.5 -0.5)">
+                <switch>
+                    <foreignObject style="overflow: visible; text-align: left;" pointer-events="none" width="100%" height="100%" requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility">
+                        <div xmlns="http://www.w3.org/1999/xhtml" style="display: flex; align-items: unsafe center; justify-content: unsafe flex-start; width: 1px; height: 1px; padding-top: 666px; margin-left: 1202px;">
+                            <div style="box-sizing: border-box; font-size: 0; text-align: left; color: #56636b; ">
+                                <div style="display: inline-block; font-size: 16px; font-family: &quot;Helvetica&quot;; color: light-dark(#56636b, #919ca3); line-height: 1.2; pointer-events: all; white-space: nowrap; ">
+                                    - union footprint remains available on shape.footprint
+                                </div>
+                            </div>
+                        </div>
+                    </foreignObject>
+                    <text x="1202" y="671" fill="#56636b" font-family="&quot;Helvetica&quot;" font-size="16px">
+                        - union footprint remains available on shape....
+                    </text>
+                </switch>
+            </g>
+        </g>
+    </g>
+    <switch>
+        <g requiredFeatures="http://www.w3.org/TR/SVG11/feature#Extensibility"/>
+        <a transform="translate(0,-5)" xlink:href="https://www.drawio.com/doc/faq/svg-export-text-problems" target="_blank">
+            <text text-anchor="middle" font-size="10px" x="50%" y="100%">
+                Text is not SVG - cannot display
+            </text>
+        </a>
+    </switch>
+</svg>

--- a/perception/autoware_object_merger/include/autoware/object_merger/object_fusion_merger_node.hpp
+++ b/perception/autoware_object_merger/include/autoware/object_merger/object_fusion_merger_node.hpp
@@ -94,6 +94,7 @@ private:
   std::shared_ptr<Sync> sync_ptr_;
 
   std::string base_link_frame_id_;
+  bool keep_input_dimensions_;
 
   std::unique_ptr<autoware_utils::DebugPublisher> processing_time_publisher_;
   std::unique_ptr<autoware_utils::StopWatch<std::chrono::milliseconds>> stop_watch_ptr_;

--- a/perception/autoware_object_merger/src/object_fusion_merger_node.cpp
+++ b/perception/autoware_object_merger/src/object_fusion_merger_node.cpp
@@ -114,6 +114,69 @@ MultiPoint2d collect_union_points_in_output_frame(
 }
 
 /**
+ * @brief Rebuild the output footprint from the convex hull of the combined union points.
+ *
+ * @param output Output object to update in place.
+ * @param combined_points Combined footprint points expressed in the output local frame.
+ */
+void fit_shape_footprint(DetectedObject & output, const MultiPoint2d & combined_points)
+{
+  Polygon2d hull_polygon;
+  boost::geometry::convex_hull(combined_points, hull_polygon);
+  output.shape.footprint.points.clear();
+  for (const auto & point : hull_polygon.outer()) {
+    output.shape.footprint.points.push_back(
+      geometry_msgs::build<geometry_msgs::msg::Point32>()
+        .x(static_cast<float>(boost::geometry::get<0>(point)))
+        .y(static_cast<float>(boost::geometry::get<1>(point)))
+        .z(0.0f));
+  }
+}
+
+/**
+ * @brief Tighten a bounding box around the grouped union in the output local frame.
+ *
+ * @param output Output object to update in place.
+ * @param combined_points Combined footprint points expressed in the output local frame.
+ */
+void fit_bounding_box_shape(DetectedObject & output, const MultiPoint2d & combined_points)
+{
+  double min_x = std::numeric_limits<double>::max();
+  double max_x = std::numeric_limits<double>::lowest();
+  double min_y = std::numeric_limits<double>::max();
+  double max_y = std::numeric_limits<double>::lowest();
+  for (const auto & point : combined_points) {
+    min_x = std::min(min_x, boost::geometry::get<0>(point));
+    max_x = std::max(max_x, boost::geometry::get<0>(point));
+    min_y = std::min(min_y, boost::geometry::get<1>(point));
+    max_y = std::max(max_y, boost::geometry::get<1>(point));
+  }
+
+  output.kinematics.pose_with_covariance.pose = autoware_utils::calc_offset_pose(
+    output.kinematics.pose_with_covariance.pose, 0.5 * (min_x + max_x), 0.5 * (min_y + max_y),
+    0.0);
+  output.shape.dimensions.x = max_x - min_x;
+  output.shape.dimensions.y = max_y - min_y;
+}
+
+/**
+ * @brief Expand a cylinder to cover the farthest grouped union point in the output local frame.
+ *
+ * @param output Output object to update in place.
+ * @param combined_points Combined footprint points expressed in the output local frame.
+ */
+void fit_cylinder_shape(DetectedObject & output, const MultiPoint2d & combined_points)
+{
+  double max_radius = 0.0;
+  for (const auto & point : combined_points) {
+    max_radius = std::max(
+      max_radius, std::hypot(boost::geometry::get<0>(point), boost::geometry::get<1>(point)));
+  }
+  output.shape.dimensions.x = 2.0 * max_radius;
+  output.shape.dimensions.y = 2.0 * max_radius;
+}
+
+/**
  * @brief Calculate the 2D footprint intersection area between one main and one sub object.
  *
  * @param main_object Main object candidate.
@@ -142,7 +205,8 @@ double get_intersection_area(const DetectedObject & main_object, const DetectedO
  * @return Main-based object whose geometry encloses the full grouped union.
  */
 DetectedObject enclose_union_with_main_shape(
-  const DetectedObject & main_object, const std::vector<DetectedObject> & sub_objects)
+  const DetectedObject & main_object, const std::vector<DetectedObject> & sub_objects,
+  const bool keep_input_dimensions)
 {
   DetectedObject output = main_object;
   output.shape = main_object.shape;
@@ -156,48 +220,27 @@ DetectedObject enclose_union_with_main_shape(
   }
 
   if (main_object.shape.type == Shape::BOUNDING_BOX) {
-    double min_x = std::numeric_limits<double>::max();
-    double max_x = std::numeric_limits<double>::lowest();
-    double min_y = std::numeric_limits<double>::max();
-    double max_y = std::numeric_limits<double>::lowest();
-    for (const auto & point : combined_points) {
-      min_x = std::min(min_x, boost::geometry::get<0>(point));
-      max_x = std::max(max_x, boost::geometry::get<0>(point));
-      min_y = std::min(min_y, boost::geometry::get<1>(point));
-      max_y = std::max(max_y, boost::geometry::get<1>(point));
+    if (keep_input_dimensions) {
+      fit_shape_footprint(output, combined_points);
+    } else {
+      fit_bounding_box_shape(output, combined_points);
     }
-    output.kinematics.pose_with_covariance.pose = autoware_utils::calc_offset_pose(
-      output.kinematics.pose_with_covariance.pose, 0.5 * (min_x + max_x), 0.5 * (min_y + max_y),
-      0.0);
-    output.shape.dimensions.x = max_x - min_x;
-    output.shape.dimensions.y = max_y - min_y;
     fit_shape_height(output, main_object, sub_objects);
     return output;
   }
 
   if (main_object.shape.type == Shape::CYLINDER) {
-    double max_radius = 0.0;
-    for (const auto & point : combined_points) {
-      max_radius = std::max(
-        max_radius, std::hypot(boost::geometry::get<0>(point), boost::geometry::get<1>(point)));
+    if (keep_input_dimensions) {
+      fit_shape_footprint(output, combined_points);
+    } else {
+      fit_cylinder_shape(output, combined_points);
     }
-    output.shape.dimensions.x = 2.0 * max_radius;
-    output.shape.dimensions.y = 2.0 * max_radius;
     fit_shape_height(output, main_object, sub_objects);
     return output;
   }
 
   if (main_object.shape.type == Shape::POLYGON) {
-    Polygon2d hull_polygon;
-    boost::geometry::convex_hull(combined_points, hull_polygon);
-    output.shape.footprint.points.clear();
-    for (const auto & point : hull_polygon.outer()) {
-      output.shape.footprint.points.push_back(
-        geometry_msgs::build<geometry_msgs::msg::Point32>()
-          .x(static_cast<float>(boost::geometry::get<0>(point)))
-          .y(static_cast<float>(boost::geometry::get<1>(point)))
-          .z(0.0f));
-    }
+    fit_shape_footprint(output, combined_points);
     fit_shape_height(output, main_object, sub_objects);
   }
   return output;
@@ -222,6 +265,8 @@ ObjectFusionMergerNode::ObjectFusionMergerNode(const rclcpp::NodeOptions & node_
   // Get parameters
   base_link_frame_id_ = declare_parameter<std::string>("base_link_frame_id");
   const auto sync_queue_size = static_cast<int>(declare_parameter<int64_t>("sync_queue_size"));
+  keep_input_dimensions_ =
+    declare_parameter<bool>("keep_input_dimensions", false);
 
   // Set up publishers, subscribers, and synchronizer
   using std::placeholders::_1;
@@ -331,7 +376,8 @@ ObjectFusionMergerNode::FusionResult ObjectFusionMergerNode::fuse_objects(
       matched_objects.push_back(main_object);
       continue;
     }
-    matched_objects.push_back(enclose_union_with_main_shape(main_object, grouped_subs));
+    matched_objects.push_back(enclose_union_with_main_shape(
+      main_object, grouped_subs, keep_input_dimensions_));
   }
 
   const auto header = std_msgs::build<std_msgs::msg::Header>()

--- a/perception/autoware_object_merger/src/object_fusion_merger_node.cpp
+++ b/perception/autoware_object_merger/src/object_fusion_merger_node.cpp
@@ -15,7 +15,8 @@
 #include "autoware/object_merger/object_fusion_merger_node.hpp"
 
 #include "autoware/object_recognition_utils/object_recognition_utils.hpp"
-#include "autoware_utils/geometry/geometry.hpp"
+#include "autoware_utils_geometry/geometry.hpp"
+#include <autoware_utils_geometry/boost_geometry.hpp>
 
 #include <boost/geometry.hpp>
 
@@ -29,10 +30,10 @@ namespace
 {
 using DetectedObject = autoware_perception_msgs::msg::DetectedObject;
 using Shape = autoware_perception_msgs::msg::Shape;
-using MultiPoint2d = autoware_utils::MultiPoint2d;
-using Point2d = autoware_utils::Point2d;
-using Polygon2d = autoware_utils::Polygon2d;
+using Point2d = autoware_utils_geometry::Point2d;
+using Polygon2d = autoware_utils_geometry::Polygon2d;
 using MultiPolygon2d = boost::geometry::model::multi_polygon<Polygon2d>;
+using MultiPoint2d = autoware_utils_geometry::MultiPoint2d;
 
 /**
  * @brief Compute the combined vertical extent of one main object and its grouped sub objects.
@@ -80,51 +81,120 @@ void fit_shape_height(
 }
 
 /**
- * @brief Collect the footprint vertices of the main and grouped sub objects in the output frame.
+ * @brief Transform a polygon into the current output local frame.
+ *
+ * @param output Current output object that defines the local output frame.
+ * @param polygon Source polygon expressed in world coordinates.
+ * @return Polygon expressed in the output local frame.
+ */
+Polygon2d transform_polygon_to_output_frame(
+  const DetectedObject & output, const Polygon2d & polygon)
+{
+  Polygon2d local_polygon;
+  for (const auto & point : polygon.outer()) {
+    geometry_msgs::msg::Point world_point;
+    world_point.x = boost::geometry::get<0>(point);
+    world_point.y = boost::geometry::get<1>(point);
+    world_point.z = output.kinematics.pose_with_covariance.pose.position.z;
+    const auto local_point = autoware_utils_geometry::inverse_transform_point(
+      world_point, output.kinematics.pose_with_covariance.pose);
+    local_polygon.outer().push_back(Point2d(local_point.x, local_point.y));
+  }
+  boost::geometry::correct(local_polygon);
+  return local_polygon;
+}
+
+/**
+ * @brief Compute the exact grouped union polygons in the output local frame.
  *
  * @param output Current output object that defines the local output frame.
  * @param main_object Main object used as the base of the fused output.
  * @param sub_objects Sub objects uniquely grouped to the main object.
- * @return Combined footprint points expressed in the output local frame.
+ * @return Grouped union polygons expressed in the output local frame.
  */
-MultiPoint2d collect_union_points_in_output_frame(
+MultiPolygon2d collect_union_polygons_in_output_frame(
   const DetectedObject & output, const DetectedObject & main_object,
   const std::vector<DetectedObject> & sub_objects)
 {
-  const auto append_local_polygon_points =
-    [&output](const Polygon2d & polygon, MultiPoint2d & combined_points) {
-      for (const auto & point : polygon.outer()) {
-        geometry_msgs::msg::Point world_point;
-        world_point.x = boost::geometry::get<0>(point);
-        world_point.y = boost::geometry::get<1>(point);
-        world_point.z = output.kinematics.pose_with_covariance.pose.position.z;
-        const auto local_point = autoware_utils::inverse_transform_point(
-          world_point, output.kinematics.pose_with_covariance.pose);
-        combined_points.push_back(Point2d(local_point.x, local_point.y));
-      }
-    };
+  MultiPolygon2d union_polygons;
 
-  const auto main_polygon = autoware_utils::to_polygon2d(main_object);
-  MultiPoint2d combined_points;
-  append_local_polygon_points(main_polygon, combined_points);
+  const auto append_union_polygon = [&union_polygons](const Polygon2d & polygon) {
+    if (union_polygons.empty()) {
+      union_polygons.push_back(polygon);
+      return;
+    }
+
+    MultiPolygon2d next_union_polygons;
+    boost::geometry::union_(union_polygons, polygon, next_union_polygons);
+    union_polygons = std::move(next_union_polygons);
+  };
+
+  const auto main_polygon = autoware_utils_geometry::to_polygon2d(main_object);
+  append_union_polygon(transform_polygon_to_output_frame(output, main_polygon));
   for (const auto & sub_object : sub_objects) {
-    append_local_polygon_points(autoware_utils::to_polygon2d(sub_object), combined_points);
+    append_union_polygon(
+      transform_polygon_to_output_frame(output, autoware_utils_geometry::to_polygon2d(sub_object)));
   }
-  return combined_points;
+  return union_polygons;
 }
 
 /**
- * @brief Rebuild the output footprint from the convex hull of the combined union points.
+ * @brief Collect all outer boundary points from grouped union polygons.
+ *
+ * @param union_polygons Grouped union polygons expressed in the output local frame.
+ * @return Outer boundary points across all grouped union polygons.
+ */
+MultiPoint2d collect_union_boundary_points(const MultiPolygon2d & union_polygons)
+{
+  MultiPoint2d boundary_points;
+  for (const auto & polygon : union_polygons) {
+    for (const auto & point : polygon.outer()) {
+      boundary_points.push_back(
+        Point2d(boost::geometry::get<0>(point), boost::geometry::get<1>(point)));
+    }
+  }
+  return boundary_points;
+}
+
+/**
+ * @brief Select the largest polygon from a grouped union result.
+ *
+ * @param union_polygons Grouped union polygons expressed in the output local frame.
+ * @return Largest polygon by absolute area, or nullptr if empty.
+ */
+const Polygon2d * find_largest_union_polygon(const MultiPolygon2d & union_polygons)
+{
+  if (union_polygons.empty()) {
+    return nullptr;
+  }
+
+  const Polygon2d * largest_polygon = &union_polygons.front();
+  double largest_area = std::abs(boost::geometry::area(*largest_polygon));
+  for (const auto & polygon : union_polygons) {
+    const double polygon_area = std::abs(boost::geometry::area(polygon));
+    if (polygon_area > largest_area) {
+      largest_polygon = &polygon;
+      largest_area = polygon_area;
+    }
+  }
+  return largest_polygon;
+}
+
+/**
+ * @brief Rebuild the output footprint from the grouped union polygons.
  *
  * @param output Output object to update in place.
- * @param combined_points Combined footprint points expressed in the output local frame.
+ * @param union_polygons Grouped union polygons expressed in the output local frame.
  */
-void fit_shape_footprint(DetectedObject & output, const MultiPoint2d & combined_points)
+void fit_shape_footprint(DetectedObject & output, const MultiPolygon2d & union_polygons)
 {
-  Polygon2d hull_polygon;
-  boost::geometry::convex_hull(combined_points, hull_polygon);
+  const auto * union_polygon = find_largest_union_polygon(union_polygons);
+  if (union_polygon == nullptr) {
+    return;
+  }
+
   output.shape.footprint.points.clear();
-  for (const auto & point : hull_polygon.outer()) {
+  for (const auto & point : union_polygon->outer()) {
     output.shape.footprint.points.push_back(
       geometry_msgs::build<geometry_msgs::msg::Point32>()
         .x(static_cast<float>(boost::geometry::get<0>(point)))
@@ -152,7 +222,7 @@ void fit_bounding_box_shape(DetectedObject & output, const MultiPoint2d & combin
     max_y = std::max(max_y, boost::geometry::get<1>(point));
   }
 
-  output.kinematics.pose_with_covariance.pose = autoware_utils::calc_offset_pose(
+  output.kinematics.pose_with_covariance.pose = autoware_utils_geometry::calc_offset_pose(
     output.kinematics.pose_with_covariance.pose, 0.5 * (min_x + max_x), 0.5 * (min_y + max_y),
     0.0);
   output.shape.dimensions.x = max_x - min_x;
@@ -187,7 +257,7 @@ double get_intersection_area(const DetectedObject & main_object, const DetectedO
 {
   MultiPolygon2d intersections;
   boost::geometry::intersection(
-    autoware_utils::to_polygon2d(main_object), autoware_utils::to_polygon2d(sub_object),
+    autoware_utils_geometry::to_polygon2d(main_object), autoware_utils_geometry::to_polygon2d(sub_object),
     intersections);
 
   double total_area = 0.0;
@@ -213,15 +283,19 @@ DetectedObject enclose_union_with_main_shape(
   if (sub_objects.empty()) {
     return output;
   }
-  const auto combined_points =
-    collect_union_points_in_output_frame(output, main_object, sub_objects);
+  const auto union_polygons =
+    collect_union_polygons_in_output_frame(output, main_object, sub_objects);
+  if (union_polygons.empty()) {
+    return output;
+  }
+  const auto combined_points = collect_union_boundary_points(union_polygons);
   if (combined_points.empty()) {
     return output;
   }
 
   if (main_object.shape.type == Shape::BOUNDING_BOX) {
     if (keep_input_dimensions) {
-      fit_shape_footprint(output, combined_points);
+      fit_shape_footprint(output, union_polygons);
     } else {
       fit_bounding_box_shape(output, combined_points);
     }
@@ -231,7 +305,7 @@ DetectedObject enclose_union_with_main_shape(
 
   if (main_object.shape.type == Shape::CYLINDER) {
     if (keep_input_dimensions) {
-      fit_shape_footprint(output, combined_points);
+      fit_shape_footprint(output, union_polygons);
     } else {
       fit_cylinder_shape(output, combined_points);
     }
@@ -240,7 +314,7 @@ DetectedObject enclose_union_with_main_shape(
   }
 
   if (main_object.shape.type == Shape::POLYGON) {
-    fit_shape_footprint(output, combined_points);
+    fit_shape_footprint(output, union_polygons);
     fit_shape_height(output, main_object, sub_objects);
   }
   return output;

--- a/perception/autoware_object_merger/test/test_object_fusion_merger_node.cpp
+++ b/perception/autoware_object_merger/test/test_object_fusion_merger_node.cpp
@@ -40,13 +40,16 @@ std::shared_ptr<autoware::test_utils::AutowareTestManager> generate_test_manager
   return std::make_shared<autoware::test_utils::AutowareTestManager>();
 }
 
-std::shared_ptr<ObjectFusionMergerNode> generate_node()
+std::shared_ptr<ObjectFusionMergerNode> generate_node(
+  const bool keep_input_dimensions = false)
 {
   auto node_options = rclcpp::NodeOptions{};
   const auto package_dir = std::filesystem::path(__FILE__).parent_path().parent_path();
-  node_options.arguments(
-    {"--ros-args", "--params-file",
-     (package_dir / "config" / "object_fusion_merger.param.yaml").string()});
+  node_options.arguments({
+    "--ros-args", "--params-file",
+    (package_dir / "config" / "object_fusion_merger.param.yaml").string(), "-p",
+    std::string("keep_input_dimensions:=") +
+      (keep_input_dimensions ? "true" : "false")});
   return std::make_shared<ObjectFusionMergerNode>(node_options);
 }
 
@@ -306,11 +309,13 @@ TEST(ObjectFusionMergerNodeTest, testPolygonSubCanExpandMainBoundingBox)
 
   DetectedObjects main_objects;
   main_objects.header.frame_id = "base_link";
-  main_objects.objects.push_back(make_object(0.0, 4.0, 0.6, 4.0, ObjectClassification::CAR));
+  auto main_object = make_object(0.0, 4.0, 0.6, 4.0, ObjectClassification::CAR);
+  main_object.kinematics.pose_with_covariance.pose.position.y = 2.0;
+  main_objects.objects.push_back(main_object);
 
   DetectedObjects sub_objects;
   sub_objects.header.frame_id = "base_link";
-  sub_objects.objects.push_back(make_polygon_object(
+  auto sub_object = make_polygon_object(
     1.0, 1.0, 0.5,
     {
       geometry_msgs::build<geometry_msgs::msg::Point32>().x(3.5).y(1.5).z(0.0),
@@ -318,7 +323,9 @@ TEST(ObjectFusionMergerNodeTest, testPolygonSubCanExpandMainBoundingBox)
       geometry_msgs::build<geometry_msgs::msg::Point32>().x(-3.5).y(-1.5).z(0.0),
       geometry_msgs::build<geometry_msgs::msg::Point32>().x(-3.5).y(1.5).z(0.0),
     },
-    ObjectClassification::CAR));
+    ObjectClassification::CAR);
+  sub_object.kinematics.pose_with_covariance.pose.position.y = 2.3;
+  sub_objects.objects.push_back(sub_object);
 
   test_manager->test_pub_msg<DetectedObjects>(test_target_node, "input/main_objects", main_objects);
   test_manager->test_pub_msg<DetectedObjects>(test_target_node, "input/sub_objects", sub_objects);
@@ -371,6 +378,105 @@ TEST(ObjectFusionMergerNodeTest, testUnionCanBeEnclosedWithMainCylinder)
   EXPECT_NEAR(
     latest_msg.objects.front().shape.dimensions.x, latest_msg.objects.front().shape.dimensions.y,
     1e-3);
+
+  rclcpp::shutdown();
+}
+
+TEST(ObjectFusionMergerNodeTest, testBoundingBoxCanRetainExpandedFootprintWithoutDimensionGrowth)
+{
+  rclcpp::init(0, nullptr);
+
+  auto test_manager = generate_test_manager();
+  auto test_target_node = generate_node(true);
+  auto tf_node = create_static_tf_broadcaster_node("map", "base_link");
+
+  DetectedObjects latest_msg;
+  test_manager->set_subscriber<DetectedObjects>(
+    "/output/objects",
+    [&latest_msg](const DetectedObjects::ConstSharedPtr msg) { latest_msg = *msg; });
+
+  DetectedObjects main_objects;
+  main_objects.header.frame_id = "base_link";
+  main_objects.objects.push_back(make_object(0.0, 4.0, 0.6, 4.0, ObjectClassification::CAR));
+
+  DetectedObjects sub_objects;
+  sub_objects.header.frame_id = "base_link";
+  sub_objects.objects.push_back(make_polygon_object(
+    1.0, 1.0, 0.5,
+    {
+      geometry_msgs::build<geometry_msgs::msg::Point32>().x(3.5).y(1.5).z(0.0),
+      geometry_msgs::build<geometry_msgs::msg::Point32>().x(3.5).y(-1.5).z(0.0),
+      geometry_msgs::build<geometry_msgs::msg::Point32>().x(-3.5).y(-1.5).z(0.0),
+      geometry_msgs::build<geometry_msgs::msg::Point32>().x(-3.5).y(1.5).z(0.0),
+    },
+    ObjectClassification::CAR));
+
+  test_manager->test_pub_msg<DetectedObjects>(test_target_node, "input/main_objects", main_objects);
+  test_manager->test_pub_msg<DetectedObjects>(test_target_node, "input/sub_objects", sub_objects);
+
+  // The position and dimensions should be the same as the main object since the sub object is fully enclosed and keep_input_dimensions is true,
+  // but the footprint should be expanded to cover the union of main and sub objects.
+  ASSERT_EQ(latest_msg.objects.size(), 1U);
+  EXPECT_EQ(latest_msg.objects.front().shape.type, Shape::BOUNDING_BOX);
+  EXPECT_NEAR(latest_msg.objects.front().kinematics.pose_with_covariance.pose.position.x, 0.0, 1e-3);
+  EXPECT_NEAR(latest_msg.objects.front().kinematics.pose_with_covariance.pose.position.y, 2.0, 1e-3);
+  EXPECT_NEAR(latest_msg.objects.front().shape.dimensions.x, 4.0, 1e-3);
+  EXPECT_NEAR(latest_msg.objects.front().shape.dimensions.y, 2.0, 1e-3);
+  EXPECT_GT(max_abs_footprint_x(latest_msg.objects.front()), 4.4);
+  EXPECT_GT(max_abs_footprint_y(latest_msg.objects.front()), 1.4);
+
+  rclcpp::shutdown();
+}
+
+TEST(ObjectFusionMergerNodeTest, testCylinderCanRetainExpandedFootprintWithoutDiameterGrowth)
+{
+  rclcpp::init(0, nullptr);
+
+  auto test_manager = generate_test_manager();
+  auto test_target_node = generate_node(true);
+  auto tf_node = create_static_tf_broadcaster_node("map", "base_link");
+
+  DetectedObjects latest_msg;
+  test_manager->set_subscriber<DetectedObjects>(
+    "/output/objects",
+    [&latest_msg](const DetectedObjects::ConstSharedPtr msg) { latest_msg = *msg; });
+
+  DetectedObjects main_objects;
+  main_objects.header.frame_id = "base_link";
+  auto main_object =
+    make_cylinder_object(0.0, 4.0, 0.6, 2.0, ObjectClassification::PEDESTRIAN);
+  main_object.kinematics.pose_with_covariance.pose.position.y = -1.5;
+  main_objects.objects.push_back(main_object);
+
+  DetectedObjects sub_objects;
+  sub_objects.header.frame_id = "base_link";
+  auto sub_object = make_polygon_object(
+    0.5, 1.0, 0.5,
+    {
+      geometry_msgs::build<geometry_msgs::msg::Point32>().x(1.5).y(1.2).z(0.0),
+      geometry_msgs::build<geometry_msgs::msg::Point32>().x(1.5).y(-1.2).z(0.0),
+      geometry_msgs::build<geometry_msgs::msg::Point32>().x(-0.5).y(-1.2).z(0.0),
+      geometry_msgs::build<geometry_msgs::msg::Point32>().x(-0.5).y(1.2).z(0.0),
+    },
+    ObjectClassification::PEDESTRIAN);
+  sub_object.kinematics.pose_with_covariance.pose.position.y = -1.1;
+  sub_objects.objects.push_back(sub_object);
+
+  test_manager->test_pub_msg<DetectedObjects>(test_target_node, "input/main_objects", main_objects);
+  test_manager->test_pub_msg<DetectedObjects>(test_target_node, "input/sub_objects", sub_objects);
+
+  // The position and dimensions should be the same as the main object since the sub object is fully enclosed and keep_input_dimensions is true,
+  // but the footprint should be expanded to cover the union of main and sub objects.
+  ASSERT_EQ(latest_msg.objects.size(), 1U);
+  EXPECT_EQ(latest_msg.objects.front().shape.type, Shape::CYLINDER);
+  EXPECT_NEAR(latest_msg.objects.front().kinematics.pose_with_covariance.pose.position.x, 0.0, 1e-3);
+  EXPECT_NEAR(latest_msg.objects.front().kinematics.pose_with_covariance.pose.position.y, -1.5, 1e-3);
+  EXPECT_NEAR(latest_msg.objects.front().shape.dimensions.x, 2.0, 1e-3);
+  EXPECT_NEAR(
+    latest_msg.objects.front().shape.dimensions.x, latest_msg.objects.front().shape.dimensions.y,
+    1e-3);
+  EXPECT_GT(max_abs_footprint_x(latest_msg.objects.front()), 1.9);
+  EXPECT_GT(max_abs_footprint_y(latest_msg.objects.front()), 1.1);
 
   rclcpp::shutdown();
 }

--- a/perception/autoware_object_merger/test/test_object_fusion_merger_node.cpp
+++ b/perception/autoware_object_merger/test/test_object_fusion_merger_node.cpp
@@ -137,6 +137,18 @@ double max_abs_footprint_y(const DetectedObject & object)
   }
   return max_abs_y;
 }
+
+bool footprint_has_vertex(
+  const DetectedObject & object, const double expected_x, const double expected_y,
+  const double epsilon = 1e-3)
+{
+  return std::any_of(
+    object.shape.footprint.points.begin(), object.shape.footprint.points.end(),
+    [expected_x, expected_y, epsilon](const auto & point) {
+      return std::abs(static_cast<double>(point.x) - expected_x) < epsilon &&
+             std::abs(static_cast<double>(point.y) - expected_y) < epsilon;
+    });
+}
 }  // namespace
 
 TEST(ObjectFusionMergerNodeTest, testMatchedObjectsAreFused)
@@ -526,6 +538,54 @@ TEST(ObjectFusionMergerNodeTest, testUnionCanBeEnclosedWithMainPolygon)
   EXPECT_GT(latest_msg.objects.front().shape.footprint.points.size(), 3U);
   EXPECT_GT(max_abs_footprint_x(latest_msg.objects.front()), 2.1);
   EXPECT_GT(max_abs_footprint_y(latest_msg.objects.front()), 0.9);
+
+  rclcpp::shutdown();
+}
+
+TEST(ObjectFusionMergerNodeTest, testPolygonUnionKeepsConcaveBoundary)
+{
+  rclcpp::init(0, nullptr);
+
+  auto test_manager = generate_test_manager();
+  auto test_target_node = generate_node();
+  auto tf_node = create_static_tf_broadcaster_node("map", "base_link");
+
+  DetectedObjects latest_msg;
+  test_manager->set_subscriber<DetectedObjects>(
+    "/output/objects",
+    [&latest_msg](const DetectedObjects::ConstSharedPtr msg) { latest_msg = *msg; });
+
+  DetectedObjects main_objects;
+  main_objects.header.frame_id = "base_link";
+  main_objects.objects.push_back(make_polygon_object(
+    0.0, 4.0, 0.6,
+    {
+      geometry_msgs::build<geometry_msgs::msg::Point32>().x(1.0).y(1.0).z(0.0),
+      geometry_msgs::build<geometry_msgs::msg::Point32>().x(1.0).y(-1.0).z(0.0),
+      geometry_msgs::build<geometry_msgs::msg::Point32>().x(-1.0).y(-1.0).z(0.0),
+      geometry_msgs::build<geometry_msgs::msg::Point32>().x(-1.0).y(1.0).z(0.0),
+    },
+    ObjectClassification::CAR));
+
+  DetectedObjects sub_objects;
+  sub_objects.header.frame_id = "base_link";
+  sub_objects.objects.push_back(make_polygon_object(
+    0.0, 1.0, 0.5,
+    {
+      geometry_msgs::build<geometry_msgs::msg::Point32>().x(2.0).y(2.0).z(0.0),
+      geometry_msgs::build<geometry_msgs::msg::Point32>().x(2.0).y(0.0).z(0.0),
+      geometry_msgs::build<geometry_msgs::msg::Point32>().x(0.0).y(0.0).z(0.0),
+      geometry_msgs::build<geometry_msgs::msg::Point32>().x(0.0).y(2.0).z(0.0),
+    },
+    ObjectClassification::CAR));
+
+  test_manager->test_pub_msg<DetectedObjects>(test_target_node, "input/main_objects", main_objects);
+  test_manager->test_pub_msg<DetectedObjects>(test_target_node, "input/sub_objects", sub_objects);
+
+  ASSERT_EQ(latest_msg.objects.size(), 1U);
+  EXPECT_EQ(latest_msg.objects.front().shape.type, Shape::POLYGON);
+  EXPECT_TRUE(footprint_has_vertex(latest_msg.objects.front(), 1.0, 0.0));
+  EXPECT_TRUE(footprint_has_vertex(latest_msg.objects.front(), 0.0, 1.0));
 
   rclcpp::shutdown();
 }


### PR DESCRIPTION
## What

[TIER IV INTERNAL TICKET LINK](https://tier4.atlassian.net/browse/RDDR-206)

This pull request introduces a new configuration option to the `object_fusion_merger` node, allowing users to preserve the original x/y dimensions of non-polygon shapes (`BOUNDING_BOX` and `CYLINDER`) during object fusion, while retaining the grouped union footprint as auxiliary metadata. The implementation refactors and extends the geometry handling logic to support this new behavior, and updates the documentation to describe the new parameter and its effects.

**New feature: Shape dimension preservation and footprint retention**

* Added a new parameter `keep_input_dimensions` to the node's configuration (`object_fusion_merger.param.yaml`), enabling users to choose whether to expand the main object's non-polygon shape or keep its original dimensions and store the grouped union footprint in `shape.footprint`. [[1]](diffhunk://#diff-014cb3865f85249fedb2a151ba3fcadc0f5b3866645c38b23b2543ed6949cd4eR5) [[2]](diffhunk://#diff-ed5cf51cac04d47bd966d689e39bc0e8ed354e4723023998515c38fe3b2a6634R97) [[3]](diffhunk://#diff-d5ce3729cf9597788414a9d2b16fbb903fad8e72de80f17862283b4ccb553a89R342-R343)

**Documentation updates**

* Updated `object_fusion_merger.md` to document the new `keep_input_dimensions` parameter, its effect on shape update rules, and the resulting output behavior for each shape type. Clarified the distinction between direct shape expansion and footprint retention, including new diagrams and test coverage notes. [[1]](diffhunk://#diff-fb128e071da7fef34b0ec23b93bbdcd1f686ac0efea0b44df16cc793c110359fL6-R6) [[2]](diffhunk://#diff-fb128e071da7fef34b0ec23b93bbdcd1f686ac0efea0b44df16cc793c110359fL39-R76) [[3]](diffhunk://#diff-fb128e071da7fef34b0ec23b93bbdcd1f686ac0efea0b44df16cc793c110359fR94) [[4]](diffhunk://#diff-fb128e071da7fef34b0ec23b93bbdcd1f686ac0efea0b44df16cc793c110359fR104-R129)

**Geometry and fusion logic refactor**

* Refactored geometry utilities to use the new `autoware_utils_geometry` namespace and added functions for polygon transformation, union, and footprint extraction in the output local frame. This supports both the legacy expansion and the new footprint retention modes. [[1]](diffhunk://#diff-d5ce3729cf9597788414a9d2b16fbb903fad8e72de80f17862283b4ccb553a89L18-R19) [[2]](diffhunk://#diff-d5ce3729cf9597788414a9d2b16fbb903fad8e72de80f17862283b4ccb553a89L32-R36) [[3]](diffhunk://#diff-d5ce3729cf9597788414a9d2b16fbb903fad8e72de80f17862283b4ccb553a89L83-R246)

* Reworked the fusion algorithm to conditionally expand shape dimensions or retain the grouped union footprint based on the `keep_input_dimensions` parameter for both `BOUNDING_BOX` and `CYLINDER` types. [[1]](diffhunk://#diff-d5ce3729cf9597788414a9d2b16fbb903fad8e72de80f17862283b4ccb553a89L145-R317) [[2]](diffhunk://#diff-d5ce3729cf9597788414a9d2b16fbb903fad8e72de80f17862283b4ccb553a89L334-R454)

* Updated intersection area calculation and related utilities to use the new geometry namespace for consistency.