### PR TITLE
chore: cherry-pick beta/v0.64 specific commits into feat/v0.64/e2e

### DIFF
--- a/control/autoware_trajectory_follower_node/README.md
+++ b/control/autoware_trajectory_follower_node/README.md
@@ -145,6 +145,11 @@ Giving the longitudinal controller information about steer convergence allows it
   - Each time the node receives lateral and longitudinal commands from each controller, it publishes an `Control` if the following two conditions are met.
     1. Both commands have been received.
     2. The last received commands are not older than defined by `timeout_thr_sec`.
+- `cyclic_message_timeout_thr_sec`: duration in second for monitoring incoming trajectory messages via diagnostic updater (default: 0.9)
+  - The diagnostic updater will report ERROR status if:
+    1. No trajectory message has been received yet.
+    2. The elapsed time since the last trajectory message exceeds this threshold.
+  - This parameter helps monitor the health of the trajectory input stream.
 - `lateral_controller_mode`: `mpc` or `pure_pursuit`
   - (currently there is only `PID` for longitudinal controller)
 - `enable_control_cmd_horizon_pub`: publish `ControlHorizon` or not (default: false)

--- a/control/autoware_trajectory_follower_node/include/autoware/trajectory_follower_node/controller_node.hpp
+++ b/control/autoware_trajectory_follower_node/include/autoware/trajectory_follower_node/controller_node.hpp
@@ -48,6 +48,7 @@
 #include <autoware_internal_debug_msgs/msg/float64_stamped.hpp>
 
 #include <memory>
+#include <optional>
 #include <string>
 #include <utility>
 #include <vector>
@@ -79,6 +80,7 @@ public:
 private:
   rclcpp::TimerBase::SharedPtr timer_control_;
   double timeout_thr_sec_;
+  double cyclic_message_timeout_thr_sec_;
   bool enable_control_cmd_horizon_pub_{false};
   boost::optional<LongitudinalOutput> longitudinal_output_{boost::none};
 
@@ -137,6 +139,7 @@ private:
   void callbackTimerControl();
   bool processData(rclcpp::Clock & clock);
   bool isTimeOut(const LongitudinalOutput & lon_out, const LateralOutput & lat_out);
+  void check_cyclic_message_timeout(diagnostic_updater::DiagnosticStatusWrapper & stat);
   LateralControllerMode getLateralControllerMode(const std::string & algorithm_name) const;
   LongitudinalControllerMode getLongitudinalControllerMode(
     const std::string & algorithm_name) const;

--- a/control/autoware_trajectory_follower_node/param/trajectory_follower_node.param.yaml
+++ b/control/autoware_trajectory_follower_node/param/trajectory_follower_node.param.yaml
@@ -6,3 +6,4 @@
     trajectory_reference_mode: "spatial"
     ctrl_period: 0.03
     timeout_thr_sec: 0.5
+    cyclic_message_timeout_thr_sec: 0.9

--- a/control/autoware_trajectory_follower_node/src/controller_node.cpp
+++ b/control/autoware_trajectory_follower_node/src/controller_node.cpp
@@ -65,6 +65,7 @@ Controller::Controller(const rclcpp::NodeOptions & node_options)
       "Invalid trajectory_reference_mode. Expected \"spatial\" or \"temporal\".");
   }
   timeout_thr_sec_ = declare_parameter<double>("timeout_thr_sec");
+  cyclic_message_timeout_thr_sec_ = declare_parameter<double>("cyclic_message_timeout_thr_sec");
   // NOTE: It is possible that using control_horizon could be expected to enhance performance,
   // but it is not a formal interface topic, only an experimental one.
   // So it is disabled by default.
@@ -72,6 +73,7 @@ Controller::Controller(const rclcpp::NodeOptions & node_options)
     declare_parameter<bool>("enable_control_cmd_horizon_pub", false);
 
   diag_updater_->setHardwareID("trajectory_follower_node");
+  diag_updater_->add("incoming_message_timeout", this, &Controller::check_cyclic_message_timeout);
 
   const auto lateral_controller_mode =
     getLateralControllerMode(declare_parameter<std::string>("lateral_controller_mode"));
