### PR TITLE
refactor(trajectory_validator): make traffic light compliance checker library

### DIFF
--- a/common/autoware_traffic_light_compliance_checker/CMakeLists.txt
+++ b/common/autoware_traffic_light_compliance_checker/CMakeLists.txt
@@ -6,6 +6,7 @@ autoware_package()
 
 ament_auto_add_library(${PROJECT_NAME} SHARED
   src/traffic_light_compliance_checker.cpp
+  src/traffic_light_status_tracker.cpp
 )
 
 if(BUILD_TESTING)

--- a/common/autoware_traffic_light_compliance_checker/CMakeLists.txt
+++ b/common/autoware_traffic_light_compliance_checker/CMakeLists.txt
@@ -1,0 +1,16 @@
+cmake_minimum_required(VERSION 3.14)
+project(autoware_traffic_light_compliance_checker)
+
+find_package(autoware_cmake REQUIRED)
+autoware_package()
+
+ament_auto_add_library(${PROJECT_NAME} SHARED
+  src/traffic_light_compliance_checker.cpp
+)
+
+if(BUILD_TESTING)
+  find_package(ament_lint_auto REQUIRED)
+  ament_lint_auto_find_test_dependencies()
+endif()
+
+ament_auto_package()

--- a/common/autoware_traffic_light_compliance_checker/README.md
+++ b/common/autoware_traffic_light_compliance_checker/README.md
@@ -1,0 +1,3 @@
+# Traffic Light Compliance Checker
+
+Library for checking whether a planned trajectory complies with traffic light signals along the route.

--- a/common/autoware_traffic_light_compliance_checker/include/autoware/traffic_light_compliance_checker/structs.hpp
+++ b/common/autoware_traffic_light_compliance_checker/include/autoware/traffic_light_compliance_checker/structs.hpp
@@ -19,6 +19,8 @@
 #include <autoware_planning_msgs/msg/lanelet_route.hpp>
 #include <autoware_planning_msgs/msg/trajectory_point.hpp>
 
+#include <rclcpp/time.hpp>
+
 #include <lanelet2_core/LaneletMap.h>
 #include <lanelet2_core/geometry/LineString.h>
 
@@ -35,9 +37,9 @@ struct Inputs
   lanelet::LaneletMapPtr map;
   autoware_planning_msgs::msg::LaneletRoute route;
   autoware_perception_msgs::msg::TrafficLightGroupArray signals;
+  rclcpp::Time current_time;
   double current_velocity;
   double current_acceleration;
-  std::vector<int64_t> force_reject_amber_ids;
 };
 
 /// @brief information about a stop line and its associated traffic light

--- a/common/autoware_traffic_light_compliance_checker/include/autoware/traffic_light_compliance_checker/structs.hpp
+++ b/common/autoware_traffic_light_compliance_checker/include/autoware/traffic_light_compliance_checker/structs.hpp
@@ -1,0 +1,89 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef AUTOWARE__TRAFFIC_LIGHT_COMPLIANCE_CHECKER__STRUCTS_HPP_
+#define AUTOWARE__TRAFFIC_LIGHT_COMPLIANCE_CHECKER__STRUCTS_HPP_
+
+#include <autoware_perception_msgs/msg/traffic_light_group_array.hpp>
+#include <autoware_planning_msgs/msg/lanelet_route.hpp>
+#include <autoware_planning_msgs/msg/trajectory_point.hpp>
+
+#include <lanelet2_core/LaneletMap.h>
+#include <lanelet2_core/geometry/LineString.h>
+
+#include <cstdint>
+#include <vector>
+
+namespace autoware::traffic_light_compliance_checker
+{
+
+/// @brief input data for traffic light compliance check
+struct Inputs
+{
+  std::vector<autoware_planning_msgs::msg::TrajectoryPoint> trajectory;
+  lanelet::LaneletMapPtr map;
+  autoware_planning_msgs::msg::LaneletRoute route;
+  autoware_perception_msgs::msg::TrafficLightGroupArray signals;
+  double current_velocity;
+  double current_acceleration;
+  std::vector<int64_t> force_reject_amber_ids;
+};
+
+/// @brief information about a stop line and its associated traffic light
+struct StopLineInfo
+{
+  lanelet::BasicLineString2d line;
+  int64_t traffic_light_id;
+};
+
+/// @brief type of traffic light violation
+enum class ViolationType { RED_LIGHT, AMBER_LIGHT };
+
+/// @brief violation detail
+struct Violation
+{
+  ViolationType type;
+  lanelet::BasicLineString2d stop_line;
+  int64_t traffic_light_id;
+};
+
+/// @brief result of compliance check
+struct ComplianceResult
+{
+  std::vector<Violation> violations;
+};
+
+/// @brief parameters for traffic light compliance check
+struct Parameters
+{
+  double deceleration_limit;
+  double jerk_limit;
+  double delay_response_time;
+  double crossing_time_limit;
+  bool treat_amber_light_as_red_light;
+  double stop_overshoot_margin;
+  double stable_duration_threshold_red;
+  double stable_duration_threshold_amber;
+  double amber_rejection_hysteresis_duration;
+  double ego_stopped_velocity_threshold;
+  struct CheckedTrajectoryLength
+  {
+    double deceleration_limit;
+    double jerk_limit;
+  } checked_trajectory_length;
+};
+
+}  // namespace autoware::traffic_light_compliance_checker
+
+#endif  // AUTOWARE__TRAFFIC_LIGHT_COMPLIANCE_CHECKER__STRUCTS_HPP_

--- a/common/autoware_traffic_light_compliance_checker/include/autoware/traffic_light_compliance_checker/structs.hpp
+++ b/common/autoware_traffic_light_compliance_checker/include/autoware/traffic_light_compliance_checker/structs.hpp
@@ -64,6 +64,13 @@ struct ComplianceResult
   std::vector<Violation> violations;
 };
 
