### PR TITLE
RDDR-354 Adjust output ptv3 (filterring only ground pointcloud)

### DIFF
--- a/perception/autoware_ptv3/config/ptv3.param.yaml
+++ b/perception/autoware_ptv3/config/ptv3.param.yaml
@@ -14,8 +14,5 @@
         "drivable_surface",
         "other_flat_surface",
         "sidewalk",
-        "vegetation",
-        "noise+ghost_point",
-        "manmade"
       ]
       output_format: ""


### PR DESCRIPTION
https://tier4.atlassian.net/browse/RDDR-353

- `/perception/obstacle_segmentation/pointcloud` rviz

<img width="1833" height="1123" alt="image" src="https://github.com/user-attachments/assets/2a1bffa9-c2a8-4346-846c-68f7f04babad" />

- `/perception/obstacle_segmentation/pointcloud` point number: ~ 18k
<img width="1227" height="778" alt="image" src="https://github.com/user-attachments/assets/91b00138-84af-4ff0-85d4-481dd0353c79" />
