### PR TITLE
feat: polar voxel noise filter cherry-picked from awf universe

### DIFF
--- a/sensing/autoware_cuda_pointcloud_preprocessor/CMakeLists.txt
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/CMakeLists.txt
@@ -87,6 +87,7 @@ cuda_add_library(cuda_pointcloud_preprocessor_lib SHARED
   src/cuda_pointcloud_preprocessor/common_kernels.cu
   src/cuda_pointcloud_preprocessor/organize_kernels.cu
   src/cuda_pointcloud_preprocessor/outlier_kernels.cu
+  src/cuda_outlier_filter/cuda_polar_voxel_noise_filter.cu
   src/cuda_pointcloud_preprocessor/undistort_kernels.cu
   src/cuda_downsample_filter/cuda_voxel_grid_downsample_filter.cu
   src/cuda_outlier_filter/cuda_polar_voxel_outlier_filter.cu
@@ -129,6 +130,7 @@ ament_auto_add_library(cuda_pointcloud_preprocessor SHARED
   src/cuda_pointcloud_preprocessor/cuda_pointcloud_preprocessor_node.cpp
   src/cuda_downsample_filter/cuda_voxel_grid_downsample_filter_node.cpp
   src/cuda_outlier_filter/cuda_polar_voxel_outlier_filter_node.cpp
+  src/cuda_outlier_filter/cuda_polar_voxel_noise_filter_node.cpp
 )
 
 target_link_libraries(cuda_pointcloud_preprocessor
@@ -158,6 +160,12 @@ rclcpp_components_register_node(cuda_pointcloud_preprocessor
 rclcpp_components_register_node(cuda_pointcloud_preprocessor
   PLUGIN "autoware::cuda_pointcloud_preprocessor::CudaPolarVoxelOutlierFilterNode"
   EXECUTABLE cuda_polar_voxel_outlier_filter_node
+)
+
+# ========== PolarVoxel noise filter ==========
+rclcpp_components_register_node(cuda_pointcloud_preprocessor
+  PLUGIN "autoware::cuda_pointcloud_preprocessor::CudaPolarVoxelNoiseFilterNode"
+  EXECUTABLE cuda_polar_voxel_noise_filter_node
 )
 
 ################################################################################

--- a/sensing/autoware_cuda_pointcloud_preprocessor/docs/cuda-polar-voxel-noise-filter.md
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/docs/cuda-polar-voxel-noise-filter.md
@@ -1,0 +1,43 @@
+# cuda_polar_voxel_noise_filter
+
+## Purpose
+
+This node is a CUDA-accelerated version of the `PolarVoxelNoiseFilter` available in [autoware_pointcloud_preprocessor](../../autoware_pointcloud_preprocessor).
+
+## Inner-workings / Algorithms
+
+This node is an alternative implementation to `autoware::pointcloud_preprocessor::PolarVoxelNoiseFilterComponent`, which removes low-density polar voxels and optionally suppresses secondary returns using return-type classification.
+
+## Inputs / Outputs
+
+### Input
+
+| Name                      | Type                                             | Description                              |
+| ------------------------- | ------------------------------------------------ | ---------------------------------------- |
+| `~/input/pointcloud`      | `sensor_msgs::msg::PointCloud2`                  | Input pointcloud topic.                  |
+| `~/input/pointcloud/cuda` | `negotiated_interfaces/msg/NegotiatedTopicsInfo` | Input pointcloud type negotiation topic. |
+
+### Output
+
+| Name                       | Type                                             | Description                                 |
+| -------------------------- | ------------------------------------------------ | ------------------------------------------- |
+| `~/output/pointcloud`      | `sensor_msgs::msg::PointCloud2`                  | Filtered pointcloud topic.                  |
+| `~/output/pointcloud/cuda` | `negotiated_interfaces/msg/NegotiatedTopicsInfo` | Filtered pointcloud type negotiation topic. |
+
+#### Additional Debug Topics
+
+| Name                            | Type                                             | Description                         |
+| ------------------------------- | ------------------------------------------------ | ----------------------------------- |
+| `~/debug/pointcloud_noise`      | `sensor_msgs::msg::PointCloud2`                  | Points classified as noise.         |
+| `~/debug/pointcloud_noise/cuda` | `negotiated_interfaces/msg/NegotiatedTopicsInfo` | Noise pointcloud negotiation topic. |
+
+## Parameters
+
+See [the original implementation in autoware_pointcloud_preprocessor](../../autoware_pointcloud_preprocessor/docs/polar-voxel-noise-filter.md) for the detailed parameter definitions.
+
+## Assumptions / Known limits
+
+- Input pointclouds must contain an `intensity` field.
+- If `use_return_type_classification` is enabled, the input pointcloud must also contain a `return_type` field.
+- The CUDA implementation supports `PointXYZIRC` input and `PointXYZIRCAEDT` input with precomputed polar coordinates.
+- Due to floating-point differences between CPU and GPU execution, results may not be bitwise identical to the CPU implementation.

--- a/sensing/autoware_cuda_pointcloud_preprocessor/include/autoware/cuda_pointcloud_preprocessor/cuda_outlier_filter/cuda_polar_voxel_noise_filter.hpp
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/include/autoware/cuda_pointcloud_preprocessor/cuda_outlier_filter/cuda_polar_voxel_noise_filter.hpp
@@ -1,0 +1,247 @@
+// Copyright 2025 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/* *INDENT-OFF* */
+#ifndef AUTOWARE__CUDA_POINTCLOUD_PREPROCESSOR__CUDA_OUTLIER_FILTER__CUDA_POLAR_VOXEL_NOISE_FILTER_HPP_
+#define AUTOWARE__CUDA_POINTCLOUD_PREPROCESSOR__CUDA_OUTLIER_FILTER__CUDA_POLAR_VOXEL_NOISE_FILTER_HPP_
+
+#include "autoware/cuda_pointcloud_preprocessor/cuda_outlier_filter/cub_executor.hpp"
+
+#include <autoware/cuda_utils/cuda_unique_ptr.hpp>
+#include <cuda/std/optional>
+#include <cuda_blackboard/cuda_pointcloud2.hpp>
+#include <cuda_blackboard/cuda_unique_ptr.hpp>
+
+#include <cuda_runtime.h>
+
+#include <cassert>
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <tuple>
+#include <type_traits>
+#include <vector>
+
+namespace autoware::cuda_pointcloud_preprocessor
+{
+struct CudaPolarVoxelNoiseFilterParameters
+{
+  double radial_resolution_m;
+  double azimuth_resolution_rad;
+  double elevation_resolution_rad;
+  int voxel_points_threshold;
+  double avg_intensity_threshold;
+  double min_radius_m;
+  double max_radius_m;
+  bool use_return_type_classification;
+  bool filter_secondary_returns;
+  int secondary_noise_threshold;
+  bool publish_noise_cloud;
+};
+
+enum class FieldDataIndex : uint8_t { radius = 0, azimuth, elevation };
+inline FieldDataIndex begin(FieldDataIndex)
+{
+  return FieldDataIndex::radius;
+}
+inline FieldDataIndex end(FieldDataIndex)
+{
+  using base_type = std::underlying_type<FieldDataIndex>::type;
+  return static_cast<FieldDataIndex>(static_cast<base_type>(FieldDataIndex::elevation) + 1);
+}
+inline FieldDataIndex operator*(FieldDataIndex f)
+{
+  return f;
+}
+inline FieldDataIndex operator++(FieldDataIndex & f)
+{
+  using base_type = std::underlying_type<FieldDataIndex>::type;
+  return f = static_cast<FieldDataIndex>(static_cast<base_type>(f) + 1);
+}
+
+template <typename T>
+struct FieldDataComposer
+{
+  T radius;
+  T azimuth;
+  T elevation;
+
+  __host__ __device__ T & operator[](FieldDataIndex i)
+  {
+    switch (i) {
+      case FieldDataIndex::radius:
+        return radius;
+      case FieldDataIndex::azimuth:
+        return azimuth;
+      case FieldDataIndex::elevation:
+        return elevation;
+      default:
+        assert(0);
+    }
+  }
+
+  __host__ __device__ const T & operator[](FieldDataIndex i) const
+  {
+    switch (i) {
+      case FieldDataIndex::radius:
+        return radius;
+      case FieldDataIndex::azimuth:
+        return azimuth;
+      case FieldDataIndex::elevation:
+        return elevation;
+      default:
+        assert(0);
+    }
+  }
+};
+
+struct ReturnTypeCandidates
+{
+  int * return_types = nullptr;
+  size_t num_candidates = 0;
+};
+
+template <typename T>
+using CudaPooledUniquePtr = autoware::cuda_utils::CudaPooledUniquePtr<T>;
+
+class CudaPolarVoxelNoiseFilter
+{
+public:
+  struct FilterReturn
+  {
+    std::unique_ptr<cuda_blackboard::CudaPointCloud2> filtered_cloud;
+    std::unique_ptr<cuda_blackboard::CudaPointCloud2> noise_cloud;
+  };
+
+  enum class PolarDataType : uint8_t { PreComputed, DeriveFromCartesian };
+
+  CudaPolarVoxelNoiseFilter();
+  ~CudaPolarVoxelNoiseFilter();
+
+  /**
+   * \brief Filters a point cloud based on polar voxel grid parameters.
+   *
+   * This function performs the main filtering process, dividing the point cloud into a
+   * polar voxel grid and removing voxels with insufficient points.
+   *
+   * \param input_cloud A shared pointer to the input point cloud.
+   * \param params Parameters controling the filtering process (resolution, thresholds, etc.).
+   * \param polar_type Specifies how polar data is handled (pre-computed or derived from Cartesian).
+   *
+   * \return A FilterReturn struct containing the filtered cloud and optional noise cloud.
+   */
+  FilterReturn filter(
+    const cuda_blackboard::CudaPointCloud2::ConstSharedPtr & input_cloud,
+    const CudaPolarVoxelNoiseFilterParameters & params, const PolarDataType polar_type);
+
+  /**
+   * \brief Sets the primary return types for filtering.
+   *
+   * This function sets the return types that are considered as primary returns,
+   * used for filtering secondary returns or noise.
+   *
+   * \param primary_types A vector of integers representing the primary return types.
+   */
+  void set_primary_return_types(const std::vector<int> & primary_types)
+  {
+    set_return_types(primary_types, primary_return_type_dev_);
+  }
+
+protected:
+  enum class ReductionType : uint8_t { Min, Max, Sum };
+
+  /** \brief Copy `types`, which lies on the host memory, to `types_dev`, which is on the device
+   *  memory
+   */
+  void set_return_types(
+    const std::vector<int> & types, std::optional<ReturnTypeCandidates> & types_dev);
+
+  /**
+   * \brief Calculates the voxel index for each point in the point cloud.
+   *
+   * This function determines the index of the voxel that each point belongs to within the polar
+   * voxel grid.
+   *
+   * \param polar_voxel_indices A pointer to the array of polar voxel indices.
+   * \param num_points The number of points in the point cloud.
+   *
+   * \return A tuple containing the number of valid voxels, the point index array, and
+   * corresponding voxel index array for each points
+   */
+  std::tuple<int, CudaPooledUniquePtr<::cuda::std::optional<int>>, CudaPooledUniquePtr<int>>
+  calculate_voxel_index(
+    const FieldDataComposer<::cuda::std::optional<int32_t> *> & polar_voxel_indices,
+    const size_t & num_points);
+
+  /**
+   * \brief Calculates the indices of points after filtering
+   *
+   * This function identifies the points that meet the criteria for being considered valid points.
+   *
+   * \param valid_points A pointer to the array indicating valid points.
+   * \param num_points The number of points in the point cloud.
+   *
+   * \return A tuple containing the filtered(valid) point indices and the number of valid points.
+   */
+  std::tuple<CudaPooledUniquePtr<int>, size_t> calculate_filtered_point_indices(
+    const CudaPooledUniquePtr<bool> & valid_points, const size_t & num_points);
+
+  /** \brief perform device reduction operation on the specified array on the device and copy the
+   *  result to the host.
+   *
+   *  Since this function calls cudaMemcpyAsync and does not call cudaStreamSynchronize inside
+   * (to make synchronization control under the caller), the device memory region that
+   * the reduction result will be stored needs to be valid (not released) until
+   * cudaStreamSynchronize is called. Hence, this function takes it as argument because allocating
+   * such region in the function may cause potential memory release before synchronization (i.e.,
+   * memory copy complete)
+   * \param reduction_type The type of reduction operation to perform (Min, Max, Sum).
+   * \param dev_array The array to reduce on the device.
+   * \param array_length The length of the array.
+   * \param result_dev A pointer to the device memory where the result will be stored.
+   * \param result_host A pointer to the host memory where the result will be copied.
+   */
+  template <typename T, typename U>
+  void reduce_and_copy_to_host(
+    const ReductionType reduction_type, const T & dev_array, const size_t & array_length,
+    U * result_dev, U & result_host);
+
+  /**
+   * \brief Creates the output point cloud from the filtered points.
+   *
+   * This function creates a new point cloud containing the filtered points.
+   *
+   * \param input_cloud A shared pointer to the input point cloud.
+   * \param points_mask A unique pointer to the mask indicating the filtered points.
+   * \param num_points The number of points in the point cloud.
+   * \param output_cloud A unique pointer to the output point cloud.
+   *
+   * \return The number of points in the output point cloud.
+   */
+  size_t create_output(
+    const cuda_blackboard::CudaPointCloud2::ConstSharedPtr & input_cloud,
+    const CudaPooledUniquePtr<bool> & points_mask, const size_t & num_points,
+    std::unique_ptr<cuda_blackboard::CudaPointCloud2> & output_cloud);
+
+private:
+  cudaStream_t stream_{};
+  cudaMemPool_t mem_pool_{};
+  CubExecutor cub_executor_;
+
+  std::optional<ReturnTypeCandidates> primary_return_type_dev_;
+};
+}  // namespace autoware::cuda_pointcloud_preprocessor
+
+#endif  // AUTOWARE__CUDA_POINTCLOUD_PREPROCESSOR__CUDA_OUTLIER_FILTER__CUDA_POLAR_VOXEL_NOISE_FILTER_HPP_
+/* *INDENT-ON* */

--- a/sensing/autoware_cuda_pointcloud_preprocessor/include/autoware/cuda_pointcloud_preprocessor/cuda_outlier_filter/cuda_polar_voxel_noise_filter_node.hpp
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/include/autoware/cuda_pointcloud_preprocessor/cuda_outlier_filter/cuda_polar_voxel_noise_filter_node.hpp
@@ -1,0 +1,85 @@
+// Copyright 2025 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef AUTOWARE__CUDA_POINTCLOUD_PREPROCESSOR__CUDA_OUTLIER_FILTER__CUDA_POLAR_VOXEL_NOISE_FILTER_NODE_HPP_
+#define AUTOWARE__CUDA_POINTCLOUD_PREPROCESSOR__CUDA_OUTLIER_FILTER__CUDA_POLAR_VOXEL_NOISE_FILTER_NODE_HPP_
+
+#include "autoware/cuda_pointcloud_preprocessor/cuda_outlier_filter/cuda_polar_voxel_noise_filter.hpp"
+
+#include <cuda_blackboard/cuda_adaptation.hpp>
+#include <cuda_blackboard/cuda_blackboard_publisher.hpp>
+#include <cuda_blackboard/cuda_blackboard_subscriber.hpp>
+#include <cuda_blackboard/cuda_pointcloud2.hpp>
+#include <rclcpp/rclcpp.hpp>
+
+#include <memory>
+#include <mutex>
+#include <string>
+#include <vector>
+
+namespace autoware::cuda_pointcloud_preprocessor
+{
+class CudaPolarVoxelNoiseFilterNode : public rclcpp::Node
+{
+public:
+  explicit CudaPolarVoxelNoiseFilterNode(const rclcpp::NodeOptions & node_options);
+
+protected:
+  /** \brief Parameter service callback result : needed to be hold */
+  OnSetParametersCallbackHandle::SharedPtr set_param_res_;
+
+  /** \brief Parameter service callback */
+  rcl_interfaces::msg::SetParametersResult param_callback(const std::vector<rclcpp::Parameter> & p);
+
+  /** \brief main callback for pointcloud processing
+   */
+  void pointcloud_callback(const cuda_blackboard::CudaPointCloud2::ConstSharedPtr msg);
+
+  // Utility functions to validate inputs
+  void validate_filter_inputs(const cuda_blackboard::CudaPointCloud2::ConstSharedPtr & input_cloud);
+  void validate_intensity_field(
+    const cuda_blackboard::CudaPointCloud2::ConstSharedPtr & input_cloud);
+  void validate_return_type_field(
+    const cuda_blackboard::CudaPointCloud2::ConstSharedPtr & input_cloud);
+  bool has_field(
+    const cuda_blackboard::CudaPointCloud2::ConstSharedPtr & input, const std::string & field_name);
+
+  // Parameter validation helper (static, private)
+  static bool validate_primary_return_types(const rclcpp::Parameter & param, std::string & reason);
+
+private:
+  enum class InputPointCloudFormat { PointXYZIRC, PointXYZIRCAEDT };
+
+  CudaPolarVoxelNoiseFilterParameters filter_params_;
+  std::vector<int> primary_return_types_;  // Return types considered as primary returns
+  std::mutex param_mutex_;
+  std::once_flag input_format_once_flag_;
+  std::optional<InputPointCloudFormat> input_format_;
+
+  // CUDA sub
+  std::shared_ptr<cuda_blackboard::CudaBlackboardSubscriber<cuda_blackboard::CudaPointCloud2>>
+    pointcloud_sub_{};
+
+  // CUDA pub
+  std::unique_ptr<cuda_blackboard::CudaBlackboardPublisher<cuda_blackboard::CudaPointCloud2>>
+    filtered_cloud_pub_{};
+  std::unique_ptr<cuda_blackboard::CudaBlackboardPublisher<cuda_blackboard::CudaPointCloud2>>
+    noise_cloud_pub_{};
+
+  std::unique_ptr<CudaPolarVoxelNoiseFilter> cuda_polar_voxel_noise_filter_{};
+};
+
+}  // namespace autoware::cuda_pointcloud_preprocessor
+
+#endif  // AUTOWARE__CUDA_POINTCLOUD_PREPROCESSOR__CUDA_OUTLIER_FILTER__CUDA_POLAR_VOXEL_NOISE_FILTER_NODE_HPP_

--- a/sensing/autoware_cuda_pointcloud_preprocessor/launch/cuda_polar_voxel_noise_filter.launch.xml
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/launch/cuda_polar_voxel_noise_filter.launch.xml
@@ -1,0 +1,39 @@
+<launch>
+  <arg name="input/pointcloud" default="/sensing/lidar/top/pointcloud_raw"/>
+  <arg name="output/pointcloud" default="/sensing/lidar/top/filtered"/>
+  <arg name="debug" default="false">
+    <choice value="true"/>
+    <choice value="false"/>
+  </arg>
+  <arg name="use_sim_time" default="false">
+    <choice value="true"/>
+    <choice value="false"/>
+  </arg>
+
+  <arg name="polar_voxel_noise_filter_param_file" default="$(find-pkg-share autoware_pointcloud_preprocessor)/config/polar_voxel_noise_filter_node.param.yaml"/>
+
+  <node pkg="autoware_cuda_pointcloud_preprocessor" exec="cuda_polar_voxel_noise_filter_node" name="cuda_polar_voxel_noise_filter" output="screen" unless="$(var debug)">
+    <remap from="~/input/pointcloud" to="$(var input/pointcloud)"/>
+    <remap from="~/input/pointcloud/cuda" to="$(var input/pointcloud)/cuda/dummy"/>
+    <remap from="~/output/pointcloud" to="$(var output/pointcloud)"/>
+    <remap from="~/output/pointcloud/cuda" to="$(var output/pointcloud)/cuda/dummy"/>
+    <param from="$(var polar_voxel_noise_filter_param_file)"/>
+    <param name="use_sim_time" value="$(var use_sim_time)"/>
+  </node>
+
+  <node
+    pkg="autoware_cuda_pointcloud_preprocessor"
+    exec="cuda_polar_voxel_noise_filter_node"
+    name="cuda_polar_voxel_noise_filter"
+    output="screen"
+    launch-prefix="gnome-terminal -- cuda-gdb --args"
+    if="$(var debug)"
+  >
+    <remap from="~/input/pointcloud" to="$(var input/pointcloud)"/>
+    <remap from="~/input/pointcloud/cuda" to="$(var input/pointcloud)/cuda/dummy"/>
+    <remap from="~/output/pointcloud" to="$(var output/pointcloud)"/>
+    <remap from="~/output/pointcloud/cuda" to="$(var output/pointcloud)/cuda/dummy"/>
+    <param from="$(var polar_voxel_noise_filter_param_file)"/>
+    <param name="use_sim_time" value="$(var use_sim_time)"/>
+  </node>
+</launch>

--- a/sensing/autoware_cuda_pointcloud_preprocessor/schema/cuda_polar_voxel_noise_filter.schema.json
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/schema/cuda_polar_voxel_noise_filter.schema.json
@@ -1,0 +1,116 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Parameters for the cuda_polar_voxel_noise_filter",
+  "type": "object",
+  "definitions": {
+    "cuda_polar_voxel_noise_filter": {
+      "type": "object",
+      "properties": {
+        "radial_resolution": {
+          "type": "number",
+          "description": "Resolution in radial direction [m].",
+          "default": "0.5",
+          "minimum": 0
+        },
+        "azimuth_resolution": {
+          "type": "number",
+          "description": "Resolution in azimuth direction [rad]. The supplied value is modified to ensure consistent voxel sizes across the whole azimuth range.",
+          "default": "0.08",
+          "minimum": 0,
+          "maximum": 6.283185307179586
+        },
+        "elevation_resolution": {
+          "type": "number",
+          "description": "Resolution in elevation direction [rad]. The supplied value is modified to ensure consistent voxel sizes across the whole elevation range.",
+          "default": "0.05",
+          "minimum": 0,
+          "maximum": 6.283185307179586
+        },
+        "voxel_points_threshold": {
+          "type": "integer",
+          "description": "Minimum number of points required per voxel.",
+          "default": "4",
+          "minimum": 1
+        },
+        "avg_intensity_threshold": {
+          "type": "number",
+          "description": "Maximum average intensity threshold for secondary returns.",
+          "default": "0.01",
+          "minimum": 0
+        },
+        "min_radius": {
+          "type": "number",
+          "description": "Minimum radius to consider [m].",
+          "default": "0.5",
+          "minimum": 0
+        },
+        "max_radius": {
+          "type": "number",
+          "description": "Maximum radius to consider [m].",
+          "default": "200.0",
+          "minimum": 0
+        },
+        "use_return_type_classification": {
+          "type": "boolean",
+          "description": "Whether to use return type classification.",
+          "default": "true"
+        },
+        "filter_secondary_returns": {
+          "type": "boolean",
+          "description": "Whether to filter secondary returns.",
+          "default": "true"
+        },
+        "secondary_noise_threshold": {
+          "type": "integer",
+          "description": "Threshold for classifying primary vs secondary returns.",
+          "default": "4",
+          "minimum": 0
+        },
+        "primary_return_types": {
+          "type": "array",
+          "description": "List of return type values considered as primary returns.",
+          "items": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 255
+          },
+          "default": "[1, 6, 8, 10]"
+        },
+        "publish_noise_cloud": {
+          "type": "boolean",
+          "description": "Whether to generate and publish a noise pointcloud for debugging.",
+          "default": "false"
+        }
+      },
+      "required": [
+        "radial_resolution",
+        "azimuth_resolution",
+        "elevation_resolution",
+        "voxel_points_threshold",
+        "avg_intensity_threshold",
+        "min_radius",
+        "max_radius",
+        "use_return_type_classification",
+        "filter_secondary_returns",
+        "secondary_noise_threshold",
+        "primary_return_types",
+        "publish_noise_cloud"
+      ],
+      "additionalProperties": false
+    }
+  },
+  "properties": {
+    "/**": {
+      "type": "object",
+      "properties": {
+        "ros__parameters": {
+          "$ref": "#/definitions/cuda_polar_voxel_noise_filter"
+        }
+      },
+      "required": ["ros__parameters"],
+      "additionalProperties": false
+    }
+  },
+  "required": ["/**"],
+  "additionalProperties": false
+}

--- a/sensing/autoware_cuda_pointcloud_preprocessor/src/cuda_outlier_filter/cuda_polar_voxel_noise_filter.cu
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/src/cuda_outlier_filter/cuda_polar_voxel_noise_filter.cu
@@ -1,0 +1,881 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/cuda_pointcloud_preprocessor/cuda_outlier_filter/cuda_polar_voxel_noise_filter.hpp"
+#include "autoware/cuda_utils/cuda_check_error.hpp"
+#include "autoware/cuda_utils/cuda_memory_pool.hpp"
+#include "autoware/cuda_utils/cuda_unique_ptr.hpp"
+
+#include <cub/cub.cuh>
+#include <cuda/functional>    // for cuda::proclaim_return_type
+#include <cuda/std/optional>  // for cuda::std::optional
+#include <cuda_blackboard/cuda_pointcloud2.hpp>
+#include <rclcpp/exceptions/exceptions.hpp>
+
+#include <thrust/iterator/transform_iterator.h>
+
+#include <cstdint>
+#include <limits>
+#include <locale>
+#include <memory>
+#include <optional>
+#include <sstream>
+#include <stdexcept>
+#include <type_traits>
+
+namespace autoware::cuda_pointcloud_preprocessor
+{
+namespace
+{
+constexpr size_t point_cloud_height_organized = 1;
+
+struct ValidAndNotEqualTo
+{
+  /**
+   * Functor (originally intended being consumed by
+   * cub::DeviceAdjacentDifference::SubtractLeft(Copy))
+   * which calculate `output[i] = difference_op(input[i], input[i-1])` for each element
+
+   * |...| i-2 | i-1 (=lhs) | i (=rhs) | i+1 |...|
+   *
+   * Since the operator takes optional, the comparison criteria is as follows considering nullopt
+   *
+   * | lhs \ rhs | nullopt | has_value                  |
+   * | nullopt   | false   | true                       |
+   * | has_value | false   | lhs.value() != rhs.value() |
+   */
+  template <typename DataType>
+  __host__ __device__ bool operator()(
+    const ::cuda::std::optional<DataType> & lhs, const ::cuda::std::optional<DataType> & rhs)
+  {
+    return rhs && (!lhs || lhs.value() != rhs.value());
+  }
+};
+
+struct NulloptToMax
+{
+  /*
+   * Functor to think cuda::std::nullopt as ::cuda::std::numeric_limits<int>::max()
+   */
+  template <typename DataType>
+  __host__ __device__ __forceinline__ DataType
+  operator()(const ::cuda::std::optional<DataType> & opt) const
+  {
+    return opt.has_value() ? opt.value() : ::cuda::std::numeric_limits<DataType>::max();
+  }
+};
+
+struct NulloptToLowest
+{
+  /*
+   * Functor to think cuda::std::nullopt as ::cuda::std::numeric_limits<int>::lowest()
+   * NOTE: std::numeric_limits::min returns the minimum, non-zero, positive value while
+   * std::numeric_limits::lowest() returns the negative minimum value
+   */
+  template <typename DataType>
+  __host__ __device__ __forceinline__ DataType
+  operator()(const ::cuda::std::optional<DataType> & opt) const
+  {
+    return opt.has_value() ? opt.value() : ::cuda::std::numeric_limits<DataType>::lowest();
+  }
+};
+
+/** \brief factory utility function to allocate unique_ptr and FieldDataComposer with allocated
+ * pointer
+ */
+template <typename T>
+[[nodiscard]] std::tuple<
+  CudaPooledUniquePtr<T>, CudaPooledUniquePtr<T>, CudaPooledUniquePtr<T>, FieldDataComposer<T *>>
+generate_field_data_composer(const size_t & num_elems, cudaStream_t & stream, cudaMemPool_t & pool)
+{
+  auto radius = autoware::cuda_utils::make_unique<T>(num_elems, stream, pool);
+  auto azimuth = autoware::cuda_utils::make_unique<T>(num_elems, stream, pool);
+  auto elevation = autoware::cuda_utils::make_unique<T>(num_elems, stream, pool);
+
+  FieldDataComposer<T *> composer;
+  composer.radius = radius.get();
+  composer.azimuth = azimuth.get();
+  composer.elevation = elevation.get();
+  return std::make_tuple(
+    std::move(radius), std::move(azimuth), std::move(elevation), std::move(composer));
+}
+
+/** \brief atomicAdd operation for size_t
+ *
+ * Since cuda's builtin atomicAdd does not have overloaded function for size_t,
+ * and the definition may differ according to platforms, this function define atomicAdd operation
+ * with size check
+ */
+__device__ void atomic_add_size_t(size_t * addr, size_t val)
+{
+  if constexpr (sizeof(size_t) == sizeof(unsigned int)) {
+    atomicAdd(reinterpret_cast<unsigned int *>(addr), static_cast<unsigned int>(val));
+  } else if constexpr (sizeof(size_t) == sizeof(unsigned long long int)) {
+    atomicAdd(
+      reinterpret_cast<unsigned long long int *>(addr), static_cast<unsigned long long int>(val));
+  } else {
+    static_assert(
+      sizeof(size_t) == sizeof(unsigned int) || sizeof(size_t) == sizeof(unsigned long long int),
+      "atomicAdd_size_t is only supported for size_t sizes equal to unsigned int or unsigned long "
+      "long int.");
+  }
+}
+
+template <typename T>
+__device__ T
+get_element_value(const uint8_t * data, const size_t index, const size_t step, const size_t offset)
+{
+  return *reinterpret_cast<const T *>(data + index * step + offset);
+}
+
+template <typename T>
+__device__ bool check_within_radius_range(
+  const FieldDataIndex & field_index, const T & field_data, const double & min_val,
+  const double & max_val)
+{
+  return (field_index == FieldDataIndex::radius)
+           ? (min_val <= field_data) && (field_data <= max_val)
+           : true;
+}
+
+template <typename T>
+__device__ bool check_sufficient_radius(const FieldDataIndex & field_index, const T & field_data)
+{
+  return (field_index == FieldDataIndex::radius)
+           ? ::cuda::std::abs(field_data) >= ::cuda::std::numeric_limits<T>::epsilon()
+           : true;
+}
+
+template <typename TFieldData>
+__device__ void assign_polar_index(
+  const TFieldData & field_data, const size_t & point_index, const FieldDataIndex & field_index,
+  const double & min_radius, const double & max_radius,
+  const FieldDataComposer<double> & resolutions,
+  FieldDataComposer<::cuda::std::optional<int32_t> *> & outputs)
+{
+  bool is_finite = isfinite(field_data);
+  bool is_within_radius_range =
+    check_within_radius_range(field_index, field_data, min_radius, max_radius);
+
+  bool has_sufficient_radius = check_sufficient_radius(field_index, field_data);
+
+  auto output = outputs[field_index];
+  if (!is_finite || !is_within_radius_range || !has_sufficient_radius) {
+    // Assign invalid index for points with invalid value and/or points outside radius range
+    output[point_index] = ::cuda::std::nullopt;
+    return;
+  }
+
+  if constexpr (::cuda::std::is_same<TFieldData, double>::value) {
+    output[point_index] = static_cast<int32_t>(floor(field_data / resolutions[field_index]));
+  } else {
+    output[point_index] = static_cast<int32_t>(floorf(field_data / resolutions[field_index]));
+  }
+}
+
+template <typename TFieldData>
+__global__ void polar_to_polar_voxel_kernel(
+  const uint8_t * __restrict__ data, const size_t num_points, const uint32_t step,
+  const FieldDataComposer<size_t> offsets, const FieldDataComposer<double> resolutions,
+  const double min_radius, const double max_radius,
+  FieldDataComposer<::cuda::std::optional<int32_t> *> outputs)
+{
+  auto point_index = blockIdx.x * blockDim.x + threadIdx.x;
+  if (point_index >= num_points) {
+    return;
+  }
+
+  // treat 3 field (radius, azimuth, elevation) in parallel using y dimension
+  auto field_index = static_cast<FieldDataIndex>(blockIdx.y);
+
+  TFieldData field_data =
+    get_element_value<TFieldData>(data, point_index, step, offsets[field_index]);
+
+  assign_polar_index(
+    field_data, point_index, field_index, min_radius, max_radius, resolutions, outputs);
+}
+
+template <typename TCartesianData, typename TPolarData>
+__global__ void cartesian_to_polar_voxel_kernel(
+  const uint8_t * __restrict__ data, const size_t num_points, const uint32_t step,
+  const FieldDataComposer<size_t> offsets, const FieldDataComposer<double> resolutions,
+  const double min_radius, const double max_radius,
+  FieldDataComposer<::cuda::std::optional<int32_t> *> outputs)
+{
+  auto point_index = blockIdx.x * blockDim.x + threadIdx.x;
+  if (point_index >= num_points) {
+    return;
+  }
+
+  TCartesianData x =
+    get_element_value<TCartesianData>(data, point_index, step, offsets[FieldDataIndex::radius]);
+  TCartesianData y =
+    get_element_value<TCartesianData>(data, point_index, step, offsets[FieldDataIndex::azimuth]);
+  TCartesianData z =
+    get_element_value<TCartesianData>(data, point_index, step, offsets[FieldDataIndex::elevation]);
+
+  // treat 3 field (radius, azimuth, elevation) in parallel using
+  // y dimension
+  auto field_index = static_cast<FieldDataIndex>(blockIdx.y);
+
+  auto field_data = static_cast<TPolarData>(0);
+  if constexpr (::cuda::std::is_same<TPolarData, double>::value) {
+    switch (field_index) {
+      case FieldDataIndex::radius:
+        field_data = sqrt(x * x + y * y + z * z);
+        break;
+      case FieldDataIndex::azimuth:
+        field_data = atan2(y, x);
+        break;
+      case FieldDataIndex::elevation:
+        field_data = atan2(z, sqrt(x * x + y * y));
+        break;
+    }
+  } else {
+    switch (field_index) {
+      case FieldDataIndex::radius:
+        field_data = sqrtf(x * x + y * y + z * z);
+        break;
+      case FieldDataIndex::azimuth:
+        field_data = atan2f(y, x);
+        break;
+      case FieldDataIndex::elevation:
+        field_data = atan2f(z, sqrtf(x * x + y * y));
+        break;
+    }
+  }
+
+  assign_polar_index(
+    field_data, point_index, field_index, min_radius, max_radius, resolutions, outputs);
+}
+
+__global__ void calculate_voxel_index_kernel(
+  const FieldDataComposer<::cuda::std::optional<int32_t> *> field_indices, const size_t num_points,
+  const FieldDataComposer<int> field_dimensions, const FieldDataComposer<int> field_mins,
+  ::cuda::std::optional<int> * point_indices, ::cuda::std::optional<int> * voxel_indices)
+{
+  auto point_index = blockIdx.x * blockDim.x + threadIdx.x;
+  if (point_index >= num_points) {
+    return;
+  }
+
+  auto radius_idx = field_indices[FieldDataIndex::radius][point_index];
+  auto azimuth_idx = field_indices[FieldDataIndex::azimuth][point_index];
+  auto elevation_idx = field_indices[FieldDataIndex::elevation][point_index];
+
+  auto radius_idx_min = field_mins[FieldDataIndex::radius];
+  auto azimuth_idx_min = field_mins[FieldDataIndex::azimuth];
+  auto elevation_idx_min = field_mins[FieldDataIndex::elevation];
+
+  auto radius_dim = field_dimensions[FieldDataIndex::radius];
+  auto azimuth_dim = field_dimensions[FieldDataIndex::azimuth];
+
+  // Save point index and corresponding voxel index in the same index position of two arrays
+  point_indices[point_index] = point_index;
+  if (!radius_idx || !azimuth_idx || !elevation_idx) {
+    // If any of field indices has invalid value, voxel index for this point will also be invalid
+    voxel_indices[point_index] = ::cuda::std::nullopt;
+    return;
+  }
+
+  // Because the following index calculation assumes all indices are zero started, positive values,
+  // make the conditions meet by subtracting the minimum values of each filed
+  auto radius_idx_shifted = radius_idx.value() - radius_idx_min;
+  auto azimuth_idx_shifted = azimuth_idx.value() - azimuth_idx_min;
+  auto elevation_idx_shifted = elevation_idx.value() - elevation_idx_min;
+
+  voxel_indices[point_index] = elevation_idx_shifted * (radius_dim * azimuth_dim) +
+                               azimuth_idx_shifted * radius_dim + radius_idx_shifted;
+}
+
+__global__ void subtract_left_optional_kernel(
+  const ::cuda::std::optional<int> * __restrict__ input_array, const size_t array_length,
+  bool * __restrict__ output_array)
+{
+  auto array_index = blockIdx.x * blockDim.x + threadIdx.x;
+  if (array_index >= array_length) {
+    return;
+  }
+
+  // Specially handle the very first element
+  if (array_index == 0) {
+    output_array[array_index] = input_array[array_index].has_value();
+    return;
+  }
+
+  auto difference_op = ValidAndNotEqualTo();
+  output_array[array_index] = difference_op(input_array[array_index - 1], input_array[array_index]);
+}
+
+__global__ void minus_one_kernel(int * __restrict__ indices, const size_t num_points)
+{
+  auto point_index = blockIdx.x * blockDim.x + threadIdx.x;
+  if (point_index >= num_points) {
+    return;
+  }
+
+  indices[point_index] -= 1;
+}
+
+template <typename TReturnType, typename TIntensity>
+__global__ void classify_point_and_sum_stats_kernel(
+  const uint8_t * __restrict__ data, const size_t num_points, const int num_voxels,
+  const size_t step, const size_t return_type_offset, const size_t intensity_offset,
+  const bool use_return_type_classification, const ReturnTypeCandidates primary_return_type,
+  const ::cuda::std::optional<int> * __restrict__ point_indices,
+  const int * __restrict__ voxel_indices, size_t * __restrict__ total_counts,
+  float * __restrict__ intensity_sums, size_t * __restrict__ secondary_counts,
+  bool * __restrict__ is_primary_flags)
+{
+  auto array_index = blockIdx.x * blockDim.x + threadIdx.x;
+  if (array_index >= num_points) return;
+
+  auto point_idx_opt = point_indices[array_index];
+  if (!point_idx_opt) return;
+
+  size_t pt_idx = point_idx_opt.value();
+  int vox_idx = voxel_indices[array_index];
+  if (vox_idx < 0 || vox_idx >= num_voxels) return;
+
+  // Get raw data
+  auto intensity = get_element_value<TIntensity>(data, pt_idx, step, intensity_offset);
+
+  // All points considered primary
+  bool is_primary = true;
+  if (use_return_type_classification) {
+    auto return_type = get_element_value<TReturnType>(data, pt_idx, step, return_type_offset);
+    is_primary = false;
+    for (size_t i = 0; i < primary_return_type.num_candidates; i++) {
+      if (primary_return_type.return_types[i] == return_type) {
+        is_primary = true;
+        break;
+      }
+    }
+  }
+
+  is_primary_flags[pt_idx] = is_primary;
+
+  // Atomic updates for voxel stats
+  atomic_add_size_t(&(total_counts[vox_idx]), 1);
+  atomicAdd(&(intensity_sums[vox_idx]), static_cast<float>(intensity));
+
+  if (use_return_type_classification && !is_primary) {
+    atomic_add_size_t(&(secondary_counts[vox_idx]), 1);
+  }
+}
+
+__global__ void evaluate_voxel_validity_kernel(
+  const size_t * __restrict__ total_counts, const float * __restrict__ intensity_sums,
+  const size_t * __restrict__ secondary_counts, const size_t num_voxels, const int count_threshold,
+  const double avg_intensity_threshold, const int secondary_threshold,
+  const bool use_return_type_classification, bool * __restrict__ voxel_valid_mask)
+{
+  auto vox_idx = blockIdx.x * blockDim.x + threadIdx.x;
+  if (vox_idx >= num_voxels) return;
+
+  size_t count = total_counts[vox_idx];
+  float avg_intensity = (count > 0) ? (intensity_sums[vox_idx] / count) : 0.0f;
+  size_t secondary_count = secondary_counts[vox_idx];
+
+  // Match CPU `VoxelStats::{meets_noise_simple_condition, meets_noise_condition}` exactly:
+  // - simple: (count <= min_points && avg_intensity <= avg_intensity_threshold)
+  // - advanced adds: (secondary_count >= secondary_threshold && avg_intensity <=
+  // avg_intensity_threshold)
+  const bool is_noise_by_density = (count <= static_cast<size_t>(count_threshold)) &&
+                                   (avg_intensity <= static_cast<float>(avg_intensity_threshold));
+
+  bool is_noise_by_secondary = false;
+  if (use_return_type_classification) {
+    is_noise_by_secondary = (secondary_count >= static_cast<size_t>(secondary_threshold)) &&
+                            (avg_intensity <= static_cast<float>(avg_intensity_threshold));
+  }
+
+  voxel_valid_mask[vox_idx] = !(is_noise_by_density || is_noise_by_secondary);
+}
+
+__global__ void point_validity_check_kernel(
+  const bool * __restrict__ voxel_valid_mask,
+  const ::cuda::std::optional<int> * __restrict__ point_indices,
+  const int * __restrict__ voxel_indices, const bool * __restrict__ is_primary_flags,
+  const size_t num_points, const int num_voxels, const bool filter_secondary_returns,
+  const bool use_return_type_classification, bool * __restrict__ valid_points_mask)
+{
+  const auto array_index = blockIdx.x * blockDim.x + threadIdx.x;
+  if (array_index >= num_points) return;
+
+  const auto point_index_opt = point_indices[array_index];
+  if (!point_index_opt) return;
+
+  const int pt_idx = point_index_opt.value();
+  const int vox_idx = voxel_indices[array_index];
+
+  if (vox_idx < 0 || vox_idx >= num_voxels) {
+    valid_points_mask[pt_idx] = false;
+    return;
+  }
+
+  const bool voxel_is_valid = voxel_valid_mask[vox_idx];
+  const bool point_is_primary = is_primary_flags[pt_idx];
+
+  const bool should_filter_secondary = use_return_type_classification && filter_secondary_returns;
+  valid_points_mask[pt_idx] = voxel_is_valid && (!should_filter_secondary || point_is_primary);
+}
+
+__global__ void copy_valid_points_kernel(
+  const uint8_t * __restrict__ input_cloud, const bool * __restrict__ valid_points_mask,
+  const int * __restrict__ filtered_indices, const size_t num_points, const size_t step,
+  uint8_t * __restrict__ output_points)
+{
+  auto point_index = blockIdx.x * blockDim.x + threadIdx.x;
+  if (point_index >= num_points) {
+    return;
+  }
+
+  bool is_valid = valid_points_mask[point_index];
+  int destination_index = filtered_indices[point_index];
+
+  if (is_valid) {
+    memcpy(output_points + destination_index * step, input_cloud + point_index * step, step);
+  }
+}
+
+__global__ void bool_flip_kernel(bool * __restrict__ flags, const size_t num_points)
+{
+  auto point_index = blockIdx.x * blockDim.x + threadIdx.x;
+  if (point_index >= num_points) {
+    return;
+  }
+
+  flags[point_index] = !flags[point_index];
+}
+
+// Helper function to get field offset
+template <typename T>
+size_t get_offset(const T & fields, const std::string & field_name)
+{
+  int index = -1;
+  for (size_t i = 0; i < fields.size(); ++i) {
+    if (fields[i].name == field_name) {
+      index = static_cast<int>(i);
+      break;
+    }
+  }
+  if (index < 0) {
+    std::stringstream ss;
+    ss << "input cloud does not contain field named '" << field_name << "'";
+    throw std::runtime_error(ss.str());
+  }
+  return fields[index].offset;
+}
+}  // namespace
+
+CudaPolarVoxelNoiseFilter::CudaPolarVoxelNoiseFilter() : primary_return_type_dev_(std::nullopt)
+{
+  CHECK_CUDA_ERROR(cudaStreamCreate(&stream_));
+
+  // create memory pool to make repeated allocation efficient
+  int current_device_id = 0;
+  CHECK_CUDA_ERROR(cudaGetDevice(&current_device_id));
+  size_t max_mem_pool_size_in_byte = 1e9;  // 1GB
+  mem_pool_ =
+    autoware::cuda_utils::create_memory_pool(max_mem_pool_size_in_byte, current_device_id);
+}
+
+CudaPolarVoxelNoiseFilter::~CudaPolarVoxelNoiseFilter()
+{
+  if (stream_) {
+    cudaStreamSynchronize(stream_);
+  }
+
+  if (primary_return_type_dev_ && primary_return_type_dev_.value().return_types && stream_) {
+    cudaFreeAsync(primary_return_type_dev_.value().return_types, stream_);
+    cudaStreamSynchronize(stream_);
+  }
+  primary_return_type_dev_.reset();
+
+  if (mem_pool_) {
+    cudaMemPoolDestroy(mem_pool_);
+    mem_pool_ = nullptr;
+  }
+  if (stream_) {
+    cudaStreamDestroy(stream_);
+    stream_ = nullptr;
+  }
+}
+
+CudaPolarVoxelNoiseFilter::FilterReturn CudaPolarVoxelNoiseFilter::filter(
+  const cuda_blackboard::CudaPointCloud2::ConstSharedPtr & input_cloud,
+  const CudaPolarVoxelNoiseFilterParameters & params, const PolarDataType polar_type)
+{
+  if (!primary_return_type_dev_) {
+    return FilterReturn{nullptr, nullptr};
+  }
+
+  size_t num_points = input_cloud->width * input_cloud->height;
+  if (num_points == 0) {
+    // sometimes topic might contain zero point even the pointer is valid
+    // For such cases, this filter returns empty results
+    auto empty_filtered_cloud = std::make_unique<cuda_blackboard::CudaPointCloud2>();
+    auto empty_noise_cloud = std::make_unique<cuda_blackboard::CudaPointCloud2>();
+    return FilterReturn{std::move(empty_filtered_cloud), std::move(empty_noise_cloud)};
+  }
+
+  FieldDataComposer<size_t> offsets{};
+  switch (polar_type) {
+    case PolarDataType::PreComputed:
+      offsets.radius = get_offset(input_cloud->fields, "distance");
+      offsets.azimuth = get_offset(input_cloud->fields, "azimuth");
+      offsets.elevation = get_offset(input_cloud->fields, "elevation");
+      break;
+    case PolarDataType::DeriveFromCartesian:
+      // Though struct member names assume polar coordinates one,
+      // fill offset for cartesian coordinates to compute polar coordinates
+      offsets.radius = get_offset(input_cloud->fields, "x");
+      offsets.azimuth = get_offset(input_cloud->fields, "y");
+      offsets.elevation = get_offset(input_cloud->fields, "z");
+      break;
+    default:
+      throw std::runtime_error("undefined polar_data_type is specified");
+  }
+
+  int num_total_voxels = 0;
+  CudaPooledUniquePtr<::cuda::std::optional<int>> point_indices = nullptr;
+  CudaPooledUniquePtr<int> voxel_indices = nullptr;
+  auto valid_points_mask = autoware::cuda_utils::make_unique<bool>(num_points, stream_, mem_pool_);
+
+  // Per-voxel stats (CPU-equivalent): count, intensity sum, secondary return count
+  CudaPooledUniquePtr<size_t> total_counts = nullptr;
+  CudaPooledUniquePtr<float> intensity_sums = nullptr;
+  CudaPooledUniquePtr<size_t> secondary_counts = nullptr;
+  CudaPooledUniquePtr<bool> is_primary_flags = nullptr;
+
+  // First pass: count points in each polar voxel using pre-computed coordinates
+  {
+    auto [radius_idx, azimuth_idx, elevation_idx, polar_voxel_indices] =
+      generate_field_data_composer<::cuda::std::optional<int32_t>>(num_points, stream_, mem_pool_);
+
+    FieldDataComposer<double> resolutions{};
+    resolutions.radius = params.radial_resolution_m;
+    resolutions.azimuth = params.azimuth_resolution_rad;
+    resolutions.elevation = params.elevation_resolution_rad;
+
+    dim3 block_dim(512);
+    dim3 grid_dim((num_points + block_dim.x - 1) / block_dim.x, 3, 1);
+
+    switch (polar_type) {
+      case PolarDataType::PreComputed:
+        polar_to_polar_voxel_kernel<float><<<grid_dim, block_dim, 0, stream_>>>(
+          input_cloud->data.get(), num_points, input_cloud->point_step, offsets, resolutions,
+          params.min_radius_m, params.max_radius_m, polar_voxel_indices);
+        break;
+      case PolarDataType::DeriveFromCartesian:
+        cartesian_to_polar_voxel_kernel<float, float><<<grid_dim, block_dim, 0, stream_>>>(
+          input_cloud->data.get(), num_points, input_cloud->point_step, offsets, resolutions,
+          params.min_radius_m, params.max_radius_m, polar_voxel_indices);
+        break;
+      default:
+        throw std::runtime_error("undefined polar_data_type is specified");
+    }
+
+    // calculate unique voxel index that each point belongs to
+    std::tie(num_total_voxels, point_indices, voxel_indices) =
+      calculate_voxel_index(polar_voxel_indices, num_points);
+
+    total_counts = autoware::cuda_utils::make_unique<size_t>(num_total_voxels, stream_, mem_pool_);
+    intensity_sums = autoware::cuda_utils::make_unique<float>(num_total_voxels, stream_, mem_pool_);
+    secondary_counts =
+      autoware::cuda_utils::make_unique<size_t>(num_total_voxels, stream_, mem_pool_);
+    is_primary_flags = autoware::cuda_utils::make_unique<bool>(num_points, stream_, mem_pool_);
+
+    const size_t return_type_offset =
+      params.use_return_type_classification ? get_offset(input_cloud->fields, "return_type") : 0U;
+    const size_t intensity_offset = get_offset(input_cloud->fields, "intensity");
+
+    dim3 grid_dim_points((num_points + block_dim.x - 1) / block_dim.x);
+    classify_point_and_sum_stats_kernel<uint8_t, uint8_t>
+      <<<grid_dim_points, block_dim, 0, stream_>>>(
+        input_cloud->data.get(), num_points, num_total_voxels, input_cloud->point_step,
+        return_type_offset, intensity_offset, params.use_return_type_classification,
+        primary_return_type_dev_.value(), point_indices.get(), voxel_indices.get(),
+        total_counts.get(), intensity_sums.get(), secondary_counts.get(), is_primary_flags.get());
+  }
+
+  // Evaluate voxel validity with CPU-equivalent criteria, then build per-point mask
+  auto voxel_valid_mask =
+    autoware::cuda_utils::make_unique<bool>(num_total_voxels, stream_, mem_pool_);
+  {
+    dim3 block_dim(512);
+    dim3 grid_dim_vox((num_total_voxels + block_dim.x - 1) / block_dim.x);
+    evaluate_voxel_validity_kernel<<<grid_dim_vox, block_dim, 0, stream_>>>(
+      total_counts.get(), intensity_sums.get(), secondary_counts.get(), num_total_voxels,
+      params.voxel_points_threshold, params.avg_intensity_threshold,
+      params.secondary_noise_threshold, params.use_return_type_classification,
+      voxel_valid_mask.get());
+
+    dim3 grid_dim_pts((num_points + block_dim.x - 1) / block_dim.x);
+    point_validity_check_kernel<<<grid_dim_pts, block_dim, 0, stream_>>>(
+      voxel_valid_mask.get(), point_indices.get(), voxel_indices.get(), is_primary_flags.get(),
+      num_points, num_total_voxels, params.filter_secondary_returns,
+      params.use_return_type_classification, valid_points_mask.get());
+  }
+
+  // Create filtered output
+  size_t valid_count = 0;
+  auto filtered_cloud = std::make_unique<cuda_blackboard::CudaPointCloud2>();
+  valid_count = create_output(input_cloud, valid_points_mask, num_points, filtered_cloud);
+
+  // Create noise cloud with filtered-out points
+  auto noise_cloud = std::make_unique<cuda_blackboard::CudaPointCloud2>();
+  if (params.publish_noise_cloud) {
+    // Flip valid flag to get filtered-out (= noise) points
+    dim3 block_dim(512);
+    dim3 grid_dim((num_points + block_dim.x - 1) / block_dim.x);
+
+    bool_flip_kernel<<<grid_dim, block_dim, 0, stream_>>>(valid_points_mask.get(), num_points);
+
+    std::ignore = create_output(input_cloud, valid_points_mask, num_points, noise_cloud);
+  }
+
+  if (params.use_return_type_classification) {
+    CHECK_CUDA_ERROR(cudaStreamSynchronize(stream_));
+  }
+
+  return {std::move(filtered_cloud), std::move(noise_cloud)};
+}
+
+void CudaPolarVoxelNoiseFilter::set_return_types(
+  const std::vector<int> & types, std::optional<ReturnTypeCandidates> & types_dev)
+{
+  if (types_dev) {
+    // Reset previously allocated region to refresh the parameters
+    CHECK_CUDA_ERROR(cudaFreeAsync(types_dev.value().return_types, stream_));
+  }
+
+  auto num_candidates = types.size();
+  using return_type_t = decltype(ReturnTypeCandidates::return_types);
+  using return_type_elem_t = std::remove_pointer_t<return_type_t>;
+  return_type_t return_type = nullptr;
+
+  CHECK_CUDA_ERROR(cudaMallocFromPoolAsync(
+    &return_type, num_candidates * sizeof(return_type_elem_t), mem_pool_, stream_));
+
+  CHECK_CUDA_ERROR(cudaMemcpyAsync(
+    return_type, types.data(), num_candidates * sizeof(return_type_elem_t), cudaMemcpyHostToDevice,
+    stream_));
+
+  CHECK_CUDA_ERROR(cudaStreamSynchronize(stream_));
+
+  types_dev = ReturnTypeCandidates{return_type, types.size()};
+}
+
+std::tuple<int, CudaPooledUniquePtr<::cuda::std::optional<int>>, CudaPooledUniquePtr<int>>
+CudaPolarVoxelNoiseFilter::calculate_voxel_index(
+  const FieldDataComposer<::cuda::std::optional<int32_t> *> & polar_voxel_indices,
+  const size_t & num_points)
+{
+  // Step 1: determine the range of each field indices by taking min and max
+  FieldDataComposer<int> polar_voxel_indices_min{0, 0, 0};
+  FieldDataComposer<int> polar_voxel_indices_max{0, 0, 0};
+  auto reduction_result_tmp_dev = autoware::cuda_utils::make_unique<int>(stream_, mem_pool_);
+  for (const auto & i : FieldDataIndex()) {
+    auto polar_voxel_index = polar_voxel_indices[i];
+    auto & min_val_host = polar_voxel_indices_min[i];
+    auto & max_val_host = polar_voxel_indices_max[i];
+
+    // Because `operator<=` for cuda::std::optional considers nullopt is less than any valid value,
+    // this conversion helps searching minimum valid value from the array of cuda::std::optional
+    auto transformed_in_null_to_max =
+      thrust::make_transform_iterator(polar_voxel_index, NulloptToMax{});
+
+    // Take Minimum value
+    reduce_and_copy_to_host(
+      ReductionType::Min, transformed_in_null_to_max, num_points, reduction_result_tmp_dev.get(),
+      min_val_host);
+
+    // Though comparison operators are defined for cuda::std::optional,
+    // cuda::std::optional does not have ::Lowest() member, which is required for
+    // cub::DeviceReduce::Max. Here, cuda::std::optional is wrapped to transform into its contained
+    // value (if nullopt, then return numeric_limits::lowest) to make cub::DeviceReduce::Max work
+    auto transformed_in_null_to_lowest =
+      thrust::make_transform_iterator(polar_voxel_index, NulloptToLowest{});
+
+    // Take maximum value
+    reduce_and_copy_to_host(
+      ReductionType::Max, transformed_in_null_to_lowest, num_points, reduction_result_tmp_dev.get(),
+      max_val_host);
+  }
+  CHECK_CUDA_ERROR(cudaStreamSynchronize(stream_));  // make sure all device to host copies complete
+
+  // Step 2: calculate voxel's (geometric-based) linear index based of determined range by Step 1
+  FieldDataComposer<int> polar_voxel_range{0, 0, 0};
+  for (const auto & i : FieldDataIndex()) {
+    polar_voxel_range[i] = polar_voxel_indices_max[i] - (polar_voxel_indices_min[i] - 1);
+  }
+
+  auto point_indices =
+    autoware::cuda_utils::make_unique<::cuda::std::optional<int>>(num_points, stream_, mem_pool_);
+  auto voxel_indices_raw =
+    autoware::cuda_utils::make_unique<::cuda::std::optional<int>>(num_points, stream_, mem_pool_);
+
+  dim3 block_dim(512);
+  dim3 grid_dim((num_points + block_dim.x - 1) / block_dim.x);
+  calculate_voxel_index_kernel<<<grid_dim, block_dim, 0, stream_>>>(
+    polar_voxel_indices, num_points, polar_voxel_range, polar_voxel_indices_min,
+    point_indices.get(), voxel_indices_raw.get());
+
+  // Step 3: Calculate the voxel indices on memory with corresponding point indices
+  auto voxel_indices = autoware::cuda_utils::make_unique<int>(num_points, stream_, mem_pool_);
+  int valid_voxel_num = 0;
+  {
+    // Sort indices
+    auto sort_pairs = [](auto &&... args) {
+      // Because radix sort cannot be applied to cuda::std::optional<int> without any conversion,
+      // use merge sort here
+      return cub::DeviceMergeSort::SortPairs(std::forward<decltype(args)>(args)...);
+    };
+
+    cub_executor_.run_with_temp_storage(
+      sort_pairs, stream_, mem_pool_, voxel_indices_raw.get(), point_indices.get(), num_points,
+      ::cuda::std::less<::cuda::std::optional<int>>(), stream_);
+
+    auto voxel_indices_bool =
+      autoware::cuda_utils::make_unique<bool>(num_points, stream_, mem_pool_);
+
+    // Because implicit data conversion from cuda::std::optional<int> to bool is not supported by
+    // nvcc (even though std::optional has a operator bool() to check it contains a value),
+    // cub::DeviceAdjacentDifference::SubtractLeftCopy cannot be applied here. To handle this case
+    // execute dedicated CUDA kernel that accepts cuda::std::optional<int> input and bool output
+    dim3 block_dim(512);
+    dim3 grid_dim((num_points + block_dim.x - 1) / block_dim.x);
+    subtract_left_optional_kernel<<<grid_dim, block_dim, 0, stream_>>>(
+      voxel_indices_raw.get(), num_points, voxel_indices_bool.get());
+
+    // calculate mapped index (from geometry-based linear voxel indices to memory-based indices)
+    auto inclusive_sum = [](auto &&... args) {
+      return cub::DeviceScan::InclusiveSum(std::forward<decltype(args)>(args)...);
+    };
+    cub_executor_.run_with_temp_storage(
+      inclusive_sum, stream_, mem_pool_, voxel_indices_bool.get(), voxel_indices.get(), num_points,
+      stream_);
+
+    // get the number of valid voxels
+    CHECK_CUDA_ERROR(cudaMemcpyAsync(
+      &valid_voxel_num,
+      voxel_indices.get() +
+        (num_points - 1),  // the end of array contains the number of valid voxels
+      sizeof(int), cudaMemcpyDeviceToHost, stream_));
+
+    // Since the current voxel_indices contain index values starting from 1,
+    //  Subtract 1 from all elements to make 0 started index
+    //// NOTE: equivalent operation can be achieved cud::DeviceFor::Forereach that is introduced
+    /// from / cub v2.4.0
+    minus_one_kernel<<<grid_dim, block_dim, 0, stream_>>>(voxel_indices.get(), num_points);
+
+    CHECK_CUDA_ERROR(cudaStreamSynchronize(stream_));  // Make sure Device to Host copy complete
+  }
+
+  return std::make_tuple(valid_voxel_num, std::move(point_indices), std::move(voxel_indices));
+}
+
+std::tuple<CudaPooledUniquePtr<int>, size_t>
+CudaPolarVoxelNoiseFilter::calculate_filtered_point_indices(
+  const CudaPooledUniquePtr<bool> & valid_points_mask, const size_t & num_points)
+{
+  // Scan valid_points_mask to calculate the total number of filtered points and map from the source
+  // point index to filtered point index
+  auto filtered_point_indices =
+    autoware::cuda_utils::make_unique<int>(num_points, stream_, mem_pool_);
+
+  auto inclusive_scan = [](auto &&... args) {
+    return cub::DeviceScan::InclusiveSum(std::forward<decltype(args)>(args)...);
+  };
+  cub_executor_.run_with_temp_storage(
+    inclusive_scan, stream_, mem_pool_, valid_points_mask.get(), filtered_point_indices.get(),
+    num_points, stream_);
+
+  int num_filtered_points = 0;
+  CHECK_CUDA_ERROR(cudaMemcpyAsync(
+    &num_filtered_points,
+    filtered_point_indices.get() +
+      (num_points - 1),  // the end of array contains the number of filtered points
+    sizeof(int), cudaMemcpyDeviceToHost, stream_));
+
+  dim3 block_dim(512);
+  dim3 grid_dim((num_points + block_dim.x - 1) / block_dim.x);
+  // Subtract 1 from all elements to make 0 started index
+  minus_one_kernel<<<grid_dim, block_dim, 0, stream_>>>(filtered_point_indices.get(), num_points);
+
+  // Making sure memcpy device to host operation completed
+  CHECK_CUDA_ERROR(cudaStreamSynchronize(stream_));
+
+  return std::make_tuple(std::move(filtered_point_indices), num_filtered_points);
+}
+
+template <typename T, typename U>
+void CudaPolarVoxelNoiseFilter::reduce_and_copy_to_host(
+  const ReductionType reduction_type, const T & dev_array, const size_t & array_length,
+  U * result_dev, U & result_host)
+{
+  auto reduction_op = [reduction_type](auto &&... args) {
+    switch (reduction_type) {
+      case ReductionType::Min:
+        return cub::DeviceReduce::Min(std::forward<decltype(args)>(args)...);
+      case ReductionType::Max:
+        return cub::DeviceReduce::Max(std::forward<decltype(args)>(args)...);
+      case ReductionType::Sum:
+        return cub::DeviceReduce::Sum(std::forward<decltype(args)>(args)...);
+      default:
+        throw std::runtime_error("Invalid reduction type was specified");
+    }
+  };
+
+  // Execute reduction
+  cub_executor_.run_with_temp_storage(
+    reduction_op, stream_, mem_pool_, dev_array, result_dev, array_length, stream_);
+
+  // Copy result asynchronously.
+  // To make synchronization timing under the control of the caller, this function does not call
+  // synchronization operation such as cudaStreamSynchronize
+  CHECK_CUDA_ERROR(
+    cudaMemcpyAsync(&result_host, result_dev, sizeof(U), cudaMemcpyDeviceToHost, stream_));
+}
+
+size_t CudaPolarVoxelNoiseFilter::create_output(
+  const cuda_blackboard::CudaPointCloud2::ConstSharedPtr & input_cloud,
+  const CudaPooledUniquePtr<bool> & points_mask, const size_t & num_points,
+  std::unique_ptr<cuda_blackboard::CudaPointCloud2> & output_cloud)
+{
+  auto [filtered_indices, count] = calculate_filtered_point_indices(points_mask, num_points);
+
+  output_cloud->header = input_cloud->header;
+  output_cloud->fields = input_cloud->fields;
+  output_cloud->is_bigendian = input_cloud->is_bigendian;
+  output_cloud->point_step = input_cloud->point_step;
+  output_cloud->is_dense = input_cloud->is_dense;
+  output_cloud->height = point_cloud_height_organized;
+  output_cloud->width = count;
+  output_cloud->row_step = output_cloud->width * output_cloud->point_step;
+  output_cloud->data = cuda_blackboard::make_unique<std::uint8_t[]>(output_cloud->row_step);
+
+  dim3 block_dim(512);
+  dim3 grid_dim((num_points + block_dim.x - 1) / block_dim.x);
+
+  copy_valid_points_kernel<<<grid_dim, block_dim, 0, stream_>>>(
+    input_cloud->data.get(), points_mask.get(), filtered_indices.get(), num_points,
+    output_cloud->point_step, output_cloud->data.get());
+
+  return count;
+}
+
+}  // namespace autoware::cuda_pointcloud_preprocessor

--- a/sensing/autoware_cuda_pointcloud_preprocessor/src/cuda_outlier_filter/cuda_polar_voxel_noise_filter_node.cpp
+++ b/sensing/autoware_cuda_pointcloud_preprocessor/src/cuda_outlier_filter/cuda_polar_voxel_noise_filter_node.cpp
@@ -1,0 +1,384 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/cuda_pointcloud_preprocessor/cuda_outlier_filter/cuda_polar_voxel_noise_filter_node.hpp"
+
+#include "autoware/pointcloud_preprocessor/filter.hpp"
+#include "autoware/pointcloud_preprocessor/utility/memory.hpp"
+
+#include <cmath>
+#include <limits>
+#include <stdexcept>
+
+namespace autoware::cuda_pointcloud_preprocessor
+{
+namespace
+{
+constexpr double two_pi = 2.0 * M_PI;
+
+inline double adjust_resolution_to_circle(double requested_resolution)
+{
+  int bins = static_cast<int>(std::round(two_pi / requested_resolution));
+  if (bins < 1) bins = 1;
+  return two_pi / bins;
+}
+
+rcl_interfaces::msg::ParameterDescriptor make_positive_double_descriptor(
+  const std::string & param_name)
+{
+  rcl_interfaces::msg::ParameterDescriptor descriptor;
+  descriptor.description = param_name + " must be positive";
+  rcl_interfaces::msg::FloatingPointRange range;
+  range.from_value = 1e-9;
+  range.to_value = std::numeric_limits<double>::max();
+  range.step = 0.0;
+  descriptor.floating_point_range.push_back(range);
+  return descriptor;
+}
+
+rcl_interfaces::msg::ParameterDescriptor make_non_negative_double_descriptor(
+  const std::string & param_name)
+{
+  rcl_interfaces::msg::ParameterDescriptor descriptor;
+  descriptor.description = param_name + " must be non-negative";
+  rcl_interfaces::msg::FloatingPointRange range;
+  range.from_value = 0.0;
+  range.to_value = std::numeric_limits<double>::max();
+  range.step = 0.0;
+  descriptor.floating_point_range.push_back(range);
+  return descriptor;
+}
+
+rcl_interfaces::msg::ParameterDescriptor make_positive_int_descriptor(
+  const std::string & param_name)
+{
+  rcl_interfaces::msg::ParameterDescriptor descriptor;
+  descriptor.description = param_name + " must be at least 1";
+  rcl_interfaces::msg::IntegerRange range;
+  range.from_value = 1;
+  range.to_value = std::numeric_limits<int64_t>::max();
+  range.step = 1;
+  descriptor.integer_range.push_back(range);
+  return descriptor;
+}
+
+rcl_interfaces::msg::ParameterDescriptor make_non_negative_int_descriptor(
+  const std::string & param_name)
+{
+  rcl_interfaces::msg::ParameterDescriptor descriptor;
+  descriptor.description = param_name + " must be non-negative";
+  rcl_interfaces::msg::IntegerRange range;
+  range.from_value = 0;
+  range.to_value = std::numeric_limits<int64_t>::max();
+  range.step = 1;
+  descriptor.integer_range.push_back(range);
+  return descriptor;
+}
+}  // namespace
+
+CudaPolarVoxelNoiseFilterNode::CudaPolarVoxelNoiseFilterNode(
+  const rclcpp::NodeOptions & node_options)
+: Node("cuda_polar_voxel_noise_filter", node_options)
+{
+  // set initial parameters
+  {
+    filter_params_.radial_resolution_m = declare_parameter<double>(
+      "radial_resolution", make_positive_double_descriptor("radial_resolution"));
+    filter_params_.azimuth_resolution_rad = adjust_resolution_to_circle(
+      declare_parameter<double>(
+        "azimuth_resolution", make_positive_double_descriptor("azimuth_resolution")));
+    filter_params_.elevation_resolution_rad = adjust_resolution_to_circle(
+      declare_parameter<double>(
+        "elevation_resolution", make_positive_double_descriptor("elevation_resolution")));
+    filter_params_.voxel_points_threshold = declare_parameter<int>(
+      "voxel_points_threshold", make_positive_int_descriptor("voxel_points_threshold"));
+    filter_params_.avg_intensity_threshold = declare_parameter<double>(
+      "avg_intensity_threshold", make_non_negative_double_descriptor("avg_intensity_threshold"));
+    filter_params_.min_radius_m =
+      declare_parameter<double>("min_radius", make_non_negative_double_descriptor("min_radius"));
+    filter_params_.max_radius_m =
+      declare_parameter<double>("max_radius", make_positive_double_descriptor("max_radius"));
+    filter_params_.use_return_type_classification =
+      declare_parameter<bool>("use_return_type_classification");
+    filter_params_.filter_secondary_returns = declare_parameter<bool>("filter_secondary_returns");
+    filter_params_.secondary_noise_threshold = declare_parameter<int>(
+      "secondary_noise_threshold", make_non_negative_int_descriptor("secondary_noise_threshold"));
+    filter_params_.publish_noise_cloud = declare_parameter<bool>("publish_noise_cloud");
+
+    // rclcpp always returns integer array as std::vector<int64_t>
+    auto primary_return_types_param =
+      declare_parameter<std::vector<int64_t>>("primary_return_types");
+    primary_return_types_.clear();
+    primary_return_types_.reserve(primary_return_types_param.size());
+    for (const auto & val : primary_return_types_param) {
+      primary_return_types_.push_back(static_cast<int>(val));
+    }
+  }
+
+  cuda_polar_voxel_noise_filter_ = std::make_unique<CudaPolarVoxelNoiseFilter>();
+  cuda_polar_voxel_noise_filter_->set_primary_return_types(primary_return_types_);
+
+  pointcloud_sub_ =
+    std::make_shared<cuda_blackboard::CudaBlackboardSubscriber<cuda_blackboard::CudaPointCloud2>>(
+      *this, "~/input/pointcloud",
+      std::bind(&CudaPolarVoxelNoiseFilterNode::pointcloud_callback, this, std::placeholders::_1));
+
+  filtered_cloud_pub_ =
+    std::make_unique<cuda_blackboard::CudaBlackboardPublisher<cuda_blackboard::CudaPointCloud2>>(
+      *this, "~/output/pointcloud");
+
+  // Create noise cloud publisher if enabled
+  if (filter_params_.publish_noise_cloud) {
+    noise_cloud_pub_ =
+      std::make_unique<cuda_blackboard::CudaBlackboardPublisher<cuda_blackboard::CudaPointCloud2>>(
+        *this, "~/debug/pointcloud_noise");
+    RCLCPP_INFO(get_logger(), "Noise cloud publishing enabled");
+  } else {
+    RCLCPP_INFO(get_logger(), "Noise cloud publishing disabled for performance optimization");
+  }
+
+  using std::placeholders::_1;
+  set_param_res_ = this->add_on_set_parameters_callback(
+    [this](const std::vector<rclcpp::Parameter> & p) { return param_callback(p); });
+
+  RCLCPP_INFO(
+    get_logger(),
+    "Polar Voxel Noise Filter initialized - supports PointXYZIRC and PointXYZIRCAEDT ");
+}
+
+void CudaPolarVoxelNoiseFilterNode::pointcloud_callback(
+  const cuda_blackboard::CudaPointCloud2::ConstSharedPtr msg)
+{
+  // Take mutex so that node configuration will not be
+  // overwritten during one frame processing
+  std::scoped_lock lock(param_mutex_);
+
+  // Check if the input point cloud has PointXYZIRCAEDT layout (with pre-computed polar coordinates)
+
+  std::call_once(input_format_once_flag_, [this, &msg]() {
+    validate_filter_inputs(msg);
+
+    const bool has_polar_coords =
+      autoware::pointcloud_preprocessor::utils::is_data_layout_compatible_with_point_xyzircaedt(
+        *msg);
+    const bool has_return_type =
+      autoware::pointcloud_preprocessor::utils::is_data_layout_compatible_with_point_xyzirc(*msg);
+
+    if (has_polar_coords) {
+      input_format_ = InputPointCloudFormat::PointXYZIRCAEDT;
+      RCLCPP_INFO(
+        get_logger(), "Processing PointXYZIRCAEDT format with pre-computed polar coordinates");
+      return;
+    }
+
+    if (has_return_type) {
+      input_format_ = InputPointCloudFormat::PointXYZIRC;
+      RCLCPP_INFO(get_logger(), "Processing PointXYZIRC format, computing azimuth and elevation");
+      return;
+    }
+
+    throw std::runtime_error("Unsupported input point cloud format");
+  });
+
+  std::unique_ptr<cuda_blackboard::CudaPointCloud2> filtered_cloud;
+  std::unique_ptr<cuda_blackboard::CudaPointCloud2> noise_cloud;
+  CudaPolarVoxelNoiseFilter::FilterReturn filter_return{};
+
+  if (input_format_ == InputPointCloudFormat::PointXYZIRCAEDT) {
+    filter_return = cuda_polar_voxel_noise_filter_->filter(
+      msg, filter_params_, CudaPolarVoxelNoiseFilter::PolarDataType::PreComputed);
+  } else if (input_format_ == InputPointCloudFormat::PointXYZIRC) {
+    filter_return = cuda_polar_voxel_noise_filter_->filter(
+      msg, filter_params_, CudaPolarVoxelNoiseFilter::PolarDataType::DeriveFromCartesian);
+  } else {
+    RCLCPP_ERROR(
+      get_logger(),
+      "Unknown point cloud format, not supported by "
+      "autoware_cuda_pointcloud_preprocessor::cuda_polar_voxel_noise_filter yet.");
+  }
+
+  filtered_cloud = std::move(filter_return.filtered_cloud);
+  noise_cloud = std::move(filter_return.noise_cloud);
+
+  if (!filtered_cloud) {
+    // filtered_cloud contains nullptr
+    return;
+  }
+
+  // Publish results
+  filtered_cloud_pub_->publish(std::move(filtered_cloud));
+  if (filter_params_.publish_noise_cloud && noise_cloud_pub_) {
+    noise_cloud_pub_->publish(std::move(noise_cloud));
+  }
+}
+
+bool CudaPolarVoxelNoiseFilterNode::validate_primary_return_types(
+  const rclcpp::Parameter & param, std::string & reason)
+{
+  for (const auto & type : param.as_integer_array()) {
+    if (type < 0 || type > 255) {
+      reason = "primary_return_types values must be between 0 and 255";
+      return false;
+    }
+  }
+  return true;
+}
+
+rcl_interfaces::msg::SetParametersResult CudaPolarVoxelNoiseFilterNode::param_callback(
+  const std::vector<rclcpp::Parameter> & params)
+{
+  std::scoped_lock lock(param_mutex_);
+
+  rcl_interfaces::msg::SetParametersResult result;
+  result.successful = true;
+  result.reason = "success";
+
+  using Validator = std::function<bool(const rclcpp::Parameter &, std::string &)>;
+  using Assigner = std::function<void(const rclcpp::Parameter &)>;
+  struct ParamOps
+  {
+    Validator validator;
+    Assigner assigner;
+  };
+
+  static const std::unordered_map<std::string, ParamOps> param_ops = {
+    {"radial_resolution",
+     {nullptr,
+      [this](const rclcpp::Parameter & p) { filter_params_.radial_resolution_m = p.as_double(); }}},
+    {"azimuth_resolution",
+     {nullptr,
+      [this](const rclcpp::Parameter & p) {
+        filter_params_.azimuth_resolution_rad = adjust_resolution_to_circle(p.as_double());
+      }}},
+    {"elevation_resolution",
+     {nullptr,
+      [this](const rclcpp::Parameter & p) {
+        filter_params_.elevation_resolution_rad = adjust_resolution_to_circle(p.as_double());
+      }}},
+    {"voxel_points_threshold",
+     {nullptr,
+      [this](const rclcpp::Parameter & p) { filter_params_.voxel_points_threshold = p.as_int(); }}},
+    {"avg_intensity_threshold",
+     {nullptr,
+      [this](const rclcpp::Parameter & p) {
+        filter_params_.avg_intensity_threshold = p.as_double();
+      }}},
+    {"min_radius",
+     {nullptr,
+      [this](const rclcpp::Parameter & p) { filter_params_.min_radius_m = p.as_double(); }}},
+    {"max_radius",
+     {nullptr,
+      [this](const rclcpp::Parameter & p) { filter_params_.max_radius_m = p.as_double(); }}},
+    {"use_return_type_classification",
+     {nullptr,
+      [this](const rclcpp::Parameter & p) {
+        filter_params_.use_return_type_classification = p.as_bool();
+      }}},
+    {"filter_secondary_returns",
+     {nullptr,
+      [this](const rclcpp::Parameter & p) {
+        filter_params_.filter_secondary_returns = p.as_bool();
+      }}},
+    {"secondary_noise_threshold",
+     {nullptr,
+      [this](const rclcpp::Parameter & p) {
+        filter_params_.secondary_noise_threshold = p.as_int();
+      }}},
+    {"primary_return_types",
+     {validate_primary_return_types,
+      [this](const rclcpp::Parameter & p) {
+        const auto & arr = p.as_integer_array();
+        primary_return_types_.clear();
+        primary_return_types_.reserve(arr.size());
+        for (auto v : arr) primary_return_types_.push_back(static_cast<int>(v));
+        cuda_polar_voxel_noise_filter_->set_primary_return_types(primary_return_types_);
+      }}},
+    {"publish_noise_cloud",
+     {nullptr, [this](const rclcpp::Parameter & p) {
+        filter_params_.publish_noise_cloud = p.as_bool();
+        if (filter_params_.publish_noise_cloud && !noise_cloud_pub_) {
+          noise_cloud_pub_ = std::make_unique<
+            cuda_blackboard::CudaBlackboardPublisher<cuda_blackboard::CudaPointCloud2>>(
+            *this, "~/debug/pointcloud_noise");
+          RCLCPP_INFO(get_logger(), "Noise cloud publisher created by parameter update");
+        }
+      }}}};
+
+  for (const auto & param : params) {
+    auto it = param_ops.find(param.get_name());
+    if (it != param_ops.end()) {
+      if (it->second.validator) {
+        std::string reason;
+        if (!it->second.validator(param, reason)) {
+          result.successful = false;
+          result.reason = reason;
+          return result;
+        }
+      }
+      it->second.assigner(param);
+    }
+  }
+
+  return result;
+}
+
+void CudaPolarVoxelNoiseFilterNode::validate_filter_inputs(
+  const cuda_blackboard::CudaPointCloud2::ConstSharedPtr & input_cloud)
+{
+  validate_return_type_field(input_cloud);
+  validate_intensity_field(input_cloud);
+}
+
+void CudaPolarVoxelNoiseFilterNode::validate_return_type_field(
+  const cuda_blackboard::CudaPointCloud2::ConstSharedPtr & input_cloud)
+{
+  if (!filter_params_.use_return_type_classification) {
+    return;
+  }
+
+  if (!has_field(input_cloud, "return_type")) {
+    RCLCPP_ERROR(
+      get_logger(),
+      "Advanced mode (use_return_type_classification=true) requires 'return_type' field. "
+      "Set use_return_type_classification=false for simple mode or ensure input has return_type "
+      "field.");
+    throw std::invalid_argument("Advanced mode requires return_type field");
+  }
+}
+
+void CudaPolarVoxelNoiseFilterNode::validate_intensity_field(
+  const cuda_blackboard::CudaPointCloud2::ConstSharedPtr & input_cloud)
+{
+  if (!has_field(input_cloud, "intensity")) {
+    RCLCPP_ERROR(get_logger(), "Input point cloud must have 'intensity' field");
+    throw std::invalid_argument("Input point cloud must have intensity field");
+  }
+}
+
+bool CudaPolarVoxelNoiseFilterNode::has_field(
+  const cuda_blackboard::CudaPointCloud2::ConstSharedPtr & input, const std::string & field_name)
+{
+  for (const auto & field : input->fields) {
+    if (field.name == field_name) {
+      return true;
+    }
+  }
+  return false;
+}
+
+}  // namespace autoware::cuda_pointcloud_preprocessor
+
+#include "rclcpp_components/register_node_macro.hpp"
+RCLCPP_COMPONENTS_REGISTER_NODE(
+  autoware::cuda_pointcloud_preprocessor::CudaPolarVoxelNoiseFilterNode)

--- a/sensing/autoware_cuda_utils/include/autoware/cuda_utils/cuda_memory_pool.hpp
+++ b/sensing/autoware_cuda_utils/include/autoware/cuda_utils/cuda_memory_pool.hpp
@@ -37,7 +37,8 @@ namespace autoware::cuda_utils
  * \param device_id The ID of the CUDA device to create the memory pool on.
  * \return A CUDA memory pool handler.
  */
-cudaMemPool_t create_memory_pool(const size_t & max_mem_pool_size_in_byte, const int device_id)
+inline cudaMemPool_t create_memory_pool(
+  const size_t & max_mem_pool_size_in_byte, const int device_id)
 {
   cudaMemPool_t mem_pool;
 

--- a/sensing/autoware_pointcloud_preprocessor/CMakeLists.txt
+++ b/sensing/autoware_pointcloud_preprocessor/CMakeLists.txt
@@ -106,6 +106,7 @@ ament_auto_add_library(pointcloud_preprocessor_filter SHARED
   src/outlier_filter/voxel_grid_outlier_filter_node.cpp
   src/outlier_filter/polar_voxel_outlier_filter_node.cpp
   src/outlier_filter/dual_return_outlier_filter_node.cpp
+  src/outlier_filter/polar_voxel_noise_filter_node.cpp
   src/passthrough_filter/passthrough_filter_node.cpp
   src/passthrough_filter/passthrough_filter_uint16_node.cpp
   src/passthrough_filter/passthrough_uint16.cpp
@@ -195,6 +196,11 @@ autoware_agnocast_wrapper_register_node(pointcloud_preprocessor_filter
   AGNOCAST_EXECUTOR CallbackIsolatedAgnocastExecutor
   ROS2_EXECUTOR SingleThreadedExecutor
 )
+
+# -- Polar Voxel Noise Filter --
+rclcpp_components_register_node(pointcloud_preprocessor_filter
+  PLUGIN "autoware::pointcloud_preprocessor::PolarVoxelNoiseFilterComponent"
+  EXECUTABLE polar_voxel_noise_filter_node)
 
 # -- Radius Search 2D Outlier Filter --
 rclcpp_components_register_node(pointcloud_preprocessor_filter
@@ -334,6 +340,10 @@ if(BUILD_TESTING)
     test/test_polar_voxel_outlier_filter_node.cpp
   )
 
+  ament_add_gtest(test_polar_voxel_noise_filter_node
+    test/test_polar_voxel_noise_filter_node.cpp
+  )
+
   ament_add_gtest(test_blockage_diag
     test/blockage_diag/test_blockage_diag.cpp
   )
@@ -364,6 +374,7 @@ if(BUILD_TESTING)
   target_link_libraries(test_pickup_based_voxel_grid_downsample_filter_node pointcloud_preprocessor_filter)
   target_link_libraries(test_concatenation_info concatenate_data)
   target_link_libraries(test_polar_voxel_outlier_filter_node pointcloud_preprocessor_filter)
+  target_link_libraries(test_polar_voxel_noise_filter_node pointcloud_preprocessor_filter)
   target_link_libraries(test_blockage_diag pointcloud_preprocessor_filter)
   target_link_libraries(test_blockage_diag_node pointcloud_preprocessor_filter)
   target_link_libraries(test_pointcloud2_to_depth_image pointcloud_preprocessor_filter)

--- a/sensing/autoware_pointcloud_preprocessor/README.md
+++ b/sensing/autoware_pointcloud_preprocessor/README.md
@@ -22,6 +22,7 @@ Detail description of each filter's algorithm is in the following links.
 | distortion_corrector          | compensate pointcloud distortion caused by ego vehicle's movement during 1 scan    | [link](docs/distortion-corrector.md)          |
 | downsample_filter             | downsampling input pointcloud                                                      | [link](docs/downsample-filter.md)             |
 | outlier_filter                | remove points caused by hardware problems, rain drops and small insects as a noise | [link](docs/outlier-filter.md)                |
+| polar_voxel_noise_filter      | remove point cloud noise using polar-coordinate voxels and return-type-aware rules | [link](docs/polar-voxel-noise-filter.md)      |
 | passthrough_filter            | remove points on the outside of a range in given field (e.g. x, y, z, intensity)   | [link](docs/passthrough-filter.md)            |
 | pointcloud_accumulator        | accumulate pointclouds for a given amount of time                                  | [link](docs/pointcloud-accumulator.md)        |
 | pointcloud_densifier          | enhance sparse point clouds by using information from previous frames              | [link](docs/pointcloud-densifier.md)          |

--- a/sensing/autoware_pointcloud_preprocessor/config/polar_voxel_noise_filter_node.param.yaml
+++ b/sensing/autoware_pointcloud_preprocessor/config/polar_voxel_noise_filter_node.param.yaml
@@ -1,0 +1,16 @@
+/**:
+  ros__parameters:
+    radial_resolution: 0.5
+    azimuth_resolution: 0.08
+    elevation_resolution: 0.05
+    voxel_points_threshold: 4
+    min_radius: 0.5
+    max_radius: 200.0
+    avg_intensity_threshold: 0.01
+
+    use_return_type_classification: true
+    filter_secondary_returns: true
+    secondary_noise_threshold: 4
+    primary_return_types: [1, 6, 8, 10]
+
+    publish_noise_cloud: false

--- a/sensing/autoware_pointcloud_preprocessor/docs/polar-voxel-noise-filter.md
+++ b/sensing/autoware_pointcloud_preprocessor/docs/polar-voxel-noise-filter.md
@@ -1,0 +1,289 @@
+# Polar Voxel Noise Filter
+
+## Overview
+
+The Polar Voxel Noise Filter is a point cloud noise filtering algorithm that operates in polar
+coordinate space for LiDAR data processing. This filter supports both simple intensity-based noise removal and return-type-aware filtering for more small objects like insects, and other
+sparse noise.
+
+**Key Features**:
+
+- **Flexible filtering modes** with optional return type classification
+- **Automatic format detection** between PointXYZIRC and PointXYZIRCAEDT
+- **Polar voxel filtering** using radius, azimuth, and elevation bins
+- **Intensity-aware noise judgement** using average voxel intensity
+- **Optional secondary return suppression** in the final output
+- **Optional debug support** with noise point cloud publishing for analysis
+
+## Purpose
+
+The purpose is to remove point cloud noise such as insects and voxels with high number of secondary returns using a polar coordinate voxel
+grid approach optimized for LiDAR sensor characteristics. This filter provides configurable
+filtering methods:
+
+1. **Simple Mode**: Noise judgement using voxel occupancy and average intensity
+2. **Return-Type-Aware Mode**: Extends noise judgement with secondary return counting
+
+The return-type-aware mode is intended for sensors where secondary returns are more likely to be
+associated with noise such as rain, or other weak reflections.
+
+## Key Differences from Cartesian Voxel Grid Filter
+
+### Coordinate System
+
+- **Cartesian Voxel Grid**: Divides 3D space into regular cubic voxels using `(x, y, z)`
+- **Polar Voxel Grid**: Divides 3D space into polar voxels using `(radius, azimuth, elevation)`
+
+### Advantages of Polar Voxelization
+
+1. **Natural LiDAR Representation**: LiDAR sensors scan in polar patterns, so the voxel structure
+   matches the data more naturally
+2. **Range-Aware Spatial Binning**: Angular bins remain consistent across the scan
+3. **Format Flexibility**: Supports both Cartesian input and precomputed polar-coordinate input
+4. **Return-Type-Aware Filtering**: Can use primary/secondary return information when available
+5. **Debug Visibility**: Can publish the removed points as a separate cloud for tuning
+
+## Point Cloud Format Support
+
+This filter supports point clouds with intensity information and automatically detects between two
+formats:
+
+### PointXYZIRC Format
+
+- **Usage**: Point format with `(x, y, z, intensity, return_type, channel)` fields
+- **Processing**: Computes polar coordinates `(radius, azimuth, elevation)` from Cartesian values
+- **Return Type**: Uses `return_type` for classification when enabled
+- **Performance**: Good performance with coordinate conversion overhead
+
+### PointXYZIRCAEDT Format
+
+- **Usage**: Point clouds with pre-computed polar coordinate fields
+- **Fields**: `(x, y, z, intensity, return_type, channel, azimuth, elevation, distance, time_stamp)`
+- **Detection**: Automatically detects when polar coordinate fields are present
+- **Processing**: Uses pre-computed polar coordinates directly
+- **Performance**: Faster processing because it avoids trigonometric conversion
+
+```yaml
+# PointXYZIRC: Computes polar coordinates from Cartesian
+# - x, y, z       (float32): Cartesian coordinates
+# - intensity     (uint8/compatible field): Point intensity
+# - return_type   (uint8):   Return type classification
+# - channel       (uint16):  Channel information
+
+# PointXYZIRCAEDT: Uses pre-computed polar coordinates
+# - x, y, z       (float32): Cartesian coordinates
+# - intensity     (uint8/compatible field): Point intensity
+# - return_type   (uint8):   Return type classification
+# - channel       (uint16):  Channel information
+# - azimuth       (float32): Pre-computed azimuth angle
+# - elevation     (float32): Pre-computed elevation angle
+# - distance      (float32): Pre-computed radius
+# - time_stamp    (uint32):  Point timestamp
+```
+
+**Note**: The filter always requires an `intensity` field. The `return_type` field is required
+only when `use_return_type_classification=true`.
+
+## Inner-workings / Algorithms
+
+### Coordinate Conversion
+
+**For PointXYZIRC format:**
+Each point `(x, y, z)` is converted to polar coordinates:
+
+- **Radius**: `r = sqrt(x² + y² + z²)`
+- **Azimuth**: `θ = atan2(y, x)`
+- **Elevation**: `φ = atan2(z, sqrt(x² + y²))`
+
+**For PointXYZIRCAEDT format:**
+Uses pre-computed polar coordinates directly from the point fields:
+
+- **Radius**: `r = point.distance`
+- **Azimuth**: `θ = point.azimuth`
+- **Elevation**: `φ = point.elevation`
+
+### Voxel Index Calculation
+
+Each point is assigned to a voxel based on:
+
+- **Radius Index**: `floor(radius / radial_resolution)`
+- **Azimuth Index**: `floor(azimuth / azimuth_resolution)`
+- **Elevation Index**: `floor(elevation / elevation_resolution)`
+
+### Return Type Classification
+
+When `use_return_type_classification=true`, points are classified using the `return_type` field:
+
+- **Primary Returns**: Return types specified in `primary_return_types`
+- **Secondary Returns**: All other return types not specified as primary
+- **Classification Use**: Applied only in the return-type-aware noise judgement path
+
+### Filtering Methodology
+
+The filter uses different algorithms based on the `use_return_type_classification` parameter.
+
+#### Simple Mode (`use_return_type_classification=false`)
+
+1. **Format Detection**: Automatically detects PointXYZIRC vs PointXYZIRCAEDT
+2. **Coordinate Processing**:
+   - PointXYZIRC: Computes polar coordinates from Cartesian
+   - PointXYZIRCAEDT: Uses pre-computed polar coordinates
+3. **Voxel Binning**: Points are grouped into polar voxels
+4. **Voxel Statistics**: For each voxel, compute:
+   - total point count
+   - average intensity
+5. **Noise Judgement**:
+   - a voxel is treated as noise when
+     `point_count <= voxel_points_threshold AND intensity_avg <= avg_intensity_threshold`
+6. **Output**: Points in non-noise voxels are kept
+
+#### Return-Type-Aware Mode (`use_return_type_classification=true`)
+
+1. **Format Detection**: Automatically detects PointXYZIRC vs PointXYZIRCAEDT
+2. **Return Type Validation**: Ensures `return_type` field is present
+3. **Coordinate Processing**:
+   - PointXYZIRC: Computes polar coordinates from Cartesian
+   - PointXYZIRCAEDT: Uses pre-computed polar coordinates
+4. **Return Type Classification**: Points are classified as primary or secondary returns
+5. **Voxel Statistics**: For each voxel, compute:
+   - total point count
+   - average intensity
+   - secondary return count
+6. **Noise Judgement**:
+   - a voxel is treated as noise when matched the next conditions:
+     - `point_count <= voxel_points_threshold AND intensity_avg <= avg_intensity_threshold`
+     - `secondary_return_count >= secondary_noise_threshold AND intensity_avg <= avg_intensity_threshold`
+7. **Optional Secondary Return Filtering**:
+   - when `filter_secondary_returns=true`, only primary returns are published even from kept voxels
+8. **Output**: Filtered point cloud plus optional debug noise cloud
+
+### Noise Judgement
+
+#### Simple Mode
+
+- **Noise voxel**:
+  `point_count <= voxel_points_threshold AND intensity_avg <= avg_intensity_threshold`
+
+#### Return-Type-Aware Mode
+
+- **Noise voxel**:
+  `((point_count <= voxel_points_threshold) OR (secondary_return_count >= secondary_noise_threshold)) AND intensity_avg <= avg_intensity_threshold`
+
+### Key Features
+
+- **Flexible Architecture**: Configurable between simple and return-type-aware filtering
+- **Format-Optimized Processing**: Automatic selection of optimal coordinate source
+- **Intensity-Aware Filtering**: Uses average voxel intensity to avoid removing dense valid returns
+- **Secondary Return Handling**: Can use or suppress secondary returns depending on configuration
+- **Debug Support**: Optional noise cloud publishing for analysis and tuning
+
+## Inputs / Outputs
+
+This implementation inherits `autoware::pointcloud_preprocessor::Filter` class, please refer
+[README](../README.md).
+
+### Input Requirements
+
+- **Supported Formats**: PointXYZIRC or PointXYZIRCAEDT
+- **Intensity Field**: Always required
+- **Return Type Field**: Required only when `use_return_type_classification=true`
+- **Invalid Inputs**: Point clouds without `intensity` are rejected, and point clouds without
+  `return_type` are rejected in return-type-aware mode
+
+### Additional Debug Topics
+
+| Name                                                | Type                            | Description                       |
+| --------------------------------------------------- | ------------------------------- | --------------------------------- |
+| `~/polar_voxel_noise_filter/debug/pointcloud_noise` | `sensor_msgs::msg::PointCloud2` | Filtered-out points for debugging |
+
+## Parameters
+
+### Node Parameters
+
+This implementation inherits `autoware::pointcloud_preprocessor::Filter` class, please refer
+[README](../README.md).
+
+{{ json_to_markdown("sensing/autoware_pointcloud_preprocessor/schema/polar_voxel_noise_filter_node.schema.json") }}
+
+### Parameter Interactions
+
+- **use_return_type_classification**: Enables return-type-aware noise filtering
+- **primary_return_types**: Only used when `use_return_type_classification=true`
+- **secondary_noise_threshold**: Only used when `use_return_type_classification=true`
+- **filter_secondary_returns**: When `true`, only primary returns remain in the output
+- **avg_intensity_threshold**: Used in both modes as part of the noise decision
+- **publish_noise_cloud**: When `true`, publishes removed points for debugging
+
+## Assumptions / Known limits
+
+- **Simple mode**: Uses point count and average intensity only
+- **Return-type-aware mode**: Requires `return_type` field
+- **Supported formats**: PointXYZIRC and PointXYZIRCAEDT only
+- **Finite coordinates required**: NaN and Inf values are ignored
+- **Radius range filtering**: Points outside `[min_radius, max_radius]` are excluded
+- **Indices unsupported**: Input indices are ignored
+- **Angular domain assumptions**:
+  - **PointXYZIRC azimuth**: Computed from `atan2(y, x)`, so the domain is `[-π, π]`; this filter
+    does not normalize it to `[0, 2π]` before voxelization
+  - **PointXYZIRCAEDT azimuth/elevation**: Uses the polar coordinates provided by the input
+    message as-is
+  - **Elevation domain**: Expected to be `[-π/2, π/2]`
+
+## Error detection and handling
+
+The filter includes input and parameter validation:
+
+- **Input validation**: Checks for missing required fields
+- **Return type validation**: Enforced only in return-type-aware mode
+- **Coordinate validation**: Ignores invalid or out-of-range points
+- **Dynamic parameter validation**: Rejects invalid runtime updates such as negative radii or
+  out-of-range return types
+
+## Usage
+
+### Launch the Filter
+
+```xml
+<node pkg="autoware_pointcloud_preprocessor"
+      exec="polar_voxel_noise_filter_node"
+      name="polar_voxel_noise_filter">
+  <param from="$(find-pkg-share autoware_pointcloud_preprocessor)/config/polar_voxel_noise_filter_node.param.yaml"/>
+</node>
+```
+
+### ROS 2 Topics
+
+- **Input**: inherited from `autoware::pointcloud_preprocessor::Filter`
+- **Output**: inherited from `autoware::pointcloud_preprocessor::Filter`
+- **Debug Noise Cloud**: `~/polar_voxel_noise_filter/debug/pointcloud_noise`
+
+## Performance characterization
+
+### Computational Complexity
+
+- **Time Complexity**: Approximately `O(n)` where `n` is the number of input points
+- **Space Complexity**: Approximately `O(v)` where `v` is the number of occupied voxels
+
+### Performance Impact by Mode
+
+#### Simple Mode
+
+- Lower overhead because no return type classification is used
+- Best choice when `return_type` is unavailable or not needed
+
+#### Return-Type-Aware Mode
+
+- Adds return type lookup and secondary return counting
+- Provides stronger suppression of sparse secondary-return-heavy noise
+
+#### Point Format Impact
+
+- **PointXYZIRCAEDT**: Faster due to pre-computed polar coordinates
+- **PointXYZIRC**: Slightly slower due to per-point coordinate conversion
+
+### Optimization Tips
+
+1. Use `PointXYZIRCAEDT` input when available for better performance
+2. Enable `publish_noise_cloud` only when debugging
+3. Tune `avg_intensity_threshold` together with `voxel_points_threshold`
+4. Use return-type-aware mode only when the sensor provides meaningful `return_type` values

--- a/sensing/autoware_pointcloud_preprocessor/include/autoware/pointcloud_preprocessor/outlier_filter/polar_voxel_noise_filter_node.hpp
+++ b/sensing/autoware_pointcloud_preprocessor/include/autoware/pointcloud_preprocessor/outlier_filter/polar_voxel_noise_filter_node.hpp
@@ -1,0 +1,281 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef AUTOWARE__POINTCLOUD_PREPROCESSOR__OUTLIER_FILTER__POLAR_VOXEL_NOISE_FILTER_NODE_HPP_
+#define AUTOWARE__POINTCLOUD_PREPROCESSOR__OUTLIER_FILTER__POLAR_VOXEL_NOISE_FILTER_NODE_HPP_
+
+#include "autoware/pointcloud_preprocessor/filter.hpp"
+
+#include <rclcpp/rclcpp.hpp>
+
+#include <sensor_msgs/msg/point_cloud2.hpp>
+#include <sensor_msgs/point_cloud2_iterator.hpp>
+
+#include <memory>
+#include <mutex>
+#include <optional>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <vector>
+
+namespace autoware::pointcloud_preprocessor
+{
+
+// Polar voxel index for 3D polar coordinate space discretization
+struct PolarVoxelIndex
+{
+  int32_t radius_idx{};
+  int32_t azimuth_idx{};
+  int32_t elevation_idx{};
+
+  PolarVoxelIndex() = default;
+  PolarVoxelIndex(int32_t radius, int32_t azimuth, int32_t elevation)
+  : radius_idx(radius), azimuth_idx(azimuth), elevation_idx(elevation)
+  {
+  }
+
+  bool operator==(const PolarVoxelIndex & other) const
+  {
+    return radius_idx == other.radius_idx && azimuth_idx == other.azimuth_idx &&
+           elevation_idx == other.elevation_idx;
+  }
+};
+
+// Hash function for PolarVoxelIndex to use in unordered containers
+struct PolarVoxelIndexHash
+{
+  std::size_t operator()(const PolarVoxelIndex & idx) const
+  {
+    // Fowler–Noll–Vo style hash combine for better distribution
+    auto hash = std::hash<int32_t>{}(idx.radius_idx);
+    hash ^= static_cast<std::size_t>(std::hash<int32_t>{}(idx.azimuth_idx)) + 0x9e3779b9u +
+            (static_cast<std::size_t>(hash) << 6u) + (static_cast<std::size_t>(hash) >> 2u);
+    hash ^= static_cast<std::size_t>(std::hash<int32_t>{}(idx.elevation_idx)) + 0x9e3779b9u +
+            (static_cast<std::size_t>(hash) << 6u) + (static_cast<std::size_t>(hash) >> 2u);
+    return hash;
+  }
+};
+
+// Information about a point's relationship to its voxel
+struct PointVoxelInfo
+{
+  PolarVoxelIndex voxel_idx;
+  bool is_primary{false};
+  uint8_t intensity{0U};
+
+  PointVoxelInfo() = default;
+  PointVoxelInfo(const PolarVoxelIndex & voxel_idx, bool is_primary, uint8_t intensity)
+  : voxel_idx(voxel_idx), is_primary(is_primary), intensity(intensity)
+  {
+  }
+};
+
+// Aggregated statistics for points within a voxel
+struct VoxelStats
+{
+  int point_count{0};
+  float intensity_sum{0.0f};
+  float intensity_avg{0.0f};
+  int secondary_return_count{0};
+
+  [[nodiscard]] bool meets_min_points(int threshold) const { return point_count >= threshold; }
+
+  [[nodiscard]] bool meets_max_intensity_avg(int threshold) const
+  {
+    return intensity_avg <= static_cast<float>(threshold);
+  }
+
+  [[nodiscard]] bool meets_max_secondary_returns(int threshold) const
+  {
+    return secondary_return_count <= threshold;
+  }
+  [[nodiscard]] bool meets_noise_condition(
+    int min_points, float avg_intensity_threshold, int max_secondary_returns) const
+  {
+    return (point_count <= min_points && intensity_avg <= avg_intensity_threshold) ||
+           (secondary_return_count >= max_secondary_returns &&
+            intensity_avg <= avg_intensity_threshold);
+  }
+  [[nodiscard]] bool meets_noise_simple_condition(
+    int min_points, float avg_intensity_threshold) const
+  {
+    return (point_count <= min_points && intensity_avg <= avg_intensity_threshold);
+  }
+};
+
+class PolarVoxelNoiseFilterComponent : public autoware::pointcloud_preprocessor::Filter
+{
+public:
+  explicit PolarVoxelNoiseFilterComponent(const rclcpp::NodeOptions & options);
+
+  // Custom coordinate types for type safety and self-documenting code
+  struct CartesianCoordinate
+  {
+    double x{};
+    double y{};
+    double z{};
+    CartesianCoordinate() = default;
+    CartesianCoordinate(double x, double y, double z) : x(x), y(y), z(z) {}
+  };
+
+  struct PolarCoordinate
+  {
+    double radius{};
+    double azimuth{};
+    double elevation{};
+    PolarCoordinate() = default;
+    PolarCoordinate(double radius, double azimuth, double elevation)
+    : radius(radius), azimuth(azimuth), elevation(elevation)
+    {
+    }
+  };
+
+protected:
+  enum class InputPointCloudFormat { PointXYZIRC, PointXYZIRCAEDT };
+
+  // Parameter update helper methods
+  void update_primary_return_types(const rclcpp::Parameter & param);
+  void update_publish_noise_cloud(const rclcpp::Parameter & param);
+
+  // Type aliases to eliminate long type name duplication
+  using PointCloud2 = sensor_msgs::msg::PointCloud2;
+  using PointCloud2ConstPtr = sensor_msgs::msg::PointCloud2::ConstSharedPtr;
+  using IndicesPtr = pcl::IndicesPtr;
+  using VoxelStatsMap = std::unordered_map<PolarVoxelIndex, VoxelStats, PolarVoxelIndexHash>;
+  using VoxelIndexSet = std::unordered_set<PolarVoxelIndex, PolarVoxelIndexHash>;
+  using PointVoxelInfoVector = std::vector<std::optional<PointVoxelInfo>>;
+  using ValidPointsMask = std::vector<bool>;
+
+  void filter(
+    const PointCloud2ConstPtr & input, const IndicesPtr & indices, PointCloud2 & output) override;
+
+  PointVoxelInfoVector collect_voxel_info(const PointCloud2 & input);
+  VoxelStatsMap analyze_voxel_stats(const PointVoxelInfoVector & point_voxel_info) const;
+  VoxelIndexSet determine_valid_voxels_simple(const VoxelStatsMap & voxel_stats_map) const;
+  VoxelIndexSet determine_valid_voxels_with_return_types(
+    const VoxelStatsMap & voxel_stats_map) const;
+  VoxelIndexSet determine_valid_voxels(const VoxelStatsMap & voxel_stats_map) const;
+  ValidPointsMask create_valid_points_mask(
+    const PointVoxelInfoVector & point_voxel_info, const VoxelIndexSet & valid_voxels) const;
+  static void create_filtered_output(
+    const PointCloud2 & input, const ValidPointsMask & valid_points_mask, PointCloud2 & output);
+  void publish_noise_cloud(
+    const PointCloud2 & input, const ValidPointsMask & valid_points_mask) const;
+
+  // Point processing helper methods
+  void process_polar_points(const PointCloud2 & input, PointVoxelInfoVector & point_voxel_info);
+
+  void process_cartesian_points(const PointCloud2 & input, PointVoxelInfoVector & point_voxel_info);
+
+  std::optional<PointVoxelInfo> process_polar_point(
+    float distance, float azimuth, float elevation, uint8_t intensity, uint8_t return_type) const;
+
+  std::optional<PointVoxelInfo> process_cartesian_point(
+    float x, float y, float z, uint8_t intensity, uint8_t return_type) const;
+
+  template <typename Predicate>
+  VoxelIndexSet determine_valid_voxels_generic(
+    const VoxelStatsMap & voxel_stats_map, Predicate predicate) const;
+
+  std::optional<PolarCoordinate> extract_polar_from_dae(
+    float distance, float azimuth, float elevation) const;
+
+  std::optional<PolarCoordinate> extract_polar_from_xyz(float x, float y, float z) const;
+
+  void update_parameter(const rclcpp::Parameter & param);
+
+  static void setup_output_header(
+    PointCloud2 & output, const PointCloud2 & input, size_t valid_count);
+
+  // Coordinate conversion methods
+  static PolarCoordinate cartesian_to_polar(const CartesianCoordinate & cartesian);
+  PolarVoxelIndex cartesian_to_polar_voxel(const CartesianCoordinate & cartesian) const;
+  PolarVoxelIndex polar_to_polar_voxel(const PolarCoordinate & polar) const;
+
+  // Return type and validation methods
+  bool is_point_primary(uint8_t return_type) const;
+  bool is_valid_polar_point(const PolarCoordinate & polar) const;
+  static bool has_polar_coordinates(const PointCloud2 & input);
+
+  // Parameter callback and diagnostics
+  rcl_interfaces::msg::SetParametersResult param_callback(const std::vector<rclcpp::Parameter> & p);
+
+  // Constants to handle circular angles
+  const double azimuth_domain_min;
+  const double azimuth_domain_max;
+  const double elevation_domain_min;
+  const double elevation_domain_max;
+
+  // Parameters
+  double radial_resolution_m_{};
+  double azimuth_resolution_rad_{};
+  double elevation_resolution_rad_{};
+  int voxel_points_threshold_{};
+  double min_radius_m_{};
+  double max_radius_m_{};
+  bool use_return_type_classification_{};
+  bool enable_secondary_return_filtering_{};
+  int secondary_noise_threshold_{};
+  double avg_intensity_threshold_{};
+  std::vector<int> primary_return_types_;
+  bool publish_noise_cloud_{};
+  std::mutex mutex_;
+  std::once_flag input_format_once_flag_;
+  std::optional<InputPointCloudFormat> input_format_;
+
+  // Publishers and diagnostics
+  rclcpp::Publisher<sensor_msgs::msg::PointCloud2>::SharedPtr noise_cloud_pub_;
+  OnSetParametersCallbackHandle::SharedPtr set_param_res_;
+
+  // Filter pipeline helper methods
+  void validate_filter_inputs(const PointCloud2 & input, const IndicesPtr & indices);
+  void create_output(
+    const PointCloud2 & input, const ValidPointsMask & valid_points_mask, PointCloud2 & output);
+  void create_empty_output(const PointCloud2 & input, PointCloud2 & output);
+
+  // Point validation helper methods
+  bool has_finite_coordinates(const PolarCoordinate & polar) const;
+  bool is_within_radius_range(const PolarCoordinate & polar) const;
+  bool has_sufficient_radius(const PolarCoordinate & polar) const;
+
+  // Point validation helper methods for mask creation
+  bool is_point_valid_for_mask(
+    const std::optional<PointVoxelInfo> & optional_info, const VoxelIndexSet & valid_voxels) const;
+  bool passes_secondary_return_filter(bool is_primary) const;
+
+private:
+  using ParamHandler = std::function<bool(const rclcpp::Parameter &, std::string &)>;
+  // Validation helper methods
+  void validate_indices(const IndicesPtr & indices);
+  void validate_required_fields(const PointCloud2 & input);
+  void validate_return_type_field(const PointCloud2 & input);
+  void validate_intensity_field(const PointCloud2 & input);
+  bool has_field(const PointCloud2 & input, const std::string & field_name);
+
+  // Parameter validation helpers (static, private)
+  static bool validate_positive_double(const rclcpp::Parameter & param, std::string & reason);
+  static bool validate_non_negative_double(const rclcpp::Parameter & param, std::string & reason);
+  static bool validate_positive_int(const rclcpp::Parameter & param, std::string & reason);
+  static bool validate_non_negative_int(const rclcpp::Parameter & param, std::string & reason);
+  static bool validate_primary_return_types(const rclcpp::Parameter & param, std::string & reason);
+  static bool validate_normalized(const rclcpp::Parameter & param, std::string & reason);
+  static bool validate_zero_to_two_pi(const rclcpp::Parameter & param, std::string & reason);
+  static bool validate_negative_half_pi_to_half_pi(
+    const rclcpp::Parameter & param, std::string & reason);
+};
+
+}  // namespace autoware::pointcloud_preprocessor
+
+#endif  // AUTOWARE__POINTCLOUD_PREPROCESSOR__OUTLIER_FILTER__POLAR_VOXEL_NOISE_FILTER_NODE_HPP_

--- a/sensing/autoware_pointcloud_preprocessor/launch/polar_voxel_noise_filter_node.launch.xml
+++ b/sensing/autoware_pointcloud_preprocessor/launch/polar_voxel_noise_filter_node.launch.xml
@@ -1,0 +1,14 @@
+<launch>
+  <arg name="input_topic_name" default="/pointcloud_raw"/>
+  <arg name="output_topic_name" default="/pointcloud_filtered"/>
+  <arg name="input_frame" default=""/>
+  <arg name="output_frame" default=""/>
+  <arg name="polar_voxel_noise_filter_param_file" default="$(find-pkg-share autoware_pointcloud_preprocessor)/config/polar_voxel_noise_filter_node.param.yaml"/>
+  <node pkg="autoware_pointcloud_preprocessor" exec="polar_voxel_noise_filter_node" name="polar_voxel_noise_filter_node">
+    <param from="$(var polar_voxel_noise_filter_param_file)"/>
+    <remap from="input" to="$(var input_topic_name)"/>
+    <remap from="output" to="$(var output_topic_name)"/>
+    <param name="input_frame" value="$(var input_frame)"/>
+    <param name="output_frame" value="$(var output_frame)"/>
+  </node>
+</launch>

--- a/sensing/autoware_pointcloud_preprocessor/schema/polar_voxel_noise_filter_node.schema.json
+++ b/sensing/autoware_pointcloud_preprocessor/schema/polar_voxel_noise_filter_node.schema.json
@@ -1,0 +1,116 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "title": "Parameters for Polar Voxel Noise Filter Node",
+  "type": "object",
+  "definitions": {
+    "polar_voxel_noise_filter": {
+      "type": "object",
+      "properties": {
+        "radial_resolution": {
+          "type": "number",
+          "description": "Resolution in radial direction [m].",
+          "default": "0.5",
+          "minimum": 0
+        },
+        "azimuth_resolution": {
+          "type": "number",
+          "description": "Resolution in azimuth direction [rad]. The supplied value is modified to ensure consistent voxel sizes across the whole azimuth range.",
+          "default": "0.08",
+          "minimum": 0,
+          "maximum": 6.283185307179586
+        },
+        "elevation_resolution": {
+          "type": "number",
+          "description": "Resolution in elevation direction [rad]. The supplied value is modified to ensure consistent voxel sizes across the whole elevation range.",
+          "default": "0.05",
+          "minimum": 0,
+          "maximum": 6.283185307179586
+        },
+        "voxel_points_threshold": {
+          "type": "integer",
+          "description": "Minimum number of points required per voxel.",
+          "default": "4",
+          "minimum": 1
+        },
+        "min_radius": {
+          "type": "number",
+          "description": "Minimum radius to consider [m].",
+          "default": "0.5",
+          "minimum": 0
+        },
+        "max_radius": {
+          "type": "number",
+          "description": "Maximum radius to consider [m].",
+          "default": "200.0",
+          "minimum": 0
+        },
+        "use_return_type_classification": {
+          "type": "boolean",
+          "description": "Whether to use return type classification.",
+          "default": "true"
+        },
+        "filter_secondary_returns": {
+          "type": "boolean",
+          "description": "Whether to filter secondary returns.",
+          "default": "true"
+        },
+        "secondary_noise_threshold": {
+          "type": "integer",
+          "description": "Threshold for classifying primary vs secondary returns.",
+          "default": "4",
+          "minimum": 0
+        },
+        "primary_return_types": {
+          "type": "array",
+          "description": "List of return type values considered as primary returns.",
+          "items": {
+            "type": "integer",
+            "minimum": 0,
+            "maximum": 255
+          },
+          "default": "[1, 6, 8, 10]"
+        },
+        "avg_intensity_threshold": {
+          "type": "number",
+          "description": "Maximum average intensity threshold for secondary returns.",
+          "default": "0.01",
+          "minimum": 0
+        },
+        "publish_noise_cloud": {
+          "type": "boolean",
+          "description": "Whether to generate and publish a noise pointcloud for debugging.",
+          "default": "false"
+        }
+      },
+      "required": [
+        "radial_resolution",
+        "azimuth_resolution",
+        "elevation_resolution",
+        "voxel_points_threshold",
+        "min_radius",
+        "max_radius",
+        "use_return_type_classification",
+        "filter_secondary_returns",
+        "secondary_noise_threshold",
+        "primary_return_types",
+        "avg_intensity_threshold",
+        "publish_noise_cloud"
+      ],
+      "additionalProperties": false
+    }
+  },
+  "properties": {
+    "/**": {
+      "type": "object",
+      "properties": {
+        "ros__parameters": {
+          "$ref": "#/definitions/polar_voxel_noise_filter"
+        }
+      },
+      "required": ["ros__parameters"],
+      "additionalProperties": false
+    }
+  },
+  "required": ["/**"],
+  "additionalProperties": false
+}

--- a/sensing/autoware_pointcloud_preprocessor/src/outlier_filter/polar_voxel_noise_filter_node.cpp
+++ b/sensing/autoware_pointcloud_preprocessor/src/outlier_filter/polar_voxel_noise_filter_node.cpp
@@ -1,0 +1,814 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/pointcloud_preprocessor/outlier_filter/polar_voxel_noise_filter_node.hpp"
+
+#include <autoware/pointcloud_preprocessor/utility/memory.hpp>
+
+#include <sensor_msgs/msg/point_cloud2.hpp>
+#include <sensor_msgs/point_cloud2_iterator.hpp>
+
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <cstring>
+#include <limits>
+#include <memory>
+#include <mutex>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace autoware::pointcloud_preprocessor
+{
+
+static constexpr size_t point_cloud_height_organized = 1;
+static constexpr double TWO_PI = 2.0 * M_PI;
+
+template <typename... T>
+bool all_finite(T... values)
+{
+  return (... && std::isfinite(values));
+}
+
+inline double adjust_resolution_to_circle(double requested_resolution)
+{
+  int bins = static_cast<int>(std::round(TWO_PI / requested_resolution));
+  if (bins < 1) bins = 1;
+  return TWO_PI / bins;
+}
+
+PolarVoxelNoiseFilterComponent::PolarVoxelNoiseFilterComponent(const rclcpp::NodeOptions & options)
+: Filter("PolarVoxelNoiseFilter", options),
+  azimuth_domain_min(0.0),
+  azimuth_domain_max(TWO_PI),
+  elevation_domain_min(-M_PI / 2.0),
+  elevation_domain_max(M_PI / 2.0)  //,
+// updater_(this)
+{
+  radial_resolution_m_ = declare_parameter<double>("radial_resolution");
+  azimuth_resolution_rad_ =
+    adjust_resolution_to_circle(declare_parameter<double>("azimuth_resolution"));
+  elevation_resolution_rad_ =
+    adjust_resolution_to_circle(declare_parameter<double>("elevation_resolution"));
+  voxel_points_threshold_ = static_cast<int>(declare_parameter<int64_t>("voxel_points_threshold"));
+  min_radius_m_ = declare_parameter<double>("min_radius");
+  max_radius_m_ = declare_parameter<double>("max_radius");
+  use_return_type_classification_ = declare_parameter<bool>("use_return_type_classification");
+  enable_secondary_return_filtering_ = declare_parameter<bool>("filter_secondary_returns");
+  secondary_noise_threshold_ =
+    static_cast<int>(declare_parameter<int64_t>("secondary_noise_threshold"));
+  publish_noise_cloud_ = declare_parameter<bool>("publish_noise_cloud");
+
+  auto primary_return_types_param = declare_parameter<std::vector<int64_t>>("primary_return_types");
+  primary_return_types_.clear();
+  primary_return_types_.reserve(primary_return_types_param.size());
+  for (const auto & val : primary_return_types_param) {
+    primary_return_types_.push_back(static_cast<int>(val));
+    RCLCPP_DEBUG(get_logger(), "primary_return_types_ value: %d", static_cast<int>(val));
+  }
+
+  avg_intensity_threshold_ = declare_parameter<double>("avg_intensity_threshold");
+
+  // Create noise cloud publisher if enabled
+  if (publish_noise_cloud_) {
+    rclcpp::PublisherOptions pub_options;
+    pub_options.qos_overriding_options = rclcpp::QosOverridingOptions::with_default_policies();
+    noise_cloud_pub_ = create_publisher<sensor_msgs::msg::PointCloud2>(
+      "polar_voxel_noise_filter/debug/pointcloud_noise", rclcpp::SensorDataQoS(), pub_options);
+    RCLCPP_INFO(get_logger(), "Noise cloud publishing enabled");
+  } else {
+    RCLCPP_INFO(get_logger(), "Noise cloud publishing disabled for performance optimization");
+  }
+
+  using std::placeholders::_1;
+  set_param_res_ = this->add_on_set_parameters_callback(
+    [this](const std::vector<rclcpp::Parameter> & p) { return param_callback(p); });
+
+  RCLCPP_INFO(
+    get_logger(),
+    "Polar Voxel Noise Filter initialized - supports PointXYZIRC and PointXYZIRCAEDT with %s",
+    use_return_type_classification_ ? "advanced two-criteria" : "simple occupancy");
+}
+
+void PolarVoxelNoiseFilterComponent::filter(
+  const PointCloud2ConstPtr & input, const IndicesPtr & indices, PointCloud2 & output)
+{
+  std::scoped_lock lock(mutex_);
+
+  std::call_once(input_format_once_flag_, [this, &input, &indices]() {
+    validate_filter_inputs(*input, indices);
+
+    if (has_polar_coordinates(*input)) {
+      input_format_ = InputPointCloudFormat::PointXYZIRCAEDT;
+      RCLCPP_DEBUG(
+        get_logger(), "Processing PointXYZIRCAEDT format with pre-computed polar coordinates");
+      return;
+    }
+
+    input_format_ = InputPointCloudFormat::PointXYZIRC;
+    RCLCPP_DEBUG(get_logger(), "Processing PointXYZIRC format, computing azimuth and elevation");
+  });
+
+  // Phase 2: Collect voxel information (unified for both formats)
+  auto point_voxel_info = collect_voxel_info(*input);
+
+  // Phase 3: Analyze per-voxel statistics and validate voxels
+  auto voxel_stats_map = analyze_voxel_stats(point_voxel_info);
+  auto valid_voxels = determine_valid_voxels(voxel_stats_map);
+
+  // Phase 4: Create valid points mask
+  auto valid_points_mask = create_valid_points_mask(point_voxel_info, valid_voxels);
+
+  // Phase 5: Create output (normal or empty based on mode)
+  create_output(*input, valid_points_mask, output);
+
+  // Phase 6: Conditionally publish noise cloud
+  if (publish_noise_cloud_) {
+    publish_noise_cloud(*input, valid_points_mask);
+  }
+}
+
+PolarVoxelNoiseFilterComponent::PointVoxelInfoVector
+PolarVoxelNoiseFilterComponent::collect_voxel_info(const PointCloud2 & input)
+{
+  PointVoxelInfoVector point_voxel_info;
+  point_voxel_info.reserve(input.width * input.height);
+
+  const bool has_polar_coords =
+    input_format_ == InputPointCloudFormat::PointXYZIRCAEDT || has_polar_coordinates(input);
+
+  if (has_polar_coords) {
+    process_polar_points(input, point_voxel_info);
+  } else {
+    process_cartesian_points(input, point_voxel_info);
+  }
+
+  return point_voxel_info;
+}
+
+void PolarVoxelNoiseFilterComponent::process_polar_points(
+  const PointCloud2 & input, PointVoxelInfoVector & point_voxel_info)
+{
+  // Create iterators for polar coordinates (always exist for polar format)
+  sensor_msgs::PointCloud2ConstIterator<float> iter_distance(input, "distance");
+  sensor_msgs::PointCloud2ConstIterator<float> iter_azimuth(input, "azimuth");
+  sensor_msgs::PointCloud2ConstIterator<float> iter_elevation(input, "elevation");
+  sensor_msgs::PointCloud2ConstIterator<uint8_t> iter_intensity(input, "intensity");
+  if (use_return_type_classification_) {
+    sensor_msgs::PointCloud2ConstIterator<uint8_t> iter_return_type(input, "return_type");
+    for (; iter_distance != iter_distance.end();
+         ++iter_distance, ++iter_azimuth, ++iter_elevation, ++iter_intensity, ++iter_return_type) {
+      point_voxel_info.emplace_back(process_polar_point(
+        *iter_distance, *iter_azimuth, *iter_elevation, *iter_intensity, *iter_return_type));
+    }
+  } else {
+    // Simple mode ignores return type, so this is only a placeholder value.
+    for (; iter_distance != iter_distance.end();
+         ++iter_distance, ++iter_azimuth, ++iter_elevation, ++iter_intensity) {
+      point_voxel_info.emplace_back(process_polar_point(
+        *iter_distance, *iter_azimuth, *iter_elevation, *iter_intensity,
+        primary_return_types_.empty() ? 0U : static_cast<uint8_t>(primary_return_types_.front())));
+    }
+  }
+}
+
+void PolarVoxelNoiseFilterComponent::process_cartesian_points(
+  const PointCloud2 & input, PointVoxelInfoVector & point_voxel_info)
+{
+  // Create iterators for cartesian coordinates (always exist for cartesian format)
+  sensor_msgs::PointCloud2ConstIterator<float> iter_x(input, "x");
+  sensor_msgs::PointCloud2ConstIterator<float> iter_y(input, "y");
+  sensor_msgs::PointCloud2ConstIterator<float> iter_z(input, "z");
+  sensor_msgs::PointCloud2ConstIterator<uint8_t> iter_intensity(input, "intensity");
+  if (use_return_type_classification_) {
+    sensor_msgs::PointCloud2ConstIterator<uint8_t> iter_return_type(input, "return_type");
+    for (; iter_x != iter_x.end();
+         ++iter_x, ++iter_y, ++iter_z, ++iter_intensity, ++iter_return_type) {
+      point_voxel_info.emplace_back(
+        process_cartesian_point(*iter_x, *iter_y, *iter_z, *iter_intensity, *iter_return_type));
+    }
+  } else {
+    // Simple mode ignores return type, so this is only a placeholder value.
+    for (; iter_x != iter_x.end(); ++iter_x, ++iter_y, ++iter_z, ++iter_intensity) {
+      point_voxel_info.emplace_back(process_cartesian_point(
+        *iter_x, *iter_y, *iter_z, *iter_intensity,
+        primary_return_types_.empty() ? 0U : static_cast<uint8_t>(primary_return_types_.front())));
+    }
+  }
+}
+
+std::optional<PointVoxelInfo> PolarVoxelNoiseFilterComponent::process_polar_point(
+  float distance, float azimuth, float elevation, uint8_t intensity, uint8_t return_type) const
+{
+  // Step 1: Extract polar coordinates and determine point classification
+  auto polar_opt = extract_polar_from_dae(distance, azimuth, elevation);
+  bool is_primary = is_point_primary(return_type);
+
+  // Step 2: Early return on invalid coordinates
+  if (!polar_opt.has_value()) {
+    return std::nullopt;
+  }
+
+  // Step 3: Create voxel index and determine point classification
+  PolarVoxelIndex voxel_idx = polar_to_polar_voxel(*polar_opt);
+
+  return PointVoxelInfo{voxel_idx, is_primary, intensity};
+}
+
+std::optional<PointVoxelInfo> PolarVoxelNoiseFilterComponent::process_cartesian_point(
+  float x, float y, float z, uint8_t intensity, uint8_t return_type) const
+{
+  auto polar_opt = extract_polar_from_xyz(x, y, z);
+
+  if (!polar_opt.has_value()) {
+    return std::nullopt;
+  }
+
+  return process_polar_point(
+    polar_opt->radius, polar_opt->azimuth, polar_opt->elevation, intensity, return_type);
+}
+
+template <typename Predicate>
+PolarVoxelNoiseFilterComponent::VoxelIndexSet
+PolarVoxelNoiseFilterComponent::determine_valid_voxels_generic(
+  const VoxelStatsMap & voxel_stats_map, Predicate predicate) const
+{
+  VoxelIndexSet valid_voxels;
+  for (const auto & [voxel_idx, stats] : voxel_stats_map) {
+    if (predicate(stats)) {
+      valid_voxels.insert(voxel_idx);
+    }
+  }
+  return valid_voxels;
+}
+
+bool PolarVoxelNoiseFilterComponent::is_point_primary(uint8_t return_type) const
+{
+  if (!use_return_type_classification_) {
+    return true;  // Treat all as primary in simple mode
+  }
+  auto it = std::find(
+    primary_return_types_.begin(), primary_return_types_.end(), static_cast<int>(return_type));
+  return it != primary_return_types_.end();
+}
+
+PolarVoxelNoiseFilterComponent::ValidPointsMask
+PolarVoxelNoiseFilterComponent::create_valid_points_mask(
+  const PointVoxelInfoVector & point_voxel_info, const VoxelIndexSet & valid_voxels) const
+{
+  ValidPointsMask valid_points_mask(point_voxel_info.size(), false);
+
+  for (size_t i = 0; i < point_voxel_info.size(); ++i) {
+    if (is_point_valid_for_mask(point_voxel_info[i], valid_voxels)) {
+      valid_points_mask[i] = true;
+    }
+  }
+
+  return valid_points_mask;
+}
+
+bool PolarVoxelNoiseFilterComponent::is_point_valid_for_mask(
+  const std::optional<PointVoxelInfo> & optional_info, const VoxelIndexSet & valid_voxels) const
+{
+  if (!optional_info.has_value()) {
+    return false;
+  }
+
+  const auto & info = *optional_info;
+
+  if (!valid_voxels.count(info.voxel_idx)) {
+    return false;
+  }
+
+  return passes_secondary_return_filter(info.is_primary);
+}
+
+bool PolarVoxelNoiseFilterComponent::passes_secondary_return_filter(bool is_primary) const
+{
+  if (!enable_secondary_return_filtering_) {
+    return true;  // All points pass when filtering is disabled
+  }
+
+  return is_primary;  // Only primary returns pass when filtering is enabled
+}
+
+void PolarVoxelNoiseFilterComponent::create_filtered_output(
+  const PointCloud2 & input, const ValidPointsMask & valid_points_mask, PointCloud2 & output)
+{
+  setup_output_header(
+    output, input, std::count(valid_points_mask.begin(), valid_points_mask.end(), true));
+
+  size_t output_idx = 0;
+  for (size_t i = 0; i < valid_points_mask.size(); ++i) {
+    if (valid_points_mask[i]) {
+      std::memcpy(
+        &output.data[output_idx * output.point_step], &input.data[i * input.point_step],
+        input.point_step);
+      output_idx++;
+    }
+  }
+}
+
+void PolarVoxelNoiseFilterComponent::publish_noise_cloud(
+  const PointCloud2 & input, const ValidPointsMask & valid_points_mask) const
+{
+  if (!publish_noise_cloud_ || !noise_cloud_pub_) {
+    return;
+  }
+
+  sensor_msgs::msg::PointCloud2 noise_cloud;
+  setup_output_header(
+    noise_cloud, input, std::count(valid_points_mask.begin(), valid_points_mask.end(), false));
+
+  size_t noise_idx = 0;
+  for (size_t i = 0; i < valid_points_mask.size(); ++i) {
+    if (!valid_points_mask[i]) {
+      std::memcpy(
+        &noise_cloud.data[noise_idx * noise_cloud.point_step], &input.data[i * input.point_step],
+        input.point_step);
+      noise_idx++;
+    }
+  }
+
+  noise_cloud_pub_->publish(noise_cloud);
+}
+
+bool PolarVoxelNoiseFilterComponent::has_polar_coordinates(const PointCloud2 & input)
+{
+  return autoware::pointcloud_preprocessor::utils::is_data_layout_compatible_with_point_xyzircaedt(
+    input);
+}
+
+PolarVoxelNoiseFilterComponent::PolarCoordinate PolarVoxelNoiseFilterComponent::cartesian_to_polar(
+  const CartesianCoordinate & cartesian)
+{
+  double radius =
+    std::sqrt(cartesian.x * cartesian.x + cartesian.y * cartesian.y + cartesian.z * cartesian.z);
+  double azimuth = std::atan2(cartesian.y, cartesian.x);
+  double elevation =
+    std::atan2(cartesian.z, std::sqrt(cartesian.x * cartesian.x + cartesian.y * cartesian.y));
+  return {radius, azimuth, elevation};
+}
+
+PolarVoxelIndex PolarVoxelNoiseFilterComponent::polar_to_polar_voxel(
+  const PolarCoordinate & polar) const
+{
+  PolarVoxelIndex voxel_idx{};
+  voxel_idx.radius_idx = static_cast<int32_t>(std::floor(polar.radius / radial_resolution_m_));
+  voxel_idx.azimuth_idx = static_cast<int32_t>(std::floor(polar.azimuth / azimuth_resolution_rad_));
+  voxel_idx.elevation_idx =
+    static_cast<int32_t>(std::floor(polar.elevation / elevation_resolution_rad_));
+  return voxel_idx;
+}
+
+bool PolarVoxelNoiseFilterComponent::is_valid_polar_point(const PolarCoordinate & polar) const
+{
+  if (!has_finite_coordinates(polar)) {
+    return false;
+  }
+
+  if (!is_within_radius_range(polar)) {
+    return false;
+  }
+
+  if (!has_sufficient_radius(polar)) {
+    return false;
+  }
+
+  return true;
+}
+
+bool PolarVoxelNoiseFilterComponent::has_finite_coordinates(const PolarCoordinate & polar) const
+{
+  if (!std::isfinite(polar.radius)) return false;
+  if (!std::isfinite(polar.azimuth)) return false;
+  if (!std::isfinite(polar.elevation)) return false;
+  return true;
+}
+
+bool PolarVoxelNoiseFilterComponent::is_within_radius_range(const PolarCoordinate & polar) const
+{
+  return polar.radius >= min_radius_m_ && polar.radius <= max_radius_m_;
+}
+
+bool PolarVoxelNoiseFilterComponent::has_sufficient_radius(const PolarCoordinate & polar) const
+{
+  return std::abs(polar.radius) >= std::numeric_limits<double>::epsilon();
+}
+
+PolarVoxelNoiseFilterComponent::VoxelStatsMap PolarVoxelNoiseFilterComponent::analyze_voxel_stats(
+  const PointVoxelInfoVector & point_voxel_info) const
+{
+  VoxelStatsMap voxel_stats_map;
+  for (const auto & info_opt : point_voxel_info) {
+    if (info_opt.has_value()) {
+      const auto & info = info_opt.value();
+      auto & voxel_stats = voxel_stats_map[info.voxel_idx];
+      voxel_stats.point_count++;
+      voxel_stats.intensity_sum += static_cast<float>(info.intensity);
+      if (use_return_type_classification_ && !info.is_primary) {
+        voxel_stats.secondary_return_count++;
+      }
+    }
+  }
+
+  // Calculate intensity average per voxel
+  for (auto & [voxel_idx, voxel_stats] : voxel_stats_map) {
+    (void)voxel_idx;
+    if (voxel_stats.point_count > 0) {
+      voxel_stats.intensity_avg = voxel_stats.intensity_sum / voxel_stats.point_count;
+    }
+  }
+  return voxel_stats_map;
+}
+
+void PolarVoxelNoiseFilterComponent::update_parameter(const rclcpp::Parameter & param)
+{
+  using ParameterUpdater = std::function<void(const rclcpp::Parameter &)>;
+
+  // Static map of parameter names to their update functions
+  static const std::unordered_map<std::string, ParameterUpdater> parameter_updaters = {
+    {"radial_resolution", [this](const auto & p) { radial_resolution_m_ = p.as_double(); }},
+    {"azimuth_resolution",
+     [this](const auto & p) {
+       azimuth_resolution_rad_ = adjust_resolution_to_circle(p.as_double());
+     }},
+    {"elevation_resolution",
+     [this](const auto & p) {
+       elevation_resolution_rad_ = adjust_resolution_to_circle(p.as_double());
+     }},
+    {"voxel_points_threshold",
+     [this](const auto & p) { voxel_points_threshold_ = static_cast<int>(p.as_int()); }},
+    {"secondary_noise_threshold",
+     [this](const auto & p) { secondary_noise_threshold_ = static_cast<int>(p.as_int()); }},
+    {"avg_intensity_threshold",
+     [this](const auto & p) { avg_intensity_threshold_ = p.as_double(); }},
+    {"min_radius", [this](const auto & p) { min_radius_m_ = p.as_double(); }},
+    {"max_radius", [this](const auto & p) { max_radius_m_ = p.as_double(); }},
+    {"use_return_type_classification",
+     [this](const auto & p) { use_return_type_classification_ = p.as_bool(); }},
+    {"filter_secondary_returns",
+     [this](const auto & p) { enable_secondary_return_filtering_ = p.as_bool(); }},
+    {"primary_return_types", [this](const auto & p) { update_primary_return_types(p); }},
+    {"publish_noise_cloud", [this](const auto & p) { update_publish_noise_cloud(p); }}};
+
+  const auto & name = param.get_name();
+  auto it = parameter_updaters.find(name);
+
+  // Early return if parameter not found (no nested logic)
+  if (it == parameter_updaters.end()) {
+    return;
+  }
+
+  // Execute the parameter update (no nested logic)
+  it->second(param);
+}
+
+void PolarVoxelNoiseFilterComponent::update_primary_return_types(const rclcpp::Parameter & param)
+{
+  auto values = param.as_integer_array();
+  primary_return_types_.clear();
+  primary_return_types_.reserve(values.size());
+  for (const auto & val : values) {
+    primary_return_types_.push_back(static_cast<int>(val));
+  }
+}
+
+void PolarVoxelNoiseFilterComponent::update_publish_noise_cloud(const rclcpp::Parameter & param)
+{
+  bool new_value = param.as_bool();
+  if (new_value == publish_noise_cloud_) {
+    return;
+  }
+
+  publish_noise_cloud_ = new_value;
+
+  // Recreate publisher if needed
+  if (publish_noise_cloud_ && !noise_cloud_pub_) {
+    rclcpp::PublisherOptions pub_options;
+    pub_options.qos_overriding_options = rclcpp::QosOverridingOptions::with_default_policies();
+    noise_cloud_pub_ = create_publisher<sensor_msgs::msg::PointCloud2>(
+      "polar_voxel_noise_filter/debug/pointcloud_noise", rclcpp::SensorDataQoS(), pub_options);
+  }
+}
+
+PolarVoxelNoiseFilterComponent::VoxelIndexSet
+PolarVoxelNoiseFilterComponent::determine_valid_voxels(const VoxelStatsMap & voxel_stats_map) const
+{
+  if (use_return_type_classification_) {
+    return determine_valid_voxels_with_return_types(voxel_stats_map);
+  } else {
+    return determine_valid_voxels_simple(voxel_stats_map);
+  }
+}
+
+PolarVoxelNoiseFilterComponent::VoxelIndexSet
+PolarVoxelNoiseFilterComponent::determine_valid_voxels_simple(
+  const VoxelStatsMap & voxel_stats_map) const
+{
+  return determine_valid_voxels_generic(voxel_stats_map, [this](const VoxelStats & stats) {
+    return !stats.meets_noise_simple_condition(voxel_points_threshold_, avg_intensity_threshold_);
+  });
+}
+
+PolarVoxelNoiseFilterComponent::VoxelIndexSet
+PolarVoxelNoiseFilterComponent::determine_valid_voxels_with_return_types(
+  const VoxelStatsMap & voxel_stats_map) const
+{
+  return determine_valid_voxels_generic(voxel_stats_map, [this](const VoxelStats & stats) {
+    if (stats.meets_noise_condition(
+          voxel_points_threshold_, avg_intensity_threshold_, secondary_noise_threshold_)) {
+      return false;
+    } else {
+      return true;
+    }
+  });
+}
+
+void PolarVoxelNoiseFilterComponent::setup_output_header(
+  PointCloud2 & output, const PointCloud2 & input, size_t valid_count)
+{
+  output.header = input.header;
+  output.height = point_cloud_height_organized;
+  output.width = static_cast<uint32_t>(valid_count);
+  output.fields = input.fields;
+  output.is_bigendian = input.is_bigendian;
+  output.point_step = input.point_step;
+  output.row_step = output.width * output.point_step;
+  output.is_dense = input.is_dense;
+  output.data.resize(output.row_step * output.height);
+}
+
+bool PolarVoxelNoiseFilterComponent::validate_positive_double(
+  const rclcpp::Parameter & param, std::string & reason)
+{
+  if (param.as_double() <= 0.0) {
+    reason = param.get_name() + " must be positive";
+    return false;
+  }
+  return true;
+}
+
+bool PolarVoxelNoiseFilterComponent::validate_non_negative_double(
+  const rclcpp::Parameter & param, std::string & reason)
+{
+  if (param.as_double() < 0.0) {
+    reason = param.get_name() + " must be non-negative";
+    return false;
+  }
+  return true;
+}
+
+bool PolarVoxelNoiseFilterComponent::validate_positive_int(
+  const rclcpp::Parameter & param, std::string & reason)
+{
+  if (param.as_int() < 1) {
+    reason = param.get_name() + " must be at least 1";
+    return false;
+  }
+  return true;
+}
+
+bool PolarVoxelNoiseFilterComponent::validate_non_negative_int(
+  const rclcpp::Parameter & param, std::string & reason)
+{
+  if (param.as_int() < 0) {
+    reason = param.get_name() + " must be non-negative";
+    return false;
+  }
+  return true;
+}
+
+bool PolarVoxelNoiseFilterComponent::validate_primary_return_types(
+  const rclcpp::Parameter & param, std::string & reason)
+{
+  for (const auto & type : param.as_integer_array()) {
+    if (type < 0 || type > 255) {
+      reason = "primary_return_types values must be between 0 and 255";
+      return false;
+    }
+  }
+  return true;
+}
+
+bool PolarVoxelNoiseFilterComponent::validate_normalized(
+  const rclcpp::Parameter & param, std::string & reason)
+{
+  double val = param.as_double();
+  if (val < 0.0 || val > 1.0) {
+    reason = param.get_name() + " must be between 0.0 and 1.0";
+    return false;
+  }
+  return true;
+}
+
+bool PolarVoxelNoiseFilterComponent::validate_zero_to_two_pi(
+  const rclcpp::Parameter & param, std::string & reason)
+{
+  double val = param.as_double();
+  if (val < 0.0 || val > TWO_PI) {
+    reason = param.get_name() + " must be between 0.0 and 2*PI";
+    return false;
+  }
+  return true;
+}
+
+bool PolarVoxelNoiseFilterComponent::validate_negative_half_pi_to_half_pi(
+  const rclcpp::Parameter & param, std::string & reason)
+{
+  double val = param.as_double();
+  if (val < -M_PI / 2.0 || val > M_PI / 2.0) {
+    reason = param.get_name() + " must be between -PI and PI";
+    return false;
+  }
+  return true;
+}
+
+rcl_interfaces::msg::SetParametersResult PolarVoxelNoiseFilterComponent::param_callback(
+  const std::vector<rclcpp::Parameter> & params)
+{
+  std::scoped_lock lock(mutex_);
+
+  rcl_interfaces::msg::SetParametersResult result;
+  result.successful = true;
+  result.reason = "success";
+
+  using Validator = std::function<bool(const rclcpp::Parameter &, std::string &)>;
+  using Assigner = std::function<void(const rclcpp::Parameter &)>;
+  struct ParamOps
+  {
+    Validator validator;
+    Assigner assigner;
+  };
+
+  static const std::unordered_map<std::string, ParamOps> param_ops = {
+    {"radial_resolution",
+     {validate_positive_double,
+      [this](const rclcpp::Parameter & p) { radial_resolution_m_ = p.as_double(); }}},
+    {"azimuth_resolution",
+     {validate_positive_double,
+      [this](const rclcpp::Parameter & p) { azimuth_resolution_rad_ = p.as_double(); }}},
+    {"elevation_resolution",
+     {validate_positive_double,
+      [this](const rclcpp::Parameter & p) { elevation_resolution_rad_ = p.as_double(); }}},
+    {"voxel_points_threshold",
+     {validate_positive_int,
+      [this](const rclcpp::Parameter & p) { voxel_points_threshold_ = p.as_int(); }}},
+    {"min_radius",
+     {validate_non_negative_double,
+      [this](const rclcpp::Parameter & p) { min_radius_m_ = p.as_double(); }}},
+    {"max_radius",
+     {validate_positive_double,
+      [this](const rclcpp::Parameter & p) { max_radius_m_ = p.as_double(); }}},
+    {"use_return_type_classification",
+     {nullptr,
+      [this](const rclcpp::Parameter & p) { use_return_type_classification_ = p.as_bool(); }}},
+    {"filter_secondary_returns",
+     {nullptr,
+      [this](const rclcpp::Parameter & p) { enable_secondary_return_filtering_ = p.as_bool(); }}},
+    {"secondary_noise_threshold",
+     {validate_non_negative_int,
+      [this](const rclcpp::Parameter & p) { secondary_noise_threshold_ = p.as_int(); }}},
+    {"primary_return_types",
+     {validate_primary_return_types,
+      [this](const rclcpp::Parameter & p) {
+        const auto & arr = p.as_integer_array();
+        primary_return_types_.clear();
+        primary_return_types_.reserve(arr.size());
+        for (auto v : arr) primary_return_types_.push_back(static_cast<int>(v));
+      }}},
+    {"publish_noise_cloud",
+     {nullptr, [this](const rclcpp::Parameter & p) { publish_noise_cloud_ = p.as_bool(); }}}};
+
+  for (const auto & param : params) {
+    auto it = param_ops.find(param.get_name());
+    if (it != param_ops.end()) {
+      if (it->second.validator) {
+        std::string reason;
+        if (!it->second.validator(param, reason)) {
+          result.successful = false;
+          result.reason = reason;
+          return result;
+        }
+      }
+      it->second.assigner(param);
+    }
+  }
+
+  return result;
+}
+
+void PolarVoxelNoiseFilterComponent::validate_filter_inputs(
+  const PointCloud2 & input, const IndicesPtr & indices)
+{
+  validate_indices(indices);
+  validate_required_fields(input);
+}
+
+void PolarVoxelNoiseFilterComponent::validate_indices(const IndicesPtr & indices)
+{
+  if (indices) {
+    RCLCPP_WARN_ONCE(get_logger(), "Indices are not supported and will be ignored");
+  }
+}
+
+void PolarVoxelNoiseFilterComponent::validate_required_fields(const PointCloud2 & input)
+{
+  validate_return_type_field(input);
+  validate_intensity_field(input);
+}
+
+void PolarVoxelNoiseFilterComponent::validate_return_type_field(const PointCloud2 & input)
+{
+  if (!use_return_type_classification_) {
+    return;
+  }
+
+  if (!has_field(input, "return_type")) {
+    RCLCPP_ERROR(
+      get_logger(),
+      "Advanced mode (use_return_type_classification=true) requires 'return_type' field. "
+      "Set use_return_type_classification=false for simple mode or ensure input has return_type "
+      "field.");
+    throw std::invalid_argument("Advanced mode requires return_type field");
+  }
+}
+
+void PolarVoxelNoiseFilterComponent::validate_intensity_field(const PointCloud2 & input)
+{
+  if (!has_field(input, "intensity")) {
+    RCLCPP_ERROR(get_logger(), "Input point cloud must have 'intensity' field");
+    throw std::invalid_argument("Input point cloud must have intensity field");
+  }
+}
+
+bool PolarVoxelNoiseFilterComponent::has_field(
+  const PointCloud2 & input, const std::string & field_name)
+{
+  for (const auto & field : input.fields) {
+    if (field.name == field_name) {
+      return true;
+    }
+  }
+  return false;
+}
+
+void PolarVoxelNoiseFilterComponent::create_output(
+  const PointCloud2 & input, const ValidPointsMask & valid_points_mask, PointCloud2 & output)
+{
+  create_filtered_output(input, valid_points_mask, output);
+}
+
+void PolarVoxelNoiseFilterComponent::create_empty_output(
+  const PointCloud2 & input, PointCloud2 & output)
+{
+  setup_output_header(output, input, 0);
+}
+
+std::optional<PolarVoxelNoiseFilterComponent::PolarCoordinate>
+PolarVoxelNoiseFilterComponent::extract_polar_from_dae(
+  float distance, float azimuth, float elevation) const
+{
+  if (!all_finite(distance, azimuth, elevation)) {
+    return std::nullopt;
+  }
+
+  PolarCoordinate polar(distance, azimuth, elevation);
+
+  if (!is_valid_polar_point(polar)) {
+    return std::nullopt;
+  }
+
+  return polar;
+}
+
+std::optional<PolarVoxelNoiseFilterComponent::PolarCoordinate>
+PolarVoxelNoiseFilterComponent::extract_polar_from_xyz(float x, float y, float z) const
+{
+  CartesianCoordinate cartesian(x, y, z);
+  PolarCoordinate polar = cartesian_to_polar(cartesian);
+
+  if (!is_valid_polar_point(polar)) {
+    return std::nullopt;
+  }
+
+  return polar;
+}
+
+}  // namespace autoware::pointcloud_preprocessor
+
+#include <rclcpp_components/register_node_macro.hpp>
+RCLCPP_COMPONENTS_REGISTER_NODE(autoware::pointcloud_preprocessor::PolarVoxelNoiseFilterComponent)

--- a/sensing/autoware_pointcloud_preprocessor/test/test_polar_voxel_noise_filter_node.cpp
+++ b/sensing/autoware_pointcloud_preprocessor/test/test_polar_voxel_noise_filter_node.cpp
@@ -1,0 +1,182 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/pointcloud_preprocessor/outlier_filter/polar_voxel_noise_filter_node.hpp"
+
+#include <rclcpp/rclcpp.hpp>
+
+#include <sensor_msgs/msg/point_cloud2.hpp>
+
+#include <gtest/gtest.h>
+
+#include <memory>
+#include <vector>
+
+using autoware::pointcloud_preprocessor::PolarVoxelNoiseFilterComponent;
+
+class PolarVoxelNoiseFilterComponentPublic : public PolarVoxelNoiseFilterComponent
+{
+public:
+  using PolarVoxelNoiseFilterComponent::filter;
+  using PolarVoxelNoiseFilterComponent::noise_cloud_pub_;
+  explicit PolarVoxelNoiseFilterComponentPublic(const rclcpp::NodeOptions & options)
+  : PolarVoxelNoiseFilterComponent(options)
+  {
+  }
+};
+
+struct SimplePoint
+{
+  float x;
+  float y;
+  float z;
+  uint8_t intensity;
+  uint8_t return_type;
+};
+
+sensor_msgs::msg::PointCloud2 make_test_cloud(const std::vector<SimplePoint> & points)
+{
+  sensor_msgs::msg::PointCloud2 cloud;
+  cloud.header.frame_id = "base_link";
+  cloud.height = 1;
+  cloud.width = static_cast<uint32_t>(points.size());
+  cloud.is_dense = true;
+  cloud.is_bigendian = false;
+  cloud.fields.resize(5);
+
+  cloud.fields[0].name = "x";
+  cloud.fields[0].offset = 0;
+  cloud.fields[0].datatype = sensor_msgs::msg::PointField::FLOAT32;
+  cloud.fields[0].count = 1;
+
+  cloud.fields[1].name = "y";
+  cloud.fields[1].offset = 4;
+  cloud.fields[1].datatype = sensor_msgs::msg::PointField::FLOAT32;
+  cloud.fields[1].count = 1;
+
+  cloud.fields[2].name = "z";
+  cloud.fields[2].offset = 8;
+  cloud.fields[2].datatype = sensor_msgs::msg::PointField::FLOAT32;
+  cloud.fields[2].count = 1;
+
+  cloud.fields[3].name = "intensity";
+  cloud.fields[3].offset = 12;
+  cloud.fields[3].datatype = sensor_msgs::msg::PointField::UINT8;
+  cloud.fields[3].count = 1;
+
+  cloud.fields[4].name = "return_type";
+  cloud.fields[4].offset = 13;
+  cloud.fields[4].datatype = sensor_msgs::msg::PointField::UINT8;
+  cloud.fields[4].count = 1;
+
+  cloud.point_step = 14;
+  cloud.row_step = cloud.point_step * cloud.width;
+  cloud.data.resize(cloud.row_step);
+
+  for (size_t i = 0; i < points.size(); ++i) {
+    const size_t offset = i * cloud.point_step;
+    *reinterpret_cast<float *>(&cloud.data[offset + 0]) = points[i].x;
+    *reinterpret_cast<float *>(&cloud.data[offset + 4]) = points[i].y;
+    *reinterpret_cast<float *>(&cloud.data[offset + 8]) = points[i].z;
+    cloud.data[offset + 12] = points[i].intensity;
+    cloud.data[offset + 13] = points[i].return_type;
+  }
+
+  return cloud;
+}
+
+rclcpp::NodeOptions make_node_options()
+{
+  return rclcpp::NodeOptions()
+    .append_parameter_override("publish_noise_cloud", false)
+    .append_parameter_override("radial_resolution", 0.5)
+    .append_parameter_override("azimuth_resolution", 0.08)
+    .append_parameter_override("elevation_resolution", 0.08)
+    .append_parameter_override("voxel_points_threshold", 4)
+    .append_parameter_override("min_radius", 0.5)
+    .append_parameter_override("max_radius", 300.0)
+    .append_parameter_override("use_return_type_classification", false)
+    .append_parameter_override("filter_secondary_returns", false)
+    .append_parameter_override("secondary_noise_threshold", 2)
+    .append_parameter_override("avg_intensity_threshold", 0.5)
+    .append_parameter_override("primary_return_types", std::vector<int64_t>{1, 6, 8, 10});
+}
+
+TEST(PolarVoxelNoiseFilterTest, SimpleMode_RemovesLowIntensitySparseVoxel)
+{
+  auto options = make_node_options()
+                   .append_parameter_override("use_return_type_classification", false)
+                   .append_parameter_override("voxel_points_threshold", 2)
+                   .append_parameter_override("avg_intensity_threshold", 5.0);
+  PolarVoxelNoiseFilterComponentPublic node(options);
+
+  // Voxel A (radius=1): 5 points, avg intensity=20 -> valid
+  // Voxel B (radius=3): 1 point, avg intensity=0 -> noise
+  const auto input = make_test_cloud(
+    {{1.0f, 0.0f, 0.0f, 20, 1},
+     {1.0f, 0.0f, 0.0f, 20, 2},
+     {1.0f, 0.0f, 0.0f, 20, 1},
+     {1.0f, 0.0f, 0.0f, 20, 1},
+     {1.0f, 0.0f, 0.0f, 20, 1},
+     {3.0f, 0.0f, 0.0f, 0, 2}});
+  auto input_ptr = std::make_shared<sensor_msgs::msg::PointCloud2>(input);
+
+  sensor_msgs::msg::PointCloud2 output;
+  node.filter(input_ptr, nullptr, output);
+
+  EXPECT_EQ(output.width, 5u);  // expect only the 5 points from Voxel A to remain
+}
+
+TEST(PolarVoxelNoiseFilterTest, ReturnTypeMode_FilterSecondaryReturnsKeepsOnlyPrimary)
+{
+  auto options = make_node_options()
+                   .append_parameter_override("use_return_type_classification", true)
+                   .append_parameter_override("filter_secondary_returns", true)
+                   .append_parameter_override("voxel_points_threshold", 1)
+                   .append_parameter_override("secondary_noise_threshold", 5)
+                   .append_parameter_override("avg_intensity_threshold", 100.0)
+                   .append_parameter_override("primary_return_types", std::vector<int64_t>{1});
+  PolarVoxelNoiseFilterComponentPublic node(options);
+
+  // Single voxel with 1 primary + 3 secondary.
+  // Voxel remains valid, but output should keep only primary when secondary filtering is enabled.
+  const auto input = make_test_cloud(
+    {{1.0f, 0.0f, 0.0f, 20, 1},
+     {1.0f, 0.0f, 0.0f, 20, 2},
+     {1.0f, 0.0f, 0.0f, 20, 2},
+     {1.0f, 0.0f, 0.0f, 20, 2}});
+  auto input_ptr = std::make_shared<sensor_msgs::msg::PointCloud2>(input);
+
+  sensor_msgs::msg::PointCloud2 output;
+  node.filter(input_ptr, nullptr, output);
+
+  EXPECT_EQ(output.width, 1u);     // expect only one point to remain
+  EXPECT_EQ(output.data[13], 1u);  // checking that it was a primary point return_type
+}
+
+TEST(PolarVoxelNoiseFilterTest, PublishNoiseCloudTrue_CreatesPublisher)
+{
+  auto options = make_node_options().append_parameter_override("publish_noise_cloud", true);
+  PolarVoxelNoiseFilterComponentPublic node(options);
+  EXPECT_NE(node.noise_cloud_pub_, nullptr);
+}
+
+int main(int argc, char ** argv)
+{
+  ::testing::InitGoogleTest(&argc, argv);
+  rclcpp::init(argc, argv);
+  int ret = RUN_ALL_TESTS();
+  rclcpp::shutdown();
+  return ret;
+}


### PR DESCRIPTION
This is the cherry-picked version that includes the changes from the Autoware Foundation of the Polar Voxel Filter

* feat: polar voxel noise filter



* chore: added missing destructor and mutex



* chore: adressing comments about depercated functions



* chore: adressing comments about unused items and readme



* chore: adressing comments about pointcloud format and prefix



* style(pre-commit): autofix

* chore: adressing new parameter in bounds checking and suffix renamed variables



* style(pre-commit): autofix

* chore: adding unit test for the polar voxel filter



* style(pre-commit): autofix

* chore: added test on cmakelist all points primary return default



* style(pre-commit): autofix

* chore: handling case when pointcloud without return type information



* chore: pointcloud msg format validation only once to avoid redundancy



---------