### PR TITLE
feat(raw_vehicle_cmd_converter): add understeer compensation only mode

### DIFF
--- a/vehicle/autoware_raw_vehicle_cmd_converter/CMakeLists.txt
+++ b/vehicle/autoware_raw_vehicle_cmd_converter/CMakeLists.txt
@@ -12,6 +12,7 @@ ament_auto_add_library(actuation_map_converter SHARED
   src/pid.cpp
   src/vgr.cpp
   src/vgr_with_understeer_compensation.cpp
+  src/understeer_compensation.cpp
 )
 
 ament_auto_add_library(vehicle_adaptor SHARED

--- a/vehicle/autoware_raw_vehicle_cmd_converter/README.md
+++ b/vehicle/autoware_raw_vehicle_cmd_converter/README.md
@@ -45,6 +45,22 @@ vgr_coef_c: 0.042
 When `convert_steer_cmd_method: "vgr"` is selected, the node receives the control command from the controller as the desired tire angle and calculates the desired steering angle to output.
 Also, when `convert_actuation_to_steering_status: true`, this node receives the `actuation_status` topic and calculates the steer tire angle from the `steer_wheel_angle` and publishes it.
 
+### Understeer Compensation
+
+At non-zero lateral acceleration the kinematic bicycle model underestimates the
+tire angle required to follow a curve, because the tires slip (understeer). Using
+a linear understeer model `δ_real = δ_Ackermann + K_us · a_y` and `a_y ≈ v² · δ / L`,
+the required tire angle is the commanded one scaled by a speed-dependent factor:
+
+$$
+\delta_{cmd} = \delta \times \left(1 + K_{us} \times \frac{v^2}{L}\right)
+$$
+
+where `K_us` is the understeer gradient (`understeer_gradient` [rad·s²/m]) and `L`
+is the wheelbase. Two methods apply this factor:
+
+`convert_steer_cmd_method: "understeer_compensation"` applies the understeer factor, leaving the output as a (compensated) tire angle `δ · (1 + K_us · v² / L)`. Use this when the tire-to-wheel gear ratio is handled elsewhere (e.g. by the vehicle firmware). Because the factor depends only on the vehicle speed, this method does **not** require the `actuation_status` topic. Since the factor inflates the tire angle, the output is clamped to `±max_steer_angle` [rad], taken from `vehicle_info` (the vehicle's physical max steer angle). Note that the `max_steer` / `min_steer` parameters only bound the `steer_map` output and do **not** apply to this method.
+
 ### Vehicle Adaptor
 
 **Under development**

--- a/vehicle/autoware_raw_vehicle_cmd_converter/config/raw_vehicle_cmd_converter.param.yaml
+++ b/vehicle/autoware_raw_vehicle_cmd_converter/config/raw_vehicle_cmd_converter.param.yaml
@@ -26,7 +26,7 @@
       max_d: 0.0
       min_d: 0.0
       invalid_integration_decay: 0.97
-    convert_steer_cmd_method: "vgr"  # "vgr" | "vgr_with_understeer_compensation" | "steer_map"
+    convert_steer_cmd_method: "vgr"  # "vgr" | "vgr_with_understeer_compensation" | "understeer_compensation" | "steer_map"
     vgr_coef_a: 15.713
     vgr_coef_b: 0.053
     vgr_coef_c: 0.042

--- a/vehicle/autoware_raw_vehicle_cmd_converter/include/autoware_raw_vehicle_cmd_converter/node.hpp
+++ b/vehicle/autoware_raw_vehicle_cmd_converter/include/autoware_raw_vehicle_cmd_converter/node.hpp
@@ -19,6 +19,7 @@
 #include "autoware_raw_vehicle_cmd_converter/brake_map.hpp"
 #include "autoware_raw_vehicle_cmd_converter/pid.hpp"
 #include "autoware_raw_vehicle_cmd_converter/steer_map.hpp"
+#include "autoware_raw_vehicle_cmd_converter/understeer_compensation.hpp"
 #include "autoware_raw_vehicle_cmd_converter/vehicle_adaptor/vehicle_adaptor.hpp"
 #include "autoware_raw_vehicle_cmd_converter/vgr.hpp"
 #include "autoware_raw_vehicle_cmd_converter/vgr_with_understeer_compensation.hpp"
@@ -117,6 +118,7 @@ public:
   SteerMap steer_map_;
   VGR vgr_;
   VGRWithUndersteerCompensation vgr_with_us_;
+  UndersteerCompensation understeer_comp_;
   VehicleAdaptor vehicle_adaptor_;
   autoware::vehicle_info_utils::VehicleInfo vehicle_info_;
   // TODO(tanaka): consider accel/brake pid too

--- a/vehicle/autoware_raw_vehicle_cmd_converter/include/autoware_raw_vehicle_cmd_converter/understeer_compensation.hpp
+++ b/vehicle/autoware_raw_vehicle_cmd_converter/include/autoware_raw_vehicle_cmd_converter/understeer_compensation.hpp
@@ -1,0 +1,42 @@
+//  Copyright 2026 Tier IV, Inc. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+#ifndef AUTOWARE_RAW_VEHICLE_CMD_CONVERTER__UNDERSTEER_COMPENSATION_HPP_
+#define AUTOWARE_RAW_VEHICLE_CMD_CONVERTER__UNDERSTEER_COMPENSATION_HPP_
+
+namespace autoware::raw_vehicle_cmd_converter
+{
+// Steady-state understeer compensation *without* the mechanical VGR. The
+// kinematic bicycle requires an extra Δδ = K_us · ay to track a curve at
+// non-zero lateral acceleration. Pulling δ/L out and treating tan(δ) ≈ δ, this
+// becomes a multiplicative factor on the (tire-angle) command:
+//   δ_cmd = δ · (1 + K_us · v² / L)
+// Unlike VGRWithUndersteerCompensation the output stays a tire angle (no gear
+// ratio is applied); use this when the tire-to-wheel gear ratio is handled
+// elsewhere (e.g. by the vehicle firmware).
+class UndersteerCompensation
+{
+public:
+  UndersteerCompensation() = default;
+  void setUndersteerParams(double k_us, double wheelbase);
+  double calculateUndersteerRatio(double vel) const;
+  double calculateSteeringTireState(double vel, double steer_status) const;
+
+private:
+  double k_us_{0.0};
+  double wheelbase_{1.0};
+};
+}  // namespace autoware::raw_vehicle_cmd_converter
+
+#endif  // AUTOWARE_RAW_VEHICLE_CMD_CONVERTER__UNDERSTEER_COMPENSATION_HPP_

--- a/vehicle/autoware_raw_vehicle_cmd_converter/schema/raw_vehicle_cmd_converter.schema.json
+++ b/vehicle/autoware_raw_vehicle_cmd_converter/schema/raw_vehicle_cmd_converter.schema.json
@@ -159,7 +159,12 @@
           "type": "string",
           "description": "method for converting steer command",
           "default": "vgr",
-          "enum": ["vgr", "vgr_with_understeer_compensation", "steer_map"]
+          "enum": [
+            "vgr",
+            "vgr_with_understeer_compensation",
+            "understeer_compensation",
+            "steer_map"
+          ]
         },
         "vgr_coef_a": {
           "type": "number",

--- a/vehicle/autoware_raw_vehicle_cmd_converter/src/node.cpp
+++ b/vehicle/autoware_raw_vehicle_cmd_converter/src/node.cpp
@@ -67,6 +67,9 @@ RawVehicleCommandConverterNode::RawVehicleCommandConverterNode(
       const double k_us = declare_parameter<double>("understeer_gradient");
       vgr_with_us_.setCoefficients(a, b, c);
       vgr_with_us_.setUndersteerParams(k_us, vehicle_info_.wheel_base_m);
+    } else if (convert_steer_cmd_method_.value() == "understeer_compensation") {
+      const double k_us = declare_parameter<double>("understeer_gradient");
+      understeer_comp_.setUndersteerParams(k_us, vehicle_info_.wheel_base_m);
     } else if (convert_steer_cmd_method_.value() == "steer_map") {
       const auto csv_path_steer_map = declare_parameter<std::string>("csv_path_steer_map");
       if (!steer_map_.readSteerMapFromCSV(csv_path_steer_map, true)) {
@@ -214,6 +217,10 @@ void RawVehicleCommandConverterNode::publishActuationCmd()
     const double adaptive_gear_ratio =
       vgr_with_us_.calculateVariableGearRatio(vel, current_steer_wheel);
     desired_steer_cmd = steer * adaptive_gear_ratio;
+  } else if (convert_steer_cmd_method_.value() == "understeer_compensation") {
+    desired_steer_cmd = steer * understeer_comp_.calculateUndersteerRatio(vel);
+    const double max_steer_tire_angle = vehicle_info_.max_steer_angle_rad;
+    desired_steer_cmd = std::clamp(desired_steer_cmd, -max_steer_tire_angle, max_steer_tire_angle);
   } else if (convert_steer_cmd_method_.value() == "steer_map") {
     desired_steer_cmd = calculateSteerFromMap(vel, steer, steer_rate);
   }
@@ -336,6 +343,13 @@ void RawVehicleCommandConverterNode::onActuationStatus(
       pub_steering_status_->publish(steering_msg);
     } else if (convert_steer_cmd_method_.value() == "vgr_with_understeer_compensation") {
       current_steer_ptr_ = std::make_unique<double>(vgr_with_us_.calculateSteeringTireState(
+        current_odometry_->twist.twist.linear.x, actuation_status_ptr_->status.steer_status));
+      Steering steering_msg{};
+      steering_msg.stamp = this->now();
+      steering_msg.steering_tire_angle = *current_steer_ptr_;
+      pub_steering_status_->publish(steering_msg);
+    } else if (convert_steer_cmd_method_.value() == "understeer_compensation") {
+      current_steer_ptr_ = std::make_unique<double>(understeer_comp_.calculateSteeringTireState(
         current_odometry_->twist.twist.linear.x, actuation_status_ptr_->status.steer_status));
       Steering steering_msg{};
       steering_msg.stamp = this->now();

--- a/vehicle/autoware_raw_vehicle_cmd_converter/src/understeer_compensation.cpp
+++ b/vehicle/autoware_raw_vehicle_cmd_converter/src/understeer_compensation.cpp
@@ -1,0 +1,37 @@
+//  Copyright 2026 Tier IV, Inc. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+
+#include "autoware_raw_vehicle_cmd_converter/understeer_compensation.hpp"
+
+namespace autoware::raw_vehicle_cmd_converter
+{
+
+void UndersteerCompensation::setUndersteerParams(const double k_us, const double wheelbase)
+{
+  k_us_ = k_us;
+  wheelbase_ = wheelbase;
+}
+
+double UndersteerCompensation::calculateUndersteerRatio(const double vel) const
+{
+  return 1.0 + k_us_ * vel * vel / wheelbase_;
+}
+
+double UndersteerCompensation::calculateSteeringTireState(
+  const double vel, const double steer_status) const
+{
+  return steer_status / calculateUndersteerRatio(vel);
+}
+
+}  // namespace autoware::raw_vehicle_cmd_converter

--- a/vehicle/autoware_raw_vehicle_cmd_converter/src/understeer_compensation.cpp
+++ b/vehicle/autoware_raw_vehicle_cmd_converter/src/understeer_compensation.cpp
@@ -25,6 +25,7 @@ void UndersteerCompensation::setUndersteerParams(const double k_us, const double
 
 double UndersteerCompensation::calculateUndersteerRatio(const double vel) const
 {
+  if (vel <= 0.0) return 1.0;
   return 1.0 + k_us_ * vel * vel / wheelbase_;
 }
 

--- a/vehicle/autoware_raw_vehicle_cmd_converter/src/vgr_with_understeer_compensation.cpp
+++ b/vehicle/autoware_raw_vehicle_cmd_converter/src/vgr_with_understeer_compensation.cpp
@@ -30,6 +30,7 @@ void VGRWithUndersteerCompensation::setUndersteerParams(const double k_us, const
 
 double VGRWithUndersteerCompensation::calculateUndersteerRatio(const double vel) const
 {
+  if (vel <= 0.0) return 1.0;
   return 1.0 + k_us_ * vel * vel / wheelbase_;
 }
 

--- a/vehicle/autoware_raw_vehicle_cmd_converter/test/test_autoware_raw_vehicle_cmd_converter.cpp
+++ b/vehicle/autoware_raw_vehicle_cmd_converter/test/test_autoware_raw_vehicle_cmd_converter.cpp
@@ -17,6 +17,7 @@
 #include "autoware_raw_vehicle_cmd_converter/brake_map.hpp"
 #include "autoware_raw_vehicle_cmd_converter/pid.hpp"
 #include "autoware_raw_vehicle_cmd_converter/steer_map.hpp"
+#include "autoware_raw_vehicle_cmd_converter/understeer_compensation.hpp"
 #include "autoware_raw_vehicle_cmd_converter/vgr.hpp"
 #include "gtest/gtest.h"
 
@@ -53,6 +54,7 @@ using autoware::raw_vehicle_cmd_converter::AccelMap;
 using autoware::raw_vehicle_cmd_converter::BrakeMap;
 using autoware::raw_vehicle_cmd_converter::PIDController;
 using autoware::raw_vehicle_cmd_converter::SteerMap;
+using autoware::raw_vehicle_cmd_converter::UndersteerCompensation;
 using autoware::raw_vehicle_cmd_converter::VGR;
 double epsilon = 1e-4;
 // may throw PackageNotFoundError exception for invalid package
@@ -372,4 +374,20 @@ TEST(VGRTests, zeroCoefficients)
   const double steer = vgr.calculateSteeringTireState(vel, steer_wheel);
   const double steer_wheel2 = steer * gear_ratio;
   EXPECT_NEAR(steer_wheel, steer_wheel2, epsilon);
+}
+
+TEST(UndersteerCompensationTests, ratioFormula)
+{
+  UndersteerCompensation us;
+  const double k_us = 0.020;
+  const double wheelbase = 4.76012;
+  us.setUndersteerParams(k_us, wheelbase);
+
+  // ratio = 1 + k_us * v^2 / L, so it is >= 1 and grows with speed.
+  const double vel = 10.0;
+  const double expected = 1.0 + k_us * vel * vel / wheelbase;
+  EXPECT_NEAR(us.calculateUndersteerRatio(vel), expected, epsilon);
+
+  // at standstill there is no understeer to compensate -> unity factor
+  EXPECT_NEAR(us.calculateUndersteerRatio(0.0), 1.0, epsilon);
 }

--- a/vehicle/autoware_raw_vehicle_cmd_converter/test/test_autoware_raw_vehicle_cmd_converter.cpp
+++ b/vehicle/autoware_raw_vehicle_cmd_converter/test/test_autoware_raw_vehicle_cmd_converter.cpp
@@ -390,4 +390,7 @@ TEST(UndersteerCompensationTests, ratioFormula)
 
   // at standstill there is no understeer to compensate -> unity factor
   EXPECT_NEAR(us.calculateUndersteerRatio(0.0), 1.0, epsilon);
+
+  // compensation is disables at negative velocities
+  EXPECT_NEAR(us.calculateUndersteerRatio(-1.0), 1.0, epsilon);
 }


### PR DESCRIPTION
add understeer only compensation mode to `raw_vehicle_cmd_converter`.

to activate:
- `convert_steer_cmd: true`
- `convert_steer_cmd_method: "understeer_compensation"`
- `understeer_gradient: (set value larger than 0)`