### PR TITLE
feat(active_generator_rviz_plugin): feat active generator rviz plugin

### DIFF
--- a/visualization/tier4_active_generator_rviz_plugin/CMakeLists.txt
+++ b/visualization/tier4_active_generator_rviz_plugin/CMakeLists.txt
@@ -1,0 +1,28 @@
+cmake_minimum_required(VERSION 3.14)
+project(tier4_active_generator_rviz_plugin)
+
+find_package(autoware_cmake REQUIRED)
+autoware_package()
+
+find_package(Qt5 REQUIRED Core Widgets)
+set(QT_LIBRARIES Qt5::Widgets)
+set(CMAKE_AUTOMOC ON)
+set(CMAKE_INCLUDE_CURRENT_DIR ON)
+add_definitions(-DQT_NO_KEYWORDS)
+
+ament_auto_add_library(${PROJECT_NAME} SHARED
+  src/active_generator_panel.cpp
+  include/active_generator_panel.hpp
+)
+
+target_link_libraries(${PROJECT_NAME}
+  ${QT_LIBRARIES}
+)
+
+# Export the plugin to be imported by rviz2
+pluginlib_export_plugin_description_file(rviz_common plugins/plugin_description.xml)
+
+ament_auto_package(
+  INSTALL_TO_SHARE
+  plugins
+)

--- a/visualization/tier4_active_generator_rviz_plugin/include/active_generator_panel.hpp
+++ b/visualization/tier4_active_generator_rviz_plugin/include/active_generator_panel.hpp
@@ -1,0 +1,59 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef ACTIVE_GENERATOR_PANEL_HPP_
+#define ACTIVE_GENERATOR_PANEL_HPP_
+
+#include <QLabel>
+#include <QVBoxLayout>
+#include <QWidget>
+#include <rclcpp/rclcpp.hpp>
+#include <rviz_common/panel.hpp>
+
+#include <autoware_internal_planning_msgs/msg/scored_candidate_trajectories.hpp>
+
+#include <memory>
+#include <string>
+
+namespace rviz_plugins
+{
+
+class ActiveGeneratorPanel : public rviz_common::Panel
+{
+  Q_OBJECT
+
+public:
+  explicit ActiveGeneratorPanel(QWidget * parent = nullptr);
+  ~ActiveGeneratorPanel() override;
+
+protected:
+  void onInitialize() override;
+  void load(const rviz_common::Config & config) override;
+  void save(rviz_common::Config config) const override;
+
+private:
+  void processMessage(
+    const autoware_internal_planning_msgs::msg::ScoredCandidateTrajectories::ConstSharedPtr msg);
+  void updateLabel(const std::string & generator_name);
+  void subscribe();
+  void unsubscribe();
+
+  rclcpp::Subscription<autoware_internal_planning_msgs::msg::ScoredCandidateTrajectories>::SharedPtr
+    subscription_;
+  QLabel * generator_label_;
+};
+
+}  // namespace rviz_plugins
+
+#endif  // ACTIVE_GENERATOR_PANEL_HPP_

--- a/visualization/tier4_active_generator_rviz_plugin/package.xml
+++ b/visualization/tier4_active_generator_rviz_plugin/package.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>tier4_active_generator_rviz_plugin</name>
+  <version>0.46.0</version>
+  <description>RViz panel that displays the trajectory generator currently selected by the trajectory ranker</description>
+
+  <maintainer email="takumi.odashima@tier4.jp">Takumi Odashima</maintainer>
+  <maintainer email="satoshi.ota@tier4.jp">Satoshi Ota</maintainer>
+
+  <license>Apache License 2.0</license>
+
+  <buildtool_depend>ament_cmake_auto</buildtool_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
+
+  <depend>autoware_internal_planning_msgs</depend>
+  <depend>libqt5-core</depend>
+  <depend>libqt5-gui</depend>
+  <depend>libqt5-widgets</depend>
+  <depend>pluginlib</depend>
+  <depend>qtbase5-dev</depend>
+  <depend>rclcpp</depend>
+  <depend>rviz_common</depend>
+
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>autoware_lint_common</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+    <rviz plugin="${prefix}/plugins/plugin_description.xml"/>
+  </export>
+</package>

