### PR TITLE
feat(perception): apply autoware_agnocast_wrapper for CIE to traffic light nodes

### DIFF
--- a/perception/autoware_crosswalk_traffic_light_estimator/CMakeLists.txt
+++ b/perception/autoware_crosswalk_traffic_light_estimator/CMakeLists.txt
@@ -14,9 +14,11 @@ ament_auto_add_library(autoware_crosswalk_traffic_light_estimator SHARED
   src/node.cpp
 )
 
-rclcpp_components_register_node(autoware_crosswalk_traffic_light_estimator
+autoware_agnocast_wrapper_register_node(autoware_crosswalk_traffic_light_estimator
   PLUGIN "autoware::crosswalk_traffic_light_estimator::CrosswalkTrafficLightEstimatorNode"
   EXECUTABLE crosswalk_traffic_light_estimator_node
+  AGNOCAST_EXECUTOR CallbackIsolatedAgnocastExecutor
+  ROS2_EXECUTOR SingleThreadedExecutor
 )
 
 if(BUILD_TESTING)

--- a/perception/autoware_crosswalk_traffic_light_estimator/package.xml
+++ b/perception/autoware_crosswalk_traffic_light_estimator/package.xml
@@ -14,6 +14,7 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
+  <depend>autoware_agnocast_wrapper</depend>
   <depend>autoware_internal_debug_msgs</depend>
   <depend>autoware_lanelet2_extension</depend>
   <depend>autoware_lanelet2_utils</depend>

--- a/perception/autoware_traffic_light_arbiter/CMakeLists.txt
+++ b/perception/autoware_traffic_light_arbiter/CMakeLists.txt
@@ -9,9 +9,11 @@ ament_auto_add_library(${PROJECT_NAME} SHARED
   src/signal_match_validator.cpp
 )
 
-rclcpp_components_register_node(${PROJECT_NAME}
+autoware_agnocast_wrapper_register_node(${PROJECT_NAME}
   PLUGIN "autoware::traffic_light::TrafficLightArbiter"
   EXECUTABLE traffic_light_arbiter_node
+  AGNOCAST_EXECUTOR CallbackIsolatedAgnocastExecutor
+  ROS2_EXECUTOR SingleThreadedExecutor
 )
 
 if(BUILD_TESTING)

--- a/perception/autoware_traffic_light_arbiter/package.xml
+++ b/perception/autoware_traffic_light_arbiter/package.xml
@@ -12,6 +12,7 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
+  <depend>autoware_agnocast_wrapper</depend>
   <depend>autoware_lanelet2_extension</depend>
   <depend>autoware_lanelet2_utils</depend>
   <depend>autoware_map_msgs</depend>

--- a/perception/autoware_traffic_light_multi_camera_fusion/CMakeLists.txt
+++ b/perception/autoware_traffic_light_multi_camera_fusion/CMakeLists.txt
@@ -13,9 +13,11 @@ ament_auto_add_library(${PROJECT_NAME} SHARED
   src/traffic_light_multi_camera_fusion_process.cpp
 )
 
-rclcpp_components_register_node(${PROJECT_NAME}
+autoware_agnocast_wrapper_register_node(${PROJECT_NAME}
   PLUGIN "autoware::traffic_light::MultiCameraFusion"
   EXECUTABLE traffic_light_multi_camera_fusion_node
+  AGNOCAST_EXECUTOR CallbackIsolatedAgnocastExecutor
+  ROS2_EXECUTOR SingleThreadedExecutor
 )
 
 if(BUILD_TESTING)

--- a/perception/autoware_traffic_light_multi_camera_fusion/package.xml
+++ b/perception/autoware_traffic_light_multi_camera_fusion/package.xml
@@ -15,6 +15,7 @@
   <build_depend>ament_cmake_gtest</build_depend>
   <build_depend>autoware_cmake</build_depend>
 
+  <depend>autoware_agnocast_wrapper</depend>
   <depend>autoware_lanelet2_extension</depend>
   <depend>autoware_lanelet2_utils</depend>
   <depend>autoware_map_msgs</depend>


### PR DESCRIPTION
## Description

Apply `autoware_agnocast_wrapper` (CallbackIsolatedAgnocastExecutor / CIE) to three traffic-light perception nodes on `beta/v0.64`, by cherry-picking the following upstream PRs:

- autowarefoundation/autoware_universe#12712 — `traffic_light_multi_camera_fusion`
- autowarefoundation/autoware_universe#12714 — `crosswalk_traffic_light_estimator`
- autowarefoundation/autoware_universe#12713 — `traffic_light_arbiter`

Each commit replaces `rclcpp_components_register_node` with `autoware_agnocast_wrapper_register_node` (adding `AGNOCAST_EXECUTOR CallbackIsolatedAgnocastExecutor` / `ROS2_EXECUTOR SingleThreadedExecutor`) in `CMakeLists.txt`, and adds the `autoware_agnocast_wrapper` dependency to `package.xml`.

### Cherry-pick note

`traffic_light_multi_camera_fusion` had a conflict during cherry-pick: on `beta/v0.64` the registered component class is still `autoware::traffic_light::MultiCameraFusion`, whereas upstream `main` had already renamed it to `MultiCameraFusionNode`. The `PLUGIN` name was therefore kept as `MultiCameraFusion` to match the class actually registered in this branch's source (`RCLCPP_COMPONENTS_REGISTER_NODE(autoware::traffic_light::MultiCameraFusion)`). The other two packages applied cleanly.

## Related links

**Related Issue:**

- https://github.com/autowarefoundation/autoware_core/issues/968

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

## Effects on system behavior

When `ENABLE_AGNOCAST=0` (default), there is no change in behavior at all — the node runs with the standard ROS 2 executor exactly as before.

When `ENABLE_AGNOCAST=1`, the executor switches to `CallbackIsolatedAgnocastExecutor` (CIE). Internally, CIE creates a dedicated `rclcpp::SingleThreadedExecutor` for each callback group, so the fundamental scheduling behavior within each group remains almost identical. The key difference is that, for nodes originally using `SingleThreadedExecutor`, callback groups now run in parallel across separate threads, similar to `MultiThreadedExecutor`.