+/// @brief parameters for traffic light signal status tracking
+struct StatusTrackerParameters
+{
+  double stable_duration_threshold_red;
+  double stable_duration_threshold_amber;
+};
+
 /// @brief parameters for traffic light compliance check
 struct Parameters
 {

--- a/common/autoware_traffic_light_compliance_checker/include/autoware/traffic_light_compliance_checker/structs.hpp
+++ b/common/autoware_traffic_light_compliance_checker/include/autoware/traffic_light_compliance_checker/structs.hpp
@@ -15,11 +15,11 @@
 #ifndef AUTOWARE__TRAFFIC_LIGHT_COMPLIANCE_CHECKER__STRUCTS_HPP_
 #define AUTOWARE__TRAFFIC_LIGHT_COMPLIANCE_CHECKER__STRUCTS_HPP_
 
+#include <rclcpp/time.hpp>
+
 #include <autoware_perception_msgs/msg/traffic_light_group_array.hpp>
 #include <autoware_planning_msgs/msg/lanelet_route.hpp>
 #include <autoware_planning_msgs/msg/trajectory_point.hpp>
-
-#include <rclcpp/time.hpp>
 
 #include <lanelet2_core/LaneletMap.h>
 #include <lanelet2_core/geometry/LineString.h>

--- a/common/autoware_traffic_light_compliance_checker/include/autoware/traffic_light_compliance_checker/traffic_light_compliance_checker.hpp
+++ b/common/autoware_traffic_light_compliance_checker/include/autoware/traffic_light_compliance_checker/traffic_light_compliance_checker.hpp
@@ -16,6 +16,7 @@
 #define AUTOWARE__TRAFFIC_LIGHT_COMPLIANCE_CHECKER__TRAFFIC_LIGHT_COMPLIANCE_CHECKER_HPP_
 
 #include "autoware/traffic_light_compliance_checker/structs.hpp"
+#include "autoware/traffic_light_compliance_checker/traffic_light_status_tracker.hpp"
 
 #include <autoware/vehicle_info_utils/vehicle_info.hpp>
 #include <tl_expected/expected.hpp>
@@ -25,8 +26,13 @@
 
 #include <lanelet2_core/LaneletMap.h>
 
+#include <rclcpp/time.hpp>
+
+#include <cstdint>
+#include <memory>
 #include <optional>
 #include <string>
+#include <unordered_map>
 #include <utility>
 #include <vector>
 
@@ -45,12 +51,14 @@ public:
   TrafficLightComplianceChecker(
     const Parameters & parameters, const vehicle_info_utils::VehicleInfo & vehicle_info);
 
+  ~TrafficLightComplianceChecker();
+
   /**
    * @brief check if the trajectory complies with traffic lights
-   * @param input input data for compliance check
+   * @param input input data for compliance check (raw signals are filtered internally)
    * @return result of compliance check, or error message if check fails
    */
-  [[nodiscard]] tl::expected<ComplianceResult, std::string> check(const Inputs & input) const;
+  [[nodiscard]] tl::expected<ComplianceResult, std::string> check(const Inputs & input);
 
   /**
    * @brief update parameters
@@ -59,6 +67,20 @@ public:
   void update_parameters(const Parameters & parameters);
 
 private:
+  [[nodiscard]] std::vector<int64_t> get_force_reject_amber_ids(
+    const rclcpp::Time & current_time, bool is_ego_stopped) const;
+
+  void update_amber_rejection_history(
+    const ComplianceResult & result, const rclcpp::Time & current_time,
+    const std::vector<int64_t> & force_reject_amber_ids);
+
+  void cleanup_amber_rejection_history(const rclcpp::Time & current_time);
+
+  [[nodiscard]] tl::expected<ComplianceResult, std::string> check_with_filtered_signals(
+    const Inputs & input,
+    const autoware_perception_msgs::msg::TrafficLightGroupArray & filtered_signals,
+    const std::vector<int64_t> & force_reject_amber_ids) const;
+
   /// @brief return the red and amber stop lines related to the given traffic light groups
   [[nodiscard]] std::pair<std::vector<StopLineInfo>, std::vector<StopLineInfo>> get_stop_lines(
     const lanelet::LaneletMap & lanelet_map,
@@ -77,6 +99,8 @@ private:
 
   Parameters params_;
   vehicle_info_utils::VehicleInfo vehicle_info_;
+  std::unique_ptr<TrafficLightStatusTracker> status_tracker_;
+  std::unordered_map<int64_t, rclcpp::Time> amber_rejection_history_;
 };
 
 }  // namespace autoware::traffic_light_compliance_checker

--- a/common/autoware_traffic_light_compliance_checker/include/autoware/traffic_light_compliance_checker/traffic_light_compliance_checker.hpp
+++ b/common/autoware_traffic_light_compliance_checker/include/autoware/traffic_light_compliance_checker/traffic_light_compliance_checker.hpp
@@ -19,14 +19,13 @@
 #include "autoware/traffic_light_compliance_checker/traffic_light_status_tracker.hpp"
 
 #include <autoware/vehicle_info_utils/vehicle_info.hpp>
+#include <rclcpp/time.hpp>
 #include <tl_expected/expected.hpp>
 
 #include <autoware_perception_msgs/msg/traffic_light_group_array.hpp>
 #include <autoware_planning_msgs/msg/lanelet_route.hpp>
 
 #include <lanelet2_core/LaneletMap.h>
-
-#include <rclcpp/time.hpp>
 
 #include <cstdint>
 #include <memory>

--- a/common/autoware_traffic_light_compliance_checker/include/autoware/traffic_light_compliance_checker/traffic_light_compliance_checker.hpp
+++ b/common/autoware_traffic_light_compliance_checker/include/autoware/traffic_light_compliance_checker/traffic_light_compliance_checker.hpp
@@ -12,82 +12,26 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef AUTOWARE__TRAJECTORY_VALIDATOR__FILTERS__TRAFFIC_RULE__TRAFFIC_LIGHT_COMPLIANCE_CHECKER_HPP_
-#define AUTOWARE__TRAJECTORY_VALIDATOR__FILTERS__TRAFFIC_RULE__TRAFFIC_LIGHT_COMPLIANCE_CHECKER_HPP_
+#ifndef AUTOWARE__TRAFFIC_LIGHT_COMPLIANCE_CHECKER__TRAFFIC_LIGHT_COMPLIANCE_CHECKER_HPP_
+#define AUTOWARE__TRAFFIC_LIGHT_COMPLIANCE_CHECKER__TRAFFIC_LIGHT_COMPLIANCE_CHECKER_HPP_
+
+#include "autoware/traffic_light_compliance_checker/structs.hpp"
 
 #include <autoware/vehicle_info_utils/vehicle_info.hpp>
 #include <tl_expected/expected.hpp>
 
 #include <autoware_perception_msgs/msg/traffic_light_group_array.hpp>
 #include <autoware_planning_msgs/msg/lanelet_route.hpp>
-#include <autoware_planning_msgs/msg/trajectory_point.hpp>
 
 #include <lanelet2_core/LaneletMap.h>
-#include <lanelet2_core/geometry/LineString.h>
 
 #include <optional>
 #include <string>
 #include <utility>
 #include <vector>
 
-namespace autoware::trajectory_validator::traffic_light_filter
+namespace autoware::traffic_light_compliance_checker
 {
-
-/// @brief input data for traffic light compliance check
-struct Inputs
-{
-  std::vector<autoware_planning_msgs::msg::TrajectoryPoint> trajectory;
-  lanelet::LaneletMapPtr map;
-  autoware_planning_msgs::msg::LaneletRoute route;
-  autoware_perception_msgs::msg::TrafficLightGroupArray signals;
-  double current_velocity;
-  double current_acceleration;
-  std::vector<int64_t> force_reject_amber_ids;
-};
-
-/// @brief information about a stop line and its associated traffic light
-struct StopLineInfo
-{
-  lanelet::BasicLineString2d line;
-  int64_t traffic_light_id;
-};
-
-/// @brief type of traffic light violation
-enum class ViolationType { RED_LIGHT, AMBER_LIGHT };
-
-/// @brief violation detail
-struct Violation
-{
-  ViolationType type;
-  lanelet::BasicLineString2d stop_line;
-  int64_t traffic_light_id;
-};
-
-/// @brief result of compliance check
-struct ComplianceResult
-{
-  std::vector<Violation> violations;
-};
-
-/// @brief parameters for traffic light compliance check
-struct Parameters
-{
-  double deceleration_limit;
-  double jerk_limit;
-  double delay_response_time;
-  double crossing_time_limit;
-  bool treat_amber_light_as_red_light;
-  double stop_overshoot_margin;
-  double stable_duration_threshold_red;
-  double stable_duration_threshold_amber;
-  double amber_rejection_hysteresis_duration;
-  double ego_stopped_velocity_threshold;
-  struct CheckedTrajectoryLength
-  {
-    double deceleration_limit;
-    double jerk_limit;
-  } checked_trajectory_length;
-};
 
 /// @brief class to check if a trajectory complies with traffic lights
 class TrafficLightComplianceChecker
@@ -135,6 +79,6 @@ private:
   vehicle_info_utils::VehicleInfo vehicle_info_;
 };
 
-}  // namespace autoware::trajectory_validator::traffic_light_filter
-// NOLINTNEXTLINE
-#endif  // AUTOWARE__TRAJECTORY_VALIDATOR__FILTERS__TRAFFIC_RULE__TRAFFIC_LIGHT_COMPLIANCE_CHECKER_HPP_
+}  // namespace autoware::traffic_light_compliance_checker
+
+#endif  // AUTOWARE__TRAFFIC_LIGHT_COMPLIANCE_CHECKER__TRAFFIC_LIGHT_COMPLIANCE_CHECKER_HPP_

--- a/common/autoware_traffic_light_compliance_checker/include/autoware/traffic_light_compliance_checker/traffic_light_status_tracker.hpp
+++ b/common/autoware_traffic_light_compliance_checker/include/autoware/traffic_light_compliance_checker/traffic_light_status_tracker.hpp
@@ -1,0 +1,65 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef AUTOWARE__TRAFFIC_LIGHT_COMPLIANCE_CHECKER__TRAFFIC_LIGHT_STATUS_TRACKER_HPP_
+#define AUTOWARE__TRAFFIC_LIGHT_COMPLIANCE_CHECKER__TRAFFIC_LIGHT_STATUS_TRACKER_HPP_
+
+#include "autoware/traffic_light_compliance_checker/structs.hpp"
+
+#include <autoware_perception_msgs/msg/traffic_light_group_array.hpp>
+
+#include <rclcpp/time.hpp>
+
+#include <cstdint>
+#include <unordered_map>
+
+namespace autoware::traffic_light_compliance_checker
+{
+
+/// @brief tracks traffic light signal stability over time
+class TrafficLightStatusTracker
+{
+public:
+  explicit TrafficLightStatusTracker(const StatusTrackerParameters & parameters);
+
+  void update_parameters(const StatusTrackerParameters & parameters);
+
+  /**
+   * @brief filter unstable red/amber signals using per-signal state history
+   * @param signals raw traffic light signals
+   * @param current_time current time stamp
+   * @param is_ego_stopped true if ego velocity is below the stopped threshold
+   * @return signals with unstable states cleared
+   */
+  [[nodiscard]] autoware_perception_msgs::msg::TrafficLightGroupArray filter_signals(
+    const autoware_perception_msgs::msg::TrafficLightGroupArray & signals,
+    const rclcpp::Time & current_time, bool is_ego_stopped);
+
+private:
+  void cleanup_signal_history(const rclcpp::Time & current_time);
+
+  struct SignalStateHistory
+  {
+    autoware_perception_msgs::msg::TrafficLightGroup msg;
+    rclcpp::Time first_seen_time;
+    rclcpp::Time last_seen_time;
+  };
+
+  StatusTrackerParameters params_;
+  std::unordered_map<int64_t, SignalStateHistory> signal_history_;
+};
+
+}  // namespace autoware::traffic_light_compliance_checker
+
+#endif  // AUTOWARE__TRAFFIC_LIGHT_COMPLIANCE_CHECKER__TRAFFIC_LIGHT_STATUS_TRACKER_HPP_

