### PR TITLE
ci: update GitHub Actions runner from ubuntu-22.04 to ubuntu-24.04

### DIFF
--- a/.github/workflows/backport.yaml
+++ b/.github/workflows/backport.yaml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   backport:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     # Only react to merged PRs for security reasons.
     # See https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#pull_request_target.
     if: >

--- a/.github/workflows/check-build-depends.yaml
+++ b/.github/workflows/check-build-depends.yaml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   check-build-depends:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     container: ${{ matrix.container }}
     strategy:
       fail-fast: false

--- a/.github/workflows/cppcheck-differential.yaml
+++ b/.github/workflows/cppcheck-differential.yaml
@@ -5,7 +5,7 @@ on:
 
 jobs:
   cppcheck-differential:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
 
     steps:
       - name: Set PR fetch depth

--- a/.github/workflows/json-schema-check.yaml
+++ b/.github/workflows/json-schema-check.yaml
@@ -6,7 +6,7 @@ on:
 
 jobs:
   check-if-relevant-files-changed:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     outputs:
       run-check: ${{ steps.paths_filter.outputs.json_or_yaml }}
     steps:
@@ -22,7 +22,7 @@ jobs:
   json-schema-check:
     needs: check-if-relevant-files-changed
     if: needs.check-if-relevant-files-changed.outputs.run-check == 'true'
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Check out repository
         uses: actions/checkout@v4
@@ -33,7 +33,7 @@ jobs:
   no-relevant-changes:
     needs: check-if-relevant-files-changed
     if: needs.check-if-relevant-files-changed.outputs.run-check == 'false'
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Dummy step
         run: echo "No relevant changes, passing check"

--- a/.github/workflows/pr-agent.yaml
+++ b/.github/workflows/pr-agent.yaml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   pr_agent_job:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     permissions:
       issues: write
       pull-requests: write

--- a/.github/workflows/pr-labeler.yaml
+++ b/.github/workflows/pr-labeler.yaml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   label:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - uses: actions/labeler@v4
         with:

--- a/.github/workflows/pre-commit-optional.yaml
+++ b/.github/workflows/pre-commit-optional.yaml
@@ -13,7 +13,7 @@ concurrency:
 
 jobs:
   pre-commit-optional:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Check out repository
         uses: actions/checkout@v4

--- a/.github/workflows/pre-commit.yaml
+++ b/.github/workflows/pre-commit.yaml
@@ -14,7 +14,7 @@ concurrency:
 jobs:
   pre-commit:
     if: ${{ github.event.repository.private }} # Use pre-commit.ci for public repositories
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Generate token
         id: generate-token

--- a/.github/workflows/spell-check-differential.yaml
+++ b/.github/workflows/spell-check-differential.yaml
@@ -13,7 +13,7 @@ concurrency:
 
 jobs:
   spell-check-differential:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Check out repository
         uses: actions/checkout@v4

--- a/.github/workflows/sync-files.yaml
+++ b/.github/workflows/sync-files.yaml
@@ -15,7 +15,7 @@ concurrency:
 
 jobs:
   sync-files:
-    runs-on: ubuntu-22.04
+    runs-on: ubuntu-24.04
     steps:
       - name: Generate token
         id: generate-token


### PR DESCRIPTION
## Summary
- Update GitHub Actions `runs-on` runners from `ubuntu-22.04` to `ubuntu-24.04`
- `ubuntu-22.04-m` and other variant runners (e.g. `ubuntu-22.04-arm`) are unchanged

## Test plan
- [ ] Verify CI workflows pass on ubuntu-24.04 runners