--- a/visualization/tier4_active_generator_rviz_plugin/plugins/plugin_description.xml
+++ b/visualization/tier4_active_generator_rviz_plugin/plugins/plugin_description.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<library path="tier4_active_generator_rviz_plugin">
+  <class name="rviz_plugins/ActiveGeneratorPanel"
+         type="rviz_plugins::ActiveGeneratorPanel"
+         base_class_type="rviz_common::Panel">
+    <description>
+      A panel that displays which trajectory generator (e.g. DiffusionPlanner_batch_0,
+      MinimumRuleBasedPlanner) is currently selected (highest score) by the trajectory ranker.
+    </description>
+  </class>
+</library>

--- a/visualization/tier4_active_generator_rviz_plugin/src/active_generator_panel.cpp
+++ b/visualization/tier4_active_generator_rviz_plugin/src/active_generator_panel.cpp
@@ -1,0 +1,168 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "active_generator_panel.hpp"
+
+#include <pluginlib/class_list_macros.hpp>
+#include <rviz_common/display_context.hpp>
+
+#include <algorithm>
+#include <limits>
+#include <string>
+
+namespace rviz_plugins
+{
+
+ActiveGeneratorPanel::ActiveGeneratorPanel(QWidget * parent)
+: rviz_common::Panel(parent), subscription_(nullptr)
+{
+  auto * layout = new QVBoxLayout(this);
+
+  generator_label_ = new QLabel(this);
+  generator_label_->setAlignment(Qt::AlignCenter);
+  generator_label_->setText("No data");
+  generator_label_->setStyleSheet(
+    "QLabel {"
+    "  padding: 10px;"
+    "  border-radius: 5px;"
+    "  background-color: #333333;"
+    "  color: white;"
+    "  font-size: 14px;"
+    "  font-weight: bold;"
+    "}");
+
+  layout->addWidget(generator_label_);
+  setLayout(layout);
+}
+
+ActiveGeneratorPanel::~ActiveGeneratorPanel()
+{
+  unsubscribe();
+}
+
+void ActiveGeneratorPanel::onInitialize()
+{
+  subscribe();
+}
+
+void ActiveGeneratorPanel::load(const rviz_common::Config & config)
+{
+  Panel::load(config);
+}
+
+void ActiveGeneratorPanel::save(rviz_common::Config config) const
+{
+  Panel::save(config);
+}
+
+void ActiveGeneratorPanel::processMessage(
+  const autoware_internal_planning_msgs::msg::ScoredCandidateTrajectories::ConstSharedPtr msg)
+{
+  if (msg->scored_candidate_trajectories.empty()) {
+    updateLabel("");
+    return;
+  }
+
+  float best_score = -std::numeric_limits<float>::infinity();
+  const autoware_internal_planning_msgs::msg::ScoredCandidateTrajectory * best = nullptr;
+  for (const auto & scored : msg->scored_candidate_trajectories) {
+    if (scored.score > best_score) {
+      best_score = scored.score;
+      best = &scored;
+    }
+  }
+
+  if (best == nullptr) {
+    updateLabel("");
+    return;
+  }
+
+  const auto & best_uuid = best->candidate_trajectory.generator_id.uuid;
+  std::string generator_name;
+  for (const auto & info : msg->generator_info) {
+    if (info.generator_id.uuid == best_uuid) {
+      generator_name = info.generator_name.data;
+      break;
+    }
+  }
+
+  updateLabel(generator_name);
+}
+
+void ActiveGeneratorPanel::updateLabel(const std::string & generator_name)
+{
+  QString text;
+  QString bg_color;
+
+  if (generator_name.empty()) {
+    text = "No data";
+    bg_color = "#333333";  // Dark gray
+  } else {
+    text = QString::fromStdString(generator_name);
+    if (generator_name.rfind("DiffusionPlanner", 0) == 0) {
+      bg_color = "#4CAF50";  // Green
+    } else if (generator_name.rfind("MinimumRuleBasedPlanner", 0) == 0) {
+      bg_color = "#2196F3";  // Blue
+    } else {
+      bg_color = "#9E9E9E";  // Gray
+    }
+  }
+
+  generator_label_->setText(text);
+  generator_label_->setStyleSheet(QString(
+                                    "QLabel {"
+                                    "  padding: 10px;"
+                                    "  border-radius: 5px;"
+                                    "  background-color: %1;"
+                                    "  color: white;"
+                                    "  font-size: 14px;"
+                                    "  font-weight: bold;"
+                                    "}")
+                                    .arg(bg_color));
+}
+
+void ActiveGeneratorPanel::subscribe()
+{
+  if (!isEnabled()) {
+    return;
+  }
+
+  try {
+    auto node = getDisplayContext()->getRosNodeAbstraction().lock()->get_raw_node();
+    subscription_ =
+      node->create_subscription<autoware_internal_planning_msgs::msg::ScoredCandidateTrajectories>(
+        "/planning/trajectory_selector/ranker/scored_trajectories", 10,
+        std::bind(&ActiveGeneratorPanel::processMessage, this, std::placeholders::_1));
+  } catch (const std::exception & e) {
+    generator_label_->setText("Error: Topic subscription failed");
+    generator_label_->setStyleSheet(
+      "QLabel {"
+      "  padding: 10px;"
+      "  border-radius: 5px;"
+      "  background-color: #F44336;"
+      "  color: white;"
+      "  font-size: 14px;"
+      "  font-weight: bold;"
+      "}");
+  }
+}
+
+void ActiveGeneratorPanel::unsubscribe()
+{
+  subscription_.reset();
+}
+
+}  // namespace rviz_plugins
+
+PLUGINLIB_EXPORT_CLASS(rviz_plugins::ActiveGeneratorPanel, rviz_common::Panel)