--- a/common/autoware_traffic_light_compliance_checker/include/autoware/traffic_light_compliance_checker/traffic_light_status_tracker.hpp
+++ b/common/autoware_traffic_light_compliance_checker/include/autoware/traffic_light_compliance_checker/traffic_light_status_tracker.hpp
@@ -17,9 +17,9 @@
 
 #include "autoware/traffic_light_compliance_checker/structs.hpp"
 
-#include <autoware_perception_msgs/msg/traffic_light_group_array.hpp>
-
 #include <rclcpp/time.hpp>
+
+#include <autoware_perception_msgs/msg/traffic_light_group_array.hpp>
 
 #include <cstdint>
 #include <unordered_map>

--- a/common/autoware_traffic_light_compliance_checker/package.xml
+++ b/common/autoware_traffic_light_compliance_checker/package.xml
@@ -5,6 +5,7 @@
   <version>0.50.0</version>
   <description>Library for checking trajectory compliance with traffic lights</description>
   <maintainer email="alqudah.mohammad@tier4.jp">Alqudah Mohammad</maintainer>
+  <maintainer email="maxime.clement@tier4.jp">Maxime Clement</maintainer>
 
   <license>Apache License 2.0</license>
 

--- a/common/autoware_traffic_light_compliance_checker/package.xml
+++ b/common/autoware_traffic_light_compliance_checker/package.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>autoware_traffic_light_compliance_checker</name>
+  <version>0.50.0</version>
+  <description>Library for checking trajectory compliance with traffic lights</description>
+  <maintainer email="alqudah.mohammad@tier4.jp">Alqudah Mohammad</maintainer>
+
+  <license>Apache License 2.0</license>
+
+  <buildtool_depend>ament_cmake_auto</buildtool_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
+
+  <depend>autoware_interpolation</depend>
+  <depend>autoware_lanelet2_utils</depend>
+  <depend>autoware_motion_utils</depend>
+  <depend>autoware_perception_msgs</depend>
+  <depend>autoware_planning_msgs</depend>
+  <depend>autoware_traffic_light_utils</depend>
+  <depend>autoware_vehicle_info_utils</depend>
+  <depend>boost</depend>
+  <depend>lanelet2_core</depend>
+  <depend>rclcpp</depend>
+  <depend>tl_expected</depend>
+
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>autoware_lint_common</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/common/autoware_traffic_light_compliance_checker/src/traffic_light_compliance_checker.cpp
+++ b/common/autoware_traffic_light_compliance_checker/src/traffic_light_compliance_checker.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "autoware/trajectory_validator/filters/traffic_rule/traffic_light_compliance_checker.hpp"
+#include "autoware/traffic_light_compliance_checker/traffic_light_compliance_checker.hpp"
 
 #include <autoware/interpolation/linear_interpolation.hpp>
 #include <autoware/motion_utils/distance/distance.hpp>
@@ -34,7 +34,7 @@
 
 namespace
 {
-using autoware::trajectory_validator::traffic_light_filter::StopLineInfo;
+using autoware::traffic_light_compliance_checker::StopLineInfo;
 
 /// @brief get stop lines where ego need to stop, and their corresponding signals from the given
 /// traffic light groups
@@ -83,7 +83,7 @@ collect_stop_lines(
 }
 }  // namespace
 
-namespace autoware::trajectory_validator::traffic_light_filter
+namespace autoware::traffic_light_compliance_checker
 {
 
 TrafficLightComplianceChecker::TrafficLightComplianceChecker(
@@ -273,4 +273,4 @@ bool TrafficLightComplianceChecker::can_pass_amber_light(
   return can_pass;
 }
 
-}  // namespace autoware::trajectory_validator::traffic_light_filter
+}  // namespace autoware::traffic_light_compliance_checker

--- a/common/autoware_traffic_light_compliance_checker/src/traffic_light_compliance_checker.cpp
+++ b/common/autoware_traffic_light_compliance_checker/src/traffic_light_compliance_checker.cpp
@@ -26,6 +26,7 @@
 #include <lanelet2_core/primitives/BasicRegulatoryElements.h>
 
 #include <algorithm>
+#include <cmath>
 #include <memory>
 #include <string>
 #include <unordered_map>
