### PR TITLE
refactor(obstacle_stop): optimize collision check logic

### DIFF
--- a/planning/autoware_minimum_rule_based_planner/plugins/obstacle_stop.cpp
+++ b/planning/autoware_minimum_rule_based_planner/plugins/obstacle_stop.cpp
@@ -160,16 +160,12 @@ std::optional<CollisionPoint> ObstacleStop::check_predicted_objects(
     debug_data_.target_polygons);
 
   autoware_perception_msgs::msg::PredictedObject colliding_object;
-  auto collision_point = std::invoke([&]() -> std::optional<CollisionPoint> {
-    if (!params_.rss_params.enable) {
-      return get_nearest_object_collision(traj_points, predicted_objects, colliding_object);
-    }
-    return get_nearest_object_collision(
-      traj_points, vehicle_info_, predicted_objects, object_decel_map_,
-      params_.rss_params.ego_decel, params_.rss_params.reaction_time,
-      params_.rss_params.safety_margin, params_.objects.stopped_velocity_th,
-      params_.rss_params.lookahead_horizon, colliding_object);
-  });
+  auto collision_point = get_nearest_object_collision(
+    traj_points, vehicle_info_, predicted_objects, object_decel_map_, params_.rss_params.ego_decel,
+    params_.rss_params.reaction_time, params_.rss_params.safety_margin,
+    params_.objects.stopped_velocity_th, params_.rss_params.lookahead_horizon, colliding_object,
+    params_.rss_params.enable);
+
   if (collision_point) debug_data_.colliding_object = colliding_object;
   return collision_point;
 }

--- a/planning/autoware_trajectory_modifier/config/trajectory_modifier.param.yaml
+++ b/planning/autoware_trajectory_modifier/config/trajectory_modifier.param.yaml
@@ -46,7 +46,7 @@
       objects:
         object_types: ["car", "truck", "bus", "trailer", "motorcycle", "bicycle", "pedestrian"] # object types to consider for obstacle stop
         max_velocity_th: 5.0      # maximum velocity threshold for target object [m/s]
-        stopped_velocity_th: 0.25 # [m/s]
+        stopped_velocity_th: 0.4 # [m/s]
         max_lateral_velocity_th: 1.0 # [m/s] max lateral velocity (w.r.t ego traj) to consider for obstacle stop
         safety_buffer: 0.0 # [m] safety buffer to expand object shape
 
@@ -74,9 +74,9 @@
           motorcycle: 3.0
           bicycle: 5.0
           pedestrian: 5.0
-        ego_decel: 4.0 # [m/s^2]
-        reaction_time: 0.2 # [s]
-        safety_margin: 2.0 # [m]
+        ego_decel: 2.0 # [m/s^2]
+        reaction_time: 0.4 # [s]
+        safety_margin: 2.5 # [m]
         lookahead_horizon: 1.5 # [s]
 
     # Traffic Light Stop Plugin Parameters

--- a/planning/autoware_trajectory_modifier/include/autoware/trajectory_modifier/trajectory_modifier_utils/obstacle_stop_utils.hpp
+++ b/planning/autoware_trajectory_modifier/include/autoware/trajectory_modifier/trajectory_modifier_utils/obstacle_stop_utils.hpp
@@ -193,20 +193,6 @@ std::optional<CollisionPoint> get_nearest_pcd_collision(
   const TrajectoryPoints & trajectory_points, const TrajectoryShape & trajectory_shape,
   const PointCloud::Ptr & pointcloud, std::vector<geometry_msgs::msg::Point> & target_pcd_points);
 
