### PR TITLE
feat(trajectory_modifier): implement traffic light stop plugin in modifier

### DIFF
--- a/common/autoware_traffic_light_compliance_checker/include/autoware/traffic_light_compliance_checker/structs.hpp
+++ b/common/autoware_traffic_light_compliance_checker/include/autoware/traffic_light_compliance_checker/structs.hpp
@@ -58,6 +58,19 @@ struct Violation
   ViolationType type;
   lanelet::BasicLineString2d stop_line;
   int64_t traffic_light_id;
+  lanelet::BasicPoint2d cross_point;
+  double arc_length_to_cross_point;
+
+  Violation(
+    ViolationType type, lanelet::BasicLineString2d stop_line, int64_t traffic_light_id,
+    lanelet::BasicPoint2d cross_point, double arc_length_to_cross_point)
+  : type(type),
+    stop_line(stop_line),
+    traffic_light_id(traffic_light_id),
+    cross_point(cross_point),
+    arc_length_to_cross_point(arc_length_to_cross_point)
+  {
+  }
 };
 
 /// @brief result of compliance check

--- a/common/autoware_traffic_light_compliance_checker/include/autoware/traffic_light_compliance_checker/structs.hpp
+++ b/common/autoware_traffic_light_compliance_checker/include/autoware/traffic_light_compliance_checker/structs.hpp
@@ -71,6 +71,11 @@ struct Violation
     arc_length_to_cross_point(arc_length_to_cross_point)
   {
   }
+
+  bool operator<(const Violation & other) const
+  {
+    return arc_length_to_cross_point < other.arc_length_to_cross_point;
+  }
 };
 
 /// @brief result of compliance check

--- a/common/autoware_traffic_light_compliance_checker/include/autoware/traffic_light_compliance_checker/traffic_light_compliance_checker.hpp
+++ b/common/autoware_traffic_light_compliance_checker/include/autoware/traffic_light_compliance_checker/traffic_light_compliance_checker.hpp
@@ -57,7 +57,8 @@ public:
    * @param input input data for compliance check (raw signals are filtered internally)
    * @return result of compliance check, or error message if check fails
    */
