### PR TITLE
feat: cherry pick crosswalk_traffic_light_estimator

### DIFF
--- a/perception/autoware_crosswalk_traffic_light_estimator/CMakeLists.txt
+++ b/perception/autoware_crosswalk_traffic_light_estimator/CMakeLists.txt
@@ -21,7 +21,15 @@ rclcpp_components_register_node(autoware_crosswalk_traffic_light_estimator
 
 if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
+  find_package(ament_cmake_gtest)
   ament_lint_auto_find_test_dependencies()
+
+  ament_add_gtest(test_crosswalk_traffic_light_estimator_node
+    test/test_crosswalk_traffic_light_estimator_node.cpp
+  )
+  target_link_libraries(test_crosswalk_traffic_light_estimator_node
+    autoware_crosswalk_traffic_light_estimator
+  )
 endif()
 
 #############

--- a/perception/autoware_crosswalk_traffic_light_estimator/CMakeLists.txt
+++ b/perception/autoware_crosswalk_traffic_light_estimator/CMakeLists.txt
@@ -11,6 +11,7 @@ autoware_package()
 include_directories()
 
 ament_auto_add_library(autoware_crosswalk_traffic_light_estimator SHARED
+  src/crosswalk_traffic_light_estimator.cpp
   src/flashing_detection.cpp
   src/node.cpp
 )

--- a/perception/autoware_crosswalk_traffic_light_estimator/CMakeLists.txt
+++ b/perception/autoware_crosswalk_traffic_light_estimator/CMakeLists.txt
@@ -11,6 +11,7 @@ autoware_package()
 include_directories()
 
 ament_auto_add_library(autoware_crosswalk_traffic_light_estimator SHARED
+  src/flashing_detection.cpp
   src/node.cpp
 )
 
@@ -28,6 +29,13 @@ if(BUILD_TESTING)
     test/test_crosswalk_traffic_light_estimator_node.cpp
   )
   target_link_libraries(test_crosswalk_traffic_light_estimator_node
+    autoware_crosswalk_traffic_light_estimator
+  )
+
+  ament_add_gtest(test_flashing_detection
+    test/test_flashing_detection.cpp
+  )
+  target_link_libraries(test_flashing_detection
     autoware_crosswalk_traffic_light_estimator
   )
 endif()

--- a/perception/autoware_crosswalk_traffic_light_estimator/CMakeLists.txt
+++ b/perception/autoware_crosswalk_traffic_light_estimator/CMakeLists.txt
@@ -39,6 +39,13 @@ if(BUILD_TESTING)
   target_link_libraries(test_flashing_detection
     autoware_crosswalk_traffic_light_estimator
   )
+
+  ament_add_gtest(test_crosswalk_traffic_light_estimator
+    test/test_crosswalk_traffic_light_estimator.cpp
+  )
+  target_link_libraries(test_crosswalk_traffic_light_estimator
+    autoware_crosswalk_traffic_light_estimator
+  )
 endif()
 
 #############

