### PR TITLE
chore(trajectory_validator): modify thresholds of vehicle constraint filter

### DIFF
--- a/planning/autoware_trajectory_validator/README.md
+++ b/planning/autoware_trajectory_validator/README.md
@@ -39,8 +39,8 @@ After these checks, the remaining trajectories, along with their original `gener
 | `out_of_lane.min_value`                 | double       | 0.0     | Minimum distance [m] from lane boundary                                    |
 | `vehicle_constraint.max_speed`          | double       | 16.7    | Maximum allowed speed [m/s]                                                |
 | `vehicle_constraint.max_acceleration`   | double       | 5.0     | Maximum allowed acceleration [m/s^2]                                       |
-| `vehicle_constraint.max_deceleration`   | double       | 5.0     | Maximum allowed deceleration; positive but represents deceleration [m/s^s] |
-| `vehicle_constraint.max_steering_angle` | double       | 0.8     | Maximum allowed steering angle [rad]                                       |
+| `vehicle_constraint.max_deceleration`   | double       | 8.0     | Maximum allowed deceleration; positive but represents deceleration [m/s^s] |
+| `vehicle_constraint.max_steering_angle` | double       | 1.0     | Maximum allowed steering angle [rad]                                       |
 | `vehicle_constraint.max_steering_rate`  | double       | 0.3     | Maximum allowed steering rate [rad/s]                                      |
 
 ## Future Work

--- a/planning/autoware_trajectory_validator/config/trajectory_validator.param.yaml
+++ b/planning/autoware_trajectory_validator/config/trajectory_validator.param.yaml
@@ -60,8 +60,8 @@
     vehicle_constraint:
       max_speed: 16.7 # m/s
       max_acceleration: 5.0 # m/s^2
-      max_deceleration: 5.0 # m/s^2 (positive but represents deceleration)
-      max_steering_angle: 0.8 # rad
+      max_deceleration: 8.0 # m/s^2 (positive but represents deceleration)
+      max_steering_angle: 1.0 # rad
       max_steering_rate: 0.3 # rad/s
 
     traffic_light:

--- a/planning/autoware_trajectory_validator/param/parameter_struct.yaml
+++ b/planning/autoware_trajectory_validator/param/parameter_struct.yaml
@@ -36,12 +36,12 @@ validator:
       read_only: false
     max_deceleration:
       type: double
-      default_value: 5.0
+      default_value: 8.0
       description: Maximum allowed deceleration (m/s^2, positive but represents deceleration)
       read_only: false
     max_steering_angle:
       type: double
-      default_value: 0.8
+      default_value: 1.0
       description: Maximum allowed steering angle (rad)
       read_only: false
     max_steering_rate:


### PR DESCRIPTION
## What

This PR should be merged with https://github.com/tier4/autoware_launch.x2/pull/2368.

This pull request updates the vehicle constraint parameters for trajectory validation to allow for higher deceleration and a wider steering angle. These changes are reflected in the configuration, parameter structure, and documentation to ensure consistency across the codebase.

**Parameter Updates:**

* Increased the default value of `max_deceleration` from 5.0 to 8.0 m/s² in `parameter_struct.yaml` and updated its description accordingly.
* Increased the default value of `max_steering_angle` from 0.8 to 1.0 radians in `parameter_struct.yaml` and updated its description accordingly.

**Configuration and Documentation:**

* Updated `trajectory_validator.param.yaml` to reflect the new values for `max_deceleration` (8.0 m/s²) and `max_steering_angle` (1.0 rad).
* Updated the documentation table in `README.md` to match the new parameter values for `max_deceleration` and `max_steering_angle`.