@@ -34,6 +35,15 @@
 
 namespace
 {
+autoware::traffic_light_compliance_checker::StatusTrackerParameters to_status_tracker_parameters(
+  const autoware::traffic_light_compliance_checker::Parameters & parameters)
+{
+  autoware::traffic_light_compliance_checker::StatusTrackerParameters p;
+  p.stable_duration_threshold_red = parameters.stable_duration_threshold_red;
+  p.stable_duration_threshold_amber = parameters.stable_duration_threshold_amber;
+  return p;
+}
+
 using autoware::traffic_light_compliance_checker::StopLineInfo;
 
 /// @brief get stop lines where ego need to stop, and their corresponding signals from the given
@@ -88,17 +98,88 @@ namespace autoware::traffic_light_compliance_checker
 
 TrafficLightComplianceChecker::TrafficLightComplianceChecker(
   const Parameters & parameters, const vehicle_info_utils::VehicleInfo & vehicle_info)
-: params_(parameters), vehicle_info_(vehicle_info)
+: params_(parameters),
+  vehicle_info_(vehicle_info),
+  status_tracker_(std::make_unique<TrafficLightStatusTracker>(to_status_tracker_parameters(parameters)))
 {
 }
+
+TrafficLightComplianceChecker::~TrafficLightComplianceChecker() = default;
 
 void TrafficLightComplianceChecker::update_parameters(const Parameters & parameters)
 {
   params_ = parameters;
+  status_tracker_->update_parameters(to_status_tracker_parameters(parameters));
 }
 
-tl::expected<ComplianceResult, std::string> TrafficLightComplianceChecker::check(
-  const Inputs & input) const
+tl::expected<ComplianceResult, std::string> TrafficLightComplianceChecker::check(const Inputs & input)
+{
+  const bool is_ego_stopped =
+    std::abs(input.current_velocity) < params_.ego_stopped_velocity_threshold;
+  const auto filtered_signals =
+    status_tracker_->filter_signals(input.signals, input.current_time, is_ego_stopped);
+
+  const auto force_reject_amber_ids =
+    get_force_reject_amber_ids(input.current_time, is_ego_stopped);
+
+  auto result = check_with_filtered_signals(input, filtered_signals, force_reject_amber_ids);
+  if (!result) {
+    return result;
+  }
+
+  update_amber_rejection_history(*result, input.current_time, force_reject_amber_ids);
+  cleanup_amber_rejection_history(input.current_time);
+
+  return result;
+}
+
+std::vector<int64_t> TrafficLightComplianceChecker::get_force_reject_amber_ids(
+  const rclcpp::Time & current_time, const bool is_ego_stopped) const
+{
+  std::vector<int64_t> force_reject_amber_ids;
+  if (is_ego_stopped) {
+    return force_reject_amber_ids;
+  }
+  for (const auto & [id, rejected_time] : amber_rejection_history_) {
+    if ((current_time - rejected_time).seconds() <= params_.amber_rejection_hysteresis_duration) {
+      force_reject_amber_ids.push_back(id);
+    }
+  }
+  return force_reject_amber_ids;
+}
+
+void TrafficLightComplianceChecker::update_amber_rejection_history(
+  const ComplianceResult & result, const rclcpp::Time & current_time,
+  const std::vector<int64_t> & force_reject_amber_ids)
+{
+  for (const auto & violation : result.violations) {
+    if (violation.type != ViolationType::AMBER_LIGHT) {
+      continue;
+    }
+    if (
+      std::find(
+        force_reject_amber_ids.begin(), force_reject_amber_ids.end(),
+        violation.traffic_light_id) == force_reject_amber_ids.end()) {
+      amber_rejection_history_[violation.traffic_light_id] = current_time;
+    }
+  }
+}
+
+void TrafficLightComplianceChecker::cleanup_amber_rejection_history(const rclcpp::Time & current_time)
+{
+  for (auto it = amber_rejection_history_.begin(); it != amber_rejection_history_.end();) {
+    if ((current_time - it->second).seconds() > params_.amber_rejection_hysteresis_duration) {
+      it = amber_rejection_history_.erase(it);
+    } else {
+      ++it;
+    }
+  }
+}
+
+tl::expected<ComplianceResult, std::string> TrafficLightComplianceChecker::check_with_filtered_signals(
+  const Inputs & input,
+  const autoware_perception_msgs::msg::TrafficLightGroupArray & filtered_signals,
+  const std::vector<int64_t> & force_reject_amber_ids) const
 {
   std::vector<autoware_planning_msgs::msg::TrajectoryPoint> trajectory;
   lanelet::BasicLineString2d trajectory_ls;
@@ -152,7 +233,7 @@ tl::expected<ComplianceResult, std::string> TrafficLightComplianceChecker::check
   }
 
   const auto [red_stop_lines, amber_stop_lines] =
-    get_stop_lines(*input.map, input.route, input.signals);
+    get_stop_lines(*input.map, input.route, filtered_signals);
 
   ComplianceResult result;
 
@@ -199,8 +280,8 @@ tl::expected<ComplianceResult, std::string> TrafficLightComplianceChecker::check
       bool is_force_reject = false;
       if (
         std::find(
-          input.force_reject_amber_ids.begin(), input.force_reject_amber_ids.end(),
-          amber_stop_line.traffic_light_id) != input.force_reject_amber_ids.end()) {
+          force_reject_amber_ids.begin(), force_reject_amber_ids.end(),
+          amber_stop_line.traffic_light_id) != force_reject_amber_ids.end()) {
         is_force_reject = true;
       }
 

--- a/common/autoware_traffic_light_compliance_checker/src/traffic_light_compliance_checker.cpp
+++ b/common/autoware_traffic_light_compliance_checker/src/traffic_light_compliance_checker.cpp
@@ -100,7 +100,8 @@ TrafficLightComplianceChecker::TrafficLightComplianceChecker(
   const Parameters & parameters, const vehicle_info_utils::VehicleInfo & vehicle_info)
 : params_(parameters),
   vehicle_info_(vehicle_info),
-  status_tracker_(std::make_unique<TrafficLightStatusTracker>(to_status_tracker_parameters(parameters)))
+  status_tracker_(
+    std::make_unique<TrafficLightStatusTracker>(to_status_tracker_parameters(parameters)))
 {
 }
 
@@ -112,7 +113,8 @@ void TrafficLightComplianceChecker::update_parameters(const Parameters & paramet
   status_tracker_->update_parameters(to_status_tracker_parameters(parameters));
 }
 
-tl::expected<ComplianceResult, std::string> TrafficLightComplianceChecker::check(const Inputs & input)
+tl::expected<ComplianceResult, std::string> TrafficLightComplianceChecker::check(
+  const Inputs & input)
 {
   const bool is_ego_stopped =
     std::abs(input.current_velocity) < params_.ego_stopped_velocity_threshold;
@@ -158,14 +160,15 @@ void TrafficLightComplianceChecker::update_amber_rejection_history(
     }
     if (
       std::find(
-        force_reject_amber_ids.begin(), force_reject_amber_ids.end(),
-        violation.traffic_light_id) == force_reject_amber_ids.end()) {
+        force_reject_amber_ids.begin(), force_reject_amber_ids.end(), violation.traffic_light_id) ==
+      force_reject_amber_ids.end()) {
       amber_rejection_history_[violation.traffic_light_id] = current_time;
     }
   }
 }
 