-/**
- * @brief Find the nearest obstacle along the path using each object's footprint polygon at the
- * current time.
- * @details For every target object, polygon vertices are projected onto arc length along the
- * trajectory; the minimum over all vertices and objects defines the collision point.
- * @param trajectory_points Reference path.
- * @param target_objects Predicted objects to test (typically already filtered).
- * @param[out] colliding_object Object that yielded the minimum arc-length collision.
- * @return Collision point and arc length, or nullopt if inputs are invalid or no objects.
- */
-std::optional<CollisionPoint> get_nearest_object_collision(
-  const TrajectoryPoints & trajectory_points, const PredictedObjects & target_objects,
-  PredictedObject & colliding_object);
-
 using ObjectDecelMap = std::unordered_map<ObjectType, double>;
 
 /**
@@ -239,7 +225,8 @@ std::optional<CollisionPoint> get_nearest_object_collision(
   const autoware::vehicle_info_utils::VehicleInfo & vehicle_info,
   const PredictedObjects & target_objects, const ObjectDecelMap & object_decel_map,
   const double ego_decel, const double reaction_time, const double safety_margin,
-  const double stopped_vel_th, const double lookahead_horizon, PredictedObject & colliding_object);
+  const double stopped_vel_th, const double lookahead_horizon, PredictedObject & colliding_object,
+  const bool use_rss_check = true);
 
 /// Filters predicted objects by semantic type, speed, and spatial relationship to the trajectory.
 struct ObjectFilter

--- a/planning/autoware_trajectory_modifier/src/trajectory_modifier_plugins/obstacle_stop.cpp
+++ b/planning/autoware_trajectory_modifier/src/trajectory_modifier_plugins/obstacle_stop.cpp
@@ -324,16 +324,11 @@ std::optional<CollisionPoint> ObstacleStop::check_predicted_objects(
     active_objects, traj_points, debug_data_.trajectory_shape.polygon, debug_data_.target_polygons);
 
   autoware_perception_msgs::msg::PredictedObject colliding_object;
-  auto collision_point = std::invoke([&]() -> std::optional<CollisionPoint> {
-    if (!params_.rss_params.enable) {
-      return get_nearest_object_collision(traj_points, active_objects, colliding_object);
-    }
-    return get_nearest_object_collision(
-      traj_points, context_->vehicle_info, active_objects, object_decel_map_,
-      params_.rss_params.ego_decel, params_.rss_params.reaction_time,
-      params_.rss_params.safety_margin, params_.objects.stopped_velocity_th,
-      params_.rss_params.lookahead_horizon, colliding_object);
-  });
+  auto collision_point = get_nearest_object_collision(
+    traj_points, context_->vehicle_info, active_objects, object_decel_map_,
+    params_.rss_params.ego_decel, params_.rss_params.reaction_time,
+    params_.rss_params.safety_margin, params_.objects.stopped_velocity_th,
+    params_.rss_params.lookahead_horizon, colliding_object, params_.rss_params.enable);
 
   if (collision_point) debug_data_.colliding_object = colliding_object;
 

--- a/planning/autoware_trajectory_modifier/src/trajectory_modifier_utils/obstacle_stop_utils.cpp
+++ b/planning/autoware_trajectory_modifier/src/trajectory_modifier_utils/obstacle_stop_utils.cpp
@@ -331,9 +331,15 @@ std::optional<CollisionPoint> get_nearest_object_collision(
   const autoware::vehicle_info_utils::VehicleInfo & vehicle_info,
   const PredictedObjects & target_objects, const ObjectDecelMap & object_decel_map,
   const double ego_decel, const double reaction_time, const double safety_margin,
-  const double stopped_vel_th, const double lookahead_horizon, PredictedObject & colliding_object)
+  const double stopped_vel_th, const double lookahead_horizon, PredictedObject & colliding_object,
+  const bool use_rss_check)
 {
   if (target_objects.objects.empty() || trajectory_points.size() < 2) return std::nullopt;
+
+  // If RSS check is disabled, get the nearest object collision by pure geometric overlap.
+  if (!use_rss_check) {
+    return get_nearest_object_collision(trajectory_points, target_objects, colliding_object);
+  }
 
   const auto ego_front_offset = vehicle_info.max_longitudinal_offset_m;
 
@@ -356,13 +362,14 @@ std::optional<CollisionPoint> get_nearest_object_collision(
   geometry_msgs::msg::Point nearest_collision_point;
   bool found_collision = false;
   auto curr_arc_length = 0.0;
-  auto last_p = trajectory_points.front().pose.position;
-  for (const auto & traj_p : trajectory_points) {
-    const auto t = rclcpp::Duration(traj_p.time_from_start).seconds();
-    if (t > lookahead_horizon) break;
-    curr_arc_length += autoware_utils::calc_distance2d(last_p, traj_p.pose.position);
-    const auto target_ego_vel = traj_p.longitudinal_velocity_mps;
-    for (const auto & object : target_objects.objects) {
+
+  for (const auto & object : target_objects.objects) {
+    auto last_p = trajectory_points.front().pose.position;
+    for (const auto & traj_p : trajectory_points) {
+      const auto t = rclcpp::Duration(traj_p.time_from_start).seconds();
+      if (t > lookahead_horizon) break;
+      curr_arc_length += autoware_utils::calc_distance2d(last_p, traj_p.pose.position);
+      const auto target_ego_vel = traj_p.longitudinal_velocity_mps;
       const auto obj_state = get_object_state_at_time(trajectory_points, object, t);
       if (is_safe(object, obj_state.arc_length, obj_state.lon_vel, curr_arc_length, target_ego_vel))
         continue;
@@ -372,8 +379,9 @@ std::optional<CollisionPoint> get_nearest_object_collision(
         colliding_object = object;
         nearest_collision_point = obj_state.nearest_point;
       }
+      last_p = traj_p.pose.position;
+      break;
     }
-    last_p = traj_p.pose.position;
   }
 
   if (!found_collision) return std::nullopt;


### PR DESCRIPTION
- refactor function get_nearest_object_collision to avoid duplicate checks of same object state for each trajectory point
- update default param values