@@ -152,6 +154,26 @@ Controller::LongitudinalControllerMode Controller::getLongitudinalControllerMode
   if (controller_mode == "pid") return LongitudinalControllerMode::PID;
 
   return LongitudinalControllerMode::INVALID;
+}
+
+void Controller::check_cyclic_message_timeout(diagnostic_updater::DiagnosticStatusWrapper & stat)
+{
+  const auto traj_timestamp = sub_ref_path_.last_taken_data_timestamp();
+
+  if (!traj_timestamp) {
+    stat.summary(diagnostic_msgs::msg::DiagnosticStatus::ERROR, "timeout");
+    stat.add("trajectory", "no message received");
+    return;
+  }
+
+  const auto elapsed = (this->now() - traj_timestamp.value()).seconds();
+  if (elapsed > cyclic_message_timeout_thr_sec_) {
+    stat.summary(diagnostic_msgs::msg::DiagnosticStatus::ERROR, "timeout");
+    stat.add("trajectory", "timeout (elapsed: " + std::to_string(elapsed) + " sec)");
+  } else {
+    stat.summary(diagnostic_msgs::msg::DiagnosticStatus::OK, "OK");
+    stat.add("trajectory", "OK");
+  }
 }
 
 bool Controller::processData(rclcpp::Clock & clock)

--- a/perception/autoware_compare_map_segmentation/src/voxel_based_approximate_compare_map_filter/node.cpp
+++ b/perception/autoware_compare_map_segmentation/src/voxel_based_approximate_compare_map_filter/node.cpp
@@ -70,8 +70,13 @@ bool VoxelBasedApproximateDynamicMapLoader::is_close_to_map(
     map_cell_voxel_grid = current_voxel_grid_array_.at(map_grid_index)->map_cell_voxel_grid;
   }
 
-  const int index = map_cell_voxel_grid.getCentroidIndexAt(
-    map_cell_voxel_grid.getGridCoordinates(point.x, point.y, point.z));
+  const Eigen::Vector3i grid_coordinates =
+    map_cell_voxel_grid.getGridCoordinates(point.x, point.y, point.z);
+#pragma GCC diagnostic push
+#pragma GCC diagnostic ignored "-Warray-bounds"
+  const int index = map_cell_voxel_grid.getCentroidIndexAt(grid_coordinates);
+#pragma GCC diagnostic pop
+
   return (index != -1);
 }
 

--- a/planning/behavior_path_planner/autoware_behavior_path_planner/config/behavior_path_planner.param.yaml
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner/config/behavior_path_planner.param.yaml
@@ -2,6 +2,11 @@
   ros__parameters:
     traffic_light_signal_timeout: 1.0
 
+    # timeout monitoring
+    # The timeout means the time between source timestamp and current time.
+    cyclic_timeout: 0.90
+    enable_traffic_signal_timeout: false
+
     planning_hz: 10.0
     backward_path_length: 5.0
     forward_path_length: 300.0

--- a/planning/behavior_path_planner/autoware_behavior_path_planner/include/autoware/behavior_path_planner/behavior_path_planner_node.hpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner/include/autoware/behavior_path_planner/behavior_path_planner_node.hpp
@@ -23,6 +23,7 @@
 #include <autoware/planning_factor_interface/planning_factor_interface.hpp>
 #include <autoware_utils/ros/polling_subscriber.hpp>
 #include <autoware_utils/ros/published_time_publisher.hpp>
+#include <autoware_utils_diagnostics/diagnostics_interface.hpp>
 
 #include <autoware_adapi_v1_msgs/msg/operation_mode_state.hpp>
 #include <autoware_internal_planning_msgs/msg/path_with_lane_id.hpp>
@@ -140,23 +141,23 @@ private:
   std::mutex mutex_pd_;       // mutex for planner_data_
   std::mutex mutex_manager_;  // mutex for bt_manager_ or planner_manager_
 