--- a/visualization/tier4_active_generator_rviz_plugin/src/active_generator_panel.cpp
+++ b/visualization/tier4_active_generator_rviz_plugin/src/active_generator_panel.cpp
@@ -14,12 +14,28 @@
 
 #include "active_generator_panel.hpp"
 
+#include <QColor>
 #include <pluginlib/class_list_macros.hpp>
 #include <rviz_common/display_context.hpp>
 
 #include <algorithm>
 #include <limits>
 #include <string>
+
+namespace
+{
+
+QString colorForGeneratorName(const std::string & name)
+{
+  int hash = 0;
+  for (const char character : name) {
+    hash = (hash * 31 + static_cast<unsigned char>(character)) % 360;
+  }
+  const int hue = (hash + 360) % 360;
+  return QColor::fromHslF(hue / 360.0, 0.62, 0.52).name();
+}
+
+}  // namespace
 
 namespace rviz_plugins
 {
@@ -110,13 +126,7 @@ void ActiveGeneratorPanel::updateLabel(const std::string & generator_name)
     bg_color = "#333333";  // Dark gray
   } else {
     text = QString::fromStdString(generator_name);
-    if (generator_name.rfind("DiffusionPlanner", 0) == 0) {
-      bg_color = "#4CAF50";  // Green
-    } else if (generator_name.rfind("MinimumRuleBasedPlanner", 0) == 0) {
-      bg_color = "#2196F3";  // Blue
-    } else {
-      bg_color = "#9E9E9E";  // Gray
-    }
+    bg_color = colorForGeneratorName(generator_name);
   }
 
   generator_label_->setText(text);


### PR DESCRIPTION
In this PR, add new rviz2 panel plugin for visualize current active trajectory generator type.

To determine active generator type, this plugin subscribes to the `/planning/trajectory_selector/ranker/scored_trajectories` topic.

e.g. 
on active diffusion planner trajectory

<img width="1385" height="914" alt="image" src="https://github.com/user-attachments/assets/d2f9b6e3-b4c4-4af4-8f05-3133909e032e" />

on active minimum rule based planner trajectory

<img width="1385" height="914" alt="image" src="https://github.com/user-attachments/assets/1b9dd80c-38b7-424f-b539-78a04a67258a" />


required: https://github.com/tier4/autoware_launch.x2/pull/2366