--- a/perception/autoware_crosswalk_traffic_light_estimator/CMakeLists.txt
+++ b/perception/autoware_crosswalk_traffic_light_estimator/CMakeLists.txt
@@ -19,7 +19,7 @@ ament_auto_add_library(autoware_crosswalk_traffic_light_estimator SHARED
 autoware_agnocast_wrapper_register_node(autoware_crosswalk_traffic_light_estimator
   PLUGIN "autoware::crosswalk_traffic_light_estimator::CrosswalkTrafficLightEstimatorNode"
   EXECUTABLE crosswalk_traffic_light_estimator_node
-  AGNOCAST_EXECUTOR CallbackIsolatedAgnocastExecutor
+  AGNOCAST_EXECUTOR AgnocastOnlyCallbackIsolatedExecutor
   ROS2_EXECUTOR SingleThreadedExecutor
 )
 
@@ -28,12 +28,14 @@ if(BUILD_TESTING)
   find_package(ament_cmake_gtest)
   ament_lint_auto_find_test_dependencies()
 
-  ament_add_gtest(test_crosswalk_traffic_light_estimator_node
-    test/test_crosswalk_traffic_light_estimator_node.cpp
-  )
-  target_link_libraries(test_crosswalk_traffic_light_estimator_node
-    autoware_crosswalk_traffic_light_estimator
-  )
+  if(NOT "$ENV{ENABLE_AGNOCAST}" STREQUAL "1")
+    ament_add_gtest(test_crosswalk_traffic_light_estimator_node
+      test/test_crosswalk_traffic_light_estimator_node.cpp
+    )
+    target_link_libraries(test_crosswalk_traffic_light_estimator_node
+      autoware_crosswalk_traffic_light_estimator
+    )
+  endif()
 
   ament_add_gtest(test_flashing_detection
     test/test_flashing_detection.cpp

--- a/perception/autoware_crosswalk_traffic_light_estimator/CMakeLists.txt
+++ b/perception/autoware_crosswalk_traffic_light_estimator/CMakeLists.txt
@@ -16,9 +16,11 @@ ament_auto_add_library(autoware_crosswalk_traffic_light_estimator SHARED
   src/node.cpp
 )
 
-rclcpp_components_register_node(autoware_crosswalk_traffic_light_estimator
+autoware_agnocast_wrapper_register_node(autoware_crosswalk_traffic_light_estimator
   PLUGIN "autoware::crosswalk_traffic_light_estimator::CrosswalkTrafficLightEstimatorNode"
   EXECUTABLE crosswalk_traffic_light_estimator_node
+  AGNOCAST_EXECUTOR CallbackIsolatedAgnocastExecutor
+  ROS2_EXECUTOR SingleThreadedExecutor
 )
 
 if(BUILD_TESTING)

--- a/perception/autoware_crosswalk_traffic_light_estimator/README.md
+++ b/perception/autoware_crosswalk_traffic_light_estimator/README.md
@@ -7,8 +7,6 @@
 - Estimate pedestrian traffic signals that are not subject to be detected by perception pipeline.
 - Estimate whether pedestrian traffic signals are flashing and modify the result.
 
-This module works without `~/input/route`, but its behavior is outputting the subscribed results as is.
-
 ## Inputs / Outputs
 
 ### Input
@@ -16,7 +14,6 @@ This module works without `~/input/route`, but its behavior is outputting the su
 | Name                                 | Type                                                  | Description        |
 | ------------------------------------ | ----------------------------------------------------- | ------------------ |
 | `~/input/vector_map`                 | autoware_map_msgs::msg::LaneletMapBin                 | vector map         |
-| `~/input/route`                      | autoware_planning_msgs::msg::LaneletRoute             | optional: route    |
 | `~/input/classified/traffic_signals` | autoware_perception_msgs::msg::TrafficLightGroupArray | classified signals |
 
 ### Output
@@ -31,7 +28,7 @@ This module works without `~/input/route`, but its behavior is outputting the su
 | Name                           | Type   | Description                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                                        | Default value |
 | :----------------------------- | :----- | :------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | :------------ |
 | `use_last_detect_color`        | bool   | If this parameter is `true`, this module estimates pedestrian's traffic signal as RED not only when vehicle's traffic signal is detected as GREEN/AMBER but also when detection results change GREEN/AMBER to UNKNOWN. (If detection results change RED or AMBER to UNKNOWN, this module estimates pedestrian's traffic signal as UNKNOWN.) If this parameter is `false`, this module use only latest detection results for estimation. (Only when the detection result is GREEN/AMBER, this module estimates pedestrian's traffic signal as RED.) | true          |
-| `use_pedestrian_signal_detect` | bool   | If this parameter is `true`, use the pedestrian's traffic signal estimated by the perception pipeline. If `false`, overwrite it with pedestrian's signals estimated from vehicle traffic signals, HDMap, and route.                                                                                                                                                                                                                                                                                                                                | true          |
+| `use_pedestrian_signal_detect` | bool   | If this parameter is `true`, use the pedestrian's traffic signal estimated by the perception pipeline. If `false`, overwrite it with pedestrian's signals estimated from vehicle traffic signals and HDMap.                                                                                                                                                                                                                                                                                                                                        | true          |
 | `last_detect_color_hold_time`  | double | The time threshold to hold for last detect color. The unit is second.                                                                                                                                                                                                                                                                                                                                                                                                                                                                              | 2.0           |
 | `last_colors_hold_time`        | double | The time threshold to hold for history detected pedestrian traffic light color. The unit is second.                                                                                                                                                                                                                                                                                                                                                                                                                                                | 1.0           |
 
@@ -44,7 +41,7 @@ When the pedestrian traffic signals **are detected** by perception pipeline
 
 When the pedestrian traffic signals **are NOT detected** by perception pipeline
 
-- Estimate the color of pedestrian traffic signals based on detected vehicle traffic signals, HDMap, and route
+- Estimate the color of pedestrian traffic signals based on detected vehicle traffic signals and HDMap
 
 Override rules specific to some traffic lights can also be defined in the lanelet map.
 In that case, the crosswalk traffic light estimation is overridden by these rules.
@@ -82,9 +79,9 @@ end
 ```plantuml
 
 start
-:subscribe detected traffic signals, HDMap, and route;
+:subscribe detected traffic signals and HDMap;
 :extract crosswalk lanelets from HDMap;
-:extract road lanelets that conflicts crosswalk from route;
+:extract road lanelets that conflicts with crosswalk;
 :initialize non_red_lanelets(lanelet::ConstLanelets);
 if (Latest detection result is **GREEN** or **AMBER**?) then (yes)
   :push back non_red_lanelets;

--- a/perception/autoware_crosswalk_traffic_light_estimator/include/autoware_crosswalk_traffic_light_estimator/flashing_detection.hpp
+++ b/perception/autoware_crosswalk_traffic_light_estimator/include/autoware_crosswalk_traffic_light_estimator/flashing_detection.hpp
@@ -1,0 +1,70 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef AUTOWARE_CROSSWALK_TRAFFIC_LIGHT_ESTIMATOR__FLASHING_DETECTION_HPP_
+#define AUTOWARE_CROSSWALK_TRAFFIC_LIGHT_ESTIMATOR__FLASHING_DETECTION_HPP_
+
+#include <rclcpp/time.hpp>
+
+#include <autoware_perception_msgs/msg/traffic_light_element.hpp>
+#include <autoware_perception_msgs/msg/traffic_light_group.hpp>
+#include <autoware_perception_msgs/msg/traffic_light_group_array.hpp>
+
+#include <lanelet2_core/Forward.h>
+
+#include <cstdint>
+#include <unordered_map>
+#include <utility>
+#include <vector>
+
+namespace autoware::crosswalk_traffic_light_estimator
+{
+
+using TrafficSignal = autoware_perception_msgs::msg::TrafficLightGroup;
+using TrafficSignalArray = autoware_perception_msgs::msg::TrafficLightGroupArray;
+using TrafficSignalElement = autoware_perception_msgs::msg::TrafficLightElement;
+using TrafficSignalAndTime = std::pair<TrafficSignal, rclcpp::Time>;
+using TrafficLightIdMap = std::unordered_map<lanelet::Id, TrafficSignalAndTime>;
+using TrafficLightIdArray = std::unordered_map<lanelet::Id, std::vector<TrafficSignalAndTime>>;
+
+struct FlashingDetectionConfig
+{
+  double last_colors_hold_time;
+};
+
+class FlashingDetector
+{
+public:
+  explicit FlashingDetector(const FlashingDetectionConfig & config);
+  FlashingDetector() = default;
+
+  uint8_t estimate_stable_color(const TrafficSignal & signal, const rclcpp::Time & current_time);
+
+  void clear_state(lanelet::Id id);
+
+private:
+  void update_signal_history(const TrafficSignal & signal, const rclcpp::Time & current_time);
+  void remove_expired_entries(lanelet::Id id, const rclcpp::Time & current_time);
+  void update_flashing_state(const TrafficSignal & signal);
+  uint8_t update_and_get_color_state(const TrafficSignal & signal);
+
+  FlashingDetectionConfig config_{};
+  std::unordered_map<lanelet::Id, bool> is_flashing_;
+  std::unordered_map<lanelet::Id, uint8_t> current_color_state_;
+  TrafficLightIdArray signal_history_;
+};
+
+}  // namespace autoware::crosswalk_traffic_light_estimator
+
+#endif  // AUTOWARE_CROSSWALK_TRAFFIC_LIGHT_ESTIMATOR__FLASHING_DETECTION_HPP_

--- a/perception/autoware_crosswalk_traffic_light_estimator/include/autoware_crosswalk_traffic_light_estimator/node.hpp
+++ b/perception/autoware_crosswalk_traffic_light_estimator/include/autoware_crosswalk_traffic_light_estimator/node.hpp
@@ -22,7 +22,6 @@
 #include <autoware_internal_debug_msgs/msg/float64_stamped.hpp>
 #include <autoware_map_msgs/msg/lanelet_map_bin.hpp>
 #include <autoware_perception_msgs/msg/traffic_light_group_array.hpp>
-#include <autoware_planning_msgs/msg/lanelet_route.hpp>
 
 #include <lanelet2_core/Attribute.h>
 #include <lanelet2_core/LaneletMap.h>
@@ -41,7 +40,6 @@ namespace autoware::crosswalk_traffic_light_estimator
 
 using autoware_internal_debug_msgs::msg::Float64Stamped;
 using autoware_map_msgs::msg::LaneletMapBin;
-using autoware_planning_msgs::msg::LaneletRoute;
 using autoware_utils::DebugPublisher;
 using autoware_utils::StopWatch;
 using TrafficSignal = autoware_perception_msgs::msg::TrafficLightGroup;
@@ -59,19 +57,15 @@ public:
 
 private:
   rclcpp::Subscription<LaneletMapBin>::SharedPtr sub_map_;
-  rclcpp::Subscription<LaneletRoute>::SharedPtr sub_route_;
   rclcpp::Subscription<TrafficSignalArray>::SharedPtr sub_traffic_light_array_;
   rclcpp::Publisher<TrafficSignalArray>::SharedPtr pub_traffic_light_array_;
 
   lanelet::LaneletMapPtr lanelet_map_ptr_;
-  lanelet::traffic_rules::TrafficRulesPtr traffic_rules_ptr_;
   lanelet::routing::RoutingGraphPtr routing_graph_ptr_;
-  std::shared_ptr<const lanelet::routing::RoutingGraphContainer> overall_graphs_ptr_;
-
-  lanelet::ConstLanelets conflicting_crosswalks_;
+  std::unordered_map<lanelet::Id, lanelet::ConstLanelets> traffic_light_id_to_crosswalks_;
+  std::unordered_map<lanelet::Id, lanelet::ConstLanelets> crosswalk_to_vehicle_lanelets_;
 
   void onMap(const LaneletMapBin::ConstSharedPtr msg);
-  void onRoute(const LaneletRoute::ConstSharedPtr msg);
   void onTrafficLightArray(const TrafficSignalArray::ConstSharedPtr msg);
 
   void updateLastDetectedSignal(const TrafficLightIdMap & traffic_signals);

--- a/perception/autoware_crosswalk_traffic_light_estimator/include/autoware_crosswalk_traffic_light_estimator/node.hpp
+++ b/perception/autoware_crosswalk_traffic_light_estimator/include/autoware_crosswalk_traffic_light_estimator/node.hpp
@@ -15,13 +15,14 @@
 #ifndef AUTOWARE_CROSSWALK_TRAFFIC_LIGHT_ESTIMATOR__NODE_HPP_
 #define AUTOWARE_CROSSWALK_TRAFFIC_LIGHT_ESTIMATOR__NODE_HPP_
 
+#include "autoware_crosswalk_traffic_light_estimator/flashing_detection.hpp"
+
 #include <autoware_utils/ros/debug_publisher.hpp>
 #include <autoware_utils/system/stop_watch.hpp>
 #include <rclcpp/rclcpp.hpp>
 
 #include <autoware_internal_debug_msgs/msg/float64_stamped.hpp>
 #include <autoware_map_msgs/msg/lanelet_map_bin.hpp>
-#include <autoware_perception_msgs/msg/traffic_light_group_array.hpp>
 
 #include <lanelet2_core/Attribute.h>
 #include <lanelet2_core/LaneletMap.h>
@@ -30,10 +31,8 @@
 #include <lanelet2_routing/RoutingGraphContainer.h>
 #include <lanelet2_traffic_rules/TrafficRulesFactory.h>
 
-#include <map>
 #include <memory>
 #include <unordered_map>
-#include <utility>
 #include <vector>
 namespace autoware::crosswalk_traffic_light_estimator
 {
@@ -42,13 +41,6 @@ using autoware_internal_debug_msgs::msg::Float64Stamped;
 using autoware_map_msgs::msg::LaneletMapBin;
 using autoware_utils::DebugPublisher;
 using autoware_utils::StopWatch;
-using TrafficSignal = autoware_perception_msgs::msg::TrafficLightGroup;
-using TrafficSignalArray = autoware_perception_msgs::msg::TrafficLightGroupArray;
-using TrafficSignalElement = autoware_perception_msgs::msg::TrafficLightElement;
-using TrafficSignalAndTime = std::pair<TrafficSignal, rclcpp::Time>;
-using TrafficLightIdMap = std::unordered_map<lanelet::Id, TrafficSignalAndTime>;
-
-using TrafficLightIdArray = std::unordered_map<lanelet::Id, std::vector<TrafficSignalAndTime>>;
 
 class CrosswalkTrafficLightEstimatorNode : public rclcpp::Node
 {
@@ -69,10 +61,6 @@ private:
   void onTrafficLightArray(const TrafficSignalArray::ConstSharedPtr msg);
 
   void updateLastDetectedSignal(const TrafficLightIdMap & traffic_signals);
-  void updateLastDetectedSignals(const TrafficLightIdMap & traffic_signals);
-  void updateFlashingState(const TrafficSignal & signal);
-
-  uint8_t updateAndGetColorState(const TrafficSignal & signal);
   /// @brief update the overrides of crosswalk signals from the lanelet map for the given traffic
   /// light id
   void update_crosswalk_overrides_from_map(
@@ -105,15 +93,12 @@ private:
   bool use_last_detect_color_;
   bool use_pedestrian_signal_detect_;
   double last_detect_color_hold_time_;
-  double last_colors_hold_time_;
 
   // Signal history
   TrafficLightIdMap last_detect_color_;
-  TrafficLightIdArray last_colors_;
 
-  // State
-  std::map<lanelet::Id, bool> is_flashing_;
-  std::map<lanelet::Id, uint8_t> current_color_state_;
+  // Flashing detection
+  FlashingDetector flashing_detector_;
 
   // Stop watch
   StopWatch<std::chrono::milliseconds> stop_watch_;

--- a/perception/autoware_crosswalk_traffic_light_estimator/launch/crosswalk_traffic_light_estimator.launch.xml
+++ b/perception/autoware_crosswalk_traffic_light_estimator/launch/crosswalk_traffic_light_estimator.launch.xml
@@ -12,14 +12,12 @@
 -->
 <launch>
   <arg name="input/vector_map" default="/map/vector_map"/>
-  <arg name="input/route" default="/planning/mission_planning/route"/>
   <arg name="input/traffic_signals" default="judged/traffic_signals"/>
   <arg name="output/traffic_signals" default="traffic_signals"/>
   <arg name="param_path" default="$(find-pkg-share autoware_crosswalk_traffic_light_estimator)/config/crosswalk_traffic_light_estimator.param.yaml"/>
 
   <node pkg="autoware_crosswalk_traffic_light_estimator" exec="crosswalk_traffic_light_estimator_node" name="crosswalk_traffic_light_estimator" output="screen">
     <remap from="~/input/vector_map" to="$(var input/vector_map)"/>
-    <remap from="~/input/route" to="$(var input/route)"/>
     <remap from="~/input/classified/traffic_signals" to="$(var input/traffic_signals)"/>
     <remap from="~/output/traffic_signals" to="$(var output/traffic_signals)"/>
     <param from="$(var param_path)"/>

--- a/perception/autoware_crosswalk_traffic_light_estimator/launch/crosswalk_traffic_light_estimator.launch.xml
+++ b/perception/autoware_crosswalk_traffic_light_estimator/launch/crosswalk_traffic_light_estimator.launch.xml
@@ -11,12 +11,14 @@
   limitations under the License.
 -->
 <launch>
+  <include file="$(find-pkg-share autoware_agnocast_wrapper)/launch/agnocast_env.launch.xml"/>
   <arg name="input/vector_map" default="/map/vector_map"/>
   <arg name="input/traffic_signals" default="judged/traffic_signals"/>
   <arg name="output/traffic_signals" default="traffic_signals"/>
   <arg name="param_path" default="$(find-pkg-share autoware_crosswalk_traffic_light_estimator)/config/crosswalk_traffic_light_estimator.param.yaml"/>
 
   <node pkg="autoware_crosswalk_traffic_light_estimator" exec="crosswalk_traffic_light_estimator_node" name="crosswalk_traffic_light_estimator" output="screen">
+    <env name="LD_PRELOAD" value="$(var ld_preload_value)"/>
     <remap from="~/input/vector_map" to="$(var input/vector_map)"/>
     <remap from="~/input/classified/traffic_signals" to="$(var input/traffic_signals)"/>
     <remap from="~/output/traffic_signals" to="$(var output/traffic_signals)"/>

--- a/perception/autoware_crosswalk_traffic_light_estimator/package.xml
+++ b/perception/autoware_crosswalk_traffic_light_estimator/package.xml
@@ -19,7 +19,6 @@
   <depend>autoware_lanelet2_utils</depend>
   <depend>autoware_map_msgs</depend>
   <depend>autoware_perception_msgs</depend>
-  <depend>autoware_planning_msgs</depend>
   <depend>autoware_utils</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>

--- a/perception/autoware_crosswalk_traffic_light_estimator/package.xml
+++ b/perception/autoware_crosswalk_traffic_light_estimator/package.xml
@@ -14,6 +14,7 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
+  <depend>autoware_agnocast_wrapper</depend>
   <depend>autoware_internal_debug_msgs</depend>
   <depend>autoware_lanelet2_extension</depend>
   <depend>autoware_lanelet2_utils</depend>

--- a/perception/autoware_crosswalk_traffic_light_estimator/package.xml
+++ b/perception/autoware_crosswalk_traffic_light_estimator/package.xml
@@ -21,6 +21,7 @@
   <depend>autoware_map_msgs</depend>
   <depend>autoware_perception_msgs</depend>
   <depend>autoware_utils</depend>
+  <depend>autoware_utils_debug</depend>
   <depend>rclcpp</depend>
   <depend>rclcpp_components</depend>
   <depend>tier4_perception_msgs</depend>

--- a/perception/autoware_crosswalk_traffic_light_estimator/src/crosswalk_traffic_light_estimator.cpp
+++ b/perception/autoware_crosswalk_traffic_light_estimator/src/crosswalk_traffic_light_estimator.cpp
@@ -526,6 +526,11 @@ lanelet::ConstLanelets CrosswalkTrafficLightEstimator::get_non_red_lanelets(
     const auto last_detected_signal =
       get_highest_confidence_traffic_signal(tl_reg_elem->id(), last_detect_color_);
 
+    const auto has_no_signal_info = !current_detected_signal && !last_detected_signal;
+    if (has_no_signal_info) {
+      continue;
+    }
+
     const auto was_not_red = current_is_unknown_or_none && last_detected_signal &&
                              (last_detected_signal.get() == TrafficSignalElement::GREEN ||
                               last_detected_signal.get() == TrafficSignalElement::AMBER) &&

--- a/perception/autoware_crosswalk_traffic_light_estimator/src/crosswalk_traffic_light_estimator.cpp
+++ b/perception/autoware_crosswalk_traffic_light_estimator/src/crosswalk_traffic_light_estimator.cpp
@@ -1,0 +1,579 @@
+// Copyright 2022-2025 UCI SORA Lab, TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+#include "crosswalk_traffic_light_estimator.hpp"
+
+#include <autoware_lanelet2_extension/regulatory_elements/Forward.hpp>
+#include <autoware_lanelet2_extension/utility/query.hpp>
+
+#include <boost/optional.hpp>
+
+#include <lanelet2_routing/RoutingGraphContainer.h>
+#include <lanelet2_traffic_rules/TrafficRulesFactory.h>
+
+#include <algorithm>
+#include <charconv>
+#include <cstdint>
+#include <optional>
+#include <string>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+namespace autoware::crosswalk_traffic_light_estimator
+{
+namespace
+{
+
+bool has_merge_lane(
+  const lanelet::ConstLanelet & lanelet_1, const lanelet::ConstLanelet & lanelet_2,
+  const lanelet::routing::RoutingGraphPtr & routing_graph_ptr)
+{
+  const auto next_lanelets_1 = routing_graph_ptr->following(lanelet_1);
+  const auto next_lanelets_2 = routing_graph_ptr->following(lanelet_2);
+
+  for (const auto & next_lanelet_1 : next_lanelets_1) {
+    for (const auto & next_lanelet_2 : next_lanelets_2) {
+      if (next_lanelet_1.id() == next_lanelet_2.id()) {
+        return true;
+      }
+    }
+  }
+
+  return false;
+}
+
+bool has_merge_lane(
+  const lanelet::ConstLanelets & lanelets,
+  const lanelet::routing::RoutingGraphPtr & routing_graph_ptr)
+{
+  for (size_t i = 0; i < lanelets.size(); ++i) {
+    for (size_t j = i + 1; j < lanelets.size(); ++j) {
+      const auto lanelet_1 = lanelets.at(i);
+      const auto lanelet_2 = lanelets.at(j);
+
+      if (lanelet_1.id() == lanelet_2.id()) {
+        continue;
+      }
+
+      const std::string turn_direction_1 = lanelet_1.attributeOr("turn_direction", "none");
+      const std::string turn_direction_2 = lanelet_2.attributeOr("turn_direction", "none");
+      if (turn_direction_1 == turn_direction_2) {
+        continue;
+      }
+
+      if (!has_merge_lane(lanelet_1, lanelet_2, routing_graph_ptr)) {
+        continue;
+      }
+
+      return true;
+    }
+  }
+
+  return false;
+}
+
+/// @brief convert a string to the corresponding traffic signal color
+std::optional<uint8_t> str_to_color(std::string_view str)
+{
+  if (str == "red") {
+    return TrafficSignalElement::RED;
+  }
+  if (str == "green") {
+    return TrafficSignalElement::GREEN;
+  }
+  if (str == "amber") {
+    return TrafficSignalElement::AMBER;
+  }
+  if (str == "white") {
+    return TrafficSignalElement::WHITE;
+  }
+  return std::nullopt;
+}
+
+/// @brief parse the input string and extract a rule to estimate a traffic signal
+/// @details the string is expected to have format "signal_color_relation:color1:color2"
+std::optional<std::pair<uint8_t, uint8_t>> parse_signal_estimation_rules(std::string_view input)
+{
+  constexpr auto delimiter = ':';
+  constexpr std::string_view prefix = "signal_color_relation:";
+  if (input.size() < prefix.size() || input.substr(0, prefix.length()) != prefix) {
+    return std::nullopt;
+  }
+  input.remove_prefix(prefix.length());
+
+  // extract the color mapping
+  const auto delimiter_pos = input.find(delimiter);
+  if (delimiter_pos == std::string_view::npos) {
+    return std::nullopt;
+  }
+
+  std::string_view from_str = input.substr(0, delimiter_pos);
+  std::string_view to_str = input.substr(delimiter_pos + 1);
+
+  if (const auto from_color = str_to_color(from_str)) {
+    if (const auto to_color = str_to_color(to_str)) {
+      return std::make_pair(*from_color, *to_color);
+    }
+  }
+  return std::nullopt;
+}
+
+/// @brief extract ids from the input string
+/// @details the string is expected to have format "id1,id2,...", without any space
+lanelet::Ids parse_ids(std::string_view input)
+{
+  lanelet::Ids ids;
+  if (input.empty()) {
+    return ids;
+  }
+
+  constexpr auto delimiter = ',';
+  size_t start = 0;
+  size_t end = 0;
+  lanelet::Id id{};
+  while ((end = input.find(delimiter, start)) != std::string_view::npos) {
+    const auto [_, err] = std::from_chars(input.data() + start, input.data() + end, id);
+    if (err == std::errc()) {
+      ids.push_back(id);
+    }
+    start = end + 1;
+  }
+  const auto [_, err] = std::from_chars(input.data() + start, input.data() + input.size(), id);
+  if (err == std::errc()) {
+    ids.push_back(id);
+  }
+  return ids;
+}
+bool is_invalid_detection_status(const TrafficSignal & signal)
+{
+  if (signal.elements.empty()) {
+    return true;
+  }
+  if (
+    signal.elements.front().color == TrafficSignalElement::UNKNOWN &&
+    signal.elements.front().confidence == 0.0) {
+    return true;
+  }
+  return false;
+}
+
+boost::optional<uint8_t> get_highest_confidence_traffic_signal(
+  const lanelet::Id & id, const TrafficLightIdMap & traffic_light_id_map)
+{
+  boost::optional<uint8_t> ret{boost::none};
+
+  double highest_confidence = 0.0;
+  if (traffic_light_id_map.count(id) == 0) {
+    return ret;
+  }
+
+  for (const auto & element : traffic_light_id_map.at(id).first.elements) {
+    if (element.confidence < highest_confidence) {
+      continue;
+    }
+
+    highest_confidence = element.confidence;
+    ret = element.color;
+  }
+
+  return ret;
+}
+
+void remove_duplicate_ids(TrafficSignalArray & signal_array)
+{
+  auto & signals = signal_array.traffic_light_groups;
+  std::stable_sort(signals.begin(), signals.end(), [](const auto & s1, const auto & s2) {
+    return s1.traffic_light_group_id < s2.traffic_light_group_id;
+  });
+
+  signals.erase(
+    std::unique(
+      signals.begin(), signals.end(),
+      [](const auto & s1, const auto s2) {
+        return s1.traffic_light_group_id == s2.traffic_light_group_id;
+      }),
+    signals.end());
+}
+
+}  // namespace
+
+CrosswalkTrafficLightEstimator::CrosswalkTrafficLightEstimator(
+  const CrosswalkTrafficLightEstimatorConfig & config)
+: config_(config), flashing_detector_(FlashingDetector(config.flashing_detection))
+{
+}
+
+void CrosswalkTrafficLightEstimator::update_map(
+  lanelet::LaneletMapPtr lanelet_map_ptr, lanelet::routing::RoutingGraphPtr routing_graph_ptr)
+{
+  lanelet_map_ptr_ = lanelet_map_ptr;
+  routing_graph_ptr_ = routing_graph_ptr;
+
+  const auto traffic_rules = lanelet::traffic_rules::TrafficRulesFactory::create(
+    lanelet::Locations::Germany, lanelet::Participants::Vehicle);
+  const auto pedestrian_rules = lanelet::traffic_rules::TrafficRulesFactory::create(
+    lanelet::Locations::Germany, lanelet::Participants::Pedestrian);
+  lanelet::routing::RoutingGraphConstPtr vehicle_graph =
+    lanelet::routing::RoutingGraph::build(*lanelet_map_ptr_, *traffic_rules);
+  lanelet::routing::RoutingGraphConstPtr pedestrian_graph =
+    lanelet::routing::RoutingGraph::build(*lanelet_map_ptr_, *pedestrian_rules);
+  const lanelet::routing::RoutingGraphContainer overall_graphs({vehicle_graph, pedestrian_graph});
+  // Build precomputed mappings: traffic light ID -> crosswalks, crosswalk -> vehicle lanelets
+  traffic_light_id_to_crosswalks_.clear();
+  crosswalk_to_vehicle_lanelets_.clear();
+
+  const auto all_lanelets = lanelet::utils::query::laneletLayer(lanelet_map_ptr_);
+  const auto crosswalk_lanelets = lanelet::utils::query::crosswalkLanelets(all_lanelets);
+
+  const int VEHICLE_GRAPH_INDEX = 0;
+  for (const auto & crosswalk : crosswalk_lanelets) {
+    const auto traffic_light_reg_elems =
+      crosswalk.regulatoryElementsAs<const lanelet::TrafficLight>();
+    if (traffic_light_reg_elems.empty()) {
+      continue;
+    }
+    const auto vehicle_lanelets = overall_graphs.conflictingInGraph(crosswalk, VEHICLE_GRAPH_INDEX);
+    if (vehicle_lanelets.empty()) {
+      continue;
+    }
+
+    crosswalk_to_vehicle_lanelets_[crosswalk.id()] = vehicle_lanelets;
+
+    std::unordered_set<lanelet::Id> added_known_color_vehicle_traffic_light_ids;
+    for (const auto & vehicle_lanelet : vehicle_lanelets) {
+      for (const auto & traffic_light :
+           vehicle_lanelet.regulatoryElementsAs<const lanelet::TrafficLight>()) {
+        if (added_known_color_vehicle_traffic_light_ids.insert(traffic_light->id()).second) {
+          traffic_light_id_to_crosswalks_[traffic_light->id()].push_back(crosswalk);
+        }
+      }
+    }
+  }
+}
+
+bool CrosswalkTrafficLightEstimator::is_map_loaded() const
+{
+  return lanelet_map_ptr_ != nullptr;
+}
+
+std::vector<lanelet::Id> CrosswalkTrafficLightEstimator::find_unregistered_traffic_light_group_ids(
+  const TrafficSignalArray & msg) const
+{
+  std::vector<lanelet::Id> unregistered_ids;
+  for (const auto & traffic_signal : msg.traffic_light_groups) {
+    const auto id = traffic_signal.traffic_light_group_id;
+    if (
+      lanelet_map_ptr_->regulatoryElementLayer.find(id) ==
+      lanelet_map_ptr_->regulatoryElementLayer.end()) {
+      unregistered_ids.push_back(id);
+    }
+  }
+  return unregistered_ids;
+}
+
+void CrosswalkTrafficLightEstimator::update_crosswalk_overrides_from_map(
+  std::unordered_map<lanelet::Id, uint8_t> & crosswalk_traffic_signal_overrides,
+  lanelet::Id traffic_light_group_id, const TrafficLightIdMap & traffic_light_id_map)
+{
+  const auto traffic_light_it =
+    lanelet_map_ptr_->regulatoryElementLayer.find(traffic_light_group_id);
+  if (traffic_light_it == lanelet_map_ptr_->regulatoryElementLayer.end()) {
+    return;
+  }
+  const auto & traffic_light = *traffic_light_it;
+  const auto current_vehicle_traffic_light_color =
+    get_highest_confidence_traffic_signal(traffic_light->id(), traffic_light_id_map);
+  for (const auto & attribute : traffic_light->attributes()) {
+    const auto & color_mapping = parse_signal_estimation_rules(attribute.first);
+    if (!color_mapping) {
+      continue;
+    }
+    const auto & [from_color, to_color] = *color_mapping;
+    if (from_color != current_vehicle_traffic_light_color) {
+      continue;
+    }
+    for (const auto id : parse_ids(attribute.second.value())) {
+      crosswalk_traffic_signal_overrides[id] = to_color;
+    }
+  }
+}
+
+TrafficSignalArray CrosswalkTrafficLightEstimator::estimate(
+  const TrafficSignalArray & msg, const rclcpp::Time & current_time)
+{
+  TrafficSignalArray output = msg;
+
+  TrafficLightIdMap traffic_light_id_map;
+
+  std::unordered_map<lanelet::Id, uint8_t> crosswalk_traffic_signal_overrides;
+  for (const auto & traffic_signal : msg.traffic_light_groups) {
+    traffic_light_id_map[traffic_signal.traffic_light_group_id] =
+      std::pair<TrafficSignal, rclcpp::Time>(traffic_signal, current_time);
+  }
+  // we need the full traffic_light_id_map before calculating overrides from map
+  for (const auto & traffic_signal : msg.traffic_light_groups) {
+    update_crosswalk_overrides_from_map(
+      crosswalk_traffic_signal_overrides, traffic_signal.traffic_light_group_id,
+      traffic_light_id_map);
+  }
+
+  // Collect vehicle traffic light IDs with known colors (from received and last detected signals)
+  std::unordered_set<lanelet::Id> known_color_vehicle_traffic_light_ids;
+  for (const auto & traffic_signal : msg.traffic_light_groups) {
+    known_color_vehicle_traffic_light_ids.insert(traffic_signal.traffic_light_group_id);
+  }
+  if (config_.use_last_detect_color) {
+    for (const auto & [traffic_light_id, _] : last_detect_color_) {
+      known_color_vehicle_traffic_light_ids.insert(traffic_light_id);
+    }
+  }
+
+  // Collect crosswalks related to the vehicle traffic lights with known colors
+  std::unordered_set<lanelet::Id> crosswalk_ids_to_process;
+  for (const auto & traffic_light_id : known_color_vehicle_traffic_light_ids) {
+    const auto crosswalks_iter = traffic_light_id_to_crosswalks_.find(traffic_light_id);
+    if (crosswalks_iter == traffic_light_id_to_crosswalks_.end()) {
+      continue;
+    }
+    for (const auto & crosswalk : crosswalks_iter->second) {
+      crosswalk_ids_to_process.insert(crosswalk.id());
+    }
+  }
+
+  for (const auto & crosswalk_id : crosswalk_ids_to_process) {
+    const auto & crosswalk = lanelet_map_ptr_->laneletLayer.get(crosswalk_id);
+    const auto & conflict_lls = crosswalk_to_vehicle_lanelets_.at(crosswalk_id);
+    const auto non_red_lanelets = get_non_red_lanelets(conflict_lls, traffic_light_id_map);
+
+    const auto crosswalk_tl_color = estimate_crosswalk_traffic_signal(crosswalk, non_red_lanelets);
+    set_crosswalk_traffic_signal(
+      crosswalk, crosswalk_tl_color, msg, output, crosswalk_traffic_signal_overrides, current_time);
+  }
+
+  remove_duplicate_ids(output);
+
+  update_last_detected_signal(traffic_light_id_map, current_time);
+
+  return output;
+}
+
+void CrosswalkTrafficLightEstimator::update_last_detected_signal(
+  const TrafficLightIdMap & traffic_light_id_map, const rclcpp::Time & current_time)
+{
+  for (const auto & input_traffic_signal : traffic_light_id_map) {
+    const auto & elements = input_traffic_signal.second.first.elements;
+
+    if (elements.empty()) {
+      continue;
+    }
+
+    if (elements.front().color == TrafficSignalElement::UNKNOWN) {
+      continue;
+    }
+
+    const auto & id = input_traffic_signal.second.first.traffic_light_group_id;
+
+    last_detect_color_.insert_or_assign(id, input_traffic_signal.second);
+  }
+
+  std::vector<int32_t> erase_id_list;
+  for (const auto & last_traffic_signal : last_detect_color_) {
+    const auto & id = last_traffic_signal.second.first.traffic_light_group_id;
+
+    if (traffic_light_id_map.count(id) == 0) {
+      // hold signal recognition results for [last_detect_color_hold_time] seconds.
+      const auto time_from_last_detected =
+        (current_time - last_traffic_signal.second.second).seconds();
+      if (time_from_last_detected > config_.last_detect_color_hold_time) {
+        erase_id_list.emplace_back(id);
+      }
+    }
+  }
+  for (const auto id : erase_id_list) {
+    last_detect_color_.erase(id);
+    flashing_detector_.clear_state(id);
+  }
+}
+
+void CrosswalkTrafficLightEstimator::set_crosswalk_traffic_signal(
+  const lanelet::ConstLanelet & crosswalk, const uint8_t color, const TrafficSignalArray & msg,
+  TrafficSignalArray & output,
+  const std::unordered_map<lanelet::Id, uint8_t> & crosswalk_traffic_signal_overrides,
+  const rclcpp::Time & current_time)
+{
+  const auto tl_reg_elems = crosswalk.regulatoryElementsAs<const lanelet::TrafficLight>();
+
+  std::unordered_map<lanelet::Id, size_t> valid_id2idx_map;  // detected traffic light
+  for (size_t i = 0; i < msg.traffic_light_groups.size(); ++i) {
+    const auto & signal = msg.traffic_light_groups[i];
+    valid_id2idx_map[signal.traffic_light_group_id] = i;
+  }
+
+  std::unordered_map<lanelet::Id, size_t> output_id2idx_map;  // to check duplicate
+  for (size_t i = 0; i < output.traffic_light_groups.size(); ++i) {
+    const auto & signal = output.traffic_light_groups[i];
+    output_id2idx_map[signal.traffic_light_group_id] = i;
+  }
+
+  TrafficSignalElement base_traffic_signal_element;
+  base_traffic_signal_element.color = color;
+  base_traffic_signal_element.shape = TrafficSignalElement::CIRCLE;
+  base_traffic_signal_element.confidence = 1.0;
+
+  for (const auto & tl_reg_elem : tl_reg_elems) {
+    const lanelet::Id id = tl_reg_elem->id();
+
+    // helper lambda to get or create output signal
+    auto get_or_create_output_signal = [&](lanelet::Id id) -> TrafficSignal & {
+      if (output_id2idx_map.count(id)) {
+        return output.traffic_light_groups[output_id2idx_map[id]];
+      } else {
+        // element need to be added in later
+        TrafficSignal new_signal;
+        new_signal.traffic_light_group_id = id;
+        output.traffic_light_groups.push_back(new_signal);
+        output_id2idx_map[id] = output.traffic_light_groups.size() - 1;
+        return output.traffic_light_groups.back();
+      }
+    };
+
+    TrafficSignal & out_signal = get_or_create_output_signal(id);
+
+    auto replace_out_signal_elements = [&](const TrafficSignalElement & element) {
+      out_signal.elements.clear();
+      out_signal.elements.push_back(element);
+    };
+
+    // 1. Map-based override (highest priority)
+    if (auto it = crosswalk_traffic_signal_overrides.find(id);
+        it != crosswalk_traffic_signal_overrides.end()) {
+      replace_out_signal_elements(base_traffic_signal_element);
+      out_signal.elements[0].color = it->second;  // override color
+      continue;
+    }
+    // 2. Use detected pedestrian signal if valid
+    if (auto it = valid_id2idx_map.find(id); it != valid_id2idx_map.end()) {
+      const auto & detected = msg.traffic_light_groups[it->second];
+
+      if (!config_.use_pedestrian_signal_detect || is_invalid_detection_status(detected)) {
+        // Replace detection with estimated base color
+        replace_out_signal_elements(base_traffic_signal_element);
+        continue;
+      }
+
+      // Update flashing state and apply the most recent color
+      if (out_signal.elements
+            .empty()) {  // unnecessary check because msg has detection but for safety
+        out_signal.elements.push_back(base_traffic_signal_element);
+      }
+      out_signal.elements[0].color =
+        flashing_detector_.estimate_stable_color(detected, current_time);
+      continue;
+    }
+
+    // 3. No detection available → use estimated vehicle-based color
+    replace_out_signal_elements(base_traffic_signal_element);
+  }
+}
+
+lanelet::ConstLanelets CrosswalkTrafficLightEstimator::get_non_red_lanelets(
+  const lanelet::ConstLanelets & lanelets, const TrafficLightIdMap & traffic_light_id_map) const
+{
+  lanelet::ConstLanelets non_red_lanelets{};
+
+  for (const auto & lanelet : lanelets) {
+    const auto tl_reg_elems = lanelet.regulatoryElementsAs<const lanelet::TrafficLight>();
+
+    if (tl_reg_elems.empty()) {
+      continue;
+    }
+
+    const auto tl_reg_elem = tl_reg_elems.front();
+    const auto current_detected_signal =
+      get_highest_confidence_traffic_signal(tl_reg_elem->id(), traffic_light_id_map);
+
+    if (!current_detected_signal && !config_.use_last_detect_color) {
+      continue;
+    }
+
+    const auto current_is_not_red =
+      current_detected_signal ? current_detected_signal.get() == TrafficSignalElement::GREEN ||
+                                  current_detected_signal.get() == TrafficSignalElement::AMBER
+                              : true;
+
+    const auto current_is_unknown_or_none =
+      current_detected_signal ? current_detected_signal.get() == TrafficSignalElement::UNKNOWN
+                              : true;
+
+    const auto last_detected_signal =
+      get_highest_confidence_traffic_signal(tl_reg_elem->id(), last_detect_color_);
+
+    if (!last_detected_signal) {
+      continue;
+    }
+
+    const auto was_not_red = current_is_unknown_or_none &&
+                             (last_detected_signal.get() == TrafficSignalElement::GREEN ||
+                              last_detected_signal.get() == TrafficSignalElement::AMBER) &&
+                             config_.use_last_detect_color;
+
+    if (!current_is_not_red && !was_not_red) {
+      continue;
+    }
+
+    non_red_lanelets.push_back(lanelet);
+  }
+
+  return non_red_lanelets;
+}
+
+uint8_t CrosswalkTrafficLightEstimator::estimate_crosswalk_traffic_signal(
+  const lanelet::ConstLanelet & crosswalk, const lanelet::ConstLanelets & non_red_lanelets) const
+{
+  bool has_left_non_red_lane = false;
+  bool has_right_non_red_lane = false;
+  bool has_straight_non_red_lane = false;
+  bool has_related_non_red_tl = false;
+
+  const std::string related_tl_id = crosswalk.attributeOr("related_traffic_light", "none");
+
+  for (const auto & lanelet : non_red_lanelets) {
+    const std::string turn_direction = lanelet.attributeOr("turn_direction", "none");
+
+    if (turn_direction == "left") {
+      has_left_non_red_lane = true;
+    } else if (turn_direction == "right") {
+      has_right_non_red_lane = true;
+    } else {
+      has_straight_non_red_lane = true;
+    }
+
+    const auto tl_reg_elems = lanelet.regulatoryElementsAs<const lanelet::TrafficLight>();
+    if (tl_reg_elems.front()->id() == std::atoi(related_tl_id.c_str())) {
+      has_related_non_red_tl = true;
+    }
+  }
+
+  if (has_straight_non_red_lane || has_related_non_red_tl) {
+    return TrafficSignalElement::RED;
+  }
+
+  const auto merge_lane_exists = has_merge_lane(non_red_lanelets, routing_graph_ptr_);
+  return !merge_lane_exists && has_left_non_red_lane && has_right_non_red_lane
+           ? TrafficSignalElement::RED
+           : TrafficSignalElement::UNKNOWN;
+}
+
+}  // namespace autoware::crosswalk_traffic_light_estimator

--- a/perception/autoware_crosswalk_traffic_light_estimator/src/crosswalk_traffic_light_estimator.cpp
+++ b/perception/autoware_crosswalk_traffic_light_estimator/src/crosswalk_traffic_light_estimator.cpp
@@ -17,8 +17,6 @@
 #include <autoware_lanelet2_extension/regulatory_elements/Forward.hpp>
 #include <autoware_lanelet2_extension/utility/query.hpp>
 
-#include <boost/optional.hpp>
-
 #include <lanelet2_routing/RoutingGraphContainer.h>
 #include <lanelet2_traffic_rules/TrafficRulesFactory.h>
 
@@ -157,6 +155,7 @@ lanelet::Ids parse_ids(std::string_view input)
   }
   return ids;
 }
+
 bool is_invalid_detection_status(const TrafficSignal & signal)
 {
   if (signal.elements.empty()) {
@@ -170,10 +169,10 @@ bool is_invalid_detection_status(const TrafficSignal & signal)
   return false;
 }
 
-boost::optional<uint8_t> get_highest_confidence_traffic_signal(
+std::optional<uint8_t> get_highest_confidence_traffic_signal(
   const lanelet::Id & id, const TrafficLightIdMap & traffic_light_id_map)
 {
-  boost::optional<uint8_t> ret{boost::none};
+  std::optional<uint8_t> ret{std::nullopt};
 
   double highest_confidence = 0.0;
   if (traffic_light_id_map.count(id) == 0) {
@@ -494,53 +493,70 @@ void CrosswalkTrafficLightEstimator::set_crosswalk_traffic_signal(
   }
 }
 
+bool is_green_or_amber(const std::optional<uint8_t> & color)
+{
+  if (!color) {
+    return false;
+  }
+  return *color == TrafficSignalElement::GREEN || *color == TrafficSignalElement::AMBER;
+}
+
+bool is_unknown_or_absent(const std::optional<uint8_t> & color)
+{
+  if (!color) {
+    return true;
+  }
+  return *color == TrafficSignalElement::UNKNOWN;
+}
+
+// Determine whether a lanelet's traffic light is in a non-red state.
+// Falls back to the last detected color when the current color is unavailable.
+//
+// | current_color | last_color     | result |
+// |---------------|----------------|--------|
+// | GREEN/AMBER   | (any)          | true   |
+// | RED           | (any)          | false  |
+// | UNKNOWN/NA    | GREEN/AMBER    | true   |
+// | UNKNOWN/NA    | RED/UNKNOWN/NA | false  |
+bool is_lanelet_non_red(
+  const lanelet::ConstLanelet & lanelet, const TrafficLightIdMap & traffic_light_id_map,
+  const TrafficLightIdMap & last_detect_color, bool use_last_detect_color)
+{
+  const auto traffic_light_reg_elems = lanelet.regulatoryElementsAs<const lanelet::TrafficLight>();
+  if (traffic_light_reg_elems.empty()) {
+    return false;
+  }
+  const auto traffic_light_id = traffic_light_reg_elems.front()->id();
+
+  // detection with current color
+  const auto current_color =
+    get_highest_confidence_traffic_signal(traffic_light_id, traffic_light_id_map);
+  const auto current_color_is_not_red = is_green_or_amber(current_color);
+  if (current_color_is_not_red) {
+    return true;
+  }
+
+  // detection with last detected color
+  if (!use_last_detect_color) {
+    return false;
+  }
+  const auto last_color =
+    get_highest_confidence_traffic_signal(traffic_light_id, last_detect_color);
+  const auto current_color_is_not_available = is_unknown_or_absent(current_color);
+  const auto last_color_is_not_red = is_green_or_amber(last_color);
+  return current_color_is_not_available && last_color_is_not_red;
+}
+
 lanelet::ConstLanelets CrosswalkTrafficLightEstimator::get_non_red_lanelets(
   const lanelet::ConstLanelets & lanelets, const TrafficLightIdMap & traffic_light_id_map) const
 {
   lanelet::ConstLanelets non_red_lanelets{};
 
   for (const auto & lanelet : lanelets) {
-    const auto tl_reg_elems = lanelet.regulatoryElementsAs<const lanelet::TrafficLight>();
-
-    if (tl_reg_elems.empty()) {
-      continue;
+    if (is_lanelet_non_red(
+          lanelet, traffic_light_id_map, last_detect_color_, config_.use_last_detect_color)) {
+      non_red_lanelets.push_back(lanelet);
     }
-
-    const auto tl_reg_elem = tl_reg_elems.front();
-    const auto current_detected_signal =
-      get_highest_confidence_traffic_signal(tl_reg_elem->id(), traffic_light_id_map);
-
-    if (!current_detected_signal && !config_.use_last_detect_color) {
-      continue;
-    }
-
-    const auto current_is_not_red =
-      current_detected_signal ? current_detected_signal.get() == TrafficSignalElement::GREEN ||
-                                  current_detected_signal.get() == TrafficSignalElement::AMBER
-                              : true;
-
-    const auto current_is_unknown_or_none =
-      current_detected_signal ? current_detected_signal.get() == TrafficSignalElement::UNKNOWN
-                              : true;
-
-    const auto last_detected_signal =
-      get_highest_confidence_traffic_signal(tl_reg_elem->id(), last_detect_color_);
-
-    const auto has_no_signal_info = !current_detected_signal && !last_detected_signal;
-    if (has_no_signal_info) {
-      continue;
-    }
-
-    const auto was_not_red = current_is_unknown_or_none && last_detected_signal &&
-                             (last_detected_signal.get() == TrafficSignalElement::GREEN ||
-                              last_detected_signal.get() == TrafficSignalElement::AMBER) &&
-                             config_.use_last_detect_color;
-
-    if (!current_is_not_red && !was_not_red) {
-      continue;
-    }
-
-    non_red_lanelets.push_back(lanelet);
   }
 
   return non_red_lanelets;

--- a/perception/autoware_crosswalk_traffic_light_estimator/src/crosswalk_traffic_light_estimator.cpp
+++ b/perception/autoware_crosswalk_traffic_light_estimator/src/crosswalk_traffic_light_estimator.cpp
@@ -13,6 +13,7 @@
 // limitations under the License.
 #include "crosswalk_traffic_light_estimator.hpp"
 
+#include <autoware/lanelet2_utils/conversion.hpp>
 #include <autoware_lanelet2_extension/regulatory_elements/Forward.hpp>
 #include <autoware_lanelet2_extension/utility/query.hpp>
 
@@ -215,9 +216,14 @@ CrosswalkTrafficLightEstimator::CrosswalkTrafficLightEstimator(
 {
 }
 
-void CrosswalkTrafficLightEstimator::update_map(
-  lanelet::LaneletMapPtr lanelet_map_ptr, lanelet::routing::RoutingGraphPtr routing_graph_ptr)
+void CrosswalkTrafficLightEstimator::update_map(lanelet::LaneletMapPtr lanelet_map_ptr)
 {
+  auto routing_graph_and_traffic_rules =
+    autoware::experimental::lanelet2_utils::instantiate_routing_graph_and_traffic_rules(
+      lanelet_map_ptr);
+  auto routing_graph_ptr =
+    autoware::experimental::lanelet2_utils::remove_const(routing_graph_and_traffic_rules.first);
+
   lanelet_map_ptr_ = lanelet_map_ptr;
   routing_graph_ptr_ = routing_graph_ptr;
 
@@ -520,11 +526,7 @@ lanelet::ConstLanelets CrosswalkTrafficLightEstimator::get_non_red_lanelets(
     const auto last_detected_signal =
       get_highest_confidence_traffic_signal(tl_reg_elem->id(), last_detect_color_);
 
-    if (!last_detected_signal) {
-      continue;
-    }
-
-    const auto was_not_red = current_is_unknown_or_none &&
+    const auto was_not_red = current_is_unknown_or_none && last_detected_signal &&
                              (last_detected_signal.get() == TrafficSignalElement::GREEN ||
                               last_detected_signal.get() == TrafficSignalElement::AMBER) &&
                              config_.use_last_detect_color;

--- a/perception/autoware_crosswalk_traffic_light_estimator/src/crosswalk_traffic_light_estimator.hpp
+++ b/perception/autoware_crosswalk_traffic_light_estimator/src/crosswalk_traffic_light_estimator.hpp
@@ -42,8 +42,7 @@ public:
   explicit CrosswalkTrafficLightEstimator(const CrosswalkTrafficLightEstimatorConfig & config);
   CrosswalkTrafficLightEstimator() = default;
 
-  void update_map(
-    lanelet::LaneletMapPtr lanelet_map_ptr, lanelet::routing::RoutingGraphPtr routing_graph_ptr);
+  void update_map(lanelet::LaneletMapPtr lanelet_map_ptr);
 
   bool is_map_loaded() const;
 

--- a/perception/autoware_crosswalk_traffic_light_estimator/src/crosswalk_traffic_light_estimator.hpp
+++ b/perception/autoware_crosswalk_traffic_light_estimator/src/crosswalk_traffic_light_estimator.hpp
@@ -1,0 +1,91 @@
+// Copyright 2022-2025 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef CROSSWALK_TRAFFIC_LIGHT_ESTIMATOR_HPP_
+#define CROSSWALK_TRAFFIC_LIGHT_ESTIMATOR_HPP_
+
+#include "flashing_detection.hpp"
+
+#include <lanelet2_core/LaneletMap.h>
+#include <lanelet2_routing/RoutingGraph.h>
+
+#include <cstdint>
+#include <string>
+#include <unordered_map>
+#include <vector>
+
+namespace autoware::crosswalk_traffic_light_estimator
+{
+
+struct CrosswalkTrafficLightEstimatorConfig
+{
+  bool use_last_detect_color;
+  bool use_pedestrian_signal_detect;
+  double last_detect_color_hold_time;
+  FlashingDetectionConfig flashing_detection;
+};
+
+class CrosswalkTrafficLightEstimator
+{
+public:
+  explicit CrosswalkTrafficLightEstimator(const CrosswalkTrafficLightEstimatorConfig & config);
+  CrosswalkTrafficLightEstimator() = default;
+
+  void update_map(
+    lanelet::LaneletMapPtr lanelet_map_ptr, lanelet::routing::RoutingGraphPtr routing_graph_ptr);
+
+  bool is_map_loaded() const;
+
+  TrafficSignalArray estimate(const TrafficSignalArray & msg, const rclcpp::Time & current_time);
+
+  std::vector<lanelet::Id> find_unregistered_traffic_light_group_ids(
+    const TrafficSignalArray & msg) const;
+
+private:
+  void update_last_detected_signal(
+    const TrafficLightIdMap & traffic_light_id_map, const rclcpp::Time & current_time);
+  /// @brief update the overrides of crosswalk signals from the lanelet map for the given traffic
+  /// light id
+  void update_crosswalk_overrides_from_map(
+    std::unordered_map<lanelet::Id, uint8_t> & crosswalk_traffic_signal_overrides,
+    lanelet::Id traffic_light_group_id, const TrafficLightIdMap & traffic_light_id_map);
+
+  void set_crosswalk_traffic_signal(
+    const lanelet::ConstLanelet & crosswalk, const uint8_t color, const TrafficSignalArray & msg,
+    TrafficSignalArray & output,
+    const std::unordered_map<lanelet::Id, uint8_t> & crosswalk_traffic_signal_overrides,
+    const rclcpp::Time & current_time);
+
+  lanelet::ConstLanelets get_non_red_lanelets(
+    const lanelet::ConstLanelets & lanelets, const TrafficLightIdMap & traffic_light_id_map) const;
+
+  uint8_t estimate_crosswalk_traffic_signal(
+    const lanelet::ConstLanelet & crosswalk, const lanelet::ConstLanelets & non_red_lanelets) const;
+
+  CrosswalkTrafficLightEstimatorConfig config_{};
+
+  // Map data
+  lanelet::LaneletMapPtr lanelet_map_ptr_;
+  lanelet::routing::RoutingGraphPtr routing_graph_ptr_;
+  std::unordered_map<lanelet::Id, lanelet::ConstLanelets> traffic_light_id_to_crosswalks_;
+  std::unordered_map<lanelet::Id, lanelet::ConstLanelets> crosswalk_to_vehicle_lanelets_;
+
+  // Signal state
+  TrafficLightIdMap last_detect_color_;
+  FlashingDetector flashing_detector_;
+};
+
+}  // namespace autoware::crosswalk_traffic_light_estimator
+
+#endif  // CROSSWALK_TRAFFIC_LIGHT_ESTIMATOR_HPP_

--- a/perception/autoware_crosswalk_traffic_light_estimator/src/flashing_detection.cpp
+++ b/perception/autoware_crosswalk_traffic_light_estimator/src/flashing_detection.cpp
@@ -1,0 +1,162 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware_crosswalk_traffic_light_estimator/flashing_detection.hpp"
+
+#include <algorithm>
+#include <vector>
+
+namespace autoware::crosswalk_traffic_light_estimator
+{
+
+FlashingDetector::FlashingDetector(const FlashingDetectionConfig & config) : config_(config)
+{
+}
+
+uint8_t FlashingDetector::estimate_stable_color(
+  const TrafficSignal & signal, const rclcpp::Time & current_time)
+{
+  update_signal_history(signal, current_time);
+  update_flashing_state(signal);
+  return update_and_get_color_state(signal);
+}
+
+bool is_skippable_signal(const TrafficSignal & signal)
+{
+  const auto & elements = signal.elements;
+  if (elements.empty()) return true;
+  // Occluded signal: UNKNOWN with confidence=0
+  return elements.front().color == TrafficSignalElement::UNKNOWN &&
+         elements.front().confidence == 0;
+}
+
+void FlashingDetector::update_signal_history(
+  const TrafficSignal & signal, const rclcpp::Time & current_time)
+{
+  const auto id = signal.traffic_light_group_id;
+
+  if (!is_skippable_signal(signal)) {
+    signal_history_[id].push_back({signal, current_time});
+  }
+
+  remove_expired_entries(id, current_time);
+}
+
+void FlashingDetector::remove_expired_entries(lanelet::Id id, const rclcpp::Time & current_time)
+{
+  if (signal_history_.count(id) == 0) return;
+
+  auto & history = signal_history_.at(id);
+  const auto is_expired = [&](const TrafficSignalAndTime & entry) {
+    return (current_time - entry.second).seconds() > config_.last_colors_hold_time;
+  };
+  history.erase(std::remove_if(history.begin(), history.end(), is_expired), history.end());
+
+  if (history.empty()) {
+    signal_history_.erase(id);
+  }
+}
+
+void FlashingDetector::clear_state(lanelet::Id id)
+{
+  is_flashing_.erase(id);
+  current_color_state_.erase(id);
+  signal_history_.erase(id);
+}
+
+bool all_history_matches_color(
+  const TrafficLightIdArray & signal_history, lanelet::Id id, uint8_t color)
+{
+  const auto history_iter = signal_history.find(id);
+  if (history_iter == signal_history.end()) return false;
+  const auto & history = history_iter->second;
+  return std::all_of(history.begin(), history.end(), [color](const auto & entry) {
+    return entry.first.elements.front().color == color;
+  });
+}
+
+bool is_flashing_green_signal(const TrafficSignal & signal)
+{
+  return !signal.elements.empty() &&
+         signal.elements.front().color == TrafficSignalElement::UNKNOWN &&
+         signal.elements.front().confidence != 0;
+}
+
+void FlashingDetector::update_flashing_state(const TrafficSignal & signal)
+{
+  const auto id = signal.traffic_light_group_id;
+
+  // no record of detected color in history
+  if (is_flashing_.count(id) == 0) {
+    is_flashing_.emplace(id, false);
+    return;
+  }
+
+  // reset flashing if history contains only UNKNOWN entries (no evidence of prior color)
+  if (all_history_matches_color(signal_history_, id, TrafficSignalElement::UNKNOWN)) {
+    is_flashing_.at(id) = false;
+    return;
+  }
+
+  // flashing green: UNKNOWN color with non-zero confidence (not occlusion)
+  if (
+    is_flashing_green_signal(signal) &&
+    current_color_state_.at(id) != TrafficSignalElement::UNKNOWN) {
+    is_flashing_.at(id) = true;
+    return;
+  }
+
+  // check history: if all entries match current signal color, flashing has stopped
+  if (all_history_matches_color(signal_history_, id, signal.elements.front().color)) {
+    is_flashing_.at(id) = false;
+  }
+}
+
+uint8_t resolve_flashing_color_transition(uint8_t current_state, uint8_t detected_color)
+{
+  if (current_state == TrafficSignalElement::GREEN && detected_color == TrafficSignalElement::RED) {
+    return TrafficSignalElement::RED;
+  }
+  if (current_state == TrafficSignalElement::RED && detected_color == TrafficSignalElement::GREEN) {
+    return TrafficSignalElement::GREEN;
+  }
+  if (current_state == TrafficSignalElement::UNKNOWN) {
+    if (detected_color == TrafficSignalElement::RED) {
+      return TrafficSignalElement::RED;
+    }
+    return TrafficSignalElement::GREEN;
+  }
+  return current_state;
+}
+
+uint8_t FlashingDetector::update_and_get_color_state(const TrafficSignal & signal)
+{
+  const auto id = signal.traffic_light_group_id;
+  const auto color = signal.elements[0].color;
+
+  // First observation: initialize with the detected color
+  if (current_color_state_.count(id) == 0) {
+    current_color_state_.emplace(id, color);
+  } else if (!is_flashing_.at(id)) {
+    // Not flashing: simply follow the detected color
+    current_color_state_.at(id) = color;
+  } else {
+    current_color_state_.at(id) =
+      resolve_flashing_color_transition(current_color_state_.at(id), color);
+  }
+
+  return current_color_state_.at(id);
+}
+
+}  // namespace autoware::crosswalk_traffic_light_estimator

--- a/perception/autoware_crosswalk_traffic_light_estimator/src/flashing_detection.cpp
+++ b/perception/autoware_crosswalk_traffic_light_estimator/src/flashing_detection.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "autoware_crosswalk_traffic_light_estimator/flashing_detection.hpp"
+#include "flashing_detection.hpp"
 
 #include <algorithm>
 #include <vector>
@@ -98,8 +98,8 @@ void FlashingDetector::update_flashing_state(const TrafficSignal & signal)
   const auto id = signal.traffic_light_group_id;
 
   // no record of detected color in history
-  if (is_flashing_.count(id) == 0) {
-    is_flashing_.emplace(id, false);
+  const auto [_, inserted] = is_flashing_.try_emplace(id, false);
+  if (inserted) {
     return;
   }
 

--- a/perception/autoware_crosswalk_traffic_light_estimator/src/flashing_detection.hpp
+++ b/perception/autoware_crosswalk_traffic_light_estimator/src/flashing_detection.hpp
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef AUTOWARE_CROSSWALK_TRAFFIC_LIGHT_ESTIMATOR__FLASHING_DETECTION_HPP_
-#define AUTOWARE_CROSSWALK_TRAFFIC_LIGHT_ESTIMATOR__FLASHING_DETECTION_HPP_
+#ifndef FLASHING_DETECTION_HPP_
+#define FLASHING_DETECTION_HPP_
 
 #include <rclcpp/time.hpp>
 
@@ -67,4 +67,4 @@ private:
 
 }  // namespace autoware::crosswalk_traffic_light_estimator
 
-#endif  // AUTOWARE_CROSSWALK_TRAFFIC_LIGHT_ESTIMATOR__FLASHING_DETECTION_HPP_
+#endif  // FLASHING_DETECTION_HPP_

--- a/perception/autoware_crosswalk_traffic_light_estimator/src/node.cpp
+++ b/perception/autoware_crosswalk_traffic_light_estimator/src/node.cpp
@@ -54,14 +54,7 @@ void CrosswalkTrafficLightEstimatorNode::on_map(const LaneletMapBin::ConstShared
   auto lanelet_map_ptr = autoware::experimental::lanelet2_utils::remove_const(
     autoware::experimental::lanelet2_utils::from_autoware_map_msgs(*msg));
 
-  auto routing_graph_and_traffic_rules =
-    autoware::experimental::lanelet2_utils::instantiate_routing_graph_and_traffic_rules(
-      lanelet_map_ptr);
-
-  auto routing_graph_ptr =
-    autoware::experimental::lanelet2_utils::remove_const(routing_graph_and_traffic_rules.first);
-
-  estimator_.update_map(lanelet_map_ptr, routing_graph_ptr);
+  estimator_.update_map(lanelet_map_ptr);
 
   RCLCPP_DEBUG(get_logger(), "[CrosswalkTrafficLightEstimatorNode]: Map is loaded");
 }

--- a/perception/autoware_crosswalk_traffic_light_estimator/src/node.cpp
+++ b/perception/autoware_crosswalk_traffic_light_estimator/src/node.cpp
@@ -1,4 +1,4 @@
-// Copyright 2022-2025 UCI SORA Lab, TIER IV, Inc.
+// Copyright 2022-2025 TIER IV, Inc.
 //
 // Licensed under the Apache License, Version 2.0 (the "License");
 // you may not use this file except in compliance with the License.
@@ -11,150 +11,15 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
+
 #include "node.hpp"
 
 #include <autoware/lanelet2_utils/conversion.hpp>
-#include <autoware_lanelet2_extension/regulatory_elements/Forward.hpp>
-#include <autoware_lanelet2_extension/utility/query.hpp>
 
-#include <lanelet2_core/Exceptions.h>
-
-#include <algorithm>
-#include <charconv>
-#include <cstdint>
 #include <memory>
-#include <string>
-#include <unordered_map>
-#include <unordered_set>
-#include <utility>
-#include <vector>
 
 namespace autoware::crosswalk_traffic_light_estimator
 {
-namespace
-{
-
-bool has_merge_lane(
-  const lanelet::ConstLanelet & lanelet_1, const lanelet::ConstLanelet & lanelet_2,
-  const lanelet::routing::RoutingGraphPtr & routing_graph_ptr)
-{
-  const auto next_lanelets_1 = routing_graph_ptr->following(lanelet_1);
-  const auto next_lanelets_2 = routing_graph_ptr->following(lanelet_2);
-
-  for (const auto & next_lanelet_1 : next_lanelets_1) {
-    for (const auto & next_lanelet_2 : next_lanelets_2) {
-      if (next_lanelet_1.id() == next_lanelet_2.id()) {
-        return true;
-      }
-    }
-  }
-
-  return false;
-}
-
-bool has_merge_lane(
-  const lanelet::ConstLanelets & lanelets,
-  const lanelet::routing::RoutingGraphPtr & routing_graph_ptr)
-{
-  for (size_t i = 0; i < lanelets.size(); ++i) {
-    for (size_t j = i + 1; j < lanelets.size(); ++j) {
-      const auto lanelet_1 = lanelets.at(i);
-      const auto lanelet_2 = lanelets.at(j);
-
-      if (lanelet_1.id() == lanelet_2.id()) {
-        continue;
-      }
-
-      const std::string turn_direction_1 = lanelet_1.attributeOr("turn_direction", "none");
-      const std::string turn_direction_2 = lanelet_2.attributeOr("turn_direction", "none");
-      if (turn_direction_1 == turn_direction_2) {
-        continue;
-      }
-
-      if (!has_merge_lane(lanelet_1, lanelet_2, routing_graph_ptr)) {
-        continue;
-      }
-
-      return true;
-    }
-  }
-
-  return false;
-}
-
-/// @brief convert a string to the corresponding traffic signal color
-std::optional<uint8_t> str_to_color(std::string_view str)
-{
-  if (str == "red") {
-    return TrafficSignalElement::RED;
-  }
-  if (str == "green") {
-    return TrafficSignalElement::GREEN;
-  }
-  if (str == "amber") {
-    return TrafficSignalElement::AMBER;
-  }
-  if (str == "white") {
-    return TrafficSignalElement::WHITE;
-  }
-  return std::nullopt;
-}
-
-/// @brief parse the input string and extract a rule to estimate a traffic signal
-/// @details the string is expected to have format "signal_color_relation:color1:color2"
-std::optional<std::pair<uint8_t, uint8_t>> parse_signal_estimation_rules(std::string_view input)
-{
-  constexpr auto delimiter = ':';
-  constexpr std::string_view prefix = "signal_color_relation:";
-  if (input.size() < prefix.size() || input.substr(0, prefix.length()) != prefix) {
-    return std::nullopt;
-  }
-  input.remove_prefix(prefix.length());
-
-  // extract the color mapping
-  const auto delimiter_pos = input.find(delimiter);
-  if (delimiter_pos == std::string_view::npos) {
-    return std::nullopt;
-  }
-
-  std::string_view from_str = input.substr(0, delimiter_pos);
-  std::string_view to_str = input.substr(delimiter_pos + 1);
-
-  if (const auto from_color = str_to_color(from_str)) {
-    if (const auto to_color = str_to_color(to_str)) {
-      return std::make_pair(*from_color, *to_color);
-    }
-  }
-  return std::nullopt;
-}
-
-/// @brief extract ids from the input string
-/// @details the string is expected to have format "id1,id2,...", without any space
-lanelet::Ids parse_ids(std::string_view input)
-{
-  lanelet::Ids ids;
-  if (input.empty()) {
-    return ids;
-  }
-
-  constexpr auto delimiter = ',';
-  size_t start = 0;
-  size_t end = 0;
-  lanelet::Id id{};
-  while ((end = input.find(delimiter, start)) != std::string_view::npos) {
-    const auto [_, err] = std::from_chars(input.data() + start, input.data() + end, id);
-    if (err == std::errc()) {
-      ids.push_back(id);
-    }
-    start = end + 1;
-  }
-  const auto [_, err] = std::from_chars(input.data() + start, input.data() + input.size(), id);
-  if (err == std::errc()) {
-    ids.push_back(id);
-  }
-  return ids;
-}
-}  // namespace
 
 CrosswalkTrafficLightEstimatorNode::CrosswalkTrafficLightEstimatorNode(
   const rclcpp::NodeOptions & options)
@@ -162,13 +27,14 @@ CrosswalkTrafficLightEstimatorNode::CrosswalkTrafficLightEstimatorNode(
 {
   using std::placeholders::_1;
 
-  use_last_detect_color_ = declare_parameter<bool>("use_last_detect_color");
-  use_pedestrian_signal_detect_ = declare_parameter<bool>("use_pedestrian_signal_detect");
-  last_detect_color_hold_time_ = declare_parameter<double>("last_detect_color_hold_time");
+  CrosswalkTrafficLightEstimatorConfig config;
+  config.use_last_detect_color = declare_parameter<bool>("use_last_detect_color");
+  config.use_pedestrian_signal_detect = declare_parameter<bool>("use_pedestrian_signal_detect");
+  config.last_detect_color_hold_time = declare_parameter<double>("last_detect_color_hold_time");
+  config.flashing_detection.last_colors_hold_time =
+    declare_parameter<double>("last_colors_hold_time");
 
-  FlashingDetectionConfig flashing_config;
-  flashing_config.last_colors_hold_time = declare_parameter<double>("last_colors_hold_time");
-  flashing_detector_ = FlashingDetector(flashing_config);
+  estimator_ = CrosswalkTrafficLightEstimator(config);
 
   sub_map_ = create_subscription<LaneletMapBin>(
     "~/input/vector_map", rclcpp::QoS{1}.transient_local(),
@@ -185,94 +51,25 @@ CrosswalkTrafficLightEstimatorNode::CrosswalkTrafficLightEstimatorNode(
 void CrosswalkTrafficLightEstimatorNode::on_map(const LaneletMapBin::ConstSharedPtr msg)
 {
   RCLCPP_DEBUG(get_logger(), "[CrosswalkTrafficLightEstimatorNode]: Start loading lanelet");
-  lanelet_map_ptr_ = autoware::experimental::lanelet2_utils::remove_const(
+  auto lanelet_map_ptr = autoware::experimental::lanelet2_utils::remove_const(
     autoware::experimental::lanelet2_utils::from_autoware_map_msgs(*msg));
 
   auto routing_graph_and_traffic_rules =
     autoware::experimental::lanelet2_utils::instantiate_routing_graph_and_traffic_rules(
-      lanelet_map_ptr_);
+      lanelet_map_ptr);
 
-  routing_graph_ptr_ =
+  auto routing_graph_ptr =
     autoware::experimental::lanelet2_utils::remove_const(routing_graph_and_traffic_rules.first);
 
-  const auto traffic_rules = lanelet::traffic_rules::TrafficRulesFactory::create(
-    lanelet::Locations::Germany, lanelet::Participants::Vehicle);
-  const auto pedestrian_rules = lanelet::traffic_rules::TrafficRulesFactory::create(
-    lanelet::Locations::Germany, lanelet::Participants::Pedestrian);
-  lanelet::routing::RoutingGraphConstPtr vehicle_graph =
-    lanelet::routing::RoutingGraph::build(*lanelet_map_ptr_, *traffic_rules);
-  lanelet::routing::RoutingGraphConstPtr pedestrian_graph =
-    lanelet::routing::RoutingGraph::build(*lanelet_map_ptr_, *pedestrian_rules);
-  const lanelet::routing::RoutingGraphContainer overall_graphs({vehicle_graph, pedestrian_graph});
-  // Build precomputed mappings: traffic light ID -> crosswalks, crosswalk -> vehicle lanelets
-  traffic_light_id_to_crosswalks_.clear();
-  crosswalk_to_vehicle_lanelets_.clear();
-
-  const auto all_lanelets = lanelet::utils::query::laneletLayer(lanelet_map_ptr_);
-  const auto crosswalk_lanelets = lanelet::utils::query::crosswalkLanelets(all_lanelets);
-
-  const int VEHICLE_GRAPH_INDEX = 0;
-  for (const auto & crosswalk : crosswalk_lanelets) {
-    const auto traffic_light_reg_elems =
-      crosswalk.regulatoryElementsAs<const lanelet::TrafficLight>();
-    if (traffic_light_reg_elems.empty()) {
-      continue;
-    }
-    const auto vehicle_lanelets = overall_graphs.conflictingInGraph(crosswalk, VEHICLE_GRAPH_INDEX);
-    if (vehicle_lanelets.empty()) {
-      continue;
-    }
-
-    crosswalk_to_vehicle_lanelets_[crosswalk.id()] = vehicle_lanelets;
-
-    std::unordered_set<lanelet::Id> added_known_color_vehicle_traffic_light_ids;
-    for (const auto & vehicle_lanelet : vehicle_lanelets) {
-      for (const auto & traffic_light :
-           vehicle_lanelet.regulatoryElementsAs<const lanelet::TrafficLight>()) {
-        if (added_known_color_vehicle_traffic_light_ids.insert(traffic_light->id()).second) {
-          traffic_light_id_to_crosswalks_[traffic_light->id()].push_back(crosswalk);
-        }
-      }
-    }
-  }
+  estimator_.update_map(lanelet_map_ptr, routing_graph_ptr);
 
   RCLCPP_DEBUG(get_logger(), "[CrosswalkTrafficLightEstimatorNode]: Map is loaded");
-}
-
-void CrosswalkTrafficLightEstimatorNode::update_crosswalk_overrides_from_map(
-  std::unordered_map<lanelet::Id, uint8_t> & crosswalk_traffic_signal_overrides,
-  const lanelet::Id traffic_light_group_id, const TrafficLightIdMap & traffic_light_id_map)
-{
-  const auto traffic_light_it =
-    lanelet_map_ptr_->regulatoryElementLayer.find(traffic_light_group_id);
-  if (traffic_light_it == lanelet_map_ptr_->regulatoryElementLayer.end()) {
-    RCLCPP_WARN(
-      get_logger(), "Traffic light group ID %ld not found in regulatory element layer",
-      traffic_light_group_id);
-    return;
-  }
-  const auto & traffic_light = *traffic_light_it;
-  const auto current_vehicle_traffic_light_color =
-    get_highest_confidence_traffic_signal(traffic_light->id(), traffic_light_id_map);
-  for (const auto & attribute : traffic_light->attributes()) {
-    const auto & color_mapping = parse_signal_estimation_rules(attribute.first);
-    if (!color_mapping) {
-      continue;
-    }
-    const auto & [from_color, to_color] = *color_mapping;
-    if (from_color != current_vehicle_traffic_light_color) {
-      continue;
-    }
-    for (const auto id : parse_ids(attribute.second.value())) {
-      crosswalk_traffic_signal_overrides[id] = to_color;
-    }
-  }
 }
 
 void CrosswalkTrafficLightEstimatorNode::on_traffic_light_array(
   const TrafficSignalArray::ConstSharedPtr msg)
 {
-  if (lanelet_map_ptr_ == nullptr) {
+  if (!estimator_.is_map_loaded()) {
     RCLCPP_WARN(get_logger(), "cannot process traffic light array because the map is not received");
     return;
   }
@@ -280,357 +77,15 @@ void CrosswalkTrafficLightEstimatorNode::on_traffic_light_array(
   StopWatch<std::chrono::milliseconds> stop_watch;
   stop_watch.tic("Total");
 
-  TrafficSignalArray output = *msg;
-
-  TrafficLightIdMap traffic_light_id_map;
-
-  std::unordered_map<lanelet::Id, uint8_t> crosswalk_traffic_signal_overrides;
-  for (const auto & traffic_signal : msg->traffic_light_groups) {
-    traffic_light_id_map[traffic_signal.traffic_light_group_id] =
-      std::pair<TrafficSignal, rclcpp::Time>(traffic_signal, get_clock()->now());
-  }
-  // we need the full traffic_light_id_map before calculating overrides from map
-  for (const auto & traffic_signal : msg->traffic_light_groups) {
-    update_crosswalk_overrides_from_map(
-      crosswalk_traffic_signal_overrides, traffic_signal.traffic_light_group_id,
-      traffic_light_id_map);
+  const auto unregistered_ids = estimator_.find_unregistered_traffic_light_group_ids(*msg);
+  for (const auto & id : unregistered_ids) {
+    RCLCPP_WARN(get_logger(), "Traffic light group ID %ld is not registered in the map", id);
   }
 
-  // Collect vehicle traffic light IDs with known colors (from received and last detected signals)
-  std::unordered_set<lanelet::Id> known_color_vehicle_traffic_light_ids;
-  for (const auto & traffic_signal : msg->traffic_light_groups) {
-    known_color_vehicle_traffic_light_ids.insert(traffic_signal.traffic_light_group_id);
-  }
-  if (use_last_detect_color_) {
-    for (const auto & [traffic_light_id, _] : last_detect_color_) {
-      known_color_vehicle_traffic_light_ids.insert(traffic_light_id);
-    }
-  }
-
-  // Collect crosswalks related to the vehicle traffic lights with known colors
-  std::unordered_set<lanelet::Id> crosswalk_ids_to_process;
-  for (const auto & traffic_light_id : known_color_vehicle_traffic_light_ids) {
-    const auto crosswalks_iter = traffic_light_id_to_crosswalks_.find(traffic_light_id);
-    if (crosswalks_iter == traffic_light_id_to_crosswalks_.end()) {
-      continue;
-    }
-    for (const auto & crosswalk : crosswalks_iter->second) {
-      crosswalk_ids_to_process.insert(crosswalk.id());
-    }
-  }
-
-  for (const auto & crosswalk_id : crosswalk_ids_to_process) {
-    const auto & crosswalk = lanelet_map_ptr_->laneletLayer.get(crosswalk_id);
-    const auto & conflict_lls = crosswalk_to_vehicle_lanelets_.at(crosswalk_id);
-    const auto non_red_lanelets = get_non_red_lanelets(conflict_lls, traffic_light_id_map);
-
-    const auto crosswalk_tl_color = estimate_crosswalk_traffic_signal(crosswalk, non_red_lanelets);
-    set_crosswalk_traffic_signal(
-      crosswalk, crosswalk_tl_color, *msg, output, crosswalk_traffic_signal_overrides);
-  }
-
-  remove_duplicate_ids(output);
-
-  update_last_detected_signal(traffic_light_id_map);
+  const auto output = estimator_.estimate(*msg, get_clock()->now());
 
   pub_traffic_light_array_->publish(output);
   pub_processing_time_->publish<Float64Stamped>("processing_time_ms", stop_watch.toc("Total"));
-
-  return;
-}
-
-void CrosswalkTrafficLightEstimatorNode::update_last_detected_signal(
-  const TrafficLightIdMap & traffic_light_id_map)
-{
-  for (const auto & input_traffic_signal : traffic_light_id_map) {
-    const auto & elements = input_traffic_signal.second.first.elements;
-
-    if (elements.empty()) {
-      continue;
-    }
-
-    if (elements.front().color == TrafficSignalElement::UNKNOWN) {
-      continue;
-    }
-
-    const auto & id = input_traffic_signal.second.first.traffic_light_group_id;
-
-    last_detect_color_.insert_or_assign(id, input_traffic_signal.second);
-  }
-
-  std::vector<int32_t> erase_id_list;
-  for (const auto & last_traffic_signal : last_detect_color_) {
-    const auto & id = last_traffic_signal.second.first.traffic_light_group_id;
-
-    if (traffic_light_id_map.count(id) == 0) {
-      // hold signal recognition results for [last_detect_color_hold_time_] seconds.
-      const auto time_from_last_detected =
-        (get_clock()->now() - last_traffic_signal.second.second).seconds();
-      if (time_from_last_detected > last_detect_color_hold_time_) {
-        erase_id_list.emplace_back(id);
-      }
-    }
-  }
-  for (const auto id : erase_id_list) {
-    last_detect_color_.erase(id);
-    flashing_detector_.clear_state(id);
-  }
-}
-
-void CrosswalkTrafficLightEstimatorNode::set_crosswalk_traffic_signal(
-  const lanelet::ConstLanelet & crosswalk, const uint8_t color, const TrafficSignalArray & msg,
-  TrafficSignalArray & output,
-  const std::unordered_map<lanelet::Id, uint8_t> & crosswalk_traffic_signal_overrides)
-{
-  const auto tl_reg_elems = crosswalk.regulatoryElementsAs<const lanelet::TrafficLight>();
-
-  std::unordered_map<lanelet::Id, size_t> valid_id2idx_map;  // detected traffic light
-  for (size_t i = 0; i < msg.traffic_light_groups.size(); ++i) {
-    const auto & signal = msg.traffic_light_groups[i];
-    valid_id2idx_map[signal.traffic_light_group_id] = i;
-  }
-
-  std::unordered_map<lanelet::Id, size_t> output_id2idx_map;  // to check duplicate
-  for (size_t i = 0; i < output.traffic_light_groups.size(); ++i) {
-    const auto & signal = output.traffic_light_groups[i];
-    output_id2idx_map[signal.traffic_light_group_id] = i;
-  }
-
-  TrafficSignalElement base_traffic_signal_element;
-  base_traffic_signal_element.color = color;
-  base_traffic_signal_element.shape = TrafficSignalElement::CIRCLE;
-  base_traffic_signal_element.confidence = 1.0;
-
-  for (const auto & tl_reg_elem : tl_reg_elems) {
-    const lanelet::Id id = tl_reg_elem->id();
-
-    // helper lambda to get or create output signal
-    auto get_or_create_output_signal = [&](lanelet::Id id) -> TrafficSignal & {
-      if (output_id2idx_map.count(id)) {
-        return output.traffic_light_groups[output_id2idx_map[id]];
-      } else {
-        // element need to be added in later
-        TrafficSignal new_signal;
-        new_signal.traffic_light_group_id = id;
-        output.traffic_light_groups.push_back(new_signal);
-        output_id2idx_map[id] = output.traffic_light_groups.size() - 1;
-        return output.traffic_light_groups.back();
-      }
-    };
-
-    TrafficSignal & out_signal = get_or_create_output_signal(id);
-
-    auto replace_out_signal_elements = [&](const TrafficSignalElement & element) {
-      out_signal.elements.clear();
-      out_signal.elements.push_back(element);
-    };
-
-    // 1. Map-based override (highest priority)
-    if (auto it = crosswalk_traffic_signal_overrides.find(id);
-        it != crosswalk_traffic_signal_overrides.end()) {
-      replace_out_signal_elements(base_traffic_signal_element);
-      out_signal.elements[0].color = it->second;  // override color
-      continue;
-    }
-    // 2. Use detected pedestrian signal if valid
-    if (auto it = valid_id2idx_map.find(id); it != valid_id2idx_map.end()) {
-      const auto & detected = msg.traffic_light_groups[it->second];
-
-      if (!use_pedestrian_signal_detect_ || is_invalid_detection_status(detected)) {
-        // Replace detection with estimated base color
-        replace_out_signal_elements(base_traffic_signal_element);
-        continue;
-      }
-
-      // Update flashing state and apply the most recent color
-      if (out_signal.elements
-            .empty()) {  // unnecessary check because msg has detection but for safety
-        out_signal.elements.push_back(base_traffic_signal_element);
-      }
-      out_signal.elements[0].color =
-        flashing_detector_.estimate_stable_color(detected, get_clock()->now());
-      continue;
-    }
-
-    // 3. No detection available → use estimated vehicle-based color
-    replace_out_signal_elements(base_traffic_signal_element);
-  }
-}
-
-bool CrosswalkTrafficLightEstimatorNode::is_invalid_detection_status(
-  const TrafficSignal & signal) const
-{
-  if (signal.elements.empty()) {
-    return true;
-  }
-  if (
-    signal.elements.front().color == TrafficSignalElement::UNKNOWN &&
-    signal.elements.front().confidence == 0.0) {
-    return true;
-  }
-  return false;
-}
-
-lanelet::ConstLanelets CrosswalkTrafficLightEstimatorNode::get_non_red_lanelets(
-  const lanelet::ConstLanelets & lanelets, const TrafficLightIdMap & traffic_light_id_map) const
-{
-  lanelet::ConstLanelets non_red_lanelets{};
-
-  for (const auto & lanelet : lanelets) {
-    const auto tl_reg_elems = lanelet.regulatoryElementsAs<const lanelet::TrafficLight>();
-
-    if (tl_reg_elems.empty()) {
-      continue;
-    }
-
-    const auto tl_reg_elem = tl_reg_elems.front();
-    const auto current_detected_signal =
-      get_highest_confidence_traffic_signal(tl_reg_elem->id(), traffic_light_id_map);
-
-    if (!current_detected_signal && !use_last_detect_color_) {
-      continue;
-    }
-
-    const auto current_is_not_red =
-      current_detected_signal ? current_detected_signal.get() == TrafficSignalElement::GREEN ||
-                                  current_detected_signal.get() == TrafficSignalElement::AMBER
-                              : true;
-
-    const auto current_is_unknown_or_none =
-      current_detected_signal ? current_detected_signal.get() == TrafficSignalElement::UNKNOWN
-                              : true;
-
-    const auto last_detected_signal =
-      get_highest_confidence_traffic_signal(tl_reg_elem->id(), last_detect_color_);
-
-    if (!last_detected_signal) {
-      continue;
-    }
-
-    const auto was_not_red = current_is_unknown_or_none &&
-                             (last_detected_signal.get() == TrafficSignalElement::GREEN ||
-                              last_detected_signal.get() == TrafficSignalElement::AMBER) &&
-                             use_last_detect_color_;
-
-    if (!current_is_not_red && !was_not_red) {
-      continue;
-    }
-
-    non_red_lanelets.push_back(lanelet);
-  }
-
-  return non_red_lanelets;
-}
-
-uint8_t CrosswalkTrafficLightEstimatorNode::estimate_crosswalk_traffic_signal(
-  const lanelet::ConstLanelet & crosswalk, const lanelet::ConstLanelets & non_red_lanelets) const
-{
-  bool has_left_non_red_lane = false;
-  bool has_right_non_red_lane = false;
-  bool has_straight_non_red_lane = false;
-  bool has_related_non_red_tl = false;
-
-  const std::string related_tl_id = crosswalk.attributeOr("related_traffic_light", "none");
-
-  for (const auto & lanelet : non_red_lanelets) {
-    const std::string turn_direction = lanelet.attributeOr("turn_direction", "none");
-
-    if (turn_direction == "left") {
-      has_left_non_red_lane = true;
-    } else if (turn_direction == "right") {
-      has_right_non_red_lane = true;
-    } else {
-      has_straight_non_red_lane = true;
-    }
-
-    const auto tl_reg_elems = lanelet.regulatoryElementsAs<const lanelet::TrafficLight>();
-    if (tl_reg_elems.front()->id() == std::atoi(related_tl_id.c_str())) {
-      has_related_non_red_tl = true;
-    }
-  }
-
-  if (has_straight_non_red_lane || has_related_non_red_tl) {
-    return TrafficSignalElement::RED;
-  }
-
-  const auto merge_lane_exists = has_merge_lane(non_red_lanelets, routing_graph_ptr_);
-  return !merge_lane_exists && has_left_non_red_lane && has_right_non_red_lane
-           ? TrafficSignalElement::RED
-           : TrafficSignalElement::UNKNOWN;
-}
-
-boost::optional<uint8_t> CrosswalkTrafficLightEstimatorNode::get_highest_confidence_traffic_signal(
-  const lanelet::ConstLineStringsOrPolygons3d & traffic_lights,
-  const TrafficLightIdMap & traffic_light_id_map) const
-{
-  boost::optional<uint8_t> ret{boost::none};
-
-  double highest_confidence = 0.0;
-  for (const auto & traffic_light : traffic_lights) {
-    if (!traffic_light.isLineString()) {
-      continue;
-    }
-
-    const int id = static_cast<lanelet::ConstLineString3d>(traffic_light).id();
-    if (traffic_light_id_map.count(id) == 0) {
-      continue;
-    }
-
-    const auto & elements = traffic_light_id_map.at(id).first.elements;
-    if (elements.empty()) {
-      continue;
-    }
-
-    const auto & color = elements.front().color;
-    const auto & confidence = elements.front().confidence;
-    if (confidence < highest_confidence) {
-      continue;
-    }
-
-    highest_confidence = confidence;
-    ret = color;
-  }
-
-  return ret;
-}
-
-boost::optional<uint8_t> CrosswalkTrafficLightEstimatorNode::get_highest_confidence_traffic_signal(
-  const lanelet::Id & id, const TrafficLightIdMap & traffic_light_id_map) const
-{
-  boost::optional<uint8_t> ret{boost::none};
-
-  double highest_confidence = 0.0;
-  if (traffic_light_id_map.count(id) == 0) {
-    return ret;
-  }
-
-  for (const auto & element : traffic_light_id_map.at(id).first.elements) {
-    if (element.confidence < highest_confidence) {
-      continue;
-    }
-
-    highest_confidence = element.confidence;
-    ret = element.color;
-  }
-
-  return ret;
-}
-
-void CrosswalkTrafficLightEstimatorNode::remove_duplicate_ids(
-  TrafficSignalArray & signal_array) const
-{
-  auto & signals = signal_array.traffic_light_groups;
-  std::stable_sort(signals.begin(), signals.end(), [](const auto & s1, const auto & s2) {
-    return s1.traffic_light_group_id < s2.traffic_light_group_id;
-  });
-
-  signals.erase(
-    std::unique(
-      signals.begin(), signals.end(),
-      [](const auto & s1, const auto s2) {
-        return s1.traffic_light_group_id == s2.traffic_light_group_id;
-      }),
-    signals.end());
 }
 
 }  // namespace autoware::crosswalk_traffic_light_estimator

--- a/perception/autoware_crosswalk_traffic_light_estimator/src/node.cpp
+++ b/perception/autoware_crosswalk_traffic_light_estimator/src/node.cpp
@@ -11,7 +11,7 @@
 // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 // See the License for the specific language governing permissions and
 // limitations under the License.
-#include "autoware_crosswalk_traffic_light_estimator/node.hpp"
+#include "node.hpp"
 
 #include <autoware/lanelet2_utils/conversion.hpp>
 #include <autoware_lanelet2_extension/regulatory_elements/Forward.hpp>
@@ -34,7 +34,7 @@ namespace autoware::crosswalk_traffic_light_estimator
 namespace
 {
 
-bool hasMergeLane(
+bool has_merge_lane(
   const lanelet::ConstLanelet & lanelet_1, const lanelet::ConstLanelet & lanelet_2,
   const lanelet::routing::RoutingGraphPtr & routing_graph_ptr)
 {
@@ -52,7 +52,7 @@ bool hasMergeLane(
   return false;
 }
 
-bool hasMergeLane(
+bool has_merge_lane(
   const lanelet::ConstLanelets & lanelets,
   const lanelet::routing::RoutingGraphPtr & routing_graph_ptr)
 {
@@ -71,7 +71,7 @@ bool hasMergeLane(
         continue;
       }
 
-      if (!hasMergeLane(lanelet_1, lanelet_2, routing_graph_ptr)) {
+      if (!has_merge_lane(lanelet_1, lanelet_2, routing_graph_ptr)) {
         continue;
       }
 
@@ -172,17 +172,17 @@ CrosswalkTrafficLightEstimatorNode::CrosswalkTrafficLightEstimatorNode(
 
   sub_map_ = create_subscription<LaneletMapBin>(
     "~/input/vector_map", rclcpp::QoS{1}.transient_local(),
-    std::bind(&CrosswalkTrafficLightEstimatorNode::onMap, this, _1));
+    std::bind(&CrosswalkTrafficLightEstimatorNode::on_map, this, _1));
   sub_traffic_light_array_ = create_subscription<TrafficSignalArray>(
     "~/input/classified/traffic_signals", rclcpp::QoS{1},
-    std::bind(&CrosswalkTrafficLightEstimatorNode::onTrafficLightArray, this, _1));
+    std::bind(&CrosswalkTrafficLightEstimatorNode::on_traffic_light_array, this, _1));
 
   pub_traffic_light_array_ =
     this->create_publisher<TrafficSignalArray>("~/output/traffic_signals", rclcpp::QoS{1});
   pub_processing_time_ = std::make_shared<DebugPublisher>(this, "~/debug");
 }
 
-void CrosswalkTrafficLightEstimatorNode::onMap(const LaneletMapBin::ConstSharedPtr msg)
+void CrosswalkTrafficLightEstimatorNode::on_map(const LaneletMapBin::ConstSharedPtr msg)
 {
   RCLCPP_DEBUG(get_logger(), "[CrosswalkTrafficLightEstimatorNode]: Start loading lanelet");
   lanelet_map_ptr_ = autoware::experimental::lanelet2_utils::remove_const(
@@ -211,7 +211,7 @@ void CrosswalkTrafficLightEstimatorNode::onMap(const LaneletMapBin::ConstSharedP
   const auto all_lanelets = lanelet::utils::query::laneletLayer(lanelet_map_ptr_);
   const auto crosswalk_lanelets = lanelet::utils::query::crosswalkLanelets(all_lanelets);
 
-  constexpr int VEHICLE_GRAPH_INDEX = 0;
+  const int VEHICLE_GRAPH_INDEX = 0;
   for (const auto & crosswalk : crosswalk_lanelets) {
     const auto traffic_light_reg_elems =
       crosswalk.regulatoryElementsAs<const lanelet::TrafficLight>();
@@ -253,7 +253,7 @@ void CrosswalkTrafficLightEstimatorNode::update_crosswalk_overrides_from_map(
   }
   const auto & traffic_light = *traffic_light_it;
   const auto current_vehicle_traffic_light_color =
-    getHighestConfidenceTrafficSignal(traffic_light->id(), traffic_light_id_map);
+    get_highest_confidence_traffic_signal(traffic_light->id(), traffic_light_id_map);
   for (const auto & attribute : traffic_light->attributes()) {
     const auto & color_mapping = parse_signal_estimation_rules(attribute.first);
     if (!color_mapping) {
@@ -269,7 +269,7 @@ void CrosswalkTrafficLightEstimatorNode::update_crosswalk_overrides_from_map(
   }
 }
 
-void CrosswalkTrafficLightEstimatorNode::onTrafficLightArray(
+void CrosswalkTrafficLightEstimatorNode::on_traffic_light_array(
   const TrafficSignalArray::ConstSharedPtr msg)
 {
   if (lanelet_map_ptr_ == nullptr) {
@@ -322,16 +322,16 @@ void CrosswalkTrafficLightEstimatorNode::onTrafficLightArray(
   for (const auto & crosswalk_id : crosswalk_ids_to_process) {
     const auto & crosswalk = lanelet_map_ptr_->laneletLayer.get(crosswalk_id);
     const auto & conflict_lls = crosswalk_to_vehicle_lanelets_.at(crosswalk_id);
-    const auto non_red_lanelets = getNonRedLanelets(conflict_lls, traffic_light_id_map);
+    const auto non_red_lanelets = get_non_red_lanelets(conflict_lls, traffic_light_id_map);
 
-    const auto crosswalk_tl_color = estimateCrosswalkTrafficSignal(crosswalk, non_red_lanelets);
-    setCrosswalkTrafficSignal(
+    const auto crosswalk_tl_color = estimate_crosswalk_traffic_signal(crosswalk, non_red_lanelets);
+    set_crosswalk_traffic_signal(
       crosswalk, crosswalk_tl_color, *msg, output, crosswalk_traffic_signal_overrides);
   }
 
-  removeDuplicateIds(output);
+  remove_duplicate_ids(output);
 
-  updateLastDetectedSignal(traffic_light_id_map);
+  update_last_detected_signal(traffic_light_id_map);
 
   pub_traffic_light_array_->publish(output);
   pub_processing_time_->publish<Float64Stamped>("processing_time_ms", stop_watch.toc("Total"));
@@ -339,7 +339,7 @@ void CrosswalkTrafficLightEstimatorNode::onTrafficLightArray(
   return;
 }
 
-void CrosswalkTrafficLightEstimatorNode::updateLastDetectedSignal(
+void CrosswalkTrafficLightEstimatorNode::update_last_detected_signal(
   const TrafficLightIdMap & traffic_light_id_map)
 {
   for (const auto & input_traffic_signal : traffic_light_id_map) {
@@ -355,12 +355,7 @@ void CrosswalkTrafficLightEstimatorNode::updateLastDetectedSignal(
 
     const auto & id = input_traffic_signal.second.first.traffic_light_group_id;
 
-    if (last_detect_color_.count(id) == 0) {
-      last_detect_color_.emplace(id, input_traffic_signal.second);
-      continue;
-    }
-
-    last_detect_color_.at(id) = input_traffic_signal.second;
+    last_detect_color_.insert_or_assign(id, input_traffic_signal.second);
   }
 
   std::vector<int32_t> erase_id_list;
@@ -382,7 +377,7 @@ void CrosswalkTrafficLightEstimatorNode::updateLastDetectedSignal(
   }
 }
 
-void CrosswalkTrafficLightEstimatorNode::setCrosswalkTrafficSignal(
+void CrosswalkTrafficLightEstimatorNode::set_crosswalk_traffic_signal(
   const lanelet::ConstLanelet & crosswalk, const uint8_t color, const TrafficSignalArray & msg,
   TrafficSignalArray & output,
   const std::unordered_map<lanelet::Id, uint8_t> & crosswalk_traffic_signal_overrides)
@@ -441,7 +436,7 @@ void CrosswalkTrafficLightEstimatorNode::setCrosswalkTrafficSignal(
     if (auto it = valid_id2idx_map.find(id); it != valid_id2idx_map.end()) {
       const auto & detected = msg.traffic_light_groups[it->second];
 
-      if (!use_pedestrian_signal_detect_ || isInvalidDetectionStatus(detected)) {
+      if (!use_pedestrian_signal_detect_ || is_invalid_detection_status(detected)) {
         // Replace detection with estimated base color
         replace_out_signal_elements(base_traffic_signal_element);
         continue;
@@ -462,7 +457,7 @@ void CrosswalkTrafficLightEstimatorNode::setCrosswalkTrafficSignal(
   }
 }
 
-bool CrosswalkTrafficLightEstimatorNode::isInvalidDetectionStatus(
+bool CrosswalkTrafficLightEstimatorNode::is_invalid_detection_status(
   const TrafficSignal & signal) const
 {
   if (signal.elements.empty()) {
@@ -476,7 +471,7 @@ bool CrosswalkTrafficLightEstimatorNode::isInvalidDetectionStatus(
   return false;
 }
 
-lanelet::ConstLanelets CrosswalkTrafficLightEstimatorNode::getNonRedLanelets(
+lanelet::ConstLanelets CrosswalkTrafficLightEstimatorNode::get_non_red_lanelets(
   const lanelet::ConstLanelets & lanelets, const TrafficLightIdMap & traffic_light_id_map) const
 {
   lanelet::ConstLanelets non_red_lanelets{};
@@ -490,7 +485,7 @@ lanelet::ConstLanelets CrosswalkTrafficLightEstimatorNode::getNonRedLanelets(
 
     const auto tl_reg_elem = tl_reg_elems.front();
     const auto current_detected_signal =
-      getHighestConfidenceTrafficSignal(tl_reg_elem->id(), traffic_light_id_map);
+      get_highest_confidence_traffic_signal(tl_reg_elem->id(), traffic_light_id_map);
 
     if (!current_detected_signal && !use_last_detect_color_) {
       continue;
@@ -506,7 +501,7 @@ lanelet::ConstLanelets CrosswalkTrafficLightEstimatorNode::getNonRedLanelets(
                               : true;
 
     const auto last_detected_signal =
-      getHighestConfidenceTrafficSignal(tl_reg_elem->id(), last_detect_color_);
+      get_highest_confidence_traffic_signal(tl_reg_elem->id(), last_detect_color_);
 
     if (!last_detected_signal) {
       continue;
@@ -527,7 +522,7 @@ lanelet::ConstLanelets CrosswalkTrafficLightEstimatorNode::getNonRedLanelets(
   return non_red_lanelets;
 }
 
-uint8_t CrosswalkTrafficLightEstimatorNode::estimateCrosswalkTrafficSignal(
+uint8_t CrosswalkTrafficLightEstimatorNode::estimate_crosswalk_traffic_signal(
   const lanelet::ConstLanelet & crosswalk, const lanelet::ConstLanelets & non_red_lanelets) const
 {
   bool has_left_non_red_lane = false;
@@ -558,13 +553,13 @@ uint8_t CrosswalkTrafficLightEstimatorNode::estimateCrosswalkTrafficSignal(
     return TrafficSignalElement::RED;
   }
 
-  const auto has_merge_lane = hasMergeLane(non_red_lanelets, routing_graph_ptr_);
-  return !has_merge_lane && has_left_non_red_lane && has_right_non_red_lane
+  const auto merge_lane_exists = has_merge_lane(non_red_lanelets, routing_graph_ptr_);
+  return !merge_lane_exists && has_left_non_red_lane && has_right_non_red_lane
            ? TrafficSignalElement::RED
            : TrafficSignalElement::UNKNOWN;
 }
 
-boost::optional<uint8_t> CrosswalkTrafficLightEstimatorNode::getHighestConfidenceTrafficSignal(
+boost::optional<uint8_t> CrosswalkTrafficLightEstimatorNode::get_highest_confidence_traffic_signal(
   const lanelet::ConstLineStringsOrPolygons3d & traffic_lights,
   const TrafficLightIdMap & traffic_light_id_map) const
 {
@@ -599,7 +594,7 @@ boost::optional<uint8_t> CrosswalkTrafficLightEstimatorNode::getHighestConfidenc
   return ret;
 }
 
-boost::optional<uint8_t> CrosswalkTrafficLightEstimatorNode::getHighestConfidenceTrafficSignal(
+boost::optional<uint8_t> CrosswalkTrafficLightEstimatorNode::get_highest_confidence_traffic_signal(
   const lanelet::Id & id, const TrafficLightIdMap & traffic_light_id_map) const
 {
   boost::optional<uint8_t> ret{boost::none};
@@ -621,7 +616,8 @@ boost::optional<uint8_t> CrosswalkTrafficLightEstimatorNode::getHighestConfidenc
   return ret;
 }
 
-void CrosswalkTrafficLightEstimatorNode::removeDuplicateIds(TrafficSignalArray & signal_array) const
+void CrosswalkTrafficLightEstimatorNode::remove_duplicate_ids(
+  TrafficSignalArray & signal_array) const
 {
   auto & signals = signal_array.traffic_light_groups;
   std::stable_sort(signals.begin(), signals.end(), [](const auto & s1, const auto & s2) {

--- a/perception/autoware_crosswalk_traffic_light_estimator/src/node.cpp
+++ b/perception/autoware_crosswalk_traffic_light_estimator/src/node.cpp
@@ -17,6 +17,7 @@
 #include <autoware/lanelet2_utils/conversion.hpp>
 
 #include <memory>
+#include <utility>
 
 namespace autoware::crosswalk_traffic_light_estimator
 {
@@ -45,10 +46,13 @@ CrosswalkTrafficLightEstimatorNode::CrosswalkTrafficLightEstimatorNode(
 
   pub_traffic_light_array_ =
     this->create_publisher<TrafficSignalArray>("~/output/traffic_signals", rclcpp::QoS{1});
-  pub_processing_time_ = std::make_shared<DebugPublisher>(this, "~/debug");
+  pub_processing_time_ =
+    std::make_shared<autoware_utils_debug::BasicDebugPublisher<autoware::agnocast_wrapper::Node>>(
+      this, "~/debug");
 }
 
-void CrosswalkTrafficLightEstimatorNode::on_map(const LaneletMapBin::ConstSharedPtr msg)
+void CrosswalkTrafficLightEstimatorNode::on_map(
+  const AUTOWARE_MESSAGE_CONST_SHARED_PTR(LaneletMapBin) & msg)
 {
   RCLCPP_DEBUG(get_logger(), "[CrosswalkTrafficLightEstimatorNode]: Start loading lanelet");
   auto lanelet_map_ptr = autoware::experimental::lanelet2_utils::remove_const(
@@ -60,25 +64,25 @@ void CrosswalkTrafficLightEstimatorNode::on_map(const LaneletMapBin::ConstShared
 }
 
 void CrosswalkTrafficLightEstimatorNode::on_traffic_light_array(
-  const TrafficSignalArray::ConstSharedPtr msg)
+  const AUTOWARE_MESSAGE_CONST_SHARED_PTR(TrafficSignalArray) & msg)
 {
   if (!estimator_.is_map_loaded()) {
     RCLCPP_WARN(get_logger(), "cannot process traffic light array because the map is not received");
     return;
   }
 
-  StopWatch<std::chrono::milliseconds> stop_watch;
-  stop_watch.tic("Total");
+  stop_watch_.tic("Total");
 
   const auto unregistered_ids = estimator_.find_unregistered_traffic_light_group_ids(*msg);
   for (const auto & id : unregistered_ids) {
     RCLCPP_WARN(get_logger(), "Traffic light group ID %ld is not registered in the map", id);
   }
 
-  const auto output = estimator_.estimate(*msg, get_clock()->now());
+  auto output_ptr = ALLOCATE_OUTPUT_MESSAGE_UNIQUE(pub_traffic_light_array_);
+  *output_ptr = estimator_.estimate(*msg, get_clock()->now());
 
-  pub_traffic_light_array_->publish(output);
-  pub_processing_time_->publish<Float64Stamped>("processing_time_ms", stop_watch.toc("Total"));
+  pub_traffic_light_array_->publish(std::move(output_ptr));
+  pub_processing_time_->publish<Float64Stamped>("processing_time_ms", stop_watch_.toc("Total"));
 }
 
 }  // namespace autoware::crosswalk_traffic_light_estimator

--- a/perception/autoware_crosswalk_traffic_light_estimator/src/node.cpp
+++ b/perception/autoware_crosswalk_traffic_light_estimator/src/node.cpp
@@ -165,7 +165,10 @@ CrosswalkTrafficLightEstimatorNode::CrosswalkTrafficLightEstimatorNode(
   use_last_detect_color_ = declare_parameter<bool>("use_last_detect_color");
   use_pedestrian_signal_detect_ = declare_parameter<bool>("use_pedestrian_signal_detect");
   last_detect_color_hold_time_ = declare_parameter<double>("last_detect_color_hold_time");
-  last_colors_hold_time_ = declare_parameter<double>("last_colors_hold_time");
+
+  FlashingDetectionConfig flashing_config;
+  flashing_config.last_colors_hold_time = declare_parameter<double>("last_colors_hold_time");
+  flashing_detector_ = FlashingDetector(flashing_config);
 
   sub_map_ = create_subscription<LaneletMapBin>(
     "~/input/vector_map", rclcpp::QoS{1}.transient_local(),
@@ -329,7 +332,6 @@ void CrosswalkTrafficLightEstimatorNode::onTrafficLightArray(
   removeDuplicateIds(output);
 
   updateLastDetectedSignal(traffic_light_id_map);
-  updateLastDetectedSignals(traffic_light_id_map);
 
   pub_traffic_light_array_->publish(output);
   pub_processing_time_->publish<Float64Stamped>("processing_time_ms", stop_watch.toc("Total"));
@@ -354,7 +356,7 @@ void CrosswalkTrafficLightEstimatorNode::updateLastDetectedSignal(
     const auto & id = input_traffic_signal.second.first.traffic_light_group_id;
 
     if (last_detect_color_.count(id) == 0) {
-      last_detect_color_.insert(std::make_pair(id, input_traffic_signal.second));
+      last_detect_color_.emplace(id, input_traffic_signal.second);
       continue;
     }
 
@@ -376,57 +378,8 @@ void CrosswalkTrafficLightEstimatorNode::updateLastDetectedSignal(
   }
   for (const auto id : erase_id_list) {
     last_detect_color_.erase(id);
-    is_flashing_.erase(id);
-    current_color_state_.erase(id);
+    flashing_detector_.clear_state(id);
   }
-}
-
-void CrosswalkTrafficLightEstimatorNode::updateLastDetectedSignals(
-  const TrafficLightIdMap & traffic_light_id_map)
-{
-  for (const auto & input_traffic_signal : traffic_light_id_map) {
-    const auto & elements = input_traffic_signal.second.first.elements;
-
-    if (elements.empty()) {
-      continue;
-    }
-
-    if (
-      elements.front().color == TrafficSignalElement::UNKNOWN && elements.front().confidence == 1) {
-      continue;
-    }
-
-    const auto & id = input_traffic_signal.second.first.traffic_light_group_id;
-
-    if (last_colors_.count(id) == 0) {
-      std::vector<TrafficSignalAndTime> signal{input_traffic_signal.second};
-      last_colors_.insert(std::make_pair(id, signal));
-      continue;
-    }
-
-    last_colors_.at(id).push_back(input_traffic_signal.second);
-  }
-
-  std::vector<int32_t> erase_id_list;
-  for (auto & last_traffic_signal : last_colors_) {
-    const auto & id = last_traffic_signal.first;
-    for (auto it = last_traffic_signal.second.begin(); it != last_traffic_signal.second.end();) {
-      auto sig = (*it).first;
-      rclcpp::Time t = (*it).second;
-
-      // hold signal recognition results for [last_colors_hold_time_] seconds.
-      const auto time_from_last_detected = (get_clock()->now() - t).seconds();
-      if (time_from_last_detected > last_colors_hold_time_) {
-        it = last_traffic_signal.second.erase(it);
-      } else {
-        ++it;
-      }
-    }
-    if (last_traffic_signal.second.empty()) {
-      erase_id_list.emplace_back(id);
-    }
-  }
-  for (const auto id : erase_id_list) last_colors_.erase(id);
 }
 
 void CrosswalkTrafficLightEstimatorNode::setCrosswalkTrafficSignal(
@@ -495,13 +448,12 @@ void CrosswalkTrafficLightEstimatorNode::setCrosswalkTrafficSignal(
       }
 
       // Update flashing state and apply the most recent color
-      updateFlashingState(detected);
       if (out_signal.elements
             .empty()) {  // unnecessary check because msg has detection but for safety
         out_signal.elements.push_back(base_traffic_signal_element);
       }
-      out_signal.elements[0].color = updateAndGetColorState(
-        detected);  // TODO(MasatoSaeki): determine what value is good for confidence
+      out_signal.elements[0].color =
+        flashing_detector_.estimate_stable_color(detected, get_clock()->now());
       continue;
     }
 
@@ -513,84 +465,15 @@ void CrosswalkTrafficLightEstimatorNode::setCrosswalkTrafficSignal(
 bool CrosswalkTrafficLightEstimatorNode::isInvalidDetectionStatus(
   const TrafficSignal & signal) const
 {
-  // invalid if elements is empty
   if (signal.elements.empty()) {
     return true;
   }
-  // check occlusion, backlight(shape is unknown) and no detection(shape is circle)
   if (
     signal.elements.front().color == TrafficSignalElement::UNKNOWN &&
     signal.elements.front().confidence == 0.0) {
     return true;
   }
-
   return false;
-}
-
-void CrosswalkTrafficLightEstimatorNode::updateFlashingState(const TrafficSignal & signal)
-{
-  const auto id = signal.traffic_light_group_id;
-
-  // no record of detected color in last_detect_color_hold_time_
-  if (is_flashing_.count(id) == 0) {
-    is_flashing_.insert(std::make_pair(id, false));
-    return;
-  }
-
-  // flashing green
-  if (
-    !signal.elements.empty() && signal.elements.front().color == TrafficSignalElement::UNKNOWN &&
-    signal.elements.front().confidence != 0 &&  // not due to occlusion
-    current_color_state_.at(id) != TrafficSignalElement::UNKNOWN) {
-    is_flashing_.at(id) = true;
-    return;
-  }
-
-  // history exists
-  if (last_colors_.count(id) > 0) {
-    std::vector<TrafficSignalAndTime> history = last_colors_.at(id);
-    for (const auto & h : history) {
-      if (h.first.elements.front().color != signal.elements.front().color) {
-        // keep the current value if not same with input signal
-        return;
-      }
-    }
-    // all history is same with input signal
-    is_flashing_.at(id) = false;
-  }
-
-  // no record of detected color in last_color_hold_time_
-  // keep the current value
-  return;
-}
-
-uint8_t CrosswalkTrafficLightEstimatorNode::updateAndGetColorState(const TrafficSignal & signal)
-{
-  const auto id = signal.traffic_light_group_id;
-  const auto color = signal.elements[0].color;
-
-  if (current_color_state_.count(id) == 0) {
-    current_color_state_.insert(std::make_pair(id, color));
-  } else if (is_flashing_.at(id) == false) {
-    current_color_state_.at(id) = color;
-  } else if (is_flashing_.at(id) == true) {
-    if (
-      current_color_state_.at(id) == TrafficSignalElement::GREEN &&
-      color == TrafficSignalElement::RED) {
-      current_color_state_.at(id) = TrafficSignalElement::RED;
-    } else if (
-      current_color_state_.at(id) == TrafficSignalElement::RED &&
-      color == TrafficSignalElement::GREEN) {
-      current_color_state_.at(id) = TrafficSignalElement::GREEN;
-    } else if (current_color_state_.at(id) == TrafficSignalElement::UNKNOWN) {
-      if (color == TrafficSignalElement::GREEN || color == TrafficSignalElement::UNKNOWN)
-        current_color_state_.at(id) = TrafficSignalElement::GREEN;
-      if (color == TrafficSignalElement::RED)
-        current_color_state_.at(id) = TrafficSignalElement::RED;
-    }
-  }
-
-  return current_color_state_.at(id);
 }
 
 lanelet::ConstLanelets CrosswalkTrafficLightEstimatorNode::getNonRedLanelets(

--- a/perception/autoware_crosswalk_traffic_light_estimator/src/node.hpp
+++ b/perception/autoware_crosswalk_traffic_light_estimator/src/node.hpp
@@ -15,7 +15,7 @@
 #ifndef NODE_HPP_
 #define NODE_HPP_
 
-#include "flashing_detection.hpp"
+#include "crosswalk_traffic_light_estimator.hpp"
 
 #include <autoware_utils/ros/debug_publisher.hpp>
 #include <autoware_utils/system/stop_watch.hpp>
@@ -24,16 +24,8 @@
 #include <autoware_internal_debug_msgs/msg/float64_stamped.hpp>
 #include <autoware_map_msgs/msg/lanelet_map_bin.hpp>
 
-#include <lanelet2_core/Attribute.h>
-#include <lanelet2_core/LaneletMap.h>
-#include <lanelet2_core/primitives/LineStringOrPolygon.h>
-#include <lanelet2_routing/RoutingGraph.h>
-#include <lanelet2_routing/RoutingGraphContainer.h>
-#include <lanelet2_traffic_rules/TrafficRulesFactory.h>
-
 #include <memory>
-#include <unordered_map>
-#include <vector>
+
 namespace autoware::crosswalk_traffic_light_estimator
 {
 
@@ -52,53 +44,10 @@ private:
   rclcpp::Subscription<TrafficSignalArray>::SharedPtr sub_traffic_light_array_;
   rclcpp::Publisher<TrafficSignalArray>::SharedPtr pub_traffic_light_array_;
 
-  lanelet::LaneletMapPtr lanelet_map_ptr_;
-  lanelet::routing::RoutingGraphPtr routing_graph_ptr_;
-  std::unordered_map<lanelet::Id, lanelet::ConstLanelets> traffic_light_id_to_crosswalks_;
-  std::unordered_map<lanelet::Id, lanelet::ConstLanelets> crosswalk_to_vehicle_lanelets_;
-
   void on_map(const LaneletMapBin::ConstSharedPtr msg);
   void on_traffic_light_array(const TrafficSignalArray::ConstSharedPtr msg);
 
-  void update_last_detected_signal(const TrafficLightIdMap & traffic_light_id_map);
-  /// @brief update the overrides of crosswalk signals from the lanelet map for the given traffic
-  /// light id
-  void update_crosswalk_overrides_from_map(
-    std::unordered_map<lanelet::Id, uint8_t> & crosswalk_traffic_signal_overrides,
-    const lanelet::Id traffic_light_group_id, const TrafficLightIdMap & traffic_light_id_map);
-
-  void set_crosswalk_traffic_signal(
-    const lanelet::ConstLanelet & crosswalk, const uint8_t color, const TrafficSignalArray & msg,
-    TrafficSignalArray & output,
-    const std::unordered_map<lanelet::Id, uint8_t> & crosswalk_traffic_signal_overrides);
-
-  lanelet::ConstLanelets get_non_red_lanelets(
-    const lanelet::ConstLanelets & lanelets, const TrafficLightIdMap & traffic_light_id_map) const;
-
-  uint8_t estimate_crosswalk_traffic_signal(
-    const lanelet::ConstLanelet & crosswalk, const lanelet::ConstLanelets & non_red_lanelets) const;
-
-  boost::optional<uint8_t> get_highest_confidence_traffic_signal(
-    const lanelet::ConstLineStringsOrPolygons3d & traffic_lights,
-    const TrafficLightIdMap & traffic_light_id_map) const;
-
-  boost::optional<uint8_t> get_highest_confidence_traffic_signal(
-    const lanelet::Id & id, const TrafficLightIdMap & traffic_light_id_map) const;
-
-  void remove_duplicate_ids(TrafficSignalArray & signal_array) const;
-
-  bool is_invalid_detection_status(const TrafficSignal & signal) const;
-
-  // Node param
-  bool use_last_detect_color_;
-  bool use_pedestrian_signal_detect_;
-  double last_detect_color_hold_time_;
-
-  // Signal history
-  TrafficLightIdMap last_detect_color_;
-
-  // Flashing detection
-  FlashingDetector flashing_detector_;
+  CrosswalkTrafficLightEstimator estimator_;
 
   // Stop watch
   StopWatch<std::chrono::milliseconds> stop_watch_;

--- a/perception/autoware_crosswalk_traffic_light_estimator/src/node.hpp
+++ b/perception/autoware_crosswalk_traffic_light_estimator/src/node.hpp
@@ -12,10 +12,10 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef AUTOWARE_CROSSWALK_TRAFFIC_LIGHT_ESTIMATOR__NODE_HPP_
-#define AUTOWARE_CROSSWALK_TRAFFIC_LIGHT_ESTIMATOR__NODE_HPP_
+#ifndef NODE_HPP_
+#define NODE_HPP_
 
-#include "autoware_crosswalk_traffic_light_estimator/flashing_detection.hpp"
+#include "flashing_detection.hpp"
 
 #include <autoware_utils/ros/debug_publisher.hpp>
 #include <autoware_utils/system/stop_watch.hpp>
@@ -57,37 +57,37 @@ private:
   std::unordered_map<lanelet::Id, lanelet::ConstLanelets> traffic_light_id_to_crosswalks_;
   std::unordered_map<lanelet::Id, lanelet::ConstLanelets> crosswalk_to_vehicle_lanelets_;
 
-  void onMap(const LaneletMapBin::ConstSharedPtr msg);
-  void onTrafficLightArray(const TrafficSignalArray::ConstSharedPtr msg);
+  void on_map(const LaneletMapBin::ConstSharedPtr msg);
+  void on_traffic_light_array(const TrafficSignalArray::ConstSharedPtr msg);
 
-  void updateLastDetectedSignal(const TrafficLightIdMap & traffic_signals);
+  void update_last_detected_signal(const TrafficLightIdMap & traffic_light_id_map);
   /// @brief update the overrides of crosswalk signals from the lanelet map for the given traffic
   /// light id
   void update_crosswalk_overrides_from_map(
     std::unordered_map<lanelet::Id, uint8_t> & crosswalk_traffic_signal_overrides,
     const lanelet::Id traffic_light_group_id, const TrafficLightIdMap & traffic_light_id_map);
 
-  void setCrosswalkTrafficSignal(
+  void set_crosswalk_traffic_signal(
     const lanelet::ConstLanelet & crosswalk, const uint8_t color, const TrafficSignalArray & msg,
     TrafficSignalArray & output,
     const std::unordered_map<lanelet::Id, uint8_t> & crosswalk_traffic_signal_overrides);
 
-  lanelet::ConstLanelets getNonRedLanelets(
+  lanelet::ConstLanelets get_non_red_lanelets(
     const lanelet::ConstLanelets & lanelets, const TrafficLightIdMap & traffic_light_id_map) const;
 
-  uint8_t estimateCrosswalkTrafficSignal(
+  uint8_t estimate_crosswalk_traffic_signal(
     const lanelet::ConstLanelet & crosswalk, const lanelet::ConstLanelets & non_red_lanelets) const;
 
-  boost::optional<uint8_t> getHighestConfidenceTrafficSignal(
+  boost::optional<uint8_t> get_highest_confidence_traffic_signal(
     const lanelet::ConstLineStringsOrPolygons3d & traffic_lights,
     const TrafficLightIdMap & traffic_light_id_map) const;
 
-  boost::optional<uint8_t> getHighestConfidenceTrafficSignal(
+  boost::optional<uint8_t> get_highest_confidence_traffic_signal(
     const lanelet::Id & id, const TrafficLightIdMap & traffic_light_id_map) const;
 
-  void removeDuplicateIds(TrafficSignalArray & signal_array) const;
+  void remove_duplicate_ids(TrafficSignalArray & signal_array) const;
 
-  bool isInvalidDetectionStatus(const TrafficSignal & signal) const;
+  bool is_invalid_detection_status(const TrafficSignal & signal) const;
 
   // Node param
   bool use_last_detect_color_;
@@ -109,4 +109,4 @@ private:
 
 }  // namespace autoware::crosswalk_traffic_light_estimator
 
-#endif  // AUTOWARE_CROSSWALK_TRAFFIC_LIGHT_ESTIMATOR__NODE_HPP_
+#endif  // NODE_HPP_

--- a/perception/autoware_crosswalk_traffic_light_estimator/src/node.hpp
+++ b/perception/autoware_crosswalk_traffic_light_estimator/src/node.hpp
@@ -17,8 +17,9 @@
 
 #include "crosswalk_traffic_light_estimator.hpp"
 
-#include <autoware_utils/ros/debug_publisher.hpp>
+#include <autoware/agnocast_wrapper/node.hpp>
 #include <autoware_utils/system/stop_watch.hpp>
+#include <autoware_utils_debug/debug_publisher.hpp>
 #include <rclcpp/rclcpp.hpp>
 
 #include <autoware_internal_debug_msgs/msg/float64_stamped.hpp>
@@ -31,21 +32,20 @@ namespace autoware::crosswalk_traffic_light_estimator
 
 using autoware_internal_debug_msgs::msg::Float64Stamped;
 using autoware_map_msgs::msg::LaneletMapBin;
-using autoware_utils::DebugPublisher;
 using autoware_utils::StopWatch;
 
-class CrosswalkTrafficLightEstimatorNode : public rclcpp::Node
+class CrosswalkTrafficLightEstimatorNode : public autoware::agnocast_wrapper::Node
 {
 public:
   explicit CrosswalkTrafficLightEstimatorNode(const rclcpp::NodeOptions & options);
 
 private:
-  rclcpp::Subscription<LaneletMapBin>::SharedPtr sub_map_;
-  rclcpp::Subscription<TrafficSignalArray>::SharedPtr sub_traffic_light_array_;
-  rclcpp::Publisher<TrafficSignalArray>::SharedPtr pub_traffic_light_array_;
+  AUTOWARE_SUBSCRIPTION_PTR(LaneletMapBin) sub_map_;
+  AUTOWARE_SUBSCRIPTION_PTR(TrafficSignalArray) sub_traffic_light_array_;
+  AUTOWARE_PUBLISHER_PTR(TrafficSignalArray) pub_traffic_light_array_;
 
-  void on_map(const LaneletMapBin::ConstSharedPtr msg);
-  void on_traffic_light_array(const TrafficSignalArray::ConstSharedPtr msg);
+  void on_map(const AUTOWARE_MESSAGE_CONST_SHARED_PTR(LaneletMapBin) & msg);
+  void on_traffic_light_array(const AUTOWARE_MESSAGE_CONST_SHARED_PTR(TrafficSignalArray) & msg);
 
   CrosswalkTrafficLightEstimator estimator_;
 
@@ -53,7 +53,8 @@ private:
   StopWatch<std::chrono::milliseconds> stop_watch_;
 
   // Debug
-  std::shared_ptr<DebugPublisher> pub_processing_time_;
+  std::shared_ptr<autoware_utils_debug::BasicDebugPublisher<autoware::agnocast_wrapper::Node>>
+    pub_processing_time_;
 };
 
 }  // namespace autoware::crosswalk_traffic_light_estimator

--- a/perception/autoware_crosswalk_traffic_light_estimator/test/test_crosswalk_traffic_light_estimator.cpp
+++ b/perception/autoware_crosswalk_traffic_light_estimator/test/test_crosswalk_traffic_light_estimator.cpp
@@ -37,6 +37,7 @@ namespace
 
 constexpr lanelet::Id VEHICLE_TL_REG_ELEM_ID = 100;
 constexpr lanelet::Id CROSSWALK_TL_REG_ELEM_ID = 200;
+constexpr lanelet::Id VEHICLE_TL_RIGHT_ID = 300;
 
 CrosswalkTrafficLightEstimatorConfig make_default_config()
 {
@@ -55,10 +56,10 @@ rclcpp::Time make_time(double seconds)
   return rclcpp::Time(static_cast<int64_t>(seconds * 1e9));
 }
 
-TrafficSignal make_vehicle_signal(uint8_t color, float confidence = 1.0)
+TrafficSignal make_signal(lanelet::Id tl_id, uint8_t color, float confidence = 1.0)
 {
   TrafficSignal signal;
-  signal.traffic_light_group_id = VEHICLE_TL_REG_ELEM_ID;
+  signal.traffic_light_group_id = tl_id;
   TrafficSignalElement element;
   element.color = color;
   element.shape = TrafficSignalElement::CIRCLE;
@@ -75,26 +76,25 @@ TrafficSignalArray make_signal_array(const std::vector<TrafficSignal> & signals)
   return array;
 }
 
-/// @brief Create a minimal lanelet map with one straight vehicle lanelet and one crosswalk
-/// that physically overlaps the vehicle lanelet.
+/// @brief Create a lanelet map with a straight vehicle lanelet (TL=100),
+/// a right-turn vehicle lanelet (TL=300), and a crosswalk (TL=200) that overlaps both.
 ///
 ///           y
 ///           ^
 ///       6   |    +------------+
 ///           |    |  Crosswalk |
 ///       4   +----+--+---------+--+---------------------+
-///           |    |  | overlap |  |    Vehicle Lanelet   |
-///           |    |  | [8,12]  |  |    (straight, ->)    |
-///           |    |  | x[0,4]  |  |    TL ID=100         |
-///       0   +----+--+---------+--+---------------------+---> x
+///           |    |  | overlap |  |  Straight (TL=100)  |
+///       0   +----+--+---------+--+---------------------+
+///           |    |  | overlap |  |  Right-turn (TL=300)|
+///      -4   +----+--+---------+--+---------------------+---> x
 ///           0    |  8        12  |                     20
-///      -2        +------------+
+///      -6        +------------+
 ///                  TL ID=200
-///                  Crosswalk
-///                  (ID=2000)
+///                  Crosswalk (ID=2000)
 lanelet::LaneletMapPtr create_test_map(const lanelet::AttributeMap & vehicle_tl_extra_attrs = {})
 {
-  // Vehicle lanelet bounds (going east)
+  // Straight vehicle lanelet bounds (y=0..4)
   lanelet::Point3d vehicle_right_start(1, 0.0, 0.0, 0.0);
   lanelet::Point3d vehicle_right_end(2, 20.0, 0.0, 0.0);
   lanelet::Point3d vehicle_left_start(3, 0.0, 4.0, 0.0);
@@ -103,10 +103,16 @@ lanelet::LaneletMapPtr create_test_map(const lanelet::AttributeMap & vehicle_tl_
   lanelet::LineString3d vehicle_right(10, {vehicle_right_start, vehicle_right_end});
   lanelet::LineString3d vehicle_left(11, {vehicle_left_start, vehicle_left_end});
 
-  // Crosswalk lanelet bounds (going north, overlaps vehicle lanelet at [8,12] x [0,4])
-  lanelet::Point3d crosswalk_left_start(5, 8.0, -2.0, 0.0);
+  // Right-turn vehicle lanelet bounds (y=-4..0)
+  lanelet::LineString3d rt_right(
+    610, {lanelet::Point3d(601, 0.0, -4.0, 0.0), lanelet::Point3d(602, 20.0, -4.0, 0.0)});
+  lanelet::LineString3d rt_left(
+    611, {lanelet::Point3d(603, 0.0, 0.0, 0.0), lanelet::Point3d(604, 20.0, 0.0, 0.0)});
+
+  // Crosswalk lanelet bounds (overlaps both vehicle lanelets)
+  lanelet::Point3d crosswalk_left_start(5, 8.0, -6.0, 0.0);
   lanelet::Point3d crosswalk_left_end(6, 8.0, 6.0, 0.0);
-  lanelet::Point3d crosswalk_right_start(7, 12.0, -2.0, 0.0);
+  lanelet::Point3d crosswalk_right_start(7, 12.0, -6.0, 0.0);
   lanelet::Point3d crosswalk_right_end(8, 12.0, 6.0, 0.0);
 
   lanelet::LineString3d crosswalk_left(12, {crosswalk_left_start, crosswalk_left_end});
@@ -114,20 +120,30 @@ lanelet::LaneletMapPtr create_test_map(const lanelet::AttributeMap & vehicle_tl_
 
   // Traffic light physical locations
   lanelet::LineString3d vehicle_tl_linestring(15, {lanelet::Point3d(14, 10.0, 5.0, 3.0)});
+  lanelet::LineString3d rt_tl_linestring(612, {lanelet::Point3d(605, 10.0, -4.0, 3.0)});
   lanelet::LineString3d crosswalk_tl_linestring(17, {lanelet::Point3d(16, 13.0, 2.0, 3.0)});
 
   // Create traffic light regulatory elements
   auto vehicle_traffic_light = lanelet::TrafficLight::make(
     VEHICLE_TL_REG_ELEM_ID, vehicle_tl_extra_attrs, {vehicle_tl_linestring});
+  auto rt_traffic_light =
+    lanelet::TrafficLight::make(VEHICLE_TL_RIGHT_ID, lanelet::AttributeMap{}, {rt_tl_linestring});
   auto crosswalk_traffic_light = lanelet::TrafficLight::make(
     CROSSWALK_TL_REG_ELEM_ID, lanelet::AttributeMap{}, {crosswalk_tl_linestring});
 
-  // Create vehicle lanelet
+  // Create straight vehicle lanelet
   lanelet::Lanelet vehicle_lanelet(1000, vehicle_left, vehicle_right);
   vehicle_lanelet.attributes()["type"] = "lanelet";
   vehicle_lanelet.attributes()["subtype"] = "road";
   vehicle_lanelet.attributes()["turn_direction"] = "straight";
   vehicle_lanelet.addRegulatoryElement(vehicle_traffic_light);
+
+  // Create right-turn vehicle lanelet
+  lanelet::Lanelet rt_lanelet(3000, rt_left, rt_right);
+  rt_lanelet.attributes()["type"] = "lanelet";
+  rt_lanelet.attributes()["subtype"] = "road";
+  rt_lanelet.attributes()["turn_direction"] = "right";
+  rt_lanelet.addRegulatoryElement(rt_traffic_light);
 
   // Create crosswalk lanelet
   lanelet::Lanelet crosswalk_lanelet(2000, crosswalk_left, crosswalk_right);
@@ -138,6 +154,7 @@ lanelet::LaneletMapPtr create_test_map(const lanelet::AttributeMap & vehicle_tl_
   // Build map
   auto map = std::make_shared<lanelet::LaneletMap>();
   map->add(vehicle_lanelet);
+  map->add(rt_lanelet);
   map->add(crosswalk_lanelet);
 
   return map;
@@ -224,7 +241,8 @@ TEST(CrosswalkTrafficLightEstimatorTest, FindUnregistered_AllRegistered_ReturnsE
 {
   // Arrange
   auto estimator = make_estimator_with_map();
-  TrafficSignalArray msg = make_signal_array({make_vehicle_signal(TrafficSignalElement::GREEN)});
+  TrafficSignalArray msg =
+    make_signal_array({make_signal(VEHICLE_TL_REG_ELEM_ID, TrafficSignalElement::GREEN)});
 
   // Act
   const auto unregistered = estimator.find_unregistered_traffic_light_group_ids(msg);
@@ -254,7 +272,7 @@ TEST(CrosswalkTrafficLightEstimatorTest, Estimate_FirstCallWithGreenVehicle_Cros
   // Arrange
   auto estimator = make_estimator_with_map();
   TrafficSignalArray green_msg =
-    make_signal_array({make_vehicle_signal(TrafficSignalElement::GREEN)});
+    make_signal_array({make_signal(VEHICLE_TL_REG_ELEM_ID, TrafficSignalElement::GREEN)});
 
   // Act: GREEN vehicle signal is sufficient to estimate crosswalk as RED, even on first call
   const auto result = estimator.estimate(green_msg, make_time(0.0));
@@ -268,7 +286,7 @@ TEST(CrosswalkTrafficLightEstimatorTest, Estimate_UnknownVehicleNoHistory_Crossw
   // Arrange
   auto estimator = make_estimator_with_map();
   TrafficSignalArray unknown_msg =
-    make_signal_array({make_vehicle_signal(TrafficSignalElement::UNKNOWN)});
+    make_signal_array({make_signal(VEHICLE_TL_REG_ELEM_ID, TrafficSignalElement::UNKNOWN)});
 
   // Act: UNKNOWN vehicle signal with no prior history → crosswalk cannot be estimated
   const auto result = estimator.estimate(unknown_msg, make_time(0.0));
@@ -282,7 +300,7 @@ TEST(CrosswalkTrafficLightEstimatorTest, Estimate_StraightGreenVehicle_Crosswalk
   // Arrange
   auto estimator = make_estimator_with_map();
   TrafficSignalArray green_msg =
-    make_signal_array({make_vehicle_signal(TrafficSignalElement::GREEN)});
+    make_signal_array({make_signal(VEHICLE_TL_REG_ELEM_ID, TrafficSignalElement::GREEN)});
 
   // Act
   const auto result = estimator.estimate(green_msg, make_time(0.0));
@@ -295,7 +313,8 @@ TEST(CrosswalkTrafficLightEstimatorTest, Estimate_RedVehicle_CrosswalkUnknown)
 {
   // Arrange
   auto estimator = make_estimator_with_map();
-  TrafficSignalArray red_msg = make_signal_array({make_vehicle_signal(TrafficSignalElement::RED)});
+  TrafficSignalArray red_msg =
+    make_signal_array({make_signal(VEHICLE_TL_REG_ELEM_ID, TrafficSignalElement::RED)});
 
   // Act
   const auto result = estimator.estimate(red_msg, make_time(0.0));
@@ -325,13 +344,35 @@ TEST(
   // Normal estimation: GREEN vehicle + straight lane → crosswalk RED
   // With override:     green matches, crosswalk becomes GREEN
   auto estimator = make_estimator_with_rule("signal_color_relation:green:green");
-  TrafficSignalArray input = make_signal_array({make_vehicle_signal(TrafficSignalElement::GREEN)});
+  TrafficSignalArray input =
+    make_signal_array({make_signal(VEHICLE_TL_REG_ELEM_ID, TrafficSignalElement::GREEN)});
 
   // Act
   const auto result = estimator.estimate(input, make_time(0.0));
 
   // Assert: override (GREEN) wins over normal estimation (RED)
   assert_crosswalk_color(result, TrafficSignalElement::GREEN);
+}
+
+/// @brief Right-turn arrow scenario: only the right-turn TL (ID=300) reports GREEN,
+/// while the straight TL (ID=100) has no detection at all.
+/// The crosswalk must be UNKNOWN because the straight lane's signal state is unknown.
+TEST(
+  CrosswalkTrafficLightEstimatorTest, Estimate_RightArrowGreen_StraightUndetected_CrosswalkUnknown)
+{
+  // Arrange: existing map (straight lane TL=100 + crosswalk) with an added right-turn lane TL=300
+  CrosswalkTrafficLightEstimator estimator(make_default_config());
+  estimator.update_map(create_test_map());
+
+  // Only the right-turn TL reports GREEN; straight TL (100) is absent from the message
+  TrafficSignalArray input =
+    make_signal_array({make_signal(VEHICLE_TL_RIGHT_ID, TrafficSignalElement::GREEN)});
+
+  // Act
+  const auto result = estimator.estimate(input, make_time(0.0));
+
+  // Assert: crosswalk must be UNKNOWN, not RED
+  assert_crosswalk_color(result, TrafficSignalElement::UNKNOWN);
 }
 
 int main(int argc, char ** argv)

--- a/perception/autoware_crosswalk_traffic_light_estimator/test/test_crosswalk_traffic_light_estimator.cpp
+++ b/perception/autoware_crosswalk_traffic_light_estimator/test/test_crosswalk_traffic_light_estimator.cpp
@@ -1,0 +1,341 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "../src/crosswalk_traffic_light_estimator.hpp"
+
+#include <gtest/gtest.h>
+#include <lanelet2_core/LaneletMap.h>
+#include <lanelet2_core/primitives/BasicRegulatoryElements.h>
+#include <lanelet2_core/primitives/Lanelet.h>
+#include <lanelet2_core/primitives/LineString.h>
+#include <lanelet2_core/primitives/Point.h>
+
+#include <memory>
+#include <string>
+#include <vector>
+
+using autoware::crosswalk_traffic_light_estimator::CrosswalkTrafficLightEstimator;
+using autoware::crosswalk_traffic_light_estimator::CrosswalkTrafficLightEstimatorConfig;
+using autoware::crosswalk_traffic_light_estimator::FlashingDetectionConfig;
+using autoware::crosswalk_traffic_light_estimator::TrafficSignal;
+using autoware::crosswalk_traffic_light_estimator::TrafficSignalArray;
+using autoware::crosswalk_traffic_light_estimator::TrafficSignalElement;
+
+namespace
+{
+
+constexpr lanelet::Id VEHICLE_TL_REG_ELEM_ID = 100;
+constexpr lanelet::Id CROSSWALK_TL_REG_ELEM_ID = 200;
+
+CrosswalkTrafficLightEstimatorConfig make_default_config()
+{
+  CrosswalkTrafficLightEstimatorConfig config;
+  config.use_last_detect_color = true;
+  config.use_pedestrian_signal_detect = false;
+  config.last_detect_color_hold_time = 2.0;
+  FlashingDetectionConfig flashing_config;
+  flashing_config.last_colors_hold_time = 1.0;
+  config.flashing_detection = flashing_config;
+  return config;
+}
+
+rclcpp::Time make_time(double seconds)
+{
+  return rclcpp::Time(static_cast<int64_t>(seconds * 1e9));
+}
+
+TrafficSignal make_vehicle_signal(uint8_t color, float confidence = 1.0)
+{
+  TrafficSignal signal;
+  signal.traffic_light_group_id = VEHICLE_TL_REG_ELEM_ID;
+  TrafficSignalElement element;
+  element.color = color;
+  element.shape = TrafficSignalElement::CIRCLE;
+  element.status = TrafficSignalElement::SOLID_ON;
+  element.confidence = confidence;
+  signal.elements.push_back(element);
+  return signal;
+}
+
+TrafficSignalArray make_signal_array(const std::vector<TrafficSignal> & signals)
+{
+  TrafficSignalArray array;
+  array.traffic_light_groups = signals;
+  return array;
+}
+
+/// @brief Create a minimal lanelet map with one straight vehicle lanelet and one crosswalk
+/// that physically overlaps the vehicle lanelet.
+///
+///           y
+///           ^
+///       6   |    +------------+
+///           |    |  Crosswalk |
+///       4   +----+--+---------+--+---------------------+
+///           |    |  | overlap |  |    Vehicle Lanelet   |
+///           |    |  | [8,12]  |  |    (straight, ->)    |
+///           |    |  | x[0,4]  |  |    TL ID=100         |
+///       0   +----+--+---------+--+---------------------+---> x
+///           0    |  8        12  |                     20
+///      -2        +------------+
+///                  TL ID=200
+///                  Crosswalk
+///                  (ID=2000)
+lanelet::LaneletMapPtr create_test_map(const lanelet::AttributeMap & vehicle_tl_extra_attrs = {})
+{
+  // Vehicle lanelet bounds (going east)
+  lanelet::Point3d vehicle_right_start(1, 0.0, 0.0, 0.0);
+  lanelet::Point3d vehicle_right_end(2, 20.0, 0.0, 0.0);
+  lanelet::Point3d vehicle_left_start(3, 0.0, 4.0, 0.0);
+  lanelet::Point3d vehicle_left_end(4, 20.0, 4.0, 0.0);
+
+  lanelet::LineString3d vehicle_right(10, {vehicle_right_start, vehicle_right_end});
+  lanelet::LineString3d vehicle_left(11, {vehicle_left_start, vehicle_left_end});
+
+  // Crosswalk lanelet bounds (going north, overlaps vehicle lanelet at [8,12] x [0,4])
+  lanelet::Point3d crosswalk_left_start(5, 8.0, -2.0, 0.0);
+  lanelet::Point3d crosswalk_left_end(6, 8.0, 6.0, 0.0);
+  lanelet::Point3d crosswalk_right_start(7, 12.0, -2.0, 0.0);
+  lanelet::Point3d crosswalk_right_end(8, 12.0, 6.0, 0.0);
+
+  lanelet::LineString3d crosswalk_left(12, {crosswalk_left_start, crosswalk_left_end});
+  lanelet::LineString3d crosswalk_right(13, {crosswalk_right_start, crosswalk_right_end});
+
+  // Traffic light physical locations
+  lanelet::LineString3d vehicle_tl_linestring(15, {lanelet::Point3d(14, 10.0, 5.0, 3.0)});
+  lanelet::LineString3d crosswalk_tl_linestring(17, {lanelet::Point3d(16, 13.0, 2.0, 3.0)});
+
+  // Create traffic light regulatory elements
+  auto vehicle_traffic_light = lanelet::TrafficLight::make(
+    VEHICLE_TL_REG_ELEM_ID, vehicle_tl_extra_attrs, {vehicle_tl_linestring});
+  auto crosswalk_traffic_light = lanelet::TrafficLight::make(
+    CROSSWALK_TL_REG_ELEM_ID, lanelet::AttributeMap{}, {crosswalk_tl_linestring});
+
+  // Create vehicle lanelet
+  lanelet::Lanelet vehicle_lanelet(1000, vehicle_left, vehicle_right);
+  vehicle_lanelet.attributes()["type"] = "lanelet";
+  vehicle_lanelet.attributes()["subtype"] = "road";
+  vehicle_lanelet.attributes()["turn_direction"] = "straight";
+  vehicle_lanelet.addRegulatoryElement(vehicle_traffic_light);
+
+  // Create crosswalk lanelet
+  lanelet::Lanelet crosswalk_lanelet(2000, crosswalk_left, crosswalk_right);
+  crosswalk_lanelet.attributes()["type"] = "lanelet";
+  crosswalk_lanelet.attributes()["subtype"] = "crosswalk";
+  crosswalk_lanelet.addRegulatoryElement(crosswalk_traffic_light);
+
+  // Build map
+  auto map = std::make_shared<lanelet::LaneletMap>();
+  map->add(vehicle_lanelet);
+  map->add(crosswalk_lanelet);
+
+  return map;
+}
+
+const TrafficSignal * find_signal(const TrafficSignalArray & array, lanelet::Id id)
+{
+  for (const auto & signal : array.traffic_light_groups) {
+    if (signal.traffic_light_group_id == id) {
+      return &signal;
+    }
+  }
+  return nullptr;
+}
+
+void assert_crosswalk_color(const TrafficSignalArray & result, uint8_t expected_color)
+{
+  const auto * crosswalk_signal = find_signal(result, CROSSWALK_TL_REG_ELEM_ID);
+  ASSERT_NE(crosswalk_signal, nullptr);
+  ASSERT_FALSE(crosswalk_signal->elements.empty());
+  EXPECT_EQ(crosswalk_signal->elements.front().color, expected_color);
+}
+
+CrosswalkTrafficLightEstimator make_estimator_with_map()
+{
+  CrosswalkTrafficLightEstimator estimator(make_default_config());
+  estimator.update_map(create_test_map());
+  return estimator;
+}
+
+lanelet::LaneletMapPtr create_test_map_with_vehicle_tl_rule(
+  const std::string & rule_attribute_key, const std::string & crosswalk_tl_ids_value)
+{
+  lanelet::AttributeMap vehicle_tl_attrs;
+  vehicle_tl_attrs[rule_attribute_key] = crosswalk_tl_ids_value;
+  return create_test_map(vehicle_tl_attrs);
+}
+
+CrosswalkTrafficLightEstimator make_estimator_with_rule(const std::string & rule_attribute_key)
+{
+  CrosswalkTrafficLightEstimator estimator(make_default_config());
+  estimator.update_map(create_test_map_with_vehicle_tl_rule(
+    rule_attribute_key, std::to_string(CROSSWALK_TL_REG_ELEM_ID)));
+  return estimator;
+}
+
+}  // namespace
+
+TEST(CrosswalkTrafficLightEstimatorTest, ConstructorDoesNotThrow)
+{
+  // Arrange
+  auto config = make_default_config();
+
+  // Act & Assert
+  EXPECT_NO_THROW({ CrosswalkTrafficLightEstimator estimator(config); });
+}
+
+TEST(CrosswalkTrafficLightEstimatorTest, IsMapLoadedInitiallyFalse)
+{
+  // Arrange
+  CrosswalkTrafficLightEstimator estimator(make_default_config());
+
+  // Act
+  const bool loaded = estimator.is_map_loaded();
+
+  // Assert
+  EXPECT_FALSE(loaded);
+}
+
+TEST(CrosswalkTrafficLightEstimatorTest, IsMapLoadedAfterUpdateMap)
+{
+  // Arrange
+  CrosswalkTrafficLightEstimator estimator(make_default_config());
+  auto map = create_test_map();
+
+  // Act
+  estimator.update_map(map);
+
+  // Assert
+  EXPECT_TRUE(estimator.is_map_loaded());
+}
+
+TEST(CrosswalkTrafficLightEstimatorTest, FindUnregistered_AllRegistered_ReturnsEmpty)
+{
+  // Arrange
+  auto estimator = make_estimator_with_map();
+  TrafficSignalArray msg = make_signal_array({make_vehicle_signal(TrafficSignalElement::GREEN)});
+
+  // Act
+  const auto unregistered = estimator.find_unregistered_traffic_light_group_ids(msg);
+
+  // Assert
+  EXPECT_TRUE(unregistered.empty());
+}
+
+TEST(CrosswalkTrafficLightEstimatorTest, FindUnregistered_WithUnknownId_ReturnsIt)
+{
+  // Arrange
+  auto estimator = make_estimator_with_map();
+  TrafficSignal unknown_signal;
+  unknown_signal.traffic_light_group_id = 99999;
+  TrafficSignalArray msg = make_signal_array({unknown_signal});
+
+  // Act
+  const auto unregistered = estimator.find_unregistered_traffic_light_group_ids(msg);
+
+  // Assert
+  ASSERT_EQ(unregistered.size(), 1u);
+  EXPECT_EQ(unregistered[0], 99999);
+}
+
+TEST(CrosswalkTrafficLightEstimatorTest, Estimate_FirstCallWithGreenVehicle_CrosswalkRed)
+{
+  // Arrange
+  auto estimator = make_estimator_with_map();
+  TrafficSignalArray green_msg =
+    make_signal_array({make_vehicle_signal(TrafficSignalElement::GREEN)});
+
+  // Act: GREEN vehicle signal is sufficient to estimate crosswalk as RED, even on first call
+  const auto result = estimator.estimate(green_msg, make_time(0.0));
+
+  // Assert
+  assert_crosswalk_color(result, TrafficSignalElement::RED);
+}
+
+TEST(CrosswalkTrafficLightEstimatorTest, Estimate_UnknownVehicleNoHistory_CrosswalkUnknown)
+{
+  // Arrange
+  auto estimator = make_estimator_with_map();
+  TrafficSignalArray unknown_msg =
+    make_signal_array({make_vehicle_signal(TrafficSignalElement::UNKNOWN)});
+
+  // Act: UNKNOWN vehicle signal with no prior history → crosswalk cannot be estimated
+  const auto result = estimator.estimate(unknown_msg, make_time(0.0));
+
+  // Assert
+  assert_crosswalk_color(result, TrafficSignalElement::UNKNOWN);
+}
+
+TEST(CrosswalkTrafficLightEstimatorTest, Estimate_StraightGreenVehicle_CrosswalkRed)
+{
+  // Arrange
+  auto estimator = make_estimator_with_map();
+  TrafficSignalArray green_msg =
+    make_signal_array({make_vehicle_signal(TrafficSignalElement::GREEN)});
+
+  // Act
+  const auto result = estimator.estimate(green_msg, make_time(0.0));
+
+  // Assert: straight green vehicle signal → crosswalk should be RED
+  assert_crosswalk_color(result, TrafficSignalElement::RED);
+}
+
+TEST(CrosswalkTrafficLightEstimatorTest, Estimate_RedVehicle_CrosswalkUnknown)
+{
+  // Arrange
+  auto estimator = make_estimator_with_map();
+  TrafficSignalArray red_msg = make_signal_array({make_vehicle_signal(TrafficSignalElement::RED)});
+
+  // Act
+  const auto result = estimator.estimate(red_msg, make_time(0.0));
+
+  // Assert: vehicle is RED → crosswalk signal is UNKNOWN (cannot determine)
+  assert_crosswalk_color(result, TrafficSignalElement::UNKNOWN);
+}
+
+TEST(CrosswalkTrafficLightEstimatorTest, Estimate_EmptyInput_ReturnsEmpty)
+{
+  // Arrange
+  auto estimator = make_estimator_with_map();
+  TrafficSignalArray empty_msg;
+
+  // Act
+  const auto result = estimator.estimate(empty_msg, make_time(0.0));
+
+  // Assert
+  EXPECT_TRUE(result.traffic_light_groups.empty());
+}
+
+TEST(
+  CrosswalkTrafficLightEstimatorTest,
+  ParseSignalEstimationRules_ValidGreenToGreen_OverridesEstimation)
+{
+  // Arrange: rule "signal_color_relation:green:green" → crosswalk TL ID 200
+  // Normal estimation: GREEN vehicle + straight lane → crosswalk RED
+  // With override:     green matches, crosswalk becomes GREEN
+  auto estimator = make_estimator_with_rule("signal_color_relation:green:green");
+  TrafficSignalArray input = make_signal_array({make_vehicle_signal(TrafficSignalElement::GREEN)});
+
+  // Act
+  const auto result = estimator.estimate(input, make_time(0.0));
+
+  // Assert: override (GREEN) wins over normal estimation (RED)
+  assert_crosswalk_color(result, TrafficSignalElement::GREEN);
+}
+
+int main(int argc, char ** argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/perception/autoware_crosswalk_traffic_light_estimator/test/test_crosswalk_traffic_light_estimator_node.cpp
+++ b/perception/autoware_crosswalk_traffic_light_estimator/test/test_crosswalk_traffic_light_estimator_node.cpp
@@ -1,0 +1,283 @@
+// Copyright 2025 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware_crosswalk_traffic_light_estimator/node.hpp"
+
+#include <autoware/lanelet2_utils/conversion.hpp>
+#include <rclcpp/rclcpp.hpp>
+
+#include <autoware_map_msgs/msg/lanelet_map_bin.hpp>
+#include <autoware_perception_msgs/msg/traffic_light_element.hpp>
+#include <autoware_perception_msgs/msg/traffic_light_group.hpp>
+#include <autoware_perception_msgs/msg/traffic_light_group_array.hpp>
+
+#include <gtest/gtest.h>
+#include <lanelet2_core/LaneletMap.h>
+#include <lanelet2_core/primitives/BasicRegulatoryElements.h>
+#include <lanelet2_core/primitives/Lanelet.h>
+#include <lanelet2_core/primitives/LineString.h>
+#include <lanelet2_core/primitives/Point.h>
+
+#include <chrono>
+#include <memory>
+#include <thread>
+
+using autoware::crosswalk_traffic_light_estimator::CrosswalkTrafficLightEstimatorNode;
+using autoware_map_msgs::msg::LaneletMapBin;
+using autoware_perception_msgs::msg::TrafficLightElement;
+using autoware_perception_msgs::msg::TrafficLightGroup;
+using autoware_perception_msgs::msg::TrafficLightGroupArray;
+
+class CrosswalkTrafficLightEstimatorIntegrationTest : public ::testing::Test
+{
+protected:
+  void SetUp() override
+  {
+    rclcpp::init(0, nullptr);
+
+    rclcpp::NodeOptions options;
+    options.append_parameter_override("use_last_detect_color", true);
+    options.append_parameter_override("use_pedestrian_signal_detect", true);
+    options.append_parameter_override("last_detect_color_hold_time", 2.0);
+    options.append_parameter_override("last_colors_hold_time", 1.0);
+
+    node_ = std::make_shared<CrosswalkTrafficLightEstimatorNode>(options);
+    test_node_ = std::make_shared<rclcpp::Node>("test_node");
+
+    executor_ = std::make_shared<rclcpp::executors::SingleThreadedExecutor>();
+    executor_->add_node(node_);
+    executor_->add_node(test_node_);
+
+    map_pub_ = test_node_->create_publisher<LaneletMapBin>(
+      "/crosswalk_traffic_light_estimator/input/vector_map", rclcpp::QoS(1).transient_local());
+    signal_pub_ = test_node_->create_publisher<TrafficLightGroupArray>(
+      "/crosswalk_traffic_light_estimator/input/classified/traffic_signals", rclcpp::QoS(1));
+
+    message_received_ = false;
+    output_sub_ = test_node_->create_subscription<TrafficLightGroupArray>(
+      "/crosswalk_traffic_light_estimator/output/traffic_signals", rclcpp::QoS(1),
+      [this](const TrafficLightGroupArray::SharedPtr msg) {
+        received_msg_ = msg;
+        message_received_ = true;
+      });
+  }
+
+  void TearDown() override
+  {
+    executor_.reset();
+    node_.reset();
+    test_node_.reset();
+    rclcpp::shutdown();
+  }
+
+  /// @brief Create a lanelet map with a vehicle road and a perpendicular crosswalk.
+  /// The vehicle lanelet (east-west, "straight") overlaps geometrically with the crosswalk
+  /// (north-south), so conflictingInGraph detects the relationship.
+  ///
+  ///   y
+  ///   8 +              cl2 -------- cr2
+  ///     |               | crosswalk |
+  ///   3 + vl1 ----------|---(VTL)---|----------- vl2    (vehicle left bound)
+  ///     |               |           |
+  ///   0 +               |           |
+  ///     |               |           |
+  ///  -3 + vr1 ----------|-----------|----------- vr2    (vehicle right bound)
+  ///     |               |           |
+  ///  -8 +              cl1 -(CTL)- cr1
+  ///     +---+---+---+--+----+------+---+---+--> x
+  ///     0               13  15     17      30
+  ///
+  ///   Vehicle lanelet: subtype="road", turn_direction="straight", TL=vehicle_tl_re_id_
+  ///   Crosswalk lanelet: subtype="crosswalk", TL=crosswalk_tl_re_id_
+  ///   (VTL): vehicle traffic light + stop line at x=13
+  LaneletMapBin createMap()
+  {
+    auto map = std::make_shared<lanelet::LaneletMap>();
+
+    // --- Vehicle lanelet (east-west road, turn_direction="straight") ---
+    lanelet::Point3d vl1(lanelet::utils::getId(), 0.0, 3.0, 0.0);
+    lanelet::Point3d vl2(lanelet::utils::getId(), 30.0, 3.0, 0.0);
+    lanelet::Point3d vr1(lanelet::utils::getId(), 0.0, -3.0, 0.0);
+    lanelet::Point3d vr2(lanelet::utils::getId(), 30.0, -3.0, 0.0);
+
+    lanelet::LineString3d vehicle_left(lanelet::utils::getId(), {vl1, vl2});
+    lanelet::LineString3d vehicle_right(lanelet::utils::getId(), {vr1, vr2});
+
+    lanelet::Lanelet vehicle_lanelet(lanelet::utils::getId(), vehicle_left, vehicle_right);
+    vehicle_lanelet.attributes()["subtype"] = "road";
+    vehicle_lanelet.attributes()["turn_direction"] = "straight";
+
+    // Vehicle traffic light regulatory element
+    lanelet::Point3d vtl_p(lanelet::utils::getId(), 13.0, 3.0, 5.0);
+    lanelet::LineString3d vehicle_tl_shape(lanelet::utils::getId(), {vtl_p});
+
+    lanelet::Point3d vsl1(lanelet::utils::getId(), 13.0, 3.0, 0.0);
+    lanelet::Point3d vsl2(lanelet::utils::getId(), 13.0, -3.0, 0.0);
+    lanelet::LineString3d vehicle_stop_line(lanelet::utils::getId(), {vsl1, vsl2});
+
+    vehicle_tl_re_id_ = lanelet::utils::getId();
+    auto vehicle_tl_re = lanelet::TrafficLight::make(
+      vehicle_tl_re_id_, lanelet::AttributeMap(), {vehicle_tl_shape}, vehicle_stop_line);
+    vehicle_lanelet.addRegulatoryElement(vehicle_tl_re);
+
+    // --- Crosswalk lanelet (north-south, overlaps vehicle lanelet at x=[13,17]) ---
+    lanelet::Point3d cl1(lanelet::utils::getId(), 13.0, -8.0, 0.0);
+    lanelet::Point3d cl2(lanelet::utils::getId(), 13.0, 8.0, 0.0);
+    lanelet::Point3d cr1(lanelet::utils::getId(), 17.0, -8.0, 0.0);
+    lanelet::Point3d cr2(lanelet::utils::getId(), 17.0, 8.0, 0.0);
+
+    lanelet::LineString3d crosswalk_left(lanelet::utils::getId(), {cl1, cl2});
+    lanelet::LineString3d crosswalk_right(lanelet::utils::getId(), {cr1, cr2});
+
+    lanelet::Lanelet crosswalk_lanelet(lanelet::utils::getId(), crosswalk_left, crosswalk_right);
+    crosswalk_lanelet.attributes()["subtype"] = "crosswalk";
+
+    // Crosswalk traffic light regulatory element
+    lanelet::Point3d ctl_p(lanelet::utils::getId(), 15.0, -8.0, 3.0);
+    lanelet::LineString3d crosswalk_tl_shape(lanelet::utils::getId(), {ctl_p});
+
+    lanelet::Point3d csl1(lanelet::utils::getId(), 13.0, -3.0, 0.0);
+    lanelet::Point3d csl2(lanelet::utils::getId(), 17.0, -3.0, 0.0);
+    lanelet::LineString3d crosswalk_stop_line(lanelet::utils::getId(), {csl1, csl2});
+
+    crosswalk_tl_re_id_ = lanelet::utils::getId();
+    auto crosswalk_tl_re = lanelet::TrafficLight::make(
+      crosswalk_tl_re_id_, lanelet::AttributeMap(), {crosswalk_tl_shape}, crosswalk_stop_line);
+    crosswalk_lanelet.addRegulatoryElement(crosswalk_tl_re);
+
+    map->add(vehicle_lanelet);
+    map->add(crosswalk_lanelet);
+
+    auto msg = autoware::experimental::lanelet2_utils::to_autoware_map_msgs(map);
+    msg.header.frame_id = "map";
+    return msg;
+  }
+
+  TrafficLightGroupArray createTrafficSignal(lanelet::Id tl_id, uint8_t color)
+  {
+    TrafficLightGroupArray msg;
+    msg.stamp = node_->now();
+
+    TrafficLightGroup group;
+    group.traffic_light_group_id = tl_id;
+
+    TrafficLightElement element;
+    element.color = color;
+    element.shape = TrafficLightElement::CIRCLE;
+    element.status = TrafficLightElement::SOLID_ON;
+    element.confidence = 1.0;
+
+    group.elements.push_back(element);
+    msg.traffic_light_groups.push_back(group);
+    return msg;
+  }
+
+  bool waitForMessage(std::chrono::milliseconds timeout = std::chrono::milliseconds(3000))
+  {
+    auto start = std::chrono::steady_clock::now();
+    message_received_ = false;
+    while (!message_received_) {
+      if (std::chrono::steady_clock::now() - start > timeout) {
+        return false;
+      }
+      executor_->spin_some();
+      std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+    return true;
+  }
+
+  void spinFor(std::chrono::milliseconds duration)
+  {
+    auto start = std::chrono::steady_clock::now();
+    while (std::chrono::steady_clock::now() - start < duration) {
+      executor_->spin_some();
+      std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+  }
+
+  std::shared_ptr<CrosswalkTrafficLightEstimatorNode> node_;
+  std::shared_ptr<rclcpp::Node> test_node_;
+  std::shared_ptr<rclcpp::executors::SingleThreadedExecutor> executor_;
+
+  rclcpp::Publisher<LaneletMapBin>::SharedPtr map_pub_;
+  rclcpp::Publisher<TrafficLightGroupArray>::SharedPtr signal_pub_;
+  rclcpp::Subscription<TrafficLightGroupArray>::SharedPtr output_sub_;
+  TrafficLightGroupArray::SharedPtr received_msg_;
+  bool message_received_ = false;
+
+  lanelet::Id vehicle_tl_re_id_{0};
+  lanelet::Id crosswalk_tl_re_id_{0};
+
+  void publishMap()
+  {
+    auto map_msg = createMap();
+    map_pub_->publish(map_msg);
+    spinFor(std::chrono::milliseconds(500));
+  }
+
+  void publishTrafficSignal(uint8_t vehicle_color)
+  {
+    auto signal = createTrafficSignal(vehicle_tl_re_id_, vehicle_color);
+    signal_pub_->publish(signal);
+    ASSERT_TRUE(waitForMessage());
+  }
+
+  /// @brief Find the crosswalk signal color in received_msg_.
+  /// Fails the test if not found.
+  uint8_t getCrosswalkColor() const
+  {
+    for (const auto & group : received_msg_->traffic_light_groups) {
+      if (group.traffic_light_group_id == crosswalk_tl_re_id_) {
+        EXPECT_FALSE(group.elements.empty());
+        return group.elements.front().color;
+      }
+    }
+    ADD_FAILURE() << "Crosswalk traffic signal not found in output";
+    return TrafficLightElement::UNKNOWN;
+  }
+};
+
+/// @brief Vehicle straight lanelet GREEN → crosswalk is estimated as RED.
+TEST_F(CrosswalkTrafficLightEstimatorIntegrationTest, StraightGreenEstimatesRed)
+{
+  // Arrange
+  publishMap();
+
+  // Act
+  publishTrafficSignal(TrafficLightElement::GREEN);
+  publishTrafficSignal(TrafficLightElement::GREEN);
+
+  // Assert
+  EXPECT_EQ(getCrosswalkColor(), TrafficLightElement::RED);
+}
+
+/// @brief Vehicle signal RED → all vehicle lanelets are RED → crosswalk is estimated as UNKNOWN.
+TEST_F(CrosswalkTrafficLightEstimatorIntegrationTest, AllRedEstimatesUnknown)
+{
+  // Arrange
+  publishMap();
+
+  // Act
+  publishTrafficSignal(TrafficLightElement::RED);
+  publishTrafficSignal(TrafficLightElement::RED);
+
+  // Assert
+  EXPECT_EQ(getCrosswalkColor(), TrafficLightElement::UNKNOWN);
+}
+
+int main(int argc, char ** argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/perception/autoware_crosswalk_traffic_light_estimator/test/test_crosswalk_traffic_light_estimator_node.cpp
+++ b/perception/autoware_crosswalk_traffic_light_estimator/test/test_crosswalk_traffic_light_estimator_node.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "autoware_crosswalk_traffic_light_estimator/node.hpp"
+#include "../src/node.hpp"
 
 #include <autoware/lanelet2_utils/conversion.hpp>
 #include <rclcpp/rclcpp.hpp>
@@ -101,7 +101,7 @@ protected:
   ///   Vehicle lanelet: subtype="road", turn_direction="straight", TL=vehicle_tl_re_id_
   ///   Crosswalk lanelet: subtype="crosswalk", TL=crosswalk_tl_re_id_
   ///   (VTL): vehicle traffic light + stop line at x=13
-  LaneletMapBin createMap()
+  LaneletMapBin create_map()
   {
     auto map = std::make_shared<lanelet::LaneletMap>();
 
@@ -164,7 +164,7 @@ protected:
     return msg;
   }
 
-  TrafficLightGroupArray createTrafficSignal(lanelet::Id tl_id, uint8_t color)
+  TrafficLightGroupArray create_traffic_signal(lanelet::Id tl_id, uint8_t color)
   {
     TrafficLightGroupArray msg;
     msg.stamp = node_->now();
@@ -183,7 +183,7 @@ protected:
     return msg;
   }
 
-  bool waitForMessage(std::chrono::milliseconds timeout = std::chrono::milliseconds(3000))
+  bool wait_for_message(std::chrono::milliseconds timeout = std::chrono::milliseconds(3000))
   {
     auto start = std::chrono::steady_clock::now();
     message_received_ = false;
@@ -197,7 +197,7 @@ protected:
     return true;
   }
 
-  void spinFor(std::chrono::milliseconds duration)
+  void spin_for(std::chrono::milliseconds duration)
   {
     auto start = std::chrono::steady_clock::now();
     while (std::chrono::steady_clock::now() - start < duration) {
@@ -219,23 +219,23 @@ protected:
   lanelet::Id vehicle_tl_re_id_{0};
   lanelet::Id crosswalk_tl_re_id_{0};
 
-  void publishMap()
+  void publish_map()
   {
-    auto map_msg = createMap();
+    auto map_msg = create_map();
     map_pub_->publish(map_msg);
-    spinFor(std::chrono::milliseconds(500));
+    spin_for(std::chrono::milliseconds(500));
   }
 
-  void publishTrafficSignal(uint8_t vehicle_color)
+  void publish_traffic_signal(uint8_t vehicle_color)
   {
-    auto signal = createTrafficSignal(vehicle_tl_re_id_, vehicle_color);
+    auto signal = create_traffic_signal(vehicle_tl_re_id_, vehicle_color);
     signal_pub_->publish(signal);
-    ASSERT_TRUE(waitForMessage());
+    ASSERT_TRUE(wait_for_message());
   }
 
   /// @brief Find the crosswalk signal color in received_msg_.
   /// Fails the test if not found.
-  uint8_t getCrosswalkColor() const
+  uint8_t get_crosswalk_color() const
   {
     for (const auto & group : received_msg_->traffic_light_groups) {
       if (group.traffic_light_group_id == crosswalk_tl_re_id_) {
@@ -252,28 +252,28 @@ protected:
 TEST_F(CrosswalkTrafficLightEstimatorIntegrationTest, StraightGreenEstimatesRed)
 {
   // Arrange
-  publishMap();
+  publish_map();
 
   // Act
-  publishTrafficSignal(TrafficLightElement::GREEN);
-  publishTrafficSignal(TrafficLightElement::GREEN);
+  publish_traffic_signal(TrafficLightElement::GREEN);
+  publish_traffic_signal(TrafficLightElement::GREEN);
 
   // Assert
-  EXPECT_EQ(getCrosswalkColor(), TrafficLightElement::RED);
+  EXPECT_EQ(get_crosswalk_color(), TrafficLightElement::RED);
 }
 
 /// @brief Vehicle signal RED → all vehicle lanelets are RED → crosswalk is estimated as UNKNOWN.
 TEST_F(CrosswalkTrafficLightEstimatorIntegrationTest, AllRedEstimatesUnknown)
 {
   // Arrange
-  publishMap();
+  publish_map();
 
   // Act
-  publishTrafficSignal(TrafficLightElement::RED);
-  publishTrafficSignal(TrafficLightElement::RED);
+  publish_traffic_signal(TrafficLightElement::RED);
+  publish_traffic_signal(TrafficLightElement::RED);
 
   // Assert
-  EXPECT_EQ(getCrosswalkColor(), TrafficLightElement::UNKNOWN);
+  EXPECT_EQ(get_crosswalk_color(), TrafficLightElement::UNKNOWN);
 }
 
 int main(int argc, char ** argv)

--- a/perception/autoware_crosswalk_traffic_light_estimator/test/test_crosswalk_traffic_light_estimator_node.cpp
+++ b/perception/autoware_crosswalk_traffic_light_estimator/test/test_crosswalk_traffic_light_estimator_node.cpp
@@ -18,16 +18,10 @@
 #include <rclcpp/rclcpp.hpp>
 
 #include <autoware_map_msgs/msg/lanelet_map_bin.hpp>
-#include <autoware_perception_msgs/msg/traffic_light_element.hpp>
-#include <autoware_perception_msgs/msg/traffic_light_group.hpp>
 #include <autoware_perception_msgs/msg/traffic_light_group_array.hpp>
 
 #include <gtest/gtest.h>
 #include <lanelet2_core/LaneletMap.h>
-#include <lanelet2_core/primitives/BasicRegulatoryElements.h>
-#include <lanelet2_core/primitives/Lanelet.h>
-#include <lanelet2_core/primitives/LineString.h>
-#include <lanelet2_core/primitives/Point.h>
 
 #include <chrono>
 #include <memory>
@@ -35,8 +29,6 @@
 
 using autoware::crosswalk_traffic_light_estimator::CrosswalkTrafficLightEstimatorNode;
 using autoware_map_msgs::msg::LaneletMapBin;
-using autoware_perception_msgs::msg::TrafficLightElement;
-using autoware_perception_msgs::msg::TrafficLightGroup;
 using autoware_perception_msgs::msg::TrafficLightGroupArray;
 
 class CrosswalkTrafficLightEstimatorIntegrationTest : public ::testing::Test
@@ -81,108 +73,6 @@ protected:
     rclcpp::shutdown();
   }
 
-  /// @brief Create a lanelet map with a vehicle road and a perpendicular crosswalk.
-  /// The vehicle lanelet (east-west, "straight") overlaps geometrically with the crosswalk
-  /// (north-south), so conflictingInGraph detects the relationship.
-  ///
-  ///   y
-  ///   8 +              cl2 -------- cr2
-  ///     |               | crosswalk |
-  ///   3 + vl1 ----------|---(VTL)---|----------- vl2    (vehicle left bound)
-  ///     |               |           |
-  ///   0 +               |           |
-  ///     |               |           |
-  ///  -3 + vr1 ----------|-----------|----------- vr2    (vehicle right bound)
-  ///     |               |           |
-  ///  -8 +              cl1 -(CTL)- cr1
-  ///     +---+---+---+--+----+------+---+---+--> x
-  ///     0               13  15     17      30
-  ///
-  ///   Vehicle lanelet: subtype="road", turn_direction="straight", TL=vehicle_tl_re_id_
-  ///   Crosswalk lanelet: subtype="crosswalk", TL=crosswalk_tl_re_id_
-  ///   (VTL): vehicle traffic light + stop line at x=13
-  LaneletMapBin create_map()
-  {
-    auto map = std::make_shared<lanelet::LaneletMap>();
-
-    // --- Vehicle lanelet (east-west road, turn_direction="straight") ---
-    lanelet::Point3d vl1(lanelet::utils::getId(), 0.0, 3.0, 0.0);
-    lanelet::Point3d vl2(lanelet::utils::getId(), 30.0, 3.0, 0.0);
-    lanelet::Point3d vr1(lanelet::utils::getId(), 0.0, -3.0, 0.0);
-    lanelet::Point3d vr2(lanelet::utils::getId(), 30.0, -3.0, 0.0);
-
-    lanelet::LineString3d vehicle_left(lanelet::utils::getId(), {vl1, vl2});
-    lanelet::LineString3d vehicle_right(lanelet::utils::getId(), {vr1, vr2});
-
-    lanelet::Lanelet vehicle_lanelet(lanelet::utils::getId(), vehicle_left, vehicle_right);
-    vehicle_lanelet.attributes()["subtype"] = "road";
-    vehicle_lanelet.attributes()["turn_direction"] = "straight";
-
-    // Vehicle traffic light regulatory element
-    lanelet::Point3d vtl_p(lanelet::utils::getId(), 13.0, 3.0, 5.0);
-    lanelet::LineString3d vehicle_tl_shape(lanelet::utils::getId(), {vtl_p});
-
-    lanelet::Point3d vsl1(lanelet::utils::getId(), 13.0, 3.0, 0.0);
-    lanelet::Point3d vsl2(lanelet::utils::getId(), 13.0, -3.0, 0.0);
-    lanelet::LineString3d vehicle_stop_line(lanelet::utils::getId(), {vsl1, vsl2});
-
-    vehicle_tl_re_id_ = lanelet::utils::getId();
-    auto vehicle_tl_re = lanelet::TrafficLight::make(
-      vehicle_tl_re_id_, lanelet::AttributeMap(), {vehicle_tl_shape}, vehicle_stop_line);
-    vehicle_lanelet.addRegulatoryElement(vehicle_tl_re);
-
-    // --- Crosswalk lanelet (north-south, overlaps vehicle lanelet at x=[13,17]) ---
-    lanelet::Point3d cl1(lanelet::utils::getId(), 13.0, -8.0, 0.0);
-    lanelet::Point3d cl2(lanelet::utils::getId(), 13.0, 8.0, 0.0);
-    lanelet::Point3d cr1(lanelet::utils::getId(), 17.0, -8.0, 0.0);
-    lanelet::Point3d cr2(lanelet::utils::getId(), 17.0, 8.0, 0.0);
-
-    lanelet::LineString3d crosswalk_left(lanelet::utils::getId(), {cl1, cl2});
-    lanelet::LineString3d crosswalk_right(lanelet::utils::getId(), {cr1, cr2});
-
-    lanelet::Lanelet crosswalk_lanelet(lanelet::utils::getId(), crosswalk_left, crosswalk_right);
-    crosswalk_lanelet.attributes()["subtype"] = "crosswalk";
-
-    // Crosswalk traffic light regulatory element
-    lanelet::Point3d ctl_p(lanelet::utils::getId(), 15.0, -8.0, 3.0);
-    lanelet::LineString3d crosswalk_tl_shape(lanelet::utils::getId(), {ctl_p});
-
-    lanelet::Point3d csl1(lanelet::utils::getId(), 13.0, -3.0, 0.0);
-    lanelet::Point3d csl2(lanelet::utils::getId(), 17.0, -3.0, 0.0);
-    lanelet::LineString3d crosswalk_stop_line(lanelet::utils::getId(), {csl1, csl2});
-
-    crosswalk_tl_re_id_ = lanelet::utils::getId();
-    auto crosswalk_tl_re = lanelet::TrafficLight::make(
-      crosswalk_tl_re_id_, lanelet::AttributeMap(), {crosswalk_tl_shape}, crosswalk_stop_line);
-    crosswalk_lanelet.addRegulatoryElement(crosswalk_tl_re);
-
-    map->add(vehicle_lanelet);
-    map->add(crosswalk_lanelet);
-
-    auto msg = autoware::experimental::lanelet2_utils::to_autoware_map_msgs(map);
-    msg.header.frame_id = "map";
-    return msg;
-  }
-
-  TrafficLightGroupArray create_traffic_signal(lanelet::Id tl_id, uint8_t color)
-  {
-    TrafficLightGroupArray msg;
-    msg.stamp = node_->now();
-
-    TrafficLightGroup group;
-    group.traffic_light_group_id = tl_id;
-
-    TrafficLightElement element;
-    element.color = color;
-    element.shape = TrafficLightElement::CIRCLE;
-    element.status = TrafficLightElement::SOLID_ON;
-    element.confidence = 1.0;
-
-    group.elements.push_back(element);
-    msg.traffic_light_groups.push_back(group);
-    return msg;
-  }
-
   bool wait_for_message(std::chrono::milliseconds timeout = std::chrono::milliseconds(3000))
   {
     auto start = std::chrono::steady_clock::now();
@@ -215,65 +105,26 @@ protected:
   rclcpp::Subscription<TrafficLightGroupArray>::SharedPtr output_sub_;
   TrafficLightGroupArray::SharedPtr received_msg_;
   bool message_received_ = false;
-
-  lanelet::Id vehicle_tl_re_id_{0};
-  lanelet::Id crosswalk_tl_re_id_{0};
-
-  void publish_map()
-  {
-    auto map_msg = create_map();
-    map_pub_->publish(map_msg);
-    spin_for(std::chrono::milliseconds(500));
-  }
-
-  void publish_traffic_signal(uint8_t vehicle_color)
-  {
-    auto signal = create_traffic_signal(vehicle_tl_re_id_, vehicle_color);
-    signal_pub_->publish(signal);
-    ASSERT_TRUE(wait_for_message());
-  }
-
-  /// @brief Find the crosswalk signal color in received_msg_.
-  /// Fails the test if not found.
-  uint8_t get_crosswalk_color() const
-  {
-    for (const auto & group : received_msg_->traffic_light_groups) {
-      if (group.traffic_light_group_id == crosswalk_tl_re_id_) {
-        EXPECT_FALSE(group.elements.empty());
-        return group.elements.front().color;
-      }
-    }
-    ADD_FAILURE() << "Crosswalk traffic signal not found in output";
-    return TrafficLightElement::UNKNOWN;
-  }
 };
 
-/// @brief Vehicle straight lanelet GREEN → crosswalk is estimated as RED.
-TEST_F(CrosswalkTrafficLightEstimatorIntegrationTest, StraightGreenEstimatesRed)
+/// @brief Empty map and empty traffic signal input produces empty traffic signal output.
+TEST_F(CrosswalkTrafficLightEstimatorIntegrationTest, EmptyInputProducesEmptyOutput)
 {
   // Arrange
-  publish_map();
+  auto empty_lanelet_map = std::make_shared<lanelet::LaneletMap>();
+  auto empty_map = autoware::experimental::lanelet2_utils::to_autoware_map_msgs(empty_lanelet_map);
+  empty_map.header.frame_id = "map";
+  map_pub_->publish(empty_map);
+  spin_for(std::chrono::milliseconds(500));
 
   // Act
-  publish_traffic_signal(TrafficLightElement::GREEN);
-  publish_traffic_signal(TrafficLightElement::GREEN);
+  TrafficLightGroupArray empty_signal;
+  empty_signal.stamp = node_->now();
+  signal_pub_->publish(empty_signal);
 
   // Assert
-  EXPECT_EQ(get_crosswalk_color(), TrafficLightElement::RED);
-}
-
-/// @brief Vehicle signal RED → all vehicle lanelets are RED → crosswalk is estimated as UNKNOWN.
-TEST_F(CrosswalkTrafficLightEstimatorIntegrationTest, AllRedEstimatesUnknown)
-{
-  // Arrange
-  publish_map();
-
-  // Act
-  publish_traffic_signal(TrafficLightElement::RED);
-  publish_traffic_signal(TrafficLightElement::RED);
-
-  // Assert
-  EXPECT_EQ(get_crosswalk_color(), TrafficLightElement::UNKNOWN);
+  ASSERT_TRUE(wait_for_message());
+  EXPECT_TRUE(received_msg_->traffic_light_groups.empty());
 }
 
 int main(int argc, char ** argv)

--- a/perception/autoware_crosswalk_traffic_light_estimator/test/test_flashing_detection.cpp
+++ b/perception/autoware_crosswalk_traffic_light_estimator/test/test_flashing_detection.cpp
@@ -1,0 +1,146 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware_crosswalk_traffic_light_estimator/flashing_detection.hpp"
+
+#include <gtest/gtest.h>
+
+#include <utility>
+
+using autoware::crosswalk_traffic_light_estimator::FlashingDetectionConfig;
+using autoware::crosswalk_traffic_light_estimator::FlashingDetector;
+using autoware::crosswalk_traffic_light_estimator::TrafficSignal;
+using autoware::crosswalk_traffic_light_estimator::TrafficSignalElement;
+
+namespace
+{
+
+const int DEFAULT_SIGNAL_ID = 100;
+
+TrafficSignal make_signal(uint8_t color, float confidence = 1.0)
+{
+  TrafficSignal signal;
+  signal.traffic_light_group_id = DEFAULT_SIGNAL_ID;
+  TrafficSignalElement element;
+  element.color = color;
+  element.shape = TrafficSignalElement::CIRCLE;
+  element.status = TrafficSignalElement::SOLID_ON;
+  element.confidence = confidence;
+  signal.elements.push_back(element);
+  return signal;
+}
+
+// Helper that manages FlashingDetector
+class FlashingDetectorDriver
+{
+public:
+  explicit FlashingDetectorDriver(FlashingDetectionConfig config = FlashingDetectionConfig{1.0})
+  : detector_(config)
+  {
+  }
+
+  uint8_t estimate(double time_sec, uint8_t color, float confidence = 1.0)
+  {
+    const auto time = rclcpp::Time(static_cast<int64_t>(time_sec * 1e9));
+    return detector_.estimate_stable_color(make_signal(color, confidence), time);
+  }
+
+  void clear_state(int signal_id = DEFAULT_SIGNAL_ID) { detector_.clear_state(signal_id); }
+
+private:
+  FlashingDetector detector_;
+};
+
+}  // namespace
+
+// --- estimate_stable_color tests ---
+
+TEST(FlashingDetectorTest, FirstCall_ReturnsDetectedColor)
+{
+  // Arrange
+  FlashingDetectorDriver driver;
+
+  // Act
+  const uint8_t color = driver.estimate(0.0, TrafficSignalElement::GREEN);
+
+  // Act & Assert
+  EXPECT_EQ(color, TrafficSignalElement::GREEN);
+}
+
+TEST(FlashingDetectorTest, FlashingDetected_UnknownAfterGreen)
+{
+  // Arrange
+  FlashingDetectorDriver driver;
+
+  // Act
+  driver.estimate(0.0, TrafficSignalElement::GREEN);
+  const uint8_t color = driver.estimate(0.1, TrafficSignalElement::UNKNOWN);
+
+  // Assert: maintains GREEN during flashing (UNKNOWN input doesn't change state to UNKNOWN)
+  EXPECT_EQ(color, TrafficSignalElement::GREEN);
+}
+
+TEST(FlashingDetectorTest, FlashingTransition_GreenToRed)
+{
+  // Arrange
+  FlashingDetectorDriver driver;
+
+  // Act: during flashing, RED input transitions from GREEN to RED
+  driver.estimate(0.0, TrafficSignalElement::GREEN);
+  driver.estimate(0.1, TrafficSignalElement::UNKNOWN);
+  const uint8_t color = driver.estimate(0.2, TrafficSignalElement::RED);
+
+  // Assert
+  EXPECT_EQ(color, TrafficSignalElement::RED);
+}
+
+TEST(FlashingDetectorTest, EstimateStableColor_PrunesOldEntries)
+{
+  // Arrange
+  FlashingDetectorDriver driver(FlashingDetectionConfig{1.0});
+
+  // Build state and trigger flashing
+  driver.estimate(0.0, TrafficSignalElement::GREEN);
+  driver.estimate(0.1, TrafficSignalElement::UNKNOWN);
+  driver.estimate(0.2, TrafficSignalElement::GREEN);
+
+  // Act: feed UNKNOWN at time > hold_time, old flashing entries are pruned
+  const uint8_t color = driver.estimate(2.0, TrafficSignalElement::UNKNOWN);
+
+  // Assert: flashing was reset because old entries were pruned, only UNKNOWN remains
+  EXPECT_EQ(color, TrafficSignalElement::UNKNOWN);
+}
+
+// --- clear_state tests ---
+
+TEST(FlashingDetectorTest, ClearState_RemovesTracking)
+{
+  // Arrange
+  FlashingDetectorDriver driver;
+
+  // Act: trigger flashing, then clear state
+  driver.estimate(0.0, TrafficSignalElement::GREEN);
+  driver.estimate(0.1, TrafficSignalElement::UNKNOWN);
+  driver.clear_state();
+  const uint8_t color = driver.estimate(0.2, TrafficSignalElement::UNKNOWN);
+
+  // Assert: returns UNKNOWN as a first call (no flashing state)
+  EXPECT_EQ(color, TrafficSignalElement::UNKNOWN);
+}
+
+int main(int argc, char ** argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/perception/autoware_crosswalk_traffic_light_estimator/test/test_flashing_detection.cpp
+++ b/perception/autoware_crosswalk_traffic_light_estimator/test/test_flashing_detection.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "autoware_crosswalk_traffic_light_estimator/flashing_detection.hpp"
+#include "../src/flashing_detection.hpp"
 
 #include <gtest/gtest.h>
 


### PR DESCRIPTION
  ## Description

  `autoware_crosswalk_traffic_light_estimator` に `agnocast_wrapper::Node` を適用するため、
  upstream の関連PRを `feat/v0.64/e2e` ブランチへ merge 順に cherry-pick しました。

目的は #12703（agnocast_wrapper::Node 適用）ですが、前提となるリファクタPR群およびCallbackIsolatedExecutorの適用PR(#12714)に依存しているため、依存PRをまとめて取り込んでいます。

## Cherry-picked PRs

  | # | Title |
  |---|-------|
  | #12116 | feat(crosswalk_traffic_light_estimator): remove /route topic to simplify estimation logic |
  | #12252 | refactor(crosswalk_traffic_light_estimator): extract flashing signal detector and unit tests |
  | #12262 | refactor(crosswalk_traffic_light_estimator): rename function names to snake case and move header file to src |
  | #12273 | refactor(crosswalk_traffic_light_estimator): extract core estimation logic |
  | #12288 | feat(crosswalk_traffic_light_estimator): simplify CrosswalkTrafficLightEstimator behavior and add unit tests |
  | #12370 | fix(crosswalk_traffic_light_estimator): skip lanelets with no signal info in get_non_red_lanelets |
  | #12380 | refactor(autoware_crosswalk_traffic_light_estimator): improve readability of get_non_red_lanelets |
  | #12714 | feat(crosswalk_traffic_light_estimator): apply autoware_agnocast_wrapper for CIE |
  | #12703 | feat(crosswalk_traffic_light_estimator): apply `agnocast_wrapper::Node` to crosswalk_traffic_light_estimator |


  ## Notes

  - `src/` 配下の全ソースは upstream #12703 と一致しています。
  - **手動解決**: #12252 の `node.cpp` のみコンフリクトしましたが、upstream 版を採用して解決しました（差分は `insert(make_pair)` vs `emplace` の表記のみでした）。

## agnocast適用全体像
https://tier4.atlassian.net/wiki/spaces/CRL/pages/5280465670/perception+nodes