+  // timeout monitoring
+  double cyclic_message_timeout_;  // seconds
+  bool enable_traffic_signal_timeout_;
+  std::unique_ptr<autoware_utils_diagnostics::DiagnosticsInterface> diagnostics_message_timeout_;
+  enum class DataReadyStatus {
+    SUCCESS,
+    NOT_RECEIVED,
+    TIMEOUT,
+  };
+
   // setup
   void takeData();
-  bool isDataReady();
+  DataReadyStatus isDataReady(const rclcpp::Time & now);
 
-  // callback
-  void onOdometry(const Odometry::ConstSharedPtr msg);
-  void onAcceleration(const AccelWithCovarianceStamped::ConstSharedPtr msg);
-  void onPerception(const PredictedObjects::ConstSharedPtr msg);
-  void onOccupancyGrid(const OccupancyGrid::ConstSharedPtr msg);
-  void onCostMap(const OccupancyGrid::ConstSharedPtr msg);
+  // data processing called from takeData()
   void onTrafficSignals(const TrafficLightGroupArray::ConstSharedPtr msg);
-  void onMap(const LaneletMapBin::ConstSharedPtr map_msg);
-  void onRoute(const LaneletRoute::ConstSharedPtr route_msg);
-  void onOperationMode(const OperationModeState::ConstSharedPtr msg);
   void onLateralOffset(const LateralOffset::ConstSharedPtr msg);
-  void on_external_velocity_limiter(
-    const autoware_internal_planning_msgs::msg::VelocityLimit::ConstSharedPtr msg);
 
   SetParametersResult onSetParam(const std::vector<rclcpp::Parameter> & parameters);
 

--- a/planning/behavior_path_planner/autoware_behavior_path_planner/package.xml
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner/package.xml
@@ -54,9 +54,11 @@
   <depend>autoware_planning_test_manager</depend>
   <depend>autoware_signal_processing</depend>
   <depend>autoware_utils</depend>
+  <depend>autoware_utils_diagnostics</depend>
   <depend>autoware_vehicle_info_utils</depend>
   <depend>autoware_vehicle_msgs</depend>
   <depend>behaviortree_cpp_v3</depend>
+  <depend>diagnostic_msgs</depend>
   <depend>geometry_msgs</depend>
   <depend>libboost-dev</depend>
   <depend>libopencv-dev</depend>

--- a/planning/behavior_path_planner/autoware_behavior_path_planner/src/behavior_path_planner_node.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner/src/behavior_path_planner_node.cpp
@@ -23,6 +23,7 @@
 #include <tier4_planning_msgs/msg/path_change_module_id.hpp>
 
 #include <memory>
+#include <optional>
 #include <string>
 #include <vector>
 
@@ -141,6 +142,14 @@ BehaviorPathPlannerNode::BehaviorPathPlannerNode(const rclcpp::NodeOptions & nod
     const auto period_ns = rclcpp::Rate(planning_hz).period();
     timer_ = rclcpp::create_timer(
       this, get_clock(), period_ns, std::bind(&BehaviorPathPlannerNode::run, this));
+  }
+  // Timeout handling
+  {
+    cyclic_message_timeout_ = declare_parameter<double>("cyclic_timeout");
+    enable_traffic_signal_timeout_ = declare_parameter<bool>("enable_traffic_signal_timeout");
+    diagnostics_message_timeout_ =
+      std::make_unique<autoware_utils_diagnostics::DiagnosticsInterface>(
+        this, "incoming_message_timeout");
   }
 
   logger_configure_ = std::make_unique<autoware_utils::LoggerLevelConfigure>(this);
@@ -265,51 +274,75 @@ void BehaviorPathPlannerNode::takeData()
   }
 }
 