-  [[nodiscard]] tl::expected<ComplianceResult, std::string> check(const Inputs & input);
+  [[nodiscard]] tl::expected<ComplianceResult, std::string> check(
+    const Inputs & input, const bool check_red_lights = true, const bool check_amber_lights = true);
 
   /**
    * @brief update parameters
@@ -78,7 +79,8 @@ private:
   [[nodiscard]] tl::expected<ComplianceResult, std::string> check_with_filtered_signals(
     const Inputs & input,
     const autoware_perception_msgs::msg::TrafficLightGroupArray & filtered_signals,
-    const std::vector<int64_t> & force_reject_amber_ids) const;
+    const std::vector<int64_t> & force_reject_amber_ids, const bool check_red_lights,
+    const bool check_amber_lights) const;
 
   std::vector<Violation> get_red_light_violations(
     const std::vector<StopLineInfo> & red_stop_lines,

--- a/common/autoware_traffic_light_compliance_checker/include/autoware/traffic_light_compliance_checker/traffic_light_compliance_checker.hpp
+++ b/common/autoware_traffic_light_compliance_checker/include/autoware/traffic_light_compliance_checker/traffic_light_compliance_checker.hpp
@@ -80,6 +80,18 @@ private:
     const autoware_perception_msgs::msg::TrafficLightGroupArray & filtered_signals,
     const std::vector<int64_t> & force_reject_amber_ids) const;
 
+  std::vector<Violation> get_red_light_violations(
+    const std::vector<StopLineInfo> & red_stop_lines,
+    const lanelet::BasicLineString2d & trajectory_ls,
+    const std::optional<lanelet::BasicPoint2d> & stop_point,
+    const double distance_offset = 0.0) const;
+  std::vector<Violation> get_amber_light_violations(
+    const std::vector<StopLineInfo> & amber_stop_lines,
+    const std::vector<autoware_planning_msgs::msg::TrajectoryPoint> & trajectory,
+    const lanelet::BasicLineString2d & trajectory_ls,
+    const std::optional<lanelet::BasicPoint2d> & stop_point,
+    const std::vector<int64_t> & force_reject_amber_ids, const double distance_offset = 0.0) const;
+
   /// @brief return the red and amber stop lines related to the given traffic light groups
   [[nodiscard]] std::pair<std::vector<StopLineInfo>, std::vector<StopLineInfo>> get_stop_lines(
     const lanelet::LaneletMap & lanelet_map,

--- a/common/autoware_traffic_light_compliance_checker/src/traffic_light_compliance_checker.cpp
+++ b/common/autoware_traffic_light_compliance_checker/src/traffic_light_compliance_checker.cpp
@@ -274,7 +274,7 @@ TrafficLightComplianceChecker::check_with_filtered_signals(
   const std::vector<int64_t> & force_reject_amber_ids, const bool check_red_lights,
   const bool check_amber_lights) const
 {
-  if (!check_red_lights && !check_amber_lights) {
+  if (input.trajectory.empty() || (!check_red_lights && !check_amber_lights)) {
     return ComplianceResult{};
   }
 

--- a/common/autoware_traffic_light_compliance_checker/src/traffic_light_compliance_checker.cpp
+++ b/common/autoware_traffic_light_compliance_checker/src/traffic_light_compliance_checker.cpp
@@ -115,7 +115,7 @@ void TrafficLightComplianceChecker::update_parameters(const Parameters & paramet
 }
 
 tl::expected<ComplianceResult, std::string> TrafficLightComplianceChecker::check(
-  const Inputs & input)
+  const Inputs & input, const bool check_red_lights, const bool check_amber_lights)
 {
   const bool is_ego_stopped =
     std::abs(input.current_velocity) < params_.ego_stopped_velocity_threshold;
@@ -125,7 +125,8 @@ tl::expected<ComplianceResult, std::string> TrafficLightComplianceChecker::check
   const auto force_reject_amber_ids =
     get_force_reject_amber_ids(input.current_time, is_ego_stopped);
 
-  auto result = check_with_filtered_signals(input, filtered_signals, force_reject_amber_ids);
+  auto result = check_with_filtered_signals(
+    input, filtered_signals, force_reject_amber_ids, check_red_lights, check_amber_lights);
   if (!result) {
     return result;
   }
@@ -270,8 +271,13 @@ tl::expected<ComplianceResult, std::string>
 TrafficLightComplianceChecker::check_with_filtered_signals(
   const Inputs & input,
   const autoware_perception_msgs::msg::TrafficLightGroupArray & filtered_signals,
-  const std::vector<int64_t> & force_reject_amber_ids) const
+  const std::vector<int64_t> & force_reject_amber_ids, const bool check_red_lights,
+  const bool check_amber_lights) const
 {
+  if (!check_red_lights && !check_amber_lights) {
+    return ComplianceResult{};
+  }
+
   std::vector<autoware_planning_msgs::msg::TrajectoryPoint> trajectory;
   lanelet::BasicLineString2d trajectory_ls;
   const auto ego_stopping_distance = autoware::motion_utils::calculate_stop_distance(
@@ -325,16 +331,20 @@ TrafficLightComplianceChecker::check_with_filtered_signals(
     get_stop_lines(*input.map, input.route, filtered_signals);
 
   ComplianceResult result;
-  result.violations =
-    get_red_light_violations(red_stop_lines, trajectory_ls, stop_point, backward_length);
-  const auto amber_light_violations =
-    params_.treat_amber_light_as_red_light
-      ? get_red_light_violations(amber_stop_lines, trajectory_ls, stop_point, backward_length)
-      : get_amber_light_violations(
-          amber_stop_lines, trajectory, trajectory_ls, stop_point, force_reject_amber_ids,
-          backward_length);
-  result.violations.insert(
-    result.violations.end(), amber_light_violations.begin(), amber_light_violations.end());
+  if (check_red_lights) {
+    result.violations =
+      get_red_light_violations(red_stop_lines, trajectory_ls, stop_point, backward_length);
+  }
+  if (check_amber_lights) {
+    const auto amber_light_violations =
+      params_.treat_amber_light_as_red_light
+        ? get_red_light_violations(amber_stop_lines, trajectory_ls, stop_point, backward_length)
+        : get_amber_light_violations(
+            amber_stop_lines, trajectory, trajectory_ls, stop_point, force_reject_amber_ids,
+            backward_length);
+    result.violations.insert(
+      result.violations.end(), amber_light_violations.begin(), amber_light_violations.end());
+  }
 
   return result;
 }

--- a/common/autoware_traffic_light_compliance_checker/src/traffic_light_compliance_checker.cpp
+++ b/common/autoware_traffic_light_compliance_checker/src/traffic_light_compliance_checker.cpp
@@ -327,9 +327,12 @@ TrafficLightComplianceChecker::check_with_filtered_signals(
   ComplianceResult result;
   result.violations =
     get_red_light_violations(red_stop_lines, trajectory_ls, stop_point, backward_length);
-  const auto amber_light_violations = get_amber_light_violations(
-    amber_stop_lines, trajectory, trajectory_ls, stop_point, force_reject_amber_ids,
-    backward_length);
+  const auto amber_light_violations =
+    params_.treat_amber_light_as_red_light
+      ? get_red_light_violations(amber_stop_lines, trajectory_ls, stop_point, backward_length)
+      : get_amber_light_violations(
+          amber_stop_lines, trajectory, trajectory_ls, stop_point, force_reject_amber_ids,
+          backward_length);
   result.violations.insert(
     result.violations.end(), amber_light_violations.begin(), amber_light_violations.end());
 

--- a/common/autoware_traffic_light_compliance_checker/src/traffic_light_compliance_checker.cpp
+++ b/common/autoware_traffic_light_compliance_checker/src/traffic_light_compliance_checker.cpp
@@ -17,6 +17,7 @@
 #include <autoware/interpolation/linear_interpolation.hpp>
 #include <autoware/motion_utils/distance/distance.hpp>
 #include <autoware/traffic_light_utils/traffic_light_utils.hpp>
+#include <autoware_utils_geometry/geometry.hpp>
 #include <rclcpp/duration.hpp>
 
 #include <boost/geometry.hpp>
@@ -179,6 +180,92 @@ void TrafficLightComplianceChecker::cleanup_amber_rejection_history(
   }
 }
 
+std::vector<Violation> TrafficLightComplianceChecker::get_red_light_violations(
+  const std::vector<StopLineInfo> & red_stop_lines,
+  const lanelet::BasicLineString2d & trajectory_ls,
+  const std::optional<lanelet::BasicPoint2d> & stop_point, const double distance_offset) const
+{
+  std::vector<Violation> violations;
+  for (const auto & red_stop_line : red_stop_lines) {
+    auto distance_to_stop_line = 0.0;
+    lanelet::BasicPoints2d intersection_points;
+    for (size_t i = 0; i + 1 < trajectory_ls.size(); ++i) {
+      const lanelet::BasicLineString2d segment{trajectory_ls[i], trajectory_ls[i + 1]};
+      boost::geometry::intersection(segment, red_stop_line.line, intersection_points);
+      if (!intersection_points.empty()) {
+        distance_to_stop_line += static_cast<double>(
+          boost::geometry::distance(segment.front(), intersection_points.front()));
+        break;
+      }
+      distance_to_stop_line += static_cast<double>(boost::geometry::length(segment));
+    }
+    if (
+      intersection_points.empty() ||
+      is_stop_point_within_margin_from_stop_line(stop_point, red_stop_line.line))
+      continue;
+    violations.emplace_back(
+      ViolationType::RED_LIGHT, red_stop_line.line, red_stop_line.traffic_light_id,
+      intersection_points.front(), distance_to_stop_line + distance_offset);
+  }
+  return violations;
+}
+
+std::vector<Violation> TrafficLightComplianceChecker::get_amber_light_violations(
+  const std::vector<StopLineInfo> & amber_stop_lines,
+  const std::vector<autoware_planning_msgs::msg::TrajectoryPoint> & trajectory,
+  const lanelet::BasicLineString2d & trajectory_ls,
+  const std::optional<lanelet::BasicPoint2d> & stop_point,
+  const std::vector<int64_t> & force_reject_amber_ids, const double distance_offset) const
+{
+  std::vector<Violation> violations;
+  for (const auto & amber_stop_line : amber_stop_lines) {
+    auto distance_to_stop_line = 0.0;
+    std::optional<double> amber_stop_line_crossing_time;
+    lanelet::BasicPoint2d intersection_point;
+    for (size_t i = 0; i + 1 < trajectory.size(); ++i) {
+      lanelet::BasicPoints2d intersection_points;
+      const lanelet::BasicLineString2d segment{trajectory_ls[i], trajectory_ls[i + 1]};
+      const auto segment_length = static_cast<double>(boost::geometry::length(segment));
+      boost::geometry::intersection(segment, amber_stop_line.line, intersection_points);
+      if (intersection_points.empty()) {
+        distance_to_stop_line += segment_length;
+        continue;
+      }
+      const auto distance_to_intersection =
+        boost::geometry::distance(segment.front(), intersection_points.front());
+      distance_to_stop_line += distance_to_intersection;
+      const auto ratio = distance_to_intersection / segment_length;
+      amber_stop_line_crossing_time = autoware::interpolation::lerp(
+        rclcpp::Duration(trajectory[i].time_from_start).seconds(),
+        rclcpp::Duration(trajectory[i + 1].time_from_start).seconds(), ratio);
+      intersection_point = intersection_points.front();
+      break;
+    }
+
+    if (
+      !amber_stop_line_crossing_time ||
+      is_stop_point_within_margin_from_stop_line(stop_point, amber_stop_line.line))
+      continue;
+
+    const auto current_velocity = trajectory.front().longitudinal_velocity_mps;
+    const auto current_acceleration = trajectory.front().acceleration_mps2;
+
+    bool is_force_reject = std::find(
+                             force_reject_amber_ids.begin(), force_reject_amber_ids.end(),
+                             amber_stop_line.traffic_light_id) != force_reject_amber_ids.end();
+
+    if (
+      is_force_reject || !can_pass_amber_light(
+                           distance_to_stop_line, current_velocity, current_acceleration,
+                           *amber_stop_line_crossing_time)) {
+      violations.emplace_back(
+        ViolationType::AMBER_LIGHT, amber_stop_line.line, amber_stop_line.traffic_light_id,
+        intersection_point, distance_to_stop_line + distance_offset);
+    }
+  }
+  return violations;
+}
+
 tl::expected<ComplianceResult, std::string>
 TrafficLightComplianceChecker::check_with_filtered_signals(
   const Inputs & input,
@@ -187,31 +274,37 @@ TrafficLightComplianceChecker::check_with_filtered_signals(
 {
   std::vector<autoware_planning_msgs::msg::TrajectoryPoint> trajectory;
   lanelet::BasicLineString2d trajectory_ls;
-  const auto distance_for_ego_to_stop = autoware::motion_utils::calculate_stop_distance(
+  const auto ego_stopping_distance = autoware::motion_utils::calculate_stop_distance(
     input.current_velocity, input.current_acceleration,
     params_.checked_trajectory_length.deceleration_limit,
     params_.checked_trajectory_length.jerk_limit, params_.delay_response_time);
-  const auto max_trajectory_length = distance_for_ego_to_stop.value_or(0.0);
+  const auto max_trajectory_length = ego_stopping_distance.value_or(0.0);
   auto length = 0.0;
-  bool is_stopping_trajectory = false;
+  auto backward_length = 0.0;
+  std::optional<lanelet::BasicPoint2d> stop_point;
+  auto last_p = input.trajectory.front();
   for (const auto & p : input.trajectory) {
     // skip points behind ego
     if (rclcpp::Duration(p.time_from_start).seconds() < 0.0) {
+      backward_length += autoware_utils_geometry::calc_distance2d(last_p.pose, p.pose);
+      last_p = p;
       continue;
     }
+
     const lanelet::BasicPoint2d lanelet_p(p.pose.position.x, p.pose.position.y);
-    if (!trajectory_ls.empty()) {
+    if (!trajectory_ls.empty())
       length += lanelet::geometry::distance2d(trajectory_ls.back(), lanelet_p);
-    }
 
     trajectory.push_back(p);
     trajectory_ls.emplace_back(lanelet_p);
 
     // skip points beyond the first stop, or skip once we reach the maximum length
-    is_stopping_trajectory = p.longitudinal_velocity_mps <= 0.0;
-    if (is_stopping_trajectory || length > max_trajectory_length) {
+    if (p.longitudinal_velocity_mps <= 1e-6) {
+      stop_point = trajectory_ls.back();
       break;
     }
+
+    if (length > max_trajectory_length) break;
   }
 
   if (trajectory_ls.size() < 2) {
@@ -221,83 +314,24 @@ TrafficLightComplianceChecker::check_with_filtered_signals(
 
   if (vehicle_info_.max_longitudinal_offset_m > 0.0) {
     // extend the trajectory linestring by the vehicle's longitudinal offset
-    const lanelet::BasicSegment2d last_segment(
-      trajectory_ls[trajectory_ls.size() - 2], trajectory_ls.back());
-    const auto last_vector = last_segment.second - last_segment.first;
-    const auto last_length = boost::geometry::length(last_segment);
-    if (last_length > 0.0) {
-      const auto ratio = (last_length + vehicle_info_.max_longitudinal_offset_m) / last_length;
-      lanelet::BasicPoint2d front_vehicle_point = last_segment.first + last_vector * ratio;
-      trajectory_ls.emplace_back(front_vehicle_point);
-    }
-  }
-  std::optional<lanelet::BasicPoint2d> stop_point;
-  if (is_stopping_trajectory) {
-    stop_point = trajectory_ls.back();
+    const auto offset_pose = autoware_utils_geometry::calc_offset_pose(
+      trajectory.back().pose, vehicle_info_.max_longitudinal_offset_m, 0.0, 0.0);
+    const lanelet::BasicPoint2d offset_point(offset_pose.position.x, offset_pose.position.y);
+    trajectory_ls.emplace_back(offset_point);
+    if (stop_point.has_value()) stop_point.value() = offset_point;
   }
 
   const auto [red_stop_lines, amber_stop_lines] =
     get_stop_lines(*input.map, input.route, filtered_signals);
 
   ComplianceResult result;
-
-  // Check for red light crossings
-  for (const auto & red_stop_line : red_stop_lines) {
-    if (boost::geometry::intersects(trajectory_ls, red_stop_line.line)) {
-      if (is_stop_point_within_margin_from_stop_line(stop_point, red_stop_line.line)) {
-        continue;
-      }
-      result.violations.push_back(
-        {ViolationType::RED_LIGHT, red_stop_line.line, red_stop_line.traffic_light_id});
-    }
-  }
-
-  // Check for amber light crossings
-  for (const auto & amber_stop_line : amber_stop_lines) {
-    auto distance_to_stop_line = 0.0;
-    std::optional<double> amber_stop_line_crossing_time;
-    for (size_t i = 0; i + 1 < trajectory.size(); ++i) {
-      lanelet::BasicPoints2d intersection_points;
-      const lanelet::BasicLineString2d segment{trajectory_ls[i], trajectory_ls[i + 1]};
-      const auto segment_length = static_cast<double>(boost::geometry::length(segment));
-      boost::geometry::intersection(segment, amber_stop_line.line, intersection_points);
-      if (!intersection_points.empty()) {
-        const auto distance_to_intersection =
-          boost::geometry::distance(segment.front(), intersection_points.front());
-        distance_to_stop_line += distance_to_intersection;
-        const auto ratio = distance_to_intersection / segment_length;
-        amber_stop_line_crossing_time = autoware::interpolation::lerp(
-          rclcpp::Duration(trajectory[i].time_from_start).seconds(),
-          rclcpp::Duration(trajectory[i + 1].time_from_start).seconds(), ratio);
-        break;
-      }
-      distance_to_stop_line += segment_length;
-    }
-
-    const auto current_velocity = trajectory.front().longitudinal_velocity_mps;
-    const auto current_acceleration = trajectory.front().acceleration_mps2;
-    if (amber_stop_line_crossing_time) {
-      if (is_stop_point_within_margin_from_stop_line(stop_point, amber_stop_line.line)) {
-        continue;
-      }
-
-      bool is_force_reject = false;
-      if (
-        std::find(
-          force_reject_amber_ids.begin(), force_reject_amber_ids.end(),
-          amber_stop_line.traffic_light_id) != force_reject_amber_ids.end()) {
-        is_force_reject = true;
-      }
-
-      if (
-        is_force_reject || !can_pass_amber_light(
-                             distance_to_stop_line, current_velocity, current_acceleration,
-                             *amber_stop_line_crossing_time)) {
-        result.violations.push_back(
-          {ViolationType::AMBER_LIGHT, amber_stop_line.line, amber_stop_line.traffic_light_id});
-      }
-    }
-  }
+  result.violations =
+    get_red_light_violations(red_stop_lines, trajectory_ls, stop_point, backward_length);
+  const auto amber_light_violations = get_amber_light_violations(
+    amber_stop_lines, trajectory, trajectory_ls, stop_point, force_reject_amber_ids,
+    backward_length);
+  result.violations.insert(
+    result.violations.end(), amber_light_violations.begin(), amber_light_violations.end());
 
   return result;
 }

--- a/planning/autoware_trajectory_modifier/CMakeLists.txt
+++ b/planning/autoware_trajectory_modifier/CMakeLists.txt
@@ -36,6 +36,7 @@ ament_auto_add_library(${PROJECT_NAME}_plugins SHARED
   src/trajectory_modifier_plugins/stop_point_fixer.cpp
   src/trajectory_modifier_plugins/obstacle_stop.cpp
   src/trajectory_modifier_plugins/velocity_modifier.cpp
+  src/trajectory_modifier_plugins/traffic_light_stop.cpp
 )
 
 target_link_libraries(${PROJECT_NAME}_plugins

--- a/planning/autoware_trajectory_modifier/config/trajectory_modifier.param.yaml
+++ b/planning/autoware_trajectory_modifier/config/trajectory_modifier.param.yaml
@@ -3,9 +3,11 @@
     plugin_names:
       - "autoware::trajectory_modifier::plugin::StopPointFixer"
       - "autoware::trajectory_modifier::plugin::ObstacleStop"
+      - "autoware::trajectory_modifier::plugin::TrafficLightStop"
       - "autoware::trajectory_modifier::plugin::VelocityModifier"
     use_stop_point_fixer: true
     use_obstacle_stop: true
+    use_traffic_light_stop: true
     use_velocity_modifier: true
     trajectory_time_step: 0.1 # [s]
 
@@ -76,3 +78,15 @@
         reaction_time: 0.2 # [s]
         safety_margin: 2.0 # [m]
         lookahead_horizon: 1.5 # [s]
+
+    # Traffic Light Stop Plugin Parameters
+    traffic_light_stop:
+      stop_margin: 1.0 # [m]
+      stop_for_red_light: true
+      stop_for_amber_light: false
+      treat_amber_light_as_red: false
+      overshoot_tolerance: 0.5 # [m]
+      th_stable_duration_red: 1.0 # [s]
+      th_stable_duration_amber: 1.0 # [s]
+      th_amber_rejection_hysteresis: 1.0 # [s]
+      crossing_time_limit: 2.75 # [s]

--- a/planning/autoware_trajectory_modifier/config/trajectory_modifier.param.yaml
+++ b/planning/autoware_trajectory_modifier/config/trajectory_modifier.param.yaml
@@ -83,9 +83,9 @@
     traffic_light_stop:
       stop_margin: 1.0 # [m]
       stop_for_red_light: true
-      stop_for_amber_light: false
+      stop_for_amber_light: true
       treat_amber_light_as_red: false
-      overshoot_tolerance: 0.5 # [m]
+      overshoot_tolerance: 0.0 # [m]
       th_stable_duration_red: 1.0 # [s]
       th_stable_duration_amber: 1.0 # [s]
       th_amber_rejection_hysteresis: 1.0 # [s]

--- a/planning/autoware_trajectory_modifier/config/trajectory_modifier.param.yaml
+++ b/planning/autoware_trajectory_modifier/config/trajectory_modifier.param.yaml
@@ -81,12 +81,12 @@
 
     # Traffic Light Stop Plugin Parameters
     traffic_light_stop:
-      stop_margin: 1.0 # [m]
+      stop_margin: 0.75 # [m]
       stop_for_red_light: true
       stop_for_amber_light: true
       treat_amber_light_as_red: false
       overshoot_tolerance: 0.0 # [m]
-      th_stable_duration_red: 1.0 # [s]
-      th_stable_duration_amber: 1.0 # [s]
-      th_amber_rejection_hysteresis: 1.0 # [s]
+      th_stable_duration_red: 0.2 # [s]
+      th_stable_duration_amber: 0.2 # [s]
+      th_amber_rejection_hysteresis: 0.5 # [s]
       crossing_time_limit: 2.75 # [s]

--- a/planning/autoware_trajectory_modifier/config/trajectory_modifier.param.yaml
+++ b/planning/autoware_trajectory_modifier/config/trajectory_modifier.param.yaml
@@ -23,6 +23,7 @@
       nominal_deceleration: 1.0 # [m/s^2]
       maximum_deceleration: 4.0 # [m/s^2]
       jerk_limit: 3.0 # [m/s^3]
+      arrived_distance_threshold: 0.5 # threshold to check if the ego vehicle has arrived at the stop point [m]
 
     # Obstacle Stop Plugin Parameters
     obstacle_stop:
@@ -33,7 +34,6 @@
       stop_margin: 6.0 # [m]
       lateral_margin: 0.0     # lateral margin on top of ego width from trajectory to consider for obstacle stop [m]
       duplicate_check_threshold: 0.5 # threshold to check if the stop point is already in the trajectory [m]
-      arrived_distance_threshold: 0.5 # threshold to check if the ego vehicle has arrived at the stop point [m]
 
       obstacle_tracking:
         on_time_buffer: 0.5

--- a/planning/autoware_trajectory_modifier/include/autoware/trajectory_modifier/trajectory_modifier.hpp
+++ b/planning/autoware_trajectory_modifier/include/autoware/trajectory_modifier/trajectory_modifier.hpp
@@ -29,7 +29,10 @@
 
 #include <autoware_internal_planning_msgs/msg/candidate_trajectories.hpp>
 #include <autoware_perception_msgs/msg/predicted_objects.hpp>
+#include <autoware_perception_msgs/msg/traffic_light_group_array.hpp>
 #include <autoware_planning_msgs/msg/trajectory.hpp>
+#include <autoware_planning_msgs/msg/lanelet_route.hpp>
+#include <autoware_map_msgs/msg/lanelet_map_bin.hpp>
 #include <geometry_msgs/msg/accel_with_covariance_stamped.hpp>
 #include <nav_msgs/msg/odometry.hpp>
 #include <sensor_msgs/msg/point_cloud2.hpp>
@@ -58,9 +61,10 @@ public:
 
 private:
   void on_traj(const CandidateTrajectories::ConstSharedPtr msg);
+  void on_map(const autoware_map_msgs::msg::LaneletMapBin::ConstSharedPtr msg);
   void load_plugin(const std::string & name);
   void unload_plugin(const std::string & name);
-  plugin::InputData make_input_data();
+  tl::expected<plugin::InputData, std::string> make_input_data();
   bool initialized_modifiers_{false};
 
   std::unique_ptr<trajectory_modifier_params::ParamListener> param_listener_;
@@ -79,6 +83,14 @@ private:
     this, "~/input/objects"};
   autoware_utils_rclcpp::InterProcessPollingSubscriber<PointCloud2> sub_pointcloud_{
     this, "~/input/pointcloud", autoware_utils_rclcpp::single_depth_sensor_qos()};
+  
+  autoware_utils_rclcpp::InterProcessPollingSubscriber<
+    autoware_perception_msgs::msg::TrafficLightGroupArray>
+    sub_traffic_lights_{this, "~/input/traffic_signals"};
+  rclcpp::Subscription<autoware_map_msgs::msg::LaneletMapBin>::SharedPtr sub_map_;
+  autoware_utils_rclcpp::InterProcessPollingSubscriber<
+    autoware_planning_msgs::msg::LaneletRoute, autoware_utils_rclcpp::polling_policy::Latest>
+    sub_route_{this, "~/input/route", rclcpp::QoS{1}.transient_local()};
 
   rclcpp::Publisher<autoware_utils_debug::ProcessingTimeDetail>::SharedPtr
     debug_processing_time_detail_pub_;
@@ -89,6 +101,7 @@ private:
   std::vector<std::shared_ptr<plugin::TrajectoryModifierPluginBase>> plugins_;
 
   std::shared_ptr<TrajectoryModifierContext> context_;
+  std::shared_ptr<lanelet::LaneletMap> lanelet_map_ptr_;
 };
 
 }  // namespace autoware::trajectory_modifier

--- a/planning/autoware_trajectory_modifier/include/autoware/trajectory_modifier/trajectory_modifier.hpp
+++ b/planning/autoware_trajectory_modifier/include/autoware/trajectory_modifier/trajectory_modifier.hpp
@@ -28,11 +28,11 @@
 #include <rclcpp/subscription.hpp>
 
 #include <autoware_internal_planning_msgs/msg/candidate_trajectories.hpp>
+#include <autoware_map_msgs/msg/lanelet_map_bin.hpp>
 #include <autoware_perception_msgs/msg/predicted_objects.hpp>
 #include <autoware_perception_msgs/msg/traffic_light_group_array.hpp>
-#include <autoware_planning_msgs/msg/trajectory.hpp>
 #include <autoware_planning_msgs/msg/lanelet_route.hpp>
-#include <autoware_map_msgs/msg/lanelet_map_bin.hpp>
+#include <autoware_planning_msgs/msg/trajectory.hpp>
 #include <geometry_msgs/msg/accel_with_covariance_stamped.hpp>
 #include <nav_msgs/msg/odometry.hpp>
 #include <sensor_msgs/msg/point_cloud2.hpp>
@@ -83,7 +83,7 @@ private:
     this, "~/input/objects"};
   autoware_utils_rclcpp::InterProcessPollingSubscriber<PointCloud2> sub_pointcloud_{
     this, "~/input/pointcloud", autoware_utils_rclcpp::single_depth_sensor_qos()};
-  
+
   autoware_utils_rclcpp::InterProcessPollingSubscriber<
     autoware_perception_msgs::msg::TrafficLightGroupArray>
     sub_traffic_lights_{this, "~/input/traffic_signals"};

--- a/planning/autoware_trajectory_modifier/include/autoware/trajectory_modifier/trajectory_modifier_plugins/input_data.hpp
+++ b/planning/autoware_trajectory_modifier/include/autoware/trajectory_modifier/trajectory_modifier_plugins/input_data.hpp
@@ -21,6 +21,9 @@
 #include <geometry_msgs/msg/accel_with_covariance_stamped.hpp>
 #include <nav_msgs/msg/odometry.hpp>
 #include <sensor_msgs/msg/point_cloud2.hpp>
+#include <lanelet2_core/LaneletMap.h>
+#include <autoware_planning_msgs/msg/lanelet_route.hpp>
+#include <autoware_perception_msgs/msg/traffic_light_group_array.hpp>
 
 namespace autoware::trajectory_modifier::plugin
 {
@@ -30,6 +33,9 @@ struct InputData
   geometry_msgs::msg::AccelWithCovarianceStamped::ConstSharedPtr current_acceleration = nullptr;
   autoware_perception_msgs::msg::PredictedObjects::ConstSharedPtr predicted_objects = nullptr;
   sensor_msgs::msg::PointCloud2::ConstSharedPtr obstacle_pointcloud = nullptr;
+  std::shared_ptr<lanelet::LaneletMap> lanelet_map = nullptr;
+  autoware_planning_msgs::msg::LaneletRoute::ConstSharedPtr route = nullptr;
+  autoware_perception_msgs::msg::TrafficLightGroupArray::ConstSharedPtr traffic_light_signals = nullptr;
 };
 
 }  // namespace autoware::trajectory_modifier::plugin

--- a/planning/autoware_trajectory_modifier/include/autoware/trajectory_modifier/trajectory_modifier_plugins/input_data.hpp
+++ b/planning/autoware_trajectory_modifier/include/autoware/trajectory_modifier/trajectory_modifier_plugins/input_data.hpp
@@ -18,12 +18,15 @@
 #define AUTOWARE__TRAJECTORY_MODIFIER__TRAJECTORY_MODIFIER_PLUGINS__INPUT_DATA_HPP_
 
 #include <autoware_perception_msgs/msg/predicted_objects.hpp>
+#include <autoware_perception_msgs/msg/traffic_light_group_array.hpp>
+#include <autoware_planning_msgs/msg/lanelet_route.hpp>
 #include <geometry_msgs/msg/accel_with_covariance_stamped.hpp>
 #include <nav_msgs/msg/odometry.hpp>
 #include <sensor_msgs/msg/point_cloud2.hpp>
+
 #include <lanelet2_core/LaneletMap.h>
-#include <autoware_planning_msgs/msg/lanelet_route.hpp>
-#include <autoware_perception_msgs/msg/traffic_light_group_array.hpp>
+
+#include <memory>
 
 namespace autoware::trajectory_modifier::plugin
 {
@@ -35,7 +38,8 @@ struct InputData
   sensor_msgs::msg::PointCloud2::ConstSharedPtr obstacle_pointcloud = nullptr;
   std::shared_ptr<lanelet::LaneletMap> lanelet_map = nullptr;
   autoware_planning_msgs::msg::LaneletRoute::ConstSharedPtr route = nullptr;
-  autoware_perception_msgs::msg::TrafficLightGroupArray::ConstSharedPtr traffic_light_signals = nullptr;
+  autoware_perception_msgs::msg::TrafficLightGroupArray::ConstSharedPtr traffic_light_signals =
+    nullptr;
 };
 
 }  // namespace autoware::trajectory_modifier::plugin

--- a/planning/autoware_trajectory_modifier/include/autoware/trajectory_modifier/trajectory_modifier_plugins/obstacle_stop.hpp
+++ b/planning/autoware_trajectory_modifier/include/autoware/trajectory_modifier/trajectory_modifier_plugins/obstacle_stop.hpp
@@ -94,9 +94,6 @@ private:
 
   bool set_stop_point(TrajectoryPoints & traj_points, const InputData & input);
 
-  bool apply_stopping(
-    TrajectoryPoints & traj_points, const double target_stop_point_arc_length) const;
-
   void publish_debug_string(bool is_safe) const;
 };
 

--- a/planning/autoware_trajectory_modifier/include/autoware/trajectory_modifier/trajectory_modifier_plugins/traffic_light_stop.hpp
+++ b/planning/autoware_trajectory_modifier/include/autoware/trajectory_modifier/trajectory_modifier_plugins/traffic_light_stop.hpp
@@ -46,7 +46,7 @@ public:
 
   void update_params(const TrajectoryModifierParams & params) override;
 
-  void publish_debug_data([[maybe_unused]] const std::string & ns) const override;
+  const TrajectoryModifierParams::TrafficLightStop & get_params() const { return params_; }
 
 protected:
   void on_initialize(const TrajectoryModifierParams & params) override;
@@ -60,20 +60,9 @@ private:
   std::unique_ptr<autoware::traffic_light_compliance_checker::TrafficLightComplianceChecker>
     checker_;
 
-  SafetyFactorArray safety_factors_;
-
-  MarkerArray marker_array_;
-  rclcpp::Publisher<visualization_msgs::msg::MarkerArray>::SharedPtr debug_viz_pub_;
-  rclcpp::Publisher<StringStamped>::SharedPtr pub_debug_text_;
-
-  void check_traffic_lights(const TrajectoryPoints & traj_points, const InputData & input);
+  bool check_traffic_lights(const TrajectoryPoints & traj_points, const InputData & input);
 
   bool set_stop_point(TrajectoryPoints & traj_points, const InputData & input);
-
-  bool apply_stopping(
-    TrajectoryPoints & traj_points, const double target_stop_point_arc_length) const;
-
-  void publish_debug_string(bool is_safe) const;
 
   bool check_inputs(const InputData & input);
 };

--- a/planning/autoware_trajectory_modifier/include/autoware/trajectory_modifier/trajectory_modifier_plugins/traffic_light_stop.hpp
+++ b/planning/autoware_trajectory_modifier/include/autoware/trajectory_modifier/trajectory_modifier_plugins/traffic_light_stop.hpp
@@ -60,11 +60,23 @@ private:
   std::unique_ptr<autoware::traffic_light_compliance_checker::TrafficLightComplianceChecker>
     checker_;
 
+  struct DebugData
+  {
+    bool active = false;
+    size_t violations_count = 0;
+    double nearest_violation_arc_length = 0.0;
+    double stop_point_arc_length = 0.0;
+  } debug_data_;
+
+  rclcpp::Publisher<StringStamped>::SharedPtr pub_debug_text_;
+
   bool check_traffic_lights(const TrajectoryPoints & traj_points, const InputData & input);
 
   bool set_stop_point(TrajectoryPoints & traj_points, const InputData & input);
 
   bool check_inputs(const InputData & input);
+
+  void publish_debug_string() const;
 };
 
 }  // namespace autoware::trajectory_modifier::plugin

--- a/planning/autoware_trajectory_modifier/include/autoware/trajectory_modifier/trajectory_modifier_plugins/traffic_light_stop.hpp
+++ b/planning/autoware_trajectory_modifier/include/autoware/trajectory_modifier/trajectory_modifier_plugins/traffic_light_stop.hpp
@@ -15,6 +15,8 @@
 #ifndef AUTOWARE__TRAJECTORY_MODIFIER__TRAJECTORY_MODIFIER_PLUGINS__TRAFFIC_LIGHT_STOP_HPP_
 #define AUTOWARE__TRAJECTORY_MODIFIER__TRAJECTORY_MODIFIER_PLUGINS__TRAFFIC_LIGHT_STOP_HPP_
 
+#include "autoware/traffic_light_compliance_checker/structs.hpp"
+#include "autoware/traffic_light_compliance_checker/traffic_light_compliance_checker.hpp"
 #include "autoware/trajectory_modifier/trajectory_modifier_plugins/trajectory_modifier_plugin_base.hpp"
 #include "autoware/trajectory_modifier/trajectory_modifier_utils/utils.hpp"
 
@@ -50,7 +52,13 @@ protected:
   void on_initialize(const TrajectoryModifierParams & params) override;
 
 private:
+  TrajectoryModifierParams::TrafficLightStop params_;
   TrajectoryModifierParams::StoppingConstraints stopping_params_;
+
+  std::optional<autoware::traffic_light_compliance_checker::Violation> nearest_violation_;
+
+  std::unique_ptr<autoware::traffic_light_compliance_checker::TrafficLightComplianceChecker>
+    checker_;
 
   SafetyFactorArray safety_factors_;
 
@@ -66,6 +74,8 @@ private:
     TrajectoryPoints & traj_points, const double target_stop_point_arc_length) const;
 
   void publish_debug_string(bool is_safe) const;
+
+  bool check_inputs(const InputData & input);
 };
 
 }  // namespace autoware::trajectory_modifier::plugin

--- a/planning/autoware_trajectory_modifier/include/autoware/trajectory_modifier/trajectory_modifier_plugins/traffic_light_stop.hpp
+++ b/planning/autoware_trajectory_modifier/include/autoware/trajectory_modifier/trajectory_modifier_plugins/traffic_light_stop.hpp
@@ -1,0 +1,73 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef AUTOWARE__TRAJECTORY_MODIFIER__TRAJECTORY_MODIFIER_PLUGINS__TRAFFIC_LIGHT_STOP_HPP_
+#define AUTOWARE__TRAJECTORY_MODIFIER__TRAJECTORY_MODIFIER_PLUGINS__TRAFFIC_LIGHT_STOP_HPP_
+
+#include "autoware/trajectory_modifier/trajectory_modifier_plugins/trajectory_modifier_plugin_base.hpp"
+#include "autoware/trajectory_modifier/trajectory_modifier_utils/utils.hpp"
+
+#include <rclcpp/rclcpp.hpp>
+
+#include <autoware_internal_debug_msgs/msg/string_stamped.hpp>
+#include <visualization_msgs/msg/marker_array.hpp>
+
+#include <memory>
+#include <string>
+
+namespace autoware::trajectory_modifier::plugin
+{
+using autoware_internal_debug_msgs::msg::StringStamped;
+using autoware_internal_planning_msgs::msg::SafetyFactorArray;
+using visualization_msgs::msg::MarkerArray;
+
+class TrafficLightStop : public TrajectoryModifierPluginBase
+{
+public:
+  TrafficLightStop() = default;
+
+  bool modify_trajectory(TrajectoryPoints & traj_points, const InputData & input) override;
+
+  [[nodiscard]] bool is_trajectory_modification_required(
+    const TrajectoryPoints & traj_points, const InputData & input) override;
+
+  void update_params(const TrajectoryModifierParams & params) override;
+
+  void publish_debug_data([[maybe_unused]] const std::string & ns) const override;
+
+protected:
+  void on_initialize(const TrajectoryModifierParams & params) override;
+
+private:
+  TrajectoryModifierParams::StoppingConstraints stopping_params_;
+
+  SafetyFactorArray safety_factors_;
+
+  MarkerArray marker_array_;
+  rclcpp::Publisher<visualization_msgs::msg::MarkerArray>::SharedPtr debug_viz_pub_;
+  rclcpp::Publisher<StringStamped>::SharedPtr pub_debug_text_;
+
+  void check_traffic_lights(const TrajectoryPoints & traj_points, const InputData & input);
+
+  bool set_stop_point(TrajectoryPoints & traj_points, const InputData & input);
+
+  bool apply_stopping(
+    TrajectoryPoints & traj_points, const double target_stop_point_arc_length) const;
+
+  void publish_debug_string(bool is_safe) const;
+};
+
+}  // namespace autoware::trajectory_modifier::plugin
+
+#endif  // AUTOWARE__TRAJECTORY_MODIFIER__TRAJECTORY_MODIFIER_PLUGINS__TRAFFIC_LIGHT_STOP_HPP_

--- a/planning/autoware_trajectory_modifier/include/autoware/trajectory_modifier/trajectory_modifier_utils/utils.hpp
+++ b/planning/autoware_trajectory_modifier/include/autoware/trajectory_modifier/trajectory_modifier_utils/utils.hpp
@@ -15,11 +15,11 @@
 #ifndef AUTOWARE__TRAJECTORY_MODIFIER__TRAJECTORY_MODIFIER_UTILS__UTILS_HPP_
 #define AUTOWARE__TRAJECTORY_MODIFIER__TRAJECTORY_MODIFIER_UTILS__UTILS_HPP_
 
+#include <tl_expected/expected.hpp>
+
 #include <autoware_planning_msgs/msg/trajectory_point.hpp>
 #include <geometry_msgs/msg/pose.hpp>
 #include <geometry_msgs/msg/twist.hpp>
-
-#include <tl_expected/expected.hpp>
 
 #include <vector>
 
@@ -43,9 +43,12 @@ double clamp_stop_point_arc_length(
   const double stop_point_arc_length, const double max_length, const double ego_vel,
   const double ego_accel, const double decel_limit, const double jerk_limit);
 
-bool stop_point_exists(const TrajectoryPoints & traj_points, const double stop_point_arc_length, const double duplicate_check_threshold = 0.0);
+bool stop_point_exists(
+  const TrajectoryPoints & traj_points, const double stop_point_arc_length,
+  const double duplicate_check_threshold = 0.0);
 
-bool insert_stop_point(TrajectoryPoints & trajectory, const double stop_point_arc_length, const double traj_length);
+bool insert_stop_point(
+  TrajectoryPoints & trajectory, const double stop_point_arc_length, const double traj_length);
 
 }  // namespace autoware::trajectory_modifier::utils
 

--- a/planning/autoware_trajectory_modifier/include/autoware/trajectory_modifier/trajectory_modifier_utils/utils.hpp
+++ b/planning/autoware_trajectory_modifier/include/autoware/trajectory_modifier/trajectory_modifier_utils/utils.hpp
@@ -19,6 +19,8 @@
 #include <geometry_msgs/msg/pose.hpp>
 #include <geometry_msgs/msg/twist.hpp>
 
+#include <tl_expected/expected.hpp>
+
 #include <vector>
 
 namespace autoware::trajectory_modifier::utils
@@ -36,6 +38,14 @@ void replace_trajectory_with_stop_point(
 
 bool is_ego_vehicle_moving(
   const geometry_msgs::msg::Twist & twist, const double velocity_threshold);
+
+double clamp_stop_point_arc_length(
+  const double stop_point_arc_length, const double max_length, const double ego_vel,
+  const double ego_accel, const double decel_limit, const double jerk_limit);
+
+bool stop_point_exists(const TrajectoryPoints & traj_points, const double stop_point_arc_length, const double duplicate_check_threshold = 0.0);
+
+bool insert_stop_point(TrajectoryPoints & trajectory, const double stop_point_arc_length, const double traj_length);
 
 }  // namespace autoware::trajectory_modifier::utils
 

--- a/planning/autoware_trajectory_modifier/launch/trajectory_modifier.launch.xml
+++ b/planning/autoware_trajectory_modifier/launch/trajectory_modifier.launch.xml
@@ -5,6 +5,9 @@
   <arg name="input_acceleration" default="/localization/acceleration"/>
   <arg name="input_objects" default="/perception/object_recognition/objects"/>
   <arg name="input_pointcloud" default="/perception/obstacle_segmentation/pointcloud"/>
+  <arg name="input_route" default="/planning/mission_planning/route"/>
+  <arg name="input_traffic_signals" default="/perception/traffic_light_recognition/traffic_signals"/>
+  <arg name="input_vector_map" default="/map/vector_map"/>
   <arg name="output_candidate_trajectories" default="~/output/candidate_trajectories"/>
 
   <node_container pkg="rclcpp_components" exec="component_container" name="trajectory_modifier_container" namespace="">
@@ -16,6 +19,9 @@
       <remap from="~/input/candidate_trajectories" to="$(var input_candidate_trajectories)"/>
       <remap from="~/input/odometry" to="$(var input_odometry)"/>
       <remap from="~/input/acceleration" to="$(var input_acceleration)"/>
+      <remap from="~/input/route" to="$(var input_route)"/>
+      <remap from="~/input/traffic_signals" to="$(var input_traffic_signals)"/>
+      <remap from="~/input/vector_map" to="$(var input_vector_map)"/>
       <remap from="~/output/candidate_trajectories" to="$(var output_candidate_trajectories)"/>
       <extra_arg name="use_intra_process_comms" value="false"/>
     </composable_node>

--- a/planning/autoware_trajectory_modifier/package.xml
+++ b/planning/autoware_trajectory_modifier/package.xml
@@ -17,12 +17,14 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
 
   <depend>autoware_internal_planning_msgs</depend>
+  <depend>autoware_lanelet2_utils</depend>
   <depend>autoware_motion_utils</depend>
   <depend>autoware_path_optimizer</depend>
   <depend>autoware_path_smoother</depend>
   <depend>autoware_planning_factor_interface</depend>
   <depend>autoware_planning_msgs</depend>
   <depend>autoware_signal_processing</depend>
+  <depend>autoware_traffic_light_compliance_checker</depend>
   <depend>autoware_trajectory</depend>
   <depend>autoware_utils</depend>
   <depend>autoware_utils_debug</depend>

--- a/planning/autoware_trajectory_modifier/param/trajectory_modifier_parameter_struct.yaml
+++ b/planning/autoware_trajectory_modifier/param/trajectory_modifier_parameter_struct.yaml
@@ -24,6 +24,11 @@ trajectory_modifier_params:
     default_value: true
     description: Enable the use of velocity modifier
     read_only: false
+  use_traffic_light_stop:
+    type: bool
+    default_value: false
+    description: Enable the use of traffic light stop
+    read_only: false
   trajectory_time_step:
     type: double
     default_value: 0.1
@@ -367,3 +372,62 @@ trajectory_modifier_params:
         validation:
           bounds<>: [0.0, 10.0]
         read_only: false
+
+  traffic_light_stop:
+    stop_margin:
+      type: double
+      default_value: 1.0
+      description: Distance to maintain from a traffic light when stopped [m]
+      validation:
+        bounds<>: [0.0, 100.0]
+      read_only: false
+    stop_for_red_light:
+      type: bool
+      default_value: true
+      description: Enable stopping behavior when red light is detected
+      read_only: false
+    stop_for_amber_light:
+      type: bool
+      default_value: false
+      description: Enable stopping behavior when amber light is detected
+      read_only: false
+    treat_amber_light_as_red:
+      type: bool
+      default_value: false
+      description: Treat amber light as red light
+      read_only: false
+    overshoot_tolerance:
+      type: double
+      default_value: 0.5
+      description: Tolerance for overshoot [m]
+      validation:
+        bounds<>: [0.0, 10.0]
+      read_only: false
+    th_stable_duration_red:
+      type: double
+      default_value: 1.0
+      description: Threshold for stable duration of red light [s]
+      validation:
+        bounds<>: [0.0, 10.0]
+      read_only: false
+    th_stable_duration_amber:
+      type: double
+      default_value: 1.0
+      description: Threshold for stable duration of amber light [s]
+      validation:
+        bounds<>: [0.0, 10.0]
+      read_only: false
+    th_amber_rejection_hysteresis:
+      type: double
+      default_value: 1.0
+      description: Threshold for amber rejection hysteresis [s]
+      validation:
+        bounds<>: [0.0, 10.0]
+      read_only: false
+    crossing_time_limit:
+      type: double
+      default_value: 2.75
+      description: Crossing time limit [s]
+      validation:
+        bounds<>: [0.0, 10.0]
+      read_only: false

--- a/planning/autoware_trajectory_modifier/param/trajectory_modifier_parameter_struct.yaml
+++ b/planning/autoware_trajectory_modifier/param/trajectory_modifier_parameter_struct.yaml
@@ -376,7 +376,7 @@ trajectory_modifier_params:
   traffic_light_stop:
     stop_margin:
       type: double
-      default_value: 1.0
+      default_value: 0.75
       description: Distance to maintain from a traffic light when stopped [m]
       validation:
         bounds<>: [0.0, 100.0]
@@ -405,21 +405,21 @@ trajectory_modifier_params:
       read_only: false
     th_stable_duration_red:
       type: double
-      default_value: 1.0
+      default_value: 0.2
       description: Threshold for stable duration of red light [s]
       validation:
         bounds<>: [0.0, 10.0]
       read_only: false
     th_stable_duration_amber:
       type: double
-      default_value: 1.0
+      default_value: 0.2
       description: Threshold for stable duration of amber light [s]
       validation:
         bounds<>: [0.0, 10.0]
       read_only: false
     th_amber_rejection_hysteresis:
       type: double
-      default_value: 1.0
+      default_value: 0.5
       description: Threshold for amber rejection hysteresis [s]
       validation:
         bounds<>: [0.0, 10.0]

--- a/planning/autoware_trajectory_modifier/param/trajectory_modifier_parameter_struct.yaml
+++ b/planning/autoware_trajectory_modifier/param/trajectory_modifier_parameter_struct.yaml
@@ -92,6 +92,13 @@ trajectory_modifier_params:
       read_only: false
       validation:
         bounds<>: [0.0, 10.0]
+    arrived_distance_threshold:
+      type: double
+      default_value: 0.5
+      description: Threshold to check if the ego vehicle has arrived at the stop point [m]
+      validation:
+        bounds<>: [0.0, 10.0]
+      read_only: false
 
   obstacle_stop:
     use_objects:
@@ -132,13 +139,6 @@ trajectory_modifier_params:
       type: double
       default_value: 0.5
       description: Threshold to check if the stop point is already in the trajectory [m]
-      validation:
-        bounds<>: [0.0, 10.0]
-      read_only: false
-    arrived_distance_threshold:
-      type: double
-      default_value: 0.5
-      description: Threshold to check if the ego vehicle has arrived at the stop point [m]
       validation:
         bounds<>: [0.0, 10.0]
       read_only: false

--- a/planning/autoware_trajectory_modifier/plugins.xml
+++ b/planning/autoware_trajectory_modifier/plugins.xml
@@ -18,4 +18,10 @@
       Modifies the velocity of a trajectory to smooth the motion
     </description>
   </class>
+  <class type="autoware::trajectory_modifier::plugin::TrafficLightStop"
+         base_class_type="autoware::trajectory_modifier::plugin::TrajectoryModifierPluginBase">
+    <description>
+      Modifies the trajectory to stop at traffic lights
+    </description>
+  </class>
 </library>

--- a/planning/autoware_trajectory_modifier/schema/trajectory_modifier.schema.json
+++ b/planning/autoware_trajectory_modifier/schema/trajectory_modifier.schema.json
@@ -94,6 +94,12 @@
               "description": "Jerk limit during stopping [m/s^3]",
               "default": 3.0,
               "minimum": 0.0
+            },
+            "arrived_distance_threshold": {
+              "type": "number",
+              "description": "Threshold to check if the ego vehicle has arrived at the stop point [m]",
+              "default": 0.5,
+              "minimum": 0.0
             }
           },
           "required": [],
@@ -137,12 +143,6 @@
             "duplicate_check_threshold": {
               "type": "number",
               "description": "Threshold to check if the stop point is already in the trajectory [m]",
-              "default": 0.5,
-              "minimum": 0.0
-            },
-            "arrived_distance_threshold": {
-              "type": "number",
-              "description": "Threshold to check if the ego vehicle has arrived at the stop point [m]",
               "default": 0.5,
               "minimum": 0.0
             },

--- a/planning/autoware_trajectory_modifier/schema/trajectory_modifier.schema.json
+++ b/planning/autoware_trajectory_modifier/schema/trajectory_modifier.schema.json
@@ -10,8 +10,9 @@
           "type": "array",
           "description": "List of trajectory modifier plugins to load",
           "default": [
-            "autoware::trajectory_modifier::plugin::ObstacleStop",
             "autoware::trajectory_modifier::plugin::StopPointFixer",
+            "autoware::trajectory_modifier::plugin::ObstacleStop",
+            "autoware::trajectory_modifier::plugin::TrafficLightStop",
             "autoware::trajectory_modifier::plugin::VelocityModifier"
           ],
           "items": {
@@ -26,6 +27,11 @@
         "use_obstacle_stop": {
           "type": "boolean",
           "description": "Enable the obstacle stop modifier plugin",
+          "default": true
+        },
+        "use_traffic_light_stop": {
+          "type": "boolean",
+          "description": "Enable the traffic light stop modifier plugin",
           "default": true
         },
         "use_velocity_modifier": {
@@ -402,6 +408,64 @@
               },
               "required": [],
               "additionalProperties": false
+            }
+          },
+          "required": [],
+          "additionalProperties": false
+        },
+        "traffic_light_stop": {
+          "type": "object",
+          "properties": {
+            "stop_margin": {
+              "type": "number",
+              "description": "Distance to maintain from a traffic light when stopped [m]",
+              "default": 0.75,
+              "minimum": 0.0
+            },
+            "stop_for_red_light": {
+              "type": "boolean",
+              "description": "Enable stopping behavior when red light is detected",
+              "default": true
+            },
+            "stop_for_amber_light": {
+              "type": "boolean",
+              "description": "Enable stopping behavior when amber light is detected",
+              "default": true
+            },
+            "treat_amber_light_as_red": {
+              "type": "boolean",
+              "description": "Treat amber light as red light",
+              "default": false
+            },
+            "overshoot_tolerance": {
+              "type": "number",
+              "description": "Overshoot tolerance [m]",
+              "default": 0.0,
+              "minimum": 0.0
+            },
+            "th_stable_duration_red": {
+              "type": "number",
+              "description": "Threshold for stable duration of red light [s]",
+              "default": 0.2,
+              "minimum": 0.0
+            },
+            "th_stable_duration_amber": {
+              "type": "number",
+              "description": "Threshold for stable duration of amber light [s]",
+              "default": 0.2,
+              "minimum": 0.0
+            },
+            "th_amber_rejection_hysteresis": {
+              "type": "number",
+              "description": "Threshold for amber rejection hysteresis [s]",
+              "default": 0.5,
+              "minimum": 0.0
+            },
+            "crossing_time_limit": {
+              "type": "number",
+              "description": "Crossing time limit [s]",
+              "default": 2.75,
+              "minimum": 0.0
             }
           },
           "required": [],

--- a/planning/autoware_trajectory_modifier/src/trajectory_modifier.cpp
+++ b/planning/autoware_trajectory_modifier/src/trajectory_modifier.cpp
@@ -142,16 +142,19 @@ tl::expected<plugin::InputData, std::string> TrajectoryModifier::make_input_data
     return tl::make_unexpected("Data is not ready: current_acceleration is not set");
   }
   if (!input.predicted_objects) {
-    RCLCPP_WARN_THROTTLE(get_logger(), *get_clock(), 1000, "Missing data: predicted_objects is not set");
+    RCLCPP_WARN_THROTTLE(
+      get_logger(), *get_clock(), 1000, "Missing data: predicted_objects is not set");
   }
   if (!input.obstacle_pointcloud) {
-    RCLCPP_WARN_THROTTLE(get_logger(), *get_clock(), 1000, "Missing data: obstacle_pointcloud is not set");
+    RCLCPP_WARN_THROTTLE(
+      get_logger(), *get_clock(), 1000, "Missing data: obstacle_pointcloud is not set");
   }
   if (!input.route) {
     RCLCPP_WARN_THROTTLE(get_logger(), *get_clock(), 1000, "Missing data: route is not set");
   }
   if (!input.traffic_light_signals) {
-    RCLCPP_WARN_THROTTLE(get_logger(), *get_clock(), 1000, "Missing data: traffic_light_signals is not set");
+    RCLCPP_WARN_THROTTLE(
+      get_logger(), *get_clock(), 1000, "Missing data: traffic_light_signals is not set");
   }
   if (!input.lanelet_map) {
     RCLCPP_WARN_THROTTLE(get_logger(), *get_clock(), 1000, "Missing data: lanelet_map is not set");

--- a/planning/autoware_trajectory_modifier/src/trajectory_modifier.cpp
+++ b/planning/autoware_trajectory_modifier/src/trajectory_modifier.cpp
@@ -39,7 +39,7 @@ TrajectoryModifier::TrajectoryModifier(const rclcpp::NodeOptions & options)
   context_{std::make_shared<TrajectoryModifierContext>(this)}
 {
   sub_map_ = create_subscription<autoware_map_msgs::msg::LaneletMapBin>(
-    "~/input/lanelet2_map", rclcpp::QoS{1}.transient_local(),
+    "~/input/vector_map", rclcpp::QoS{1}.transient_local(),
     std::bind(&TrajectoryModifier::on_map, this, std::placeholders::_1));
 
   trajectories_sub_ = create_subscription<CandidateTrajectories>(
@@ -142,19 +142,19 @@ tl::expected<plugin::InputData, std::string> TrajectoryModifier::make_input_data
     return tl::make_unexpected("Data is not ready: current_acceleration is not set");
   }
   if (!input.predicted_objects) {
-    RCLCPP_WARN(get_logger(), "Missing data: predicted_objects is not set");
+    RCLCPP_WARN_THROTTLE(get_logger(), *get_clock(), 1000, "Missing data: predicted_objects is not set");
   }
   if (!input.obstacle_pointcloud) {
-    RCLCPP_WARN(get_logger(), "Missing data: obstacle_pointcloud is not set");
+    RCLCPP_WARN_THROTTLE(get_logger(), *get_clock(), 1000, "Missing data: obstacle_pointcloud is not set");
   }
   if (!input.route) {
-    RCLCPP_WARN(get_logger(), "Missing data: route is not set");
+    RCLCPP_WARN_THROTTLE(get_logger(), *get_clock(), 1000, "Missing data: route is not set");
   }
   if (!input.traffic_light_signals) {
-    RCLCPP_WARN(get_logger(), "Missing data: traffic_light_signals is not set");
+    RCLCPP_WARN_THROTTLE(get_logger(), *get_clock(), 1000, "Missing data: traffic_light_signals is not set");
   }
   if (!input.lanelet_map) {
-    RCLCPP_WARN(get_logger(), "Missing data: lanelet_map is not set");
+    RCLCPP_WARN_THROTTLE(get_logger(), *get_clock(), 1000, "Missing data: lanelet_map is not set");
   }
   return input;
 }

--- a/planning/autoware_trajectory_modifier/src/trajectory_modifier.cpp
+++ b/planning/autoware_trajectory_modifier/src/trajectory_modifier.cpp
@@ -14,10 +14,10 @@
 
 #include "autoware/trajectory_modifier/trajectory_modifier.hpp"
 
+#include <autoware/lanelet2_utils/conversion.hpp>
 #include <autoware_utils_system/stop_watch.hpp>
 #include <rclcpp/logging.hpp>
 #include <rclcpp_components/register_node_macro.hpp>
-#include <autoware/lanelet2_utils/conversion.hpp>
 
 #include <lanelet2_core/LaneletMap.h>
 #include <lanelet2_core/geometry/LaneletMap.h>
@@ -38,7 +38,6 @@ TrajectoryModifier::TrajectoryModifier(const rclcpp::NodeOptions & options)
     "autoware::trajectory_modifier::plugin::TrajectoryModifierPluginBase"),
   context_{std::make_shared<TrajectoryModifierContext>(this)}
 {
-
   sub_map_ = create_subscription<autoware_map_msgs::msg::LaneletMapBin>(
     "~/input/lanelet2_map", rclcpp::QoS{1}.transient_local(),
     std::bind(&TrajectoryModifier::on_map, this, std::placeholders::_1));

--- a/planning/autoware_trajectory_modifier/src/trajectory_modifier.cpp
+++ b/planning/autoware_trajectory_modifier/src/trajectory_modifier.cpp
@@ -17,6 +17,10 @@
 #include <autoware_utils_system/stop_watch.hpp>
 #include <rclcpp/logging.hpp>
 #include <rclcpp_components/register_node_macro.hpp>
+#include <autoware/lanelet2_utils/conversion.hpp>
+
+#include <lanelet2_core/LaneletMap.h>
+#include <lanelet2_core/geometry/LaneletMap.h>
 
 #include <memory>
 #include <string>
@@ -34,6 +38,11 @@ TrajectoryModifier::TrajectoryModifier(const rclcpp::NodeOptions & options)
     "autoware::trajectory_modifier::plugin::TrajectoryModifierPluginBase"),
   context_{std::make_shared<TrajectoryModifierContext>(this)}
 {
+
+  sub_map_ = create_subscription<autoware_map_msgs::msg::LaneletMapBin>(
+    "~/input/lanelet2_map", rclcpp::QoS{1}.transient_local(),
+    std::bind(&TrajectoryModifier::on_map, this, std::placeholders::_1));
+
   trajectories_sub_ = create_subscription<CandidateTrajectories>(
     "~/input/candidate_trajectories", 1,
     std::bind(&TrajectoryModifier::on_traj, this, std::placeholders::_1));
@@ -58,6 +67,14 @@ TrajectoryModifier::TrajectoryModifier(const rclcpp::NodeOptions & options)
   RCLCPP_INFO(get_logger(), "TrajectoryModifier initialized");
 }
 
+void TrajectoryModifier::on_map(const autoware_map_msgs::msg::LaneletMapBin::ConstSharedPtr msg)
+{
+  autoware_utils_debug::ScopedTimeTrack st(__func__, *time_keeper_);
+
+  lanelet_map_ptr_ = autoware::experimental::lanelet2_utils::remove_const(
+    autoware::experimental::lanelet2_utils::from_autoware_map_msgs(*msg));
+}
+
 void TrajectoryModifier::on_traj(const CandidateTrajectories::ConstSharedPtr msg)
 {
   autoware_utils_debug::ScopedTimeTrack st(__func__, *time_keeper_);
@@ -70,20 +87,11 @@ void TrajectoryModifier::on_traj(const CandidateTrajectories::ConstSharedPtr msg
   }
 
   const auto input = make_input_data();
-  if (!input.current_odometry) {
-    RCLCPP_ERROR(get_logger(), "Data is not ready: current_odometry is not set");
+  if (!input) {
+    RCLCPP_ERROR(get_logger(), "%s", input.error().c_str());
     return;
   }
-  if (!input.current_acceleration) {
-    RCLCPP_ERROR(get_logger(), "Data is not ready: current_acceleration is not set");
-    return;
-  }
-  if (!input.predicted_objects) {
-    RCLCPP_WARN(get_logger(), "Missing data: predicted_objects is not set");
-  }
-  if (!input.obstacle_pointcloud) {
-    RCLCPP_WARN(get_logger(), "Missing data: obstacle_pointcloud is not set");
-  }
+  const auto & input_data = input.value();
 
   CandidateTrajectories output_trajectories = *msg;
 
@@ -95,7 +103,7 @@ void TrajectoryModifier::on_traj(const CandidateTrajectories::ConstSharedPtr msg
   std::string modified_plugins_str;
   for (auto & trajectory : output_trajectories.candidate_trajectories) {
     for (auto & modifier : plugins_) {
-      if (!modifier->modify_trajectory(trajectory.points, input)) continue;
+      if (!modifier->modify_trajectory(trajectory.points, input_data)) continue;
       modifier->publish_planning_factor();
       const auto ns = "trajectory_" + std::to_string(trajectory_count);
       modifier->publish_debug_data(ns);
@@ -117,13 +125,38 @@ void TrajectoryModifier::on_traj(const CandidateTrajectories::ConstSharedPtr msg
     "processing_time_ms", processing_time_ms);
 }
 
-plugin::InputData TrajectoryModifier::make_input_data()
+tl::expected<plugin::InputData, std::string> TrajectoryModifier::make_input_data()
 {
   plugin::InputData input;
   input.current_odometry = sub_current_odometry_.take_data();
   input.current_acceleration = sub_current_acceleration_.take_data();
   input.predicted_objects = sub_objects_.take_data();
   input.obstacle_pointcloud = sub_pointcloud_.take_data();
+  input.route = sub_route_.take_data();
+  input.traffic_light_signals = sub_traffic_lights_.take_data();
+  input.lanelet_map = lanelet_map_ptr_;
+
+  if (!input.current_odometry) {
+    return tl::make_unexpected("Data is not ready: current_odometry is not set");
+  }
+  if (!input.current_acceleration) {
+    return tl::make_unexpected("Data is not ready: current_acceleration is not set");
+  }
+  if (!input.predicted_objects) {
+    RCLCPP_WARN(get_logger(), "Missing data: predicted_objects is not set");
+  }
+  if (!input.obstacle_pointcloud) {
+    RCLCPP_WARN(get_logger(), "Missing data: obstacle_pointcloud is not set");
+  }
+  if (!input.route) {
+    RCLCPP_WARN(get_logger(), "Missing data: route is not set");
+  }
+  if (!input.traffic_light_signals) {
+    RCLCPP_WARN(get_logger(), "Missing data: traffic_light_signals is not set");
+  }
+  if (!input.lanelet_map) {
+    RCLCPP_WARN(get_logger(), "Missing data: lanelet_map is not set");
+  }
   return input;
 }
 

--- a/planning/autoware_trajectory_modifier/src/trajectory_modifier_plugins/obstacle_stop.cpp
+++ b/planning/autoware_trajectory_modifier/src/trajectory_modifier_plugins/obstacle_stop.cpp
@@ -211,14 +211,12 @@ bool ObstacleStop::set_stop_point(TrajectoryPoints & traj_points, const InputDat
   const auto stop_margin = params_.stop_margin + context_->vehicle_info.max_longitudinal_offset_m;
   const auto target_stop_point_arc_length = utils::clamp_stop_point_arc_length(
     nearest_collision_point_->arc_length - stop_margin,
-    debug_data_.trajectory_shape.trajectory_length,
-    input.current_odometry->twist.twist.linear.x,
-    input.current_acceleration->accel.accel.linear.x,
-    stopping_params_.maximum_deceleration,
-    stopping_params_.jerk_limit
-  );
+    debug_data_.trajectory_shape.trajectory_length, input.current_odometry->twist.twist.linear.x,
+    input.current_acceleration->accel.accel.linear.x, stopping_params_.maximum_deceleration,
+    stopping_params_.jerk_limit);
 
-  if (utils::stop_point_exists(traj_points, target_stop_point_arc_length, params_.duplicate_check_threshold)) {
+  if (utils::stop_point_exists(
+        traj_points, target_stop_point_arc_length, params_.duplicate_check_threshold)) {
     RCLCPP_WARN_THROTTLE(
       get_node_ptr()->get_logger(), *get_clock(), 1000,
       "[TM ObstacleStop] Preceding (or duplicate) stop point exists, skip inserting stop point");
@@ -227,7 +225,8 @@ bool ObstacleStop::set_stop_point(TrajectoryPoints & traj_points, const InputDat
 
   if (
     target_stop_point_arc_length < stopping_params_.arrived_distance_threshold ||
-    !utils::insert_stop_point(traj_points, target_stop_point_arc_length, debug_data_.trajectory_shape.trajectory_length)) {
+    !utils::insert_stop_point(
+      traj_points, target_stop_point_arc_length, debug_data_.trajectory_shape.trajectory_length)) {
     traj_points = std::invoke([&]() {
       TrajectoryPoints stop_points;
       auto p = traj_points.front();

--- a/planning/autoware_trajectory_modifier/src/trajectory_modifier_plugins/obstacle_stop.cpp
+++ b/planning/autoware_trajectory_modifier/src/trajectory_modifier_plugins/obstacle_stop.cpp
@@ -207,41 +207,27 @@ bool ObstacleStop::modify_trajectory(TrajectoryPoints & traj_points, const Input
 bool ObstacleStop::set_stop_point(TrajectoryPoints & traj_points, const InputData & input)
 {
   autoware_utils_debug::ScopedTimeTrack st("ObstacleStop::set_stop_point", *get_time_keeper());
-  const auto target_stop_point_arc_length = std::invoke([&]() -> double {
-    const auto stop_margin = params_.stop_margin + context_->vehicle_info.max_longitudinal_offset_m;
-    auto min_stopping_distance = motion_utils::calculate_stop_distance(
-      input.current_odometry->twist.twist.linear.x,
-      input.current_acceleration->accel.accel.linear.x, stopping_params_.maximum_deceleration,
-      stopping_params_.jerk_limit, 0.0);
-    if (!min_stopping_distance) min_stopping_distance = 0.0;
-    return std::clamp(
-      nearest_collision_point_->arc_length - stop_margin, min_stopping_distance.value(),
-      debug_data_.trajectory_shape.trajectory_length);
-  });
 
-  auto skip = [&](const std::string & msg) {
+  const auto stop_margin = params_.stop_margin + context_->vehicle_info.max_longitudinal_offset_m;
+  const auto target_stop_point_arc_length = utils::clamp_stop_point_arc_length(
+    nearest_collision_point_->arc_length - stop_margin,
+    debug_data_.trajectory_shape.trajectory_length,
+    input.current_odometry->twist.twist.linear.x,
+    input.current_acceleration->accel.accel.linear.x,
+    stopping_params_.maximum_deceleration,
+    stopping_params_.jerk_limit
+  );
+
+  if (utils::stop_point_exists(traj_points, target_stop_point_arc_length, params_.duplicate_check_threshold)) {
     RCLCPP_WARN_THROTTLE(
       get_node_ptr()->get_logger(), *get_clock(), 1000,
-      "[TM ObstacleStop] %s, skip inserting stop point", msg.c_str());
+      "[TM ObstacleStop] Preceding (or duplicate) stop point exists, skip inserting stop point");
     return false;
-  };
-
-  constexpr double stop_velocity_threshold = 0.01;
-  auto checked_distance = 0.0;
-  for (size_t i = 1; i < traj_points.size(); ++i) {
-    const auto & curr = traj_points.at(i);
-    const auto & prev = traj_points.at(i - 1);
-    checked_distance +=
-      autoware_utils_geometry::calc_distance2d(curr.pose.position, prev.pose.position);
-    if (checked_distance > target_stop_point_arc_length + params_.duplicate_check_threshold) break;
-    if (curr.longitudinal_velocity_mps < stop_velocity_threshold) {
-      return skip("Preceding (or duplicate) stop point exists");
-    }
   }
 
   if (
-    target_stop_point_arc_length < params_.arrived_distance_threshold ||
-    !apply_stopping(traj_points, target_stop_point_arc_length)) {
+    target_stop_point_arc_length < stopping_params_.arrived_distance_threshold ||
+    !utils::insert_stop_point(traj_points, target_stop_point_arc_length, debug_data_.trajectory_shape.trajectory_length)) {
     traj_points = std::invoke([&]() {
       TrajectoryPoints stop_points;
       auto p = traj_points.front();
@@ -265,49 +251,6 @@ bool ObstacleStop::set_stop_point(TrajectoryPoints & traj_points, const InputDat
   RCLCPP_WARN_THROTTLE(
     get_node_ptr()->get_logger(), *get_clock(), 1000,
     "[TM ObstacleStop] Inserted stop point at arc length %f m", target_stop_point_arc_length);
-  return true;
-}
-
-size_t insert_stop_point(
-  TrajectoryPoints & trajectory, const double target_stop_point_arc_length,
-  const double traj_length)
-{
-  const auto index = motion_utils::insertStopPoint(target_stop_point_arc_length, trajectory);
-  if (index) return index.value();
-
-  // TODO(Quda): this is a temporary fix, need to check why insertStopPoint fails when target
-  // distance is equal to trajectory length
-  if (target_stop_point_arc_length < traj_length) {
-    auto dist = 0.0;
-    auto it = std::adjacent_find(
-      trajectory.begin(), trajectory.end(), [&](const auto & p, const auto & next) {
-        dist += autoware_utils_geometry::calc_distance2d(p.pose.position, next.pose.position);
-        return dist >= target_stop_point_arc_length - 1e-3;
-      });
-    if (it != trajectory.end()) {
-      it->longitudinal_velocity_mps = 0.0;
-      it->acceleration_mps2 = 0.0;
-      return std::distance(trajectory.begin(), it);
-    }
-  }
-
-  trajectory.back().longitudinal_velocity_mps = 0.0;
-  trajectory.back().acceleration_mps2 = 0.0;
-  return trajectory.size() - 1;
-}
-
-bool ObstacleStop::apply_stopping(
-  TrajectoryPoints & traj_points, const double target_stop_point_arc_length) const
-{
-  if (target_stop_point_arc_length < 1e-3) return false;
-
-  const auto stop_index = insert_stop_point(
-    traj_points, target_stop_point_arc_length, debug_data_.trajectory_shape.trajectory_length);
-
-  traj_points.erase(traj_points.begin() + stop_index + 1, traj_points.end());
-  traj_points.back().longitudinal_velocity_mps = 0.0;
-  traj_points.back().acceleration_mps2 = 0.0;
-
   return true;
 }
 

--- a/planning/autoware_trajectory_modifier/src/trajectory_modifier_plugins/traffic_light_stop.cpp
+++ b/planning/autoware_trajectory_modifier/src/trajectory_modifier_plugins/traffic_light_stop.cpp
@@ -1,0 +1,79 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/trajectory_modifier/trajectory_modifier_plugins/traffic_light_stop.hpp"
+
+#include "autoware/trajectory_modifier/trajectory_modifier_utils/utils.hpp"
+
+namespace autoware::trajectory_modifier::plugin
+{
+
+void TrafficLightStop::on_initialize([[maybe_unused]] const TrajectoryModifierParams & params)
+{
+  const auto node_ptr = get_node_ptr();
+  planning_factor_interface_ =
+    std::make_unique<autoware::planning_factor_interface::PlanningFactorInterface>(
+      node_ptr, "modifier_traffic_light_stop");
+}
+
+void TrafficLightStop::update_params([[maybe_unused]] const TrajectoryModifierParams & params)
+{
+}
+
+bool TrafficLightStop::is_trajectory_modification_required(
+  [[maybe_unused]] const TrajectoryPoints & traj_points,
+  [[maybe_unused]] const InputData & input)
+{
+  return false;
+}
+
+bool TrafficLightStop::modify_trajectory(
+  [[maybe_unused]] TrajectoryPoints & traj_points, [[maybe_unused]] const InputData & input)
+{
+  return false;
+}
+
+void TrafficLightStop::check_traffic_lights(
+  [[maybe_unused]] const TrajectoryPoints & traj_points,
+  [[maybe_unused]] const InputData & input)
+{
+}
+
+bool TrafficLightStop::set_stop_point(
+  [[maybe_unused]] TrajectoryPoints & traj_points, [[maybe_unused]] const InputData & input)
+{
+  return false;
+}
+
+bool TrafficLightStop::apply_stopping(
+  [[maybe_unused]] TrajectoryPoints & traj_points,
+  [[maybe_unused]] const double target_stop_point_arc_length) const
+{
+  return false;
+}
+
+void TrafficLightStop::publish_debug_string([[maybe_unused]] bool is_safe) const
+{
+}
+
+void TrafficLightStop::publish_debug_data([[maybe_unused]] const std::string & ns) const
+{
+}
+
+}  // namespace autoware::trajectory_modifier::plugin
+
+#include <pluginlib/class_list_macros.hpp>
+PLUGINLIB_EXPORT_CLASS(
+  autoware::trajectory_modifier::plugin::TrafficLightStop,
+  autoware::trajectory_modifier::plugin::TrajectoryModifierPluginBase)

--- a/planning/autoware_trajectory_modifier/src/trajectory_modifier_plugins/traffic_light_stop.cpp
+++ b/planning/autoware_trajectory_modifier/src/trajectory_modifier_plugins/traffic_light_stop.cpp
@@ -16,6 +16,9 @@
 
 #include "autoware/trajectory_modifier/trajectory_modifier_utils/utils.hpp"
 
+#include <memory>
+#include <string>
+
 namespace autoware::trajectory_modifier::plugin
 {
 
@@ -32,8 +35,7 @@ void TrafficLightStop::update_params([[maybe_unused]] const TrajectoryModifierPa
 }
 
 bool TrafficLightStop::is_trajectory_modification_required(
-  [[maybe_unused]] const TrajectoryPoints & traj_points,
-  [[maybe_unused]] const InputData & input)
+  [[maybe_unused]] const TrajectoryPoints & traj_points, [[maybe_unused]] const InputData & input)
 {
   return false;
 }
@@ -45,8 +47,7 @@ bool TrafficLightStop::modify_trajectory(
 }
 
 void TrafficLightStop::check_traffic_lights(
-  [[maybe_unused]] const TrajectoryPoints & traj_points,
-  [[maybe_unused]] const InputData & input)
+  [[maybe_unused]] const TrajectoryPoints & traj_points, [[maybe_unused]] const InputData & input)
 {
 }
 

--- a/planning/autoware_trajectory_modifier/src/trajectory_modifier_plugins/traffic_light_stop.cpp
+++ b/planning/autoware_trajectory_modifier/src/trajectory_modifier_plugins/traffic_light_stop.cpp
@@ -14,10 +14,32 @@
 
 #include "autoware/trajectory_modifier/trajectory_modifier_plugins/traffic_light_stop.hpp"
 
+#include "autoware/traffic_light_compliance_checker/traffic_light_compliance_checker.hpp"
 #include "autoware/trajectory_modifier/trajectory_modifier_utils/utils.hpp"
 
+#include <algorithm>
 #include <memory>
 #include <string>
+
+namespace
+{
+autoware::traffic_light_compliance_checker::Parameters to_checker_params(
+  const autoware::trajectory_modifier::plugin::TrajectoryModifierParams & params)
+{
+  const auto tl_stop_p = params.traffic_light_stop;
+  const auto stopping_params = params.stopping_constraints;
+  autoware::traffic_light_compliance_checker::Parameters p;
+  p.deceleration_limit = stopping_params.nominal_deceleration;
+  p.jerk_limit = stopping_params.jerk_limit;
+  p.crossing_time_limit = tl_stop_p.crossing_time_limit;
+  p.treat_amber_light_as_red_light = tl_stop_p.treat_amber_light_as_red;
+  p.stop_overshoot_margin = tl_stop_p.overshoot_tolerance;
+  p.stable_duration_threshold_red = tl_stop_p.th_stable_duration_red;
+  p.stable_duration_threshold_amber = tl_stop_p.th_stable_duration_amber;
+  p.amber_rejection_hysteresis_duration = tl_stop_p.th_amber_rejection_hysteresis;
+  return p;
+}
+}  // namespace
 
 namespace autoware::trajectory_modifier::plugin
 {
@@ -28,22 +50,67 @@ void TrafficLightStop::on_initialize([[maybe_unused]] const TrajectoryModifierPa
   planning_factor_interface_ =
     std::make_unique<autoware::planning_factor_interface::PlanningFactorInterface>(
       node_ptr, "modifier_traffic_light_stop");
+
+  enabled_ = params.use_traffic_light_stop;
+  params_ = params.traffic_light_stop;
+  stopping_params_ = params.stopping_constraints;
+
+  checker_ =
+    std::make_unique<autoware::traffic_light_compliance_checker::TrafficLightComplianceChecker>(
+      to_checker_params(params), context_->vehicle_info);
 }
 
 void TrafficLightStop::update_params([[maybe_unused]] const TrajectoryModifierParams & params)
 {
+  enabled_ = params.use_traffic_light_stop;
+  params_ = params.traffic_light_stop;
+  stopping_params_ = params.stopping_constraints;
+  checker_->update_parameters(to_checker_params(params));
 }
 
 bool TrafficLightStop::is_trajectory_modification_required(
   [[maybe_unused]] const TrajectoryPoints & traj_points, [[maybe_unused]] const InputData & input)
 {
-  return false;
+  if (!enabled_ || !check_inputs(input)) return false;
+
+  if (!checker_) {
+    RCLCPP_ERROR(get_node_ptr()->get_logger(), "Compliance checker is not initialized.");
+    return false;
+  }
+
+  const traffic_light_compliance_checker::Inputs inputs{
+    traj_points,
+    input.lanelet_map,
+    *input.route,
+    *input.traffic_light_signals,
+    get_clock()->now(),
+    input.current_odometry->twist.twist.linear.x,
+    input.current_acceleration->accel.accel.linear.x};
+
+  const auto result = checker_->check(inputs);
+  if (!result) return false;
+
+  if (result->violations.empty()) return false;
+
+  const auto nearest_it = std::min_element(result->violations.begin(), result->violations.end());
+  nearest_violation_ = *nearest_it;
+  return true;
+}
+
+bool TrafficLightStop::check_inputs(const InputData & input)
+{
+  return input.current_odometry && input.current_acceleration && input.route &&
+         input.traffic_light_signals && input.lanelet_map;
 }
 
 bool TrafficLightStop::modify_trajectory(
   [[maybe_unused]] TrajectoryPoints & traj_points, [[maybe_unused]] const InputData & input)
 {
-  return false;
+  if (!is_trajectory_modification_required(traj_points, input)) return false;
+
+  if (!nearest_violation_) return false;
+
+  return true;
 }
 
 void TrafficLightStop::check_traffic_lights(

--- a/planning/autoware_trajectory_modifier/src/trajectory_modifier_plugins/traffic_light_stop.cpp
+++ b/planning/autoware_trajectory_modifier/src/trajectory_modifier_plugins/traffic_light_stop.cpp
@@ -53,6 +53,8 @@ void TrafficLightStop::on_initialize([[maybe_unused]] const TrajectoryModifierPa
     std::make_unique<autoware::planning_factor_interface::PlanningFactorInterface>(
       node_ptr, "modifier_traffic_light_stop");
 
+  pub_debug_text_ = node_ptr->create_publisher<StringStamped>("~/traffic_light_stop/debug/text", 1);
+
   enabled_ = params.use_traffic_light_stop;
   params_ = params.traffic_light_stop;
   stopping_params_ = params.stopping_constraints;
@@ -115,6 +117,9 @@ bool TrafficLightStop::check_traffic_lights(
   const auto nearest_it = std::min_element(result->violations.begin(), result->violations.end());
   nearest_violation_ = *nearest_it;
 
+  debug_data_.violations_count = result->violations.size();
+  debug_data_.nearest_violation_arc_length = nearest_it->arc_length_to_cross_point;
+
   RCLCPP_WARN_THROTTLE(
     get_node_ptr()->get_logger(), *get_clock(), 1000,
     "[TM TrafficLightStop] Detected traffic light violation at arc length %f m",
@@ -127,11 +132,14 @@ bool TrafficLightStop::modify_trajectory(
 {
   autoware_utils_debug::ScopedTimeTrack st(
     "TrafficLightStop::modify_trajectory", *get_time_keeper());
-  if (!is_trajectory_modification_required(traj_points, input)) return false;
+  debug_data_ = DebugData{};
 
-  if (!nearest_violation_) return false;
+  if (is_trajectory_modification_required(traj_points, input) && nearest_violation_) {
+    debug_data_.active = set_stop_point(traj_points, input);
+  }
 
-  return set_stop_point(traj_points, input);
+  publish_debug_string();
+  return debug_data_.active;
 }
 
 bool TrafficLightStop::set_stop_point(TrajectoryPoints & traj_points, const InputData & input)
@@ -178,10 +186,30 @@ bool TrafficLightStop::set_stop_point(TrajectoryPoints & traj_points, const Inpu
   if (std::isnan(distance)) distance = 0.0;
   planning_factor_interface_->add(distance, stop_pose, PlanningFactor::STOP, SafetyFactorArray{});
 
+  debug_data_.stop_point_arc_length = target_stop_point_arc_length;
+
   RCLCPP_WARN_THROTTLE(
     get_node_ptr()->get_logger(), *get_clock(), 1000,
     "[TM TrafficLightStop] Inserted stop point at arc length %f m", target_stop_point_arc_length);
   return true;
+}
+
+void TrafficLightStop::publish_debug_string() const
+{
+  std::ostringstream ss;
+  ss << std::fixed << std::setprecision(2) << std::boolalpha;
+  ss << "TRAFFIC LIGHT STOP MODIFIER: " << "\n";
+  ss << "\t\t" << "ACTIVE: " << debug_data_.active << "\n";
+  if (debug_data_.active) {
+    ss << "\t\t" << "VIOLATIONS: " << debug_data_.violations_count << "\n";
+    ss << "\t\t" << "NEAREST VIOLATION: " << debug_data_.nearest_violation_arc_length << " m"
+       << "\n";
+    ss << "\t\t" << "STOP POINT: " << debug_data_.stop_point_arc_length << " m" << "\n";
+  }
+  StringStamped string_stamp;
+  string_stamp.stamp = get_clock()->now();
+  string_stamp.data = ss.str();
+  pub_debug_text_->publish(string_stamp);
 }
 
 }  // namespace autoware::trajectory_modifier::plugin

--- a/planning/autoware_trajectory_modifier/src/trajectory_modifier_plugins/traffic_light_stop.cpp
+++ b/planning/autoware_trajectory_modifier/src/trajectory_modifier_plugins/traffic_light_stop.cpp
@@ -29,7 +29,7 @@ autoware::traffic_light_compliance_checker::Parameters to_checker_params(
   const auto tl_stop_p = params.traffic_light_stop;
   const auto stopping_params = params.stopping_constraints;
   autoware::traffic_light_compliance_checker::Parameters p;
-  p.deceleration_limit = stopping_params.nominal_deceleration;
+  p.deceleration_limit = stopping_params.maximum_deceleration;
   p.jerk_limit = stopping_params.jerk_limit;
   p.crossing_time_limit = tl_stop_p.crossing_time_limit;
   p.treat_amber_light_as_red_light = tl_stop_p.treat_amber_light_as_red;
@@ -37,6 +37,8 @@ autoware::traffic_light_compliance_checker::Parameters to_checker_params(
   p.stable_duration_threshold_red = tl_stop_p.th_stable_duration_red;
   p.stable_duration_threshold_amber = tl_stop_p.th_stable_duration_amber;
   p.amber_rejection_hysteresis_duration = tl_stop_p.th_amber_rejection_hysteresis;
+  p.checked_trajectory_length.deceleration_limit = stopping_params.nominal_deceleration;
+  p.checked_trajectory_length.jerk_limit = stopping_params.jerk_limit;
   return p;
 }
 }  // namespace
@@ -71,12 +73,29 @@ void TrafficLightStop::update_params([[maybe_unused]] const TrajectoryModifierPa
 bool TrafficLightStop::is_trajectory_modification_required(
   [[maybe_unused]] const TrajectoryPoints & traj_points, [[maybe_unused]] const InputData & input)
 {
+  autoware_utils_debug::ScopedTimeTrack st(
+    "TrafficLightStop::is_trajectory_modification_required", *get_time_keeper());
   if (!enabled_ || !check_inputs(input)) return false;
 
   if (!checker_) {
     RCLCPP_ERROR(get_node_ptr()->get_logger(), "Compliance checker is not initialized.");
     return false;
   }
+
+  return check_traffic_lights(traj_points, input);
+}
+
+bool TrafficLightStop::check_inputs(const InputData & input)
+{
+  return input.current_odometry && input.current_acceleration && input.route &&
+         input.traffic_light_signals && input.lanelet_map;
+}
+
+bool TrafficLightStop::check_traffic_lights(
+  const TrajectoryPoints & traj_points, const InputData & input)
+{
+  autoware_utils_debug::ScopedTimeTrack st(
+    "TrafficLightStop::check_traffic_lights", *get_time_keeper());
 
   const traffic_light_compliance_checker::Inputs inputs{
     traj_points,
@@ -87,56 +106,82 @@ bool TrafficLightStop::is_trajectory_modification_required(
     input.current_odometry->twist.twist.linear.x,
     input.current_acceleration->accel.accel.linear.x};
 
-  const auto result = checker_->check(inputs);
+  const auto result =
+    checker_->check(inputs, params_.stop_for_red_light, params_.stop_for_amber_light);
   if (!result) return false;
 
   if (result->violations.empty()) return false;
 
   const auto nearest_it = std::min_element(result->violations.begin(), result->violations.end());
   nearest_violation_ = *nearest_it;
-  return true;
-}
 
-bool TrafficLightStop::check_inputs(const InputData & input)
-{
-  return input.current_odometry && input.current_acceleration && input.route &&
-         input.traffic_light_signals && input.lanelet_map;
+  RCLCPP_WARN_THROTTLE(
+    get_node_ptr()->get_logger(), *get_clock(), 1000,
+    "[TM TrafficLightStop] Detected traffic light violation at arc length %f m",
+    nearest_it->arc_length_to_cross_point);
+  return true;
 }
 
 bool TrafficLightStop::modify_trajectory(
   [[maybe_unused]] TrajectoryPoints & traj_points, [[maybe_unused]] const InputData & input)
 {
+  autoware_utils_debug::ScopedTimeTrack st(
+    "TrafficLightStop::modify_trajectory", *get_time_keeper());
   if (!is_trajectory_modification_required(traj_points, input)) return false;
 
   if (!nearest_violation_) return false;
 
+  return set_stop_point(traj_points, input);
+}
+
+bool TrafficLightStop::set_stop_point(TrajectoryPoints & traj_points, const InputData & input)
+{
+  autoware_utils_debug::ScopedTimeTrack st("TrafficLightStop::set_stop_point", *get_time_keeper());
+
+  const auto trajectory_length =
+    motion_utils::calcSignedArcLength(traj_points, 0, traj_points.size() - 1);
+
+  const auto stop_margin = params_.stop_margin + context_->vehicle_info.max_longitudinal_offset_m;
+  const auto target_stop_point_arc_length = utils::clamp_stop_point_arc_length(
+    nearest_violation_->arc_length_to_cross_point - stop_margin, trajectory_length,
+    input.current_odometry->twist.twist.linear.x, input.current_acceleration->accel.accel.linear.x,
+    stopping_params_.maximum_deceleration, stopping_params_.jerk_limit);
+
+  if (utils::stop_point_exists(traj_points, target_stop_point_arc_length)) {
+    RCLCPP_WARN_THROTTLE(
+      get_node_ptr()->get_logger(), *get_clock(), 1000,
+      "[TM TrafficLightStop] Preceding (or duplicate) stop point exists, skip inserting stop "
+      "point");
+    return false;
+  }
+
+  if (
+    target_stop_point_arc_length < stopping_params_.arrived_distance_threshold ||
+    !utils::insert_stop_point(traj_points, target_stop_point_arc_length, trajectory_length)) {
+    traj_points = std::invoke([&]() {
+      TrajectoryPoints stop_points;
+      auto p = traj_points.front();
+      p.longitudinal_velocity_mps = 0.0;
+      p.acceleration_mps2 = 0.0;
+      p.time_from_start = rclcpp::Duration::from_seconds(0.0);
+      stop_points.push_back(p);
+      p.time_from_start = rclcpp::Duration::from_seconds(trajectory_time_step_);
+      stop_points.push_back(p);
+      return stop_points;
+    });
+  }
+
+  const auto & stop_pose = traj_points.back().pose;
+  const auto & ego_pose = input.current_odometry->pose.pose;
+  auto distance =
+    motion_utils::calcSignedArcLength(traj_points, ego_pose.position, stop_pose.position);
+  if (std::isnan(distance)) distance = 0.0;
+  planning_factor_interface_->add(distance, stop_pose, PlanningFactor::STOP, SafetyFactorArray{});
+
+  RCLCPP_WARN_THROTTLE(
+    get_node_ptr()->get_logger(), *get_clock(), 1000,
+    "[TM TrafficLightStop] Inserted stop point at arc length %f m", target_stop_point_arc_length);
   return true;
-}
-
-void TrafficLightStop::check_traffic_lights(
-  [[maybe_unused]] const TrajectoryPoints & traj_points, [[maybe_unused]] const InputData & input)
-{
-}
-
-bool TrafficLightStop::set_stop_point(
-  [[maybe_unused]] TrajectoryPoints & traj_points, [[maybe_unused]] const InputData & input)
-{
-  return false;
-}
-
-bool TrafficLightStop::apply_stopping(
-  [[maybe_unused]] TrajectoryPoints & traj_points,
-  [[maybe_unused]] const double target_stop_point_arc_length) const
-{
-  return false;
-}
-
-void TrafficLightStop::publish_debug_string([[maybe_unused]] bool is_safe) const
-{
-}
-
-void TrafficLightStop::publish_debug_data([[maybe_unused]] const std::string & ns) const
-{
 }
 
 }  // namespace autoware::trajectory_modifier::plugin

--- a/planning/autoware_trajectory_modifier/src/trajectory_modifier_utils/utils.cpp
+++ b/planning/autoware_trajectory_modifier/src/trajectory_modifier_utils/utils.cpp
@@ -14,8 +14,8 @@
 
 #include "autoware/trajectory_modifier/trajectory_modifier_utils/utils.hpp"
 
-#include <autoware/motion_utils/trajectory/trajectory.hpp>
 #include <autoware/motion_utils/distance/distance.hpp>
+#include <autoware/motion_utils/trajectory/trajectory.hpp>
 
 #include <cmath>
 
@@ -68,16 +68,18 @@ bool is_ego_vehicle_moving(const geometry_msgs::msg::Twist & twist, const double
 }
 
 double clamp_stop_point_arc_length(
-  const double stop_point_arc_length, const double max_length,
-  const double ego_vel, const double ego_accel, const double decel_limit, const double jerk_limit)
+  const double stop_point_arc_length, const double max_length, const double ego_vel,
+  const double ego_accel, const double decel_limit, const double jerk_limit)
 {
-  auto min_stopping_distance = motion_utils::calculate_stop_distance(
-    ego_vel, ego_accel, decel_limit, jerk_limit, 0.0);
+  auto min_stopping_distance =
+    motion_utils::calculate_stop_distance(ego_vel, ego_accel, decel_limit, jerk_limit, 0.0);
   if (!min_stopping_distance) min_stopping_distance = 0.0;
   return std::clamp(stop_point_arc_length, min_stopping_distance.value(), max_length);
 }
 
-bool stop_point_exists(const TrajectoryPoints & traj_points, const double stop_point_arc_length, const double duplicate_check_threshold)
+bool stop_point_exists(
+  const TrajectoryPoints & traj_points, const double stop_point_arc_length,
+  const double duplicate_check_threshold)
 {
   constexpr double stop_velocity_threshold = 0.01;
   auto checked_distance = 0.0;

--- a/planning/autoware_trajectory_modifier/src/trajectory_modifier_utils/utils.cpp
+++ b/planning/autoware_trajectory_modifier/src/trajectory_modifier_utils/utils.cpp
@@ -15,6 +15,7 @@
 #include "autoware/trajectory_modifier/trajectory_modifier_utils/utils.hpp"
 
 #include <autoware/motion_utils/trajectory/trajectory.hpp>
+#include <autoware/motion_utils/distance/distance.hpp>
 
 #include <cmath>
 
@@ -64,6 +65,70 @@ bool is_ego_vehicle_moving(const geometry_msgs::msg::Twist & twist, const double
     twist.linear.z * twist.linear.z);
 
   return current_velocity > velocity_threshold;
+}
+
+double clamp_stop_point_arc_length(
+  const double stop_point_arc_length, const double max_length,
+  const double ego_vel, const double ego_accel, const double decel_limit, const double jerk_limit)
+{
+  auto min_stopping_distance = motion_utils::calculate_stop_distance(
+    ego_vel, ego_accel, decel_limit, jerk_limit, 0.0);
+  if (!min_stopping_distance) min_stopping_distance = 0.0;
+  return std::clamp(stop_point_arc_length, min_stopping_distance.value(), max_length);
+}
+
+bool stop_point_exists(const TrajectoryPoints & traj_points, const double stop_point_arc_length, const double duplicate_check_threshold)
+{
+  constexpr double stop_velocity_threshold = 0.01;
+  auto checked_distance = 0.0;
+  for (size_t i = 1; i < traj_points.size(); ++i) {
+    const auto & curr = traj_points.at(i);
+    const auto & prev = traj_points.at(i - 1);
+    checked_distance +=
+      autoware_utils_geometry::calc_distance2d(curr.pose.position, prev.pose.position);
+    if (checked_distance > stop_point_arc_length + duplicate_check_threshold) break;
+    if (curr.longitudinal_velocity_mps < stop_velocity_threshold) {
+      return true;
+    }
+  }
+  return false;
+}
+
+bool insert_stop_point(
+  TrajectoryPoints & trajectory, const double stop_point_arc_length, const double traj_length)
+{
+  if (stop_point_arc_length < 1e-3) return false;
+
+  const auto stop_index = [&]() -> size_t {
+    const auto index = motion_utils::insertStopPoint(stop_point_arc_length, trajectory);
+    if (index) return index.value();
+
+    // TODO(Quda): this is a temporary fix, need to check why insertStopPoint fails when target
+    // distance is equal to trajectory length
+    if (stop_point_arc_length < traj_length) {
+      auto dist = 0.0;
+      auto it = std::adjacent_find(
+        trajectory.begin(), trajectory.end(), [&](const auto & p, const auto & next) {
+          dist += autoware_utils_geometry::calc_distance2d(p.pose.position, next.pose.position);
+          return dist >= stop_point_arc_length - 1e-3;
+        });
+      if (it != trajectory.end()) {
+        it->longitudinal_velocity_mps = 0.0;
+        it->acceleration_mps2 = 0.0;
+        return std::distance(trajectory.begin(), it);
+      }
+    }
+
+    trajectory.back().longitudinal_velocity_mps = 0.0;
+    trajectory.back().acceleration_mps2 = 0.0;
+    return trajectory.size() - 1;
+  }();
+
+  trajectory.erase(trajectory.begin() + stop_index + 1, trajectory.end());
+  trajectory.back().longitudinal_velocity_mps = 0.0;
+  trajectory.back().acceleration_mps2 = 0.0;
+
+  return true;
 }
 
 }  // namespace autoware::trajectory_modifier::utils

--- a/planning/autoware_trajectory_modifier/tests/test_obstacle_stop_integration.cpp
+++ b/planning/autoware_trajectory_modifier/tests/test_obstacle_stop_integration.cpp
@@ -221,6 +221,7 @@ protected:
     params_.stopping_constraints.nominal_deceleration = 1.0;
     params_.stopping_constraints.maximum_deceleration = 4.0;
     params_.stopping_constraints.jerk_limit = 3.0;
+    params_.stopping_constraints.arrived_distance_threshold = 0.5;
 
     auto & p = params_.obstacle_stop;
     p.use_objects = true;
@@ -229,7 +230,6 @@ protected:
     p.enable_stop_for_pointcloud = true;
     p.stop_margin = 6.0;
     p.lateral_margin = 0.5;
-    p.arrived_distance_threshold = 0.5;
 
     p.obstacle_tracking.on_time_buffer = 0.01;
     p.obstacle_tracking.off_time_buffer = 1.0;


### PR DESCRIPTION
This PR adds `traffic_light_stop` plugin to `trajectory_modifier` node:
- Refactor stop point insertion logic from `obstacle_stop` and move to utility functions to commonize logic
- Add subscribers for lanelet_map, route, and signals
- Update trajectory_modifier plugin `InputData` struct
- Update and refactor trajectory_modifier node to process new input data
- Implement `TrafficLightStop` plugin
- Add traffic_light_stop parameters to trajectory_modifier config

requires https://github.com/tier4/autoware_launch.x2/pull/2365

[Screencast from 2026年06月03日 11時31分33秒.webm](https://github.com/user-attachments/assets/5dc53929-1641-4149-bd91-e911b478c0e9)