-void TrafficLightComplianceChecker::cleanup_amber_rejection_history(const rclcpp::Time & current_time)
+void TrafficLightComplianceChecker::cleanup_amber_rejection_history(
+  const rclcpp::Time & current_time)
 {
   for (auto it = amber_rejection_history_.begin(); it != amber_rejection_history_.end();) {
     if ((current_time - it->second).seconds() > params_.amber_rejection_hysteresis_duration) {
@@ -176,7 +179,8 @@ void TrafficLightComplianceChecker::cleanup_amber_rejection_history(const rclcpp
   }
 }
 
-tl::expected<ComplianceResult, std::string> TrafficLightComplianceChecker::check_with_filtered_signals(
+tl::expected<ComplianceResult, std::string>
+TrafficLightComplianceChecker::check_with_filtered_signals(
   const Inputs & input,
   const autoware_perception_msgs::msg::TrafficLightGroupArray & filtered_signals,
   const std::vector<int64_t> & force_reject_amber_ids) const

--- a/common/autoware_traffic_light_compliance_checker/src/traffic_light_status_tracker.cpp
+++ b/common/autoware_traffic_light_compliance_checker/src/traffic_light_status_tracker.cpp
@@ -1,0 +1,120 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/traffic_light_compliance_checker/traffic_light_status_tracker.hpp"
+
+#include <autoware/traffic_light_utils/traffic_light_utils.hpp>
+
+namespace
+{
+bool is_equal(
+  const autoware_perception_msgs::msg::TrafficLightElement & a,
+  const autoware_perception_msgs::msg::TrafficLightElement & b)
+{
+  return a.color == b.color && a.shape == b.shape && a.status == b.status;
+}
+
+bool is_equal(
+  const std::vector<autoware_perception_msgs::msg::TrafficLightElement> & a,
+  const std::vector<autoware_perception_msgs::msg::TrafficLightElement> & b)
+{
+  if (a.size() != b.size()) {
+    return false;
+  }
+
+  for (size_t i = 0; i < a.size(); ++i) {
+    if (!is_equal(a[i], b[i])) {
+      return false;
+    }
+  }
+
+  return true;
+}
+}  // namespace
+
+namespace autoware::traffic_light_compliance_checker
+{
+
+TrafficLightStatusTracker::TrafficLightStatusTracker(const StatusTrackerParameters & parameters)
+: params_(parameters)
+{
+}
+
+void TrafficLightStatusTracker::update_parameters(const StatusTrackerParameters & parameters)
+{
+  params_ = parameters;
+}
+
+autoware_perception_msgs::msg::TrafficLightGroupArray TrafficLightStatusTracker::filter_signals(
+  const autoware_perception_msgs::msg::TrafficLightGroupArray & signals,
+  const rclcpp::Time & current_time, const bool is_ego_stopped)
+{
+  autoware_perception_msgs::msg::TrafficLightGroupArray filtered_signals;
+  filtered_signals.stamp = signals.stamp;
+
+  for (const auto & signal : signals.traffic_light_groups) {
+    const auto id = signal.traffic_light_group_id;
+    if (signal_history_.find(id) == signal_history_.end()) {
+      signal_history_[id] = {signal, current_time, current_time};
+    } else {
+      if (!is_equal(signal_history_[id].msg.elements, signal.elements)) {
+        signal_history_[id].first_seen_time = current_time;
+        signal_history_[id].msg = signal;
+      }
+      signal_history_[id].last_seen_time = current_time;
+    }
+
+    auto filtered_signal = signal;
+    if (is_ego_stopped) {
+      filtered_signals.traffic_light_groups.push_back(filtered_signal);
+      continue;
+    }
+    const auto state_duration = (current_time - signal_history_[id].first_seen_time).seconds();
+    const bool is_red = autoware::traffic_light_utils::hasTrafficLightShapeAndColor(
+      signal.elements, autoware_perception_msgs::msg::TrafficLightElement::CIRCLE,
+      autoware_perception_msgs::msg::TrafficLightElement::RED);
+    const bool is_amber = autoware::traffic_light_utils::hasTrafficLightShapeAndColor(
+      signal.elements, autoware_perception_msgs::msg::TrafficLightElement::CIRCLE,
+      autoware_perception_msgs::msg::TrafficLightElement::AMBER);
+
+    if (is_red && state_duration < params_.stable_duration_threshold_red) {
+      filtered_signal.elements.clear();
+    } else if (is_amber && state_duration < params_.stable_duration_threshold_amber) {
+      filtered_signal.elements.clear();
+    }
+    filtered_signals.traffic_light_groups.push_back(filtered_signal);
+  }
+
+  cleanup_signal_history(current_time);
+
+  return filtered_signals;
+}
+
+void TrafficLightStatusTracker::cleanup_signal_history(const rclcpp::Time & current_time)
+{
+  for (auto it = signal_history_.begin(); it != signal_history_.end();) {
+    const auto stable_duration =
+      autoware::traffic_light_utils::hasTrafficLightColor(
+        it->second.msg.elements, autoware_perception_msgs::msg::TrafficLightElement::RED)
+        ? params_.stable_duration_threshold_red
+        : params_.stable_duration_threshold_amber;
+    if ((current_time - it->second.last_seen_time).seconds() > stable_duration) {
+      it = signal_history_.erase(it);
+    } else {
+      ++it;
+    }
+  }
+}
+
+}  // namespace autoware::traffic_light_compliance_checker

--- a/common/autoware_traffic_light_compliance_checker/src/traffic_light_status_tracker.cpp
+++ b/common/autoware_traffic_light_compliance_checker/src/traffic_light_status_tracker.cpp
@@ -16,6 +16,8 @@
 
 #include <autoware/traffic_light_utils/traffic_light_utils.hpp>
 
+#include <vector>
+
 namespace
 {
 bool is_equal(

--- a/planning/autoware_trajectory_modifier/launch/trajectory_modifier.launch.xml
+++ b/planning/autoware_trajectory_modifier/launch/trajectory_modifier.launch.xml
@@ -7,17 +7,17 @@
   <arg name="input_pointcloud" default="/perception/obstacle_segmentation/pointcloud"/>
   <arg name="output_candidate_trajectories" default="~/output/candidate_trajectories"/>
 
-  <node_container pkg="rclcpp_components" exec="component_container" name="trajectory_modifier_container" namespace="">
-    <composable_node pkg="autoware_glog_component" plugin="autoware::glog_component::GlogComponent" name="glog_component" namespace=""/>
-    <composable_node pkg="autoware_trajectory_modifier" plugin="autoware::trajectory_modifier::TrajectoryModifier" name="trajectory_modifier" namespace="">
-      <param from="$(var trajectory_modifier_param_path)"/>
-      <remap from="~/input/objects" to="$(var input_objects)"/>
-      <remap from="~/input/pointcloud" to="$(var input_pointcloud)"/>
-      <remap from="~/input/candidate_trajectories" to="$(var input_candidate_trajectories)"/>
-      <remap from="~/input/odometry" to="$(var input_odometry)"/>
-      <remap from="~/input/acceleration" to="$(var input_acceleration)"/>
-      <remap from="~/output/candidate_trajectories" to="$(var output_candidate_trajectories)"/>
-      <extra_arg name="use_intra_process_comms" value="false"/>
-    </composable_node>
-  </node_container>
+  <!-- <node_container pkg="rclcpp_components" exec="component_container" name="trajectory_modifier_container" namespace="">
+    <composable_node pkg="autoware_glog_component" plugin="autoware::glog_component::GlogComponent" name="glog_component" namespace=""/> -->
+  <node pkg="autoware_trajectory_modifier" exec="autoware_trajectory_modifier_node" name="trajectory_modifier" namespace="" launch-prefix="konsole -e gdb -ex run --args">
+    <param from="$(var trajectory_modifier_param_path)"/>
+    <remap from="~/input/objects" to="$(var input_objects)"/>
+    <remap from="~/input/pointcloud" to="$(var input_pointcloud)"/>
+    <remap from="~/input/candidate_trajectories" to="$(var input_candidate_trajectories)"/>
+    <remap from="~/input/odometry" to="$(var input_odometry)"/>
+    <remap from="~/input/acceleration" to="$(var input_acceleration)"/>
+    <remap from="~/output/candidate_trajectories" to="$(var output_candidate_trajectories)"/>
+    <!-- <extra_arg name="use_intra_process_comms" value="false"/> -->
+  </node>
+  <!-- </node_container> -->
 </launch>

--- a/planning/autoware_trajectory_modifier/launch/trajectory_modifier.launch.xml
+++ b/planning/autoware_trajectory_modifier/launch/trajectory_modifier.launch.xml
@@ -7,17 +7,17 @@
   <arg name="input_pointcloud" default="/perception/obstacle_segmentation/pointcloud"/>
   <arg name="output_candidate_trajectories" default="~/output/candidate_trajectories"/>
 
-  <!-- <node_container pkg="rclcpp_components" exec="component_container" name="trajectory_modifier_container" namespace="">
-    <composable_node pkg="autoware_glog_component" plugin="autoware::glog_component::GlogComponent" name="glog_component" namespace=""/> -->
-  <node pkg="autoware_trajectory_modifier" exec="autoware_trajectory_modifier_node" name="trajectory_modifier" namespace="" launch-prefix="konsole -e gdb -ex run --args">
-    <param from="$(var trajectory_modifier_param_path)"/>
-    <remap from="~/input/objects" to="$(var input_objects)"/>
-    <remap from="~/input/pointcloud" to="$(var input_pointcloud)"/>
-    <remap from="~/input/candidate_trajectories" to="$(var input_candidate_trajectories)"/>
-    <remap from="~/input/odometry" to="$(var input_odometry)"/>
-    <remap from="~/input/acceleration" to="$(var input_acceleration)"/>
-    <remap from="~/output/candidate_trajectories" to="$(var output_candidate_trajectories)"/>
-    <!-- <extra_arg name="use_intra_process_comms" value="false"/> -->
-  </node>
-  <!-- </node_container> -->
+  <node_container pkg="rclcpp_components" exec="component_container" name="trajectory_modifier_container" namespace="">
+    <composable_node pkg="autoware_glog_component" plugin="autoware::glog_component::GlogComponent" name="glog_component" namespace=""/>
+    <composable_node pkg="autoware_trajectory_modifier" plugin="autoware::trajectory_modifier::TrajectoryModifier" name="trajectory_modifier" namespace="">
+      <param from="$(var trajectory_modifier_param_path)"/>
+      <remap from="~/input/objects" to="$(var input_objects)"/>
+      <remap from="~/input/pointcloud" to="$(var input_pointcloud)"/>
+      <remap from="~/input/candidate_trajectories" to="$(var input_candidate_trajectories)"/>
+      <remap from="~/input/odometry" to="$(var input_odometry)"/>
+      <remap from="~/input/acceleration" to="$(var input_acceleration)"/>
+      <remap from="~/output/candidate_trajectories" to="$(var output_candidate_trajectories)"/>
+      <extra_arg name="use_intra_process_comms" value="false"/>
+    </composable_node>
+  </node_container>
 </launch>

--- a/planning/autoware_trajectory_validator/CMakeLists.txt
+++ b/planning/autoware_trajectory_validator/CMakeLists.txt
@@ -43,7 +43,6 @@ ament_auto_add_library(autoware_trajectory_validator_plugins SHARED
   src/filters/safety/collision_check_filter/assessment.cpp
   src/filters/safety/collision_check_filter/trajectory_utils.cpp
   src/filters/traffic_rule/traffic_light_filter.cpp
-  src/filters/traffic_rule/traffic_light_compliance_checker.cpp
 )
 
 set_target_properties(autoware_trajectory_validator_plugins PROPERTIES CXX_VISIBILITY_PRESET default)

--- a/planning/autoware_trajectory_validator/include/autoware/trajectory_validator/filters/traffic_rule/traffic_light_filter.hpp
+++ b/planning/autoware_trajectory_validator/include/autoware/trajectory_validator/filters/traffic_rule/traffic_light_filter.hpp
@@ -18,14 +18,8 @@
 #include "autoware/trajectory_validator/validator_interface.hpp"
 
 #include <autoware/traffic_light_compliance_checker/traffic_light_compliance_checker.hpp>
-#include <autoware/traffic_light_compliance_checker/traffic_light_status_tracker.hpp>
 
-#include <rclcpp/time.hpp>
-
-#include <cstdint>
 #include <memory>
-#include <unordered_map>
-#include <vector>
 
 namespace autoware::trajectory_validator::plugin::traffic_rule
 {
@@ -42,15 +36,7 @@ public:
 
 private:
   std::unique_ptr<traffic_light_compliance_checker::TrafficLightComplianceChecker> checker_;
-  std::unique_ptr<traffic_light_compliance_checker::TrafficLightStatusTracker> status_tracker_;
   validator::Params::TrafficLight params_;
-
-  std::unordered_map<int64_t, rclcpp::Time> amber_rejection_history_;
-
-  [[nodiscard]] std::vector<int64_t> get_force_reject_amber_ids(
-    const rclcpp::Time & current_time, bool is_ego_stopped) const;
-
-  void cleanup_history(const rclcpp::Time & current_time);
 };
 
 }  // namespace autoware::trajectory_validator::plugin::traffic_rule

--- a/planning/autoware_trajectory_validator/include/autoware/trajectory_validator/filters/traffic_rule/traffic_light_filter.hpp
+++ b/planning/autoware_trajectory_validator/include/autoware/trajectory_validator/filters/traffic_rule/traffic_light_filter.hpp
@@ -15,8 +15,9 @@
 #ifndef AUTOWARE__TRAJECTORY_VALIDATOR__FILTERS__TRAFFIC_RULE__TRAFFIC_LIGHT_FILTER_HPP_
 #define AUTOWARE__TRAJECTORY_VALIDATOR__FILTERS__TRAFFIC_RULE__TRAFFIC_LIGHT_FILTER_HPP_
 
-#include "autoware/trajectory_validator/filters/traffic_rule/traffic_light_compliance_checker.hpp"
 #include "autoware/trajectory_validator/validator_interface.hpp"
+
+#include <autoware/traffic_light_compliance_checker/traffic_light_compliance_checker.hpp>
 
 #include <autoware_planning_msgs/msg/lanelet_route.hpp>
 
@@ -47,7 +48,7 @@ private:
     rclcpp::Time last_seen_time;
   };
 
-  std::unique_ptr<traffic_light_filter::TrafficLightComplianceChecker> checker_;
+  std::unique_ptr<traffic_light_compliance_checker::TrafficLightComplianceChecker> checker_;
   validator::Params::TrafficLight params_;
 
   std::unordered_map<int64_t, SignalStateHistory> signal_history_;

--- a/planning/autoware_trajectory_validator/include/autoware/trajectory_validator/filters/traffic_rule/traffic_light_filter.hpp
+++ b/planning/autoware_trajectory_validator/include/autoware/trajectory_validator/filters/traffic_rule/traffic_light_filter.hpp
@@ -18,11 +18,11 @@
 #include "autoware/trajectory_validator/validator_interface.hpp"
 
 #include <autoware/traffic_light_compliance_checker/traffic_light_compliance_checker.hpp>
+#include <autoware/traffic_light_compliance_checker/traffic_light_status_tracker.hpp>
 
-#include <autoware_planning_msgs/msg/lanelet_route.hpp>
+#include <rclcpp/time.hpp>
 
-#include <lanelet2_core/Forward.h>
-
+#include <cstdint>
 #include <memory>
 #include <unordered_map>
 #include <vector>
@@ -41,24 +41,13 @@ public:
   void set_vehicle_info(const VehicleInfo & vehicle_info) final;
 
 private:
-  struct SignalStateHistory
-  {
-    autoware_perception_msgs::msg::TrafficLightGroup msg;
-    rclcpp::Time first_seen_time;
-    rclcpp::Time last_seen_time;
-  };
-
   std::unique_ptr<traffic_light_compliance_checker::TrafficLightComplianceChecker> checker_;
+  std::unique_ptr<traffic_light_compliance_checker::TrafficLightStatusTracker> status_tracker_;
   validator::Params::TrafficLight params_;
 
-  std::unordered_map<int64_t, SignalStateHistory> signal_history_;
   std::unordered_map<int64_t, rclcpp::Time> amber_rejection_history_;
 
-  autoware_perception_msgs::msg::TrafficLightGroupArray filter_signals(
-    const autoware_perception_msgs::msg::TrafficLightGroupArray & signals,
-    const rclcpp::Time & current_time, bool is_ego_stopped);
-
-  std::vector<int64_t> get_force_reject_amber_ids(
+  [[nodiscard]] std::vector<int64_t> get_force_reject_amber_ids(
     const rclcpp::Time & current_time, bool is_ego_stopped) const;
 
   void cleanup_history(const rclcpp::Time & current_time);

--- a/planning/autoware_trajectory_validator/package.xml
+++ b/planning/autoware_trajectory_validator/package.xml
@@ -33,6 +33,7 @@
   <depend>autoware_perception_msgs</depend>
   <depend>autoware_planning_factor_interface</depend>
   <depend>autoware_planning_msgs</depend>
+  <depend>autoware_traffic_light_compliance_checker</depend>
   <depend>autoware_traffic_light_utils</depend>
   <depend>autoware_utils_debug</depend>
   <depend>autoware_utils_diagnostics</depend>

--- a/planning/autoware_trajectory_validator/src/filters/traffic_rule/traffic_light_filter.cpp
+++ b/planning/autoware_trajectory_validator/src/filters/traffic_rule/traffic_light_filter.cpp
@@ -14,8 +14,6 @@
 
 #include "autoware/trajectory_validator/filters/traffic_rule/traffic_light_filter.hpp"
 
-#include <algorithm>
-#include <cmath>
 #include <memory>
 #include <string>
 #include <utility>
@@ -69,15 +67,6 @@ autoware::traffic_light_compliance_checker::Parameters to_checker_params(
   p.checked_trajectory_length.jerk_limit = params.checked_trajectory_length.jerk_limit;
   return p;
 }
-
-autoware::traffic_light_compliance_checker::StatusTrackerParameters to_status_tracker_params(
-  const validator::Params::TrafficLight & params)
-{
-  autoware::traffic_light_compliance_checker::StatusTrackerParameters p;
-  p.stable_duration_threshold_red = params.stable_duration_threshold_red;
-  p.stable_duration_threshold_amber = params.stable_duration_threshold_amber;
-  return p;
-}
 }  // namespace
 
 namespace autoware::trajectory_validator::plugin::traffic_rule
@@ -90,15 +79,6 @@ TrafficLightFilter::TrafficLightFilter() : ValidatorInterface("traffic_light_fil
 void TrafficLightFilter::update_parameters(const validator::Params & params)
 {
   params_ = params.traffic_light;
-
-  const auto status_tracker_params = to_status_tracker_params(params_);
-  if (!status_tracker_) {
-    status_tracker_ = std::make_unique<traffic_light_compliance_checker::TrafficLightStatusTracker>(
-      status_tracker_params);
-  } else {
-    status_tracker_->update_parameters(status_tracker_params);
-  }
-
   if (checker_) {
     checker_->update_parameters(to_checker_params(params_));
   }
@@ -122,28 +102,16 @@ TrafficLightFilter::result_t TrafficLightFilter::is_feasible(
     return tl::make_unexpected("Compliance checker is not initialized.");
   }
 
-  if (!status_tracker_) {
-    return tl::make_unexpected("Traffic light status tracker is not initialized.");
-  }
-
   const auto current_time = rclcpp::Time(context.odometry->header.stamp);
-  const auto velocity = context.odometry->twist.twist.linear.x;
-  const bool is_ego_stopped = std::abs(velocity) < params_.ego_stopped_velocity_threshold;
-
-  const auto filtered_signals = status_tracker_->filter_signals(
-    *context.traffic_light_signals, current_time, is_ego_stopped);
-
-  // Amber Hysteresis Tracking
-  const auto force_reject_amber_ids = get_force_reject_amber_ids(current_time, is_ego_stopped);
 
   const traffic_light_compliance_checker::Inputs inputs{
     traj_points,
     context.lanelet_map,
     *context.route,
-    filtered_signals,
+    *context.traffic_light_signals,
+    current_time,
     context.odometry->twist.twist.linear.x,
-    context.acceleration->accel.accel.linear.x,
-    force_reject_amber_ids};
+    context.acceleration->accel.accel.linear.x};
 
   const auto result = checker_->check(inputs);
   if (!result) {
@@ -158,17 +126,8 @@ TrafficLightFilter::result_t TrafficLightFilter::is_feasible(
       is_crossing_red = true;
     } else if (violation.type == traffic_light_compliance_checker::ViolationType::AMBER_LIGHT) {
       is_crossing_amber = true;
-      if (
-        std::find(
-          force_reject_amber_ids.begin(), force_reject_amber_ids.end(),
-          violation.traffic_light_id) == force_reject_amber_ids.end()) {
-        amber_rejection_history_[violation.traffic_light_id] = current_time;
-      }
     }
   }
-
-  // Memory Management
-  cleanup_history(current_time);
 
   std::vector<MetricReport> metrics;
   metrics.push_back(
@@ -190,32 +149,6 @@ TrafficLightFilter::result_t TrafficLightFilter::is_feasible(
   const bool is_feasible = !is_crossing_red && !is_crossing_amber;
 
   return ValidationResult{is_feasible, std::move(metrics)};
-}
-
-std::vector<int64_t> TrafficLightFilter::get_force_reject_amber_ids(
-  const rclcpp::Time & current_time, bool is_ego_stopped) const
-{
-  std::vector<int64_t> force_reject_amber_ids;
-  if (is_ego_stopped) {
-    return force_reject_amber_ids;
-  }
-  for (const auto & [id, rejected_time] : amber_rejection_history_) {
-    if ((current_time - rejected_time).seconds() <= params_.amber_rejection_hysteresis_duration) {
-      force_reject_amber_ids.push_back(id);
-    }
-  }
-  return force_reject_amber_ids;
-}
-
-void TrafficLightFilter::cleanup_history(const rclcpp::Time & current_time)
-{
-  for (auto it = amber_rejection_history_.begin(); it != amber_rejection_history_.end();) {
-    if ((current_time - it->second).seconds() > params_.amber_rejection_hysteresis_duration) {
-      it = amber_rejection_history_.erase(it);
-    } else {
-      ++it;
-    }
-  }
 }
 }  // namespace autoware::trajectory_validator::plugin::traffic_rule
 

--- a/planning/autoware_trajectory_validator/src/filters/traffic_rule/traffic_light_filter.cpp
+++ b/planning/autoware_trajectory_validator/src/filters/traffic_rule/traffic_light_filter.cpp
@@ -53,10 +53,10 @@ std::optional<std::string> is_invalid_input(
   return std::nullopt;
 }
 
-autoware::trajectory_validator::traffic_light_filter::Parameters to_checker_params(
+autoware::traffic_light_compliance_checker::Parameters to_checker_params(
   const validator::Params::TrafficLight & params)
 {
-  autoware::trajectory_validator::traffic_light_filter::Parameters p;
+  autoware::traffic_light_compliance_checker::Parameters p;
   p.deceleration_limit = params.deceleration_limit;
   p.jerk_limit = params.jerk_limit;
   p.delay_response_time = params.delay_response_time;
@@ -116,7 +116,7 @@ void TrafficLightFilter::update_parameters(const validator::Params & params)
 void TrafficLightFilter::set_vehicle_info(const VehicleInfo & vehicle_info)
 {
   ValidatorInterface::set_vehicle_info(vehicle_info);
-  checker_ = std::make_unique<traffic_light_filter::TrafficLightComplianceChecker>(
+  checker_ = std::make_unique<traffic_light_compliance_checker::TrafficLightComplianceChecker>(
     to_checker_params(params_), vehicle_info);
 }
 
@@ -142,7 +142,7 @@ TrafficLightFilter::result_t TrafficLightFilter::is_feasible(
   // Amber Hysteresis Tracking
   const auto force_reject_amber_ids = get_force_reject_amber_ids(current_time, is_ego_stopped);
 
-  const traffic_light_filter::Inputs inputs{
+  const traffic_light_compliance_checker::Inputs inputs{
     traj_points,
     context.lanelet_map,
     *context.route,
@@ -160,9 +160,9 @@ TrafficLightFilter::result_t TrafficLightFilter::is_feasible(
   bool is_crossing_amber = false;
 
   for (const auto & violation : result->violations) {
-    if (violation.type == traffic_light_filter::ViolationType::RED_LIGHT) {
+    if (violation.type == traffic_light_compliance_checker::ViolationType::RED_LIGHT) {
       is_crossing_red = true;
-    } else if (violation.type == traffic_light_filter::ViolationType::AMBER_LIGHT) {
+    } else if (violation.type == traffic_light_compliance_checker::ViolationType::AMBER_LIGHT) {
       is_crossing_amber = true;
       if (
         std::find(

--- a/planning/autoware_trajectory_validator/src/filters/traffic_rule/traffic_light_filter.cpp
+++ b/planning/autoware_trajectory_validator/src/filters/traffic_rule/traffic_light_filter.cpp
@@ -14,9 +14,6 @@
 
 #include "autoware/trajectory_validator/filters/traffic_rule/traffic_light_filter.hpp"
 
-#include <autoware/traffic_light_utils/traffic_light_utils.hpp>
-#include <rclcpp/logging.hpp>
-
 #include <algorithm>
 #include <cmath>
 #include <memory>
@@ -73,28 +70,13 @@ autoware::traffic_light_compliance_checker::Parameters to_checker_params(
   return p;
 }
 
-bool is_equal(
-  const autoware_perception_msgs::msg::TrafficLightElement & a,
-  const autoware_perception_msgs::msg::TrafficLightElement & b)
+autoware::traffic_light_compliance_checker::StatusTrackerParameters to_status_tracker_params(
+  const validator::Params::TrafficLight & params)
 {
-  return a.color == b.color && a.shape == b.shape && a.status == b.status;
-}
-
-bool is_equal(
-  const std::vector<autoware_perception_msgs::msg::TrafficLightElement> & a,
-  const std::vector<autoware_perception_msgs::msg::TrafficLightElement> & b)
-{
-  if (a.size() != b.size()) {
-    return false;
-  }
-
-  for (size_t i = 0; i < a.size(); ++i) {
-    if (!is_equal(a[i], b[i])) {
-      return false;
-    }
-  }
-
-  return true;
+  autoware::traffic_light_compliance_checker::StatusTrackerParameters p;
+  p.stable_duration_threshold_red = params.stable_duration_threshold_red;
+  p.stable_duration_threshold_amber = params.stable_duration_threshold_amber;
+  return p;
 }
 }  // namespace
 
@@ -108,6 +90,15 @@ TrafficLightFilter::TrafficLightFilter() : ValidatorInterface("traffic_light_fil
 void TrafficLightFilter::update_parameters(const validator::Params & params)
 {
   params_ = params.traffic_light;
+
+  const auto status_tracker_params = to_status_tracker_params(params_);
+  if (!status_tracker_) {
+    status_tracker_ = std::make_unique<traffic_light_compliance_checker::TrafficLightStatusTracker>(
+      status_tracker_params);
+  } else {
+    status_tracker_->update_parameters(status_tracker_params);
+  }
+
   if (checker_) {
     checker_->update_parameters(to_checker_params(params_));
   }
@@ -131,13 +122,16 @@ TrafficLightFilter::result_t TrafficLightFilter::is_feasible(
     return tl::make_unexpected("Compliance checker is not initialized.");
   }
 
+  if (!status_tracker_) {
+    return tl::make_unexpected("Traffic light status tracker is not initialized.");
+  }
+
   const auto current_time = rclcpp::Time(context.odometry->header.stamp);
   const auto velocity = context.odometry->twist.twist.linear.x;
   const bool is_ego_stopped = std::abs(velocity) < params_.ego_stopped_velocity_threshold;
 
-  // Signal Stability Filter
-  const auto filtered_signals =
-    filter_signals(*context.traffic_light_signals, current_time, is_ego_stopped);
+  const auto filtered_signals = status_tracker_->filter_signals(
+    *context.traffic_light_signals, current_time, is_ego_stopped);
 
   // Amber Hysteresis Tracking
   const auto force_reject_amber_ids = get_force_reject_amber_ids(current_time, is_ego_stopped);
@@ -198,49 +192,6 @@ TrafficLightFilter::result_t TrafficLightFilter::is_feasible(
   return ValidationResult{is_feasible, std::move(metrics)};
 }
 
-autoware_perception_msgs::msg::TrafficLightGroupArray TrafficLightFilter::filter_signals(
-  const autoware_perception_msgs::msg::TrafficLightGroupArray & signals,
-  const rclcpp::Time & current_time, bool is_ego_stopped)
-{
-  autoware_perception_msgs::msg::TrafficLightGroupArray filtered_signals;
-  filtered_signals.stamp = signals.stamp;
-
-  for (const auto & signal : signals.traffic_light_groups) {
-    const auto id = signal.traffic_light_group_id;
-    if (signal_history_.find(id) == signal_history_.end()) {
-      signal_history_[id] = {signal, current_time, current_time};
-    } else {
-      if (!is_equal(signal_history_[id].msg.elements, signal.elements)) {
-        signal_history_[id].first_seen_time = current_time;
-        signal_history_[id].msg = signal;
-      }
-      signal_history_[id].last_seen_time = current_time;
-    }
-
-    auto filtered_signal = signal;
-    if (is_ego_stopped) {
-      filtered_signals.traffic_light_groups.push_back(filtered_signal);
-      continue;
-    }
-    const auto state_duration = (current_time - signal_history_[id].first_seen_time).seconds();
-    const bool is_red = autoware::traffic_light_utils::hasTrafficLightShapeAndColor(
-      signal.elements, autoware_perception_msgs::msg::TrafficLightElement::CIRCLE,
-      autoware_perception_msgs::msg::TrafficLightElement::RED);
-    const bool is_amber = autoware::traffic_light_utils::hasTrafficLightShapeAndColor(
-      signal.elements, autoware_perception_msgs::msg::TrafficLightElement::CIRCLE,
-      autoware_perception_msgs::msg::TrafficLightElement::AMBER);
-
-    if (is_red && state_duration < params_.stable_duration_threshold_red) {
-      filtered_signal.elements.clear();
-    } else if (is_amber && state_duration < params_.stable_duration_threshold_amber) {
-      filtered_signal.elements.clear();
-    }
-    filtered_signals.traffic_light_groups.push_back(filtered_signal);
-  }
-
-  return filtered_signals;
-}
-
 std::vector<int64_t> TrafficLightFilter::get_force_reject_amber_ids(
   const rclcpp::Time & current_time, bool is_ego_stopped) const
 {
@@ -261,19 +212,6 @@ void TrafficLightFilter::cleanup_history(const rclcpp::Time & current_time)
   for (auto it = amber_rejection_history_.begin(); it != amber_rejection_history_.end();) {
     if ((current_time - it->second).seconds() > params_.amber_rejection_hysteresis_duration) {
       it = amber_rejection_history_.erase(it);
-    } else {
-      ++it;
-    }
-  }
-
-  for (auto it = signal_history_.begin(); it != signal_history_.end();) {
-    const auto stable_duration =
-      autoware::traffic_light_utils::hasTrafficLightColor(
-        it->second.msg.elements, autoware_perception_msgs::msg::TrafficLightElement::RED)
-        ? params_.stable_duration_threshold_red
-        : params_.stable_duration_threshold_amber;
-    if ((current_time - it->second.last_seen_time).seconds() > stable_duration) {
-      it = signal_history_.erase(it);
     } else {
       ++it;
     }


### PR DESCRIPTION
Following refactoring is applied:
- move tl compliance check code from `trajecroy_validator` filters to a separate package `autoware_traffic_light_compliance_checker`
- update `trajectory_validator` dependencies and remove obsolete filter files
- add new class `TrafficLightStatusTracker` to compliance checker library
- move signal history logic from `traffic_light_filter` to `TrafficLightStatusTracker`
- move amber_rejection_history logic to compliance checker library