-// wait until mandatory data is ready
-bool BehaviorPathPlannerNode::isDataReady()
+// check if mandatory data is ready and check if cyclic data is not timed out.
+BehaviorPathPlannerNode::DataReadyStatus BehaviorPathPlannerNode::isDataReady(
+  const rclcpp::Time & now)
 {
-  const auto missing = [this](const auto & name) {
-    RCLCPP_INFO_SKIPFIRST_THROTTLE(get_logger(), *get_clock(), 5000, "waiting for %s", name);
-    return false;
-  };
+  diagnostics_message_timeout_->clear();
+  DataReadyStatus status = DataReadyStatus::SUCCESS;
 
-  if (!current_scenario_) {
-    return missing("scenario_topic");
+  // 1: Check if mandatory data has been received at least once.
+  {
+    const auto update_reception_diagnostics = [&](const auto & ptr, const std::string & name) {
+      if (!ptr) {
+        RCLCPP_INFO_SKIPFIRST_THROTTLE(
+          get_logger(), *get_clock(), 5000, "waiting for %s", name.c_str());
+        diagnostics_message_timeout_->add_key_value(name, std::string("not received"));
+        status = DataReadyStatus::NOT_RECEIVED;
+        return;
+      }
+      diagnostics_message_timeout_->add_key_value(name, std::string("OK"));
+    };
+
+    update_reception_diagnostics(route_ptr_, "route");
+    update_reception_diagnostics(map_ptr_, "vector_map");
+    update_reception_diagnostics(current_scenario_, "scenario");
+    update_reception_diagnostics(planner_data_->self_acceleration, "acceleration");
+    update_reception_diagnostics(planner_data_->operation_mode, "operation_mode");
   }
 
+  // Step 2: Check if cyclic data is not timed out instead of `topic_state_monitor`.
   {
-    if (!route_ptr_) {
-      return missing("route");
+    const auto update_timeout_diagnostics =
+      [&](const std::optional<rclcpp::Time> & ts, double timeout, const std::string & name) {
+        if (!ts.has_value()) {
+          RCLCPP_INFO_SKIPFIRST_THROTTLE(
+            get_logger(), *get_clock(), 5000, "waiting for %s", name.c_str());
+          diagnostics_message_timeout_->add_key_value(name, std::string("not received"));
+          status = DataReadyStatus::NOT_RECEIVED;
+          return;
+        }
+        if ((now - ts.value()).seconds() > timeout) {
+          diagnostics_message_timeout_->add_key_value(name, std::string("timeout"));
+          if (status == DataReadyStatus::SUCCESS) {
+            status = DataReadyStatus::TIMEOUT;
+          }
+          return;
+        }
+        diagnostics_message_timeout_->add_key_value(name, std::string("OK"));
+      };
+
+    update_timeout_diagnostics(
+      perception_subscriber_.last_taken_data_timestamp(), cyclic_message_timeout_,
+      "perception_objects");
+    update_timeout_diagnostics(
+      velocity_subscriber_.last_taken_data_timestamp(), cyclic_message_timeout_, "odometry");
+    update_timeout_diagnostics(
+      occupancy_grid_subscriber_.last_taken_data_timestamp(), cyclic_message_timeout_,
+      "occupancy_grid_map");
+    if (enable_traffic_signal_timeout_) {
+      update_timeout_diagnostics(
+        traffic_signals_subscriber_.last_taken_data_timestamp(), cyclic_message_timeout_,
+        "traffic_signal");
     }
   }
 
-  {
-    if (!map_ptr_) {
-      return missing("map");
-    }
+  if (status != DataReadyStatus::SUCCESS) {
+    diagnostics_message_timeout_->update_level_and_message(
+      diagnostic_msgs::msg::DiagnosticStatus::ERROR, "message timeout detected");
   }
 
-  if (!planner_data_->dynamic_object) {
-    return missing("dynamic_object");
-  }
-
-  if (!planner_data_->self_odometry) {
-    return missing("self_odometry");
-  }
-
-  if (!planner_data_->self_acceleration) {
-    return missing("self_acceleration");
-  }
-
-  if (!planner_data_->operation_mode) {
-    return missing("operation_mode");
-  }
-
-  if (!planner_data_->occupancy_grid) {
-    return missing("occupancy_grid");
-  }
-
-  return true;
+  return status;
 }
 
 void BehaviorPathPlannerNode::run()
@@ -318,7 +351,17 @@ void BehaviorPathPlannerNode::run()
 
   takeData();
 
-  if (!isDataReady()) {
+  const auto data_ready_status = isDataReady(stamp);
+  // `DataReadyStatus::TIMEOUT` is not handled intentionally as the reason in "NOTE" below
+  if (data_ready_status == DataReadyStatus::NOT_RECEIVED) {
+    /*
+     * NOTE:
+     * To preserve the existing logic of the run() callback,
+     * the run() callback will return early when mandatory data not received.
+     * There is controversy about the behavior when data is timed out. It will be discussed in the
+     * future.
+     */
+    diagnostics_message_timeout_->publish(stamp);
     return;
   }
 
@@ -326,6 +369,7 @@ void BehaviorPathPlannerNode::run()
 
   // behavior_path_planner runs only in LANE DRIVING scenario.
   if (current_scenario_->current_scenario != Scenario::LANEDRIVING) {
+    diagnostics_message_timeout_->publish(stamp);
     return;
   }
 
@@ -450,6 +494,9 @@ void BehaviorPathPlannerNode::run()
   planner_manager_->publishMarker();
   planner_manager_->publishVirtualWall();
   lk_manager.unlock();  // release planner_manager_
+
+  // publish diagnostics for timeout checking.
+  diagnostics_message_timeout_->publish(stamp);
 
   RCLCPP_DEBUG(get_logger(), "----- behavior path planner end -----\n\n");
 }

--- a/planning/behavior_path_planner/autoware_behavior_path_planner/src/planner_manager.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_planner/src/planner_manager.cpp
@@ -261,6 +261,32 @@ void PlannerManager::updateCurrentRouteLanelet(
   const auto & pose = data->self_odometry->pose.pose;
   const auto p = data->parameters;
 
+  const bool skip_global_route_snap =
+    data->operation_mode && data->operation_mode->mode == OperationModeState::AUTONOMOUS &&
+    data->operation_mode->is_autoware_control_enabled;
+
+  const auto snap_to_global_route_if_ego_out = [&]() {
+    if (skip_global_route_snap) {
+      return;
+    }
+    if (!current_route_lanelet_->has_value()) {
+      return;
+    }
+    if (!utils::isEgoOutOfRoute(
+          pose, current_route_lanelet_->value(), data->prev_modified_goal, route_handler)) {
+      return;
+    }
+    lanelet::ConstLanelet constrained{};
+    if (route_handler->getClosestLaneletWithConstrainsWithinRoute(
+          pose, &constrained, p.ego_nearest_dist_threshold, p.ego_nearest_yaw_threshold)) {
+      *current_route_lanelet_ = constrained;
+      return;
+    }
+    if (!is_any_approved_module_running) {
+      resetCurrentRouteLanelet(data);
+    }
+  };
+
   constexpr double extra_margin = 10.0;
   const auto backward_length =
     std::max(p.backward_path_length, p.backward_path_length + extra_margin);
@@ -271,6 +297,7 @@ void PlannerManager::updateCurrentRouteLanelet(
         pose, current_route_lanelet_->value(), &closest_lane, p.ego_nearest_dist_threshold,
         p.ego_nearest_yaw_threshold)) {
     *current_route_lanelet_ = closest_lane;
+    snap_to_global_route_if_ego_out();
     return;
   }
 
@@ -282,10 +309,12 @@ void PlannerManager::updateCurrentRouteLanelet(
   if (opt.has_value()) {
     closest_lane = *opt;
     *current_route_lanelet_ = closest_lane;
+    snap_to_global_route_if_ego_out();
   } else if (const auto opt_constraint =
                experimental::lanelet2_utils::get_closest_lanelet(lanelet_sequence, pose);
              opt_constraint) {
     *current_route_lanelet_ = opt_constraint.value();
+    snap_to_global_route_if_ego_out();
   } else if (!is_any_approved_module_running) {
     resetCurrentRouteLanelet(data);
   }
@@ -904,8 +933,9 @@ SlotOutput SubPlannerManager::runApprovedModules(
   if (std::any_of(approved_module_ptrs_.begin(), approved_module_ptrs_.end(), [](const auto & m) {
         return m->getCurrentStatus() == ModuleStatus::SUCCESS &&
                m->isCurrentRouteLaneletToBeReset();
-      }))
+      })) {
     resetCurrentRouteLanelet(data);
+  }
 
   // remove success module immediately.
   for (auto success_itr = std::find_if(

--- a/vehicle/autoware_steer_offset_estimator/CMakeLists.txt
+++ b/vehicle/autoware_steer_offset_estimator/CMakeLists.txt
@@ -14,6 +14,8 @@ ament_target_dependencies(${PROJECT_NAME}
   yaml_cpp_vendor
 )
 
+target_link_libraries(${PROJECT_NAME} yaml-cpp)
+
 rclcpp_components_register_node(${PROJECT_NAME}
   PLUGIN "autoware::steer_offset_estimator::SteerOffsetEstimatorNode"
   EXECUTABLE steer_offset_estimator_node


### PR DESCRIPTION
## Summary

`beta/v0.64` にのみ存在し `feat/v0.64/e2e` に未取り込みだった 4 コミットを cherry-pick しました。

- fix(compare_map_segmentation): ignore Werror=array-bounds (#2928)
- fix(steer_offset_estimator): link yaml-cpp (#2929)
- fix(behavior_path_planner): recover route lanelet after manual override (#2961)
- feat: replace topic state monitor beta/v0.64 (#2985)

**Note:** `fix(boundary_departure_checker): link pybind11 properly (#2930)` は e2e のライブラリ構成との差異が大きいため、今回は除外しています。

## E2E 構成（`PLANNING_SETTING=diffusion_planner`）への影響

E2E 起動時は `diffusion_planner` パイプラインが使われ、`behavior_path_planner` は起動しません。
control スタック（`trajectory_follower_node` 等）は rule_based と共通です。
### 影響まとめ

| 変更 | 走行挙動 |diagnostics |
|---|---|---|
| trajectory_follower timeout 監視 (#2985) | 変化なし | **新規 diagnostics 診断が出る (MRMには紐付いていない)** |
| behavior_path_planner timeout 監視 (#2985) | 変化なし（未起動） | 変化なし |
| route lanelet 復帰 (#2961) | 変化なし（未起動） | — |
| steer_offset yaml-cpp (#2929) | 変化なし | — |
| compare_map Werror (#2928) | 変化なし | — |

### 変更ごとの詳細

#### 1. Topic state monitor 内蔵化 (#2985)

**`trajectory_follower_node` — 影響あり（新たにdiagnosticsが出るのみ）**

- **MRMには未連携**（`/control/017-incoming_message_timeout` は feat/v4.4/e2e では定義していない）
- `/planning/trajectory` の最終受信時刻を監視し、`controller_node_exe` の `incoming_message_timeout` 診断を `/diagnostics` に publish
- 既存の `component_state_monitor`（`e2e_topics.yaml`）が `/planning/trajectory` を **1.0 秒** で別途監視しており、二重監視になる

**`behavior_path_planner` — 影響なし**

- E2E では `behavior_path_planner` は起動しないため、コードは含まれるがランタイムでは無効
- `rule_based` モードに切り替えた場合のみ有効になる

#### 2. 手動オーバーライド後の route lanelet 復帰 (#2961) — 影響なし

- `behavior_path_planner` 専用の修正
- E2E パイプラインは diffusion_planner ベースであり、lanelet 追従は `behavior_path_planner` 経由ではない

#### 3. `steer_offset_estimator` の yaml-cpp リンク (#2929) — ビルド影響のみ

- ランタイム挙動の変更なし
- `YAML::` 未定義参照によるビルド失敗を解消

#### 4. `compare_map_segmentation` の Werror 抑制 (#2928) — ビルド影響のみ

- ランタイム挙動の変更なし（コンパイラ警告抑制のみ）
- 対象: `VoxelBasedApproximateDynamicMapLoader::is_close_to_map()`


## Tests
- [x] planning simulator

tested on Ubuntu24.04 + ROS2 Jazzy
<img width="2494" height="1568" alt="image" src="https://github.com/user-attachments/assets/429a13fd-2a15-48cc-ad2d-39b64b02d8fd" />
