### PR TITLE
feat(simple_planning_simulator): add understeer simulation

### DIFF
--- a/simulator/autoware_simple_planning_simulator/include/autoware/simple_planning_simulator/vehicle_model/sim_model_delay_steer_acc_geared_wo_fall_guard.hpp
+++ b/simulator/autoware_simple_planning_simulator/include/autoware/simple_planning_simulator/vehicle_model/sim_model_delay_steer_acc_geared_wo_fall_guard.hpp
@@ -45,12 +45,13 @@ public:
    * @param [in] steer_bias steering bias [rad]
    * @param [in] debug_acc_scaling_factor scaling factor for accel command
    * @param [in] debug_steer_scaling_factor scaling factor for steering command
+   * @param [in] k_us understeer coefficient [rad/(m/s²)]; 0 keeps the ideal bicycle model
    */
   SimModelDelaySteerAccGearedWoFallGuard(
     double vx_lim, double steer_lim, double vx_rate_lim, double steer_rate_lim, double wheelbase,
     double dt, double acc_delay, double acc_time_constant, double steer_delay,
     double steer_time_constant, double steer_dead_band, double steer_bias,
-    double debug_acc_scaling_factor, double debug_steer_scaling_factor);
+    double debug_acc_scaling_factor, double debug_steer_scaling_factor, double k_us);
 
   /**
    * @brief default destructor
@@ -87,6 +88,14 @@ private:
   const double steer_bias_;                  //!< @brief steering angle bias [rad]
   const double debug_acc_scaling_factor_;    //!< @brief scaling factor for accel command
   const double debug_steer_scaling_factor_;  //!< @brief scaling factor for steering command
+  const double k_us_;                        //!< @brief understeer coefficient [rad/(m/s²)]
+
+  /**
+   * @brief steady-state yaw rate including understeer:
+   *        ω = vx · tan(δ) / (L + k_us · vx²)
+   * Reduces to the ideal kinematic bicycle ω when k_us = 0.
+   */
+  double calc_yaw_rate(double vel, double steer) const;
 
   /**
    * @brief set queue buffer for input command

--- a/simulator/autoware_simple_planning_simulator/src/simple_planning_simulator/simple_planning_simulator_core.cpp
+++ b/simulator/autoware_simple_planning_simulator/src/simple_planning_simulator/simple_planning_simulator_core.cpp
@@ -245,6 +245,7 @@ void SimplePlanningSimulator::initialize_vehicle_model(const std::string & vehic
 
   const double debug_acc_scaling_factor = declare_parameter("debug_acc_scaling_factor", 1.0);
   const double debug_steer_scaling_factor = declare_parameter("debug_steer_scaling_factor", 1.0);
+  const double k_us = declare_parameter("k_us", 0.0);
   const auto vehicle_info = autoware::vehicle_info_utils::VehicleInfoUtils(*this).getVehicleInfo();
   const double wheelbase = vehicle_info.wheel_base_m;
 
@@ -287,7 +288,7 @@ void SimplePlanningSimulator::initialize_vehicle_model(const std::string & vehic
     vehicle_model_ptr_ = std::make_shared<SimModelDelaySteerAccGearedWoFallGuard>(
       vel_lim, steer_lim, vel_rate_lim, steer_rate_lim, wheelbase, timer_sampling_time_ms_ / 1000.0,
       acc_time_delay, acc_time_constant, steer_time_delay, steer_time_constant, steer_dead_band,
-      steer_bias, debug_acc_scaling_factor, debug_steer_scaling_factor);
+      steer_bias, debug_acc_scaling_factor, debug_steer_scaling_factor, k_us);
   } else if (vehicle_model_type_str == "DELAY_STEER_MAP_ACC_GEARED") {
     vehicle_model_type_ = VehicleModelType::DELAY_STEER_MAP_ACC_GEARED;
     const std::string acceleration_map_path =

--- a/simulator/autoware_simple_planning_simulator/src/simple_planning_simulator/vehicle_model/sim_model_delay_steer_acc_geared_wo_fall_guard.cpp
+++ b/simulator/autoware_simple_planning_simulator/src/simple_planning_simulator/vehicle_model/sim_model_delay_steer_acc_geared_wo_fall_guard.cpp
@@ -25,7 +25,7 @@ SimModelDelaySteerAccGearedWoFallGuard::SimModelDelaySteerAccGearedWoFallGuard(
   double vx_lim, double steer_lim, double vx_rate_lim, double steer_rate_lim, double wheelbase,
   double dt, double acc_delay, double acc_time_constant, double steer_delay,
   double steer_time_constant, double steer_dead_band, double steer_bias,
-  double debug_acc_scaling_factor, double debug_steer_scaling_factor)
+  double debug_acc_scaling_factor, double debug_steer_scaling_factor, double k_us)
 : SimModelInterface(7 /* dim x */, 4 /* dim u */),
   MIN_TIME_CONSTANT(0.03),
   vx_lim_(vx_lim),
@@ -40,9 +40,16 @@ SimModelDelaySteerAccGearedWoFallGuard::SimModelDelaySteerAccGearedWoFallGuard(
   steer_dead_band_(steer_dead_band),
   steer_bias_(steer_bias),
   debug_acc_scaling_factor_(std::max(debug_acc_scaling_factor, 0.0)),
-  debug_steer_scaling_factor_(std::max(debug_steer_scaling_factor, 0.0))
+  debug_steer_scaling_factor_(std::max(debug_steer_scaling_factor, 0.0)),
+  k_us_(k_us)
 {
   initializeInputQueue(dt);
+}
+
+double SimModelDelaySteerAccGearedWoFallGuard::calc_yaw_rate(double vel, double steer) const
+{
+  const double denom = wheelbase_ + k_us_ * vel * vel;
+  return vel * std::tan(steer) / denom;
 }
 
 double SimModelDelaySteerAccGearedWoFallGuard::getX()
@@ -71,7 +78,7 @@ double SimModelDelaySteerAccGearedWoFallGuard::getAx()
 }
 double SimModelDelaySteerAccGearedWoFallGuard::getWz()
 {
-  return state_(IDX::VX) * std::tan(state_(IDX::STEER)) / wheelbase_;
+  return calc_yaw_rate(state_(IDX::VX), state_(IDX::STEER));
 }
 double SimModelDelaySteerAccGearedWoFallGuard::getSteer()
 {
@@ -153,7 +160,7 @@ Eigen::VectorXd SimModelDelaySteerAccGearedWoFallGuard::calcModel(
 
   d_state(IDX::X) = vel * cos(yaw);
   d_state(IDX::Y) = vel * sin(yaw);
-  d_state(IDX::YAW) = vel * std::tan(steer) / wheelbase_;
+  d_state(IDX::YAW) = calc_yaw_rate(vel, steer);
   d_state(IDX::VX) = [&] {
     if (pedal_acc >= 0.0) {
       using autoware_vehicle_msgs::msg::GearCommand;


### PR DESCRIPTION
This PR introduces an understeer simulation model. We can simulate understeer on a curve using the understeer gradient  parameter `k_us`.

without understeer
<img width="1800" height="1800" alt="image" src="https://github.com/user-attachments/assets/36e12538-f1f4-472c-b20a-c62ffc4f7516" />

with understeer
<img width="1800" height="1800" alt="image" src="https://github.com/user-attachments/assets/09202658-f2ac-403b-b435-4b27b3d91986" />


## Notes for reviewers
This is a **temporary** implementation for E2E development. Future discussions will be needed to extend this feature to other simulation models and vehicle descriptions.