### PR TITLE
feat(traffic_light_multi_camera_fusion): cherry pick PRs to apply agnocast to `traffic_light_multi_camera_fusion`

### DIFF
--- a/perception/autoware_traffic_light_multi_camera_fusion/CMakeLists.txt
+++ b/perception/autoware_traffic_light_multi_camera_fusion/CMakeLists.txt
@@ -18,11 +18,11 @@ ament_auto_add_library(${PROJECT_NAME} SHARED
 autoware_agnocast_wrapper_register_node(${PROJECT_NAME}
   PLUGIN "autoware::traffic_light::MultiCameraFusionNode"
   EXECUTABLE traffic_light_multi_camera_fusion_node
-  AGNOCAST_EXECUTOR CallbackIsolatedAgnocastExecutor
+  AGNOCAST_EXECUTOR AgnocastOnlyCallbackIsolatedExecutor
   ROS2_EXECUTOR SingleThreadedExecutor
 )
 
-if(BUILD_TESTING)
+if(BUILD_TESTING AND (NOT "$ENV{ENABLE_AGNOCAST}" STREQUAL "1"))
   find_package(ament_cmake_gtest REQUIRED)
   find_package(ament_cmake_ros REQUIRED)
   ament_auto_add_gtest(${PROJECT_NAME}_test

--- a/perception/autoware_traffic_light_multi_camera_fusion/CMakeLists.txt
+++ b/perception/autoware_traffic_light_multi_camera_fusion/CMakeLists.txt
@@ -21,9 +21,16 @@ rclcpp_components_register_node(${PROJECT_NAME}
 
 if(BUILD_TESTING)
   find_package(ament_cmake_gtest REQUIRED)
+  find_package(ament_cmake_ros REQUIRED)
   ament_auto_add_gtest(${PROJECT_NAME}_test
     test/test_utils.cpp
     test/test_signal_validator.cpp
+  )
+  ament_add_ros_isolated_gtest(${PROJECT_NAME}_node_test
+    test/test_traffic_light_multi_camera_fusion_node.cpp
+  )
+  target_link_libraries(${PROJECT_NAME}_node_test
+    ${PROJECT_NAME}
   )
 endif()
 

--- a/perception/autoware_traffic_light_multi_camera_fusion/CMakeLists.txt
+++ b/perception/autoware_traffic_light_multi_camera_fusion/CMakeLists.txt
@@ -15,9 +15,11 @@ ament_auto_add_library(${PROJECT_NAME} SHARED
   src/signal_validator.cpp
 )
 
-rclcpp_components_register_node(${PROJECT_NAME}
+autoware_agnocast_wrapper_register_node(${PROJECT_NAME}
   PLUGIN "autoware::traffic_light::MultiCameraFusionNode"
   EXECUTABLE traffic_light_multi_camera_fusion_node
+  AGNOCAST_EXECUTOR CallbackIsolatedAgnocastExecutor
+  ROS2_EXECUTOR SingleThreadedExecutor
 )
 
 if(BUILD_TESTING)

--- a/perception/autoware_traffic_light_multi_camera_fusion/CMakeLists.txt
+++ b/perception/autoware_traffic_light_multi_camera_fusion/CMakeLists.txt
@@ -26,6 +26,7 @@ if(BUILD_TESTING)
   ament_auto_add_gtest(${PROJECT_NAME}_test
     test/test_utils.cpp
     test/test_signal_validator.cpp
+    test/test_multi_camera_fusion.cpp
   )
   ament_add_ros_isolated_gtest(${PROJECT_NAME}_node_test
     test/test_traffic_light_multi_camera_fusion_node.cpp

--- a/perception/autoware_traffic_light_multi_camera_fusion/CMakeLists.txt
+++ b/perception/autoware_traffic_light_multi_camera_fusion/CMakeLists.txt
@@ -10,12 +10,13 @@ include_directories(
 
 ament_auto_add_library(${PROJECT_NAME} SHARED
   src/traffic_light_multi_camera_fusion_node.cpp
+  src/multi_camera_fusion.cpp
   src/traffic_light_multi_camera_fusion_process.cpp
   src/signal_validator.cpp
 )
 
 rclcpp_components_register_node(${PROJECT_NAME}
-  PLUGIN "autoware::traffic_light::MultiCameraFusion"
+  PLUGIN "autoware::traffic_light::MultiCameraFusionNode"
   EXECUTABLE traffic_light_multi_camera_fusion_node
 )
 

--- a/perception/autoware_traffic_light_multi_camera_fusion/CMakeLists.txt
+++ b/perception/autoware_traffic_light_multi_camera_fusion/CMakeLists.txt
@@ -18,7 +18,7 @@ ament_auto_add_library(${PROJECT_NAME} SHARED
 autoware_agnocast_wrapper_register_node(${PROJECT_NAME}
   PLUGIN "autoware::traffic_light::MultiCameraFusionNode"
   EXECUTABLE traffic_light_multi_camera_fusion_node
-  AGNOCAST_EXECUTOR AgnocastOnlyCallbackIsolatedExecutor
+  AGNOCAST_EXECUTOR CallbackIsolatedAgnocastExecutor
   ROS2_EXECUTOR SingleThreadedExecutor
 )
 

--- a/perception/autoware_traffic_light_multi_camera_fusion/launch/traffic_light_multi_camera_fusion.launch.xml
+++ b/perception/autoware_traffic_light_multi_camera_fusion/launch/traffic_light_multi_camera_fusion.launch.xml
@@ -1,11 +1,14 @@
 <?xml version="1.0"?>
 <launch>
+  <include file="$(find-pkg-share autoware_agnocast_wrapper)/launch/agnocast_env.launch.xml"/>
+
   <arg name="input/vector_map" default="/map/vector_map"/>
   <arg name="param_path" default="$(find-pkg-share autoware_traffic_light_multi_camera_fusion)/config/traffic_light_multi_camera_fusion.param.yaml"/>
   <arg name="output/traffic_signals" default="/perception/traffic_light_recognition/traffic_signals"/>
   <arg name="camera_namespaces" default="[camera6, camera7]"/>
 
   <node pkg="autoware_traffic_light_multi_camera_fusion" exec="traffic_light_multi_camera_fusion_node" name="traffic_light_multi_camera_fusion" output="screen">
+    <env name="LD_PRELOAD" value="$(var ld_preload_value)"/>
     <remap from="~/input/vector_map" to="$(var input/vector_map)"/>
     <remap from="~/output/traffic_signals" to="$(var output/traffic_signals)"/>
     <param from="$(var param_path)"/>

--- a/perception/autoware_traffic_light_multi_camera_fusion/package.xml
+++ b/perception/autoware_traffic_light_multi_camera_fusion/package.xml
@@ -15,6 +15,7 @@
   <build_depend>ament_cmake_gtest</build_depend>
   <build_depend>autoware_cmake</build_depend>
 
+  <depend>autoware_agnocast_wrapper</depend>
   <depend>autoware_lanelet2_extension</depend>
   <depend>autoware_lanelet2_utils</depend>
   <depend>autoware_map_msgs</depend>

--- a/perception/autoware_traffic_light_multi_camera_fusion/src/multi_camera_fusion.cpp
+++ b/perception/autoware_traffic_light_multi_camera_fusion/src/multi_camera_fusion.cpp
@@ -20,7 +20,6 @@
 #include <algorithm>
 #include <cmath>
 #include <map>
-#include <memory>
 #include <utility>
 #include <vector>
 
@@ -51,6 +50,29 @@ double probability_to_log_odds(double prob)
    */
   prob = std::clamp(prob, 1e-9, 1.0 - 1e-9);
   return std::log(prob / (1.0 - prob));
+}
+
+bool is_state_key_unknown(const StateKey & state_key)
+{
+  return state_key.size() == 1 &&
+         state_key[0].first == tier4_perception_msgs::msg::TrafficLightElement::UNKNOWN;
+}
+
+bool compare_state_key_log_odds(
+  const std::pair<StateKey, double> & key1, const std::pair<StateKey, double> & key2)
+{
+  // Ordering rule:
+  // 1. Unknown StateKey is always lower priority
+  // 2. Otherwise, smaller log-odds comes first
+  const bool key1_is_unknown = is_state_key_unknown(key1.first);
+  const bool key2_is_unknown = is_state_key_unknown(key2.first);
+  if (key1_is_unknown && !key2_is_unknown) {
+    return true;
+  }
+  if (!key1_is_unknown && key2_is_unknown) {
+    return false;
+  }
+  return key1.second < key2.second;
 }
 
 /**
@@ -88,6 +110,46 @@ std::map<lanelet::Id, std::vector<lanelet::Id>> build_traffic_light_id_to_regula
   return traffic_light_id_to_regulatory_ele_id;
 }
 
+void convert_output_msg(
+  const std::map<MultiCameraFusion::IdType, utils::FusionRecord> & grouped_record_map,
+  autoware_perception_msgs::msg::TrafficLightGroupArray & msg_out)
+{
+  msg_out.traffic_light_groups.clear();
+  for (const auto & [regulatory_element_id, record] : grouped_record_map) {
+    autoware_perception_msgs::msg::TrafficLightGroup signal_out;
+    signal_out.traffic_light_group_id = regulatory_element_id;
+    for (const auto & element : record.signal.elements) {
+      signal_out.elements.push_back(utils::convert_t4_to_autoware(element));
+    }
+    msg_out.traffic_light_groups.push_back(signal_out);
+  }
+}
+
+/**
+ * @brief Handles the logic for tracking the best record for a given state.
+ */
+void update_best_record(
+  std::map<StateKey, utils::FusionRecord> & best_record_map, const StateKey & state_key,
+  double confidence, const utils::FusionRecord & record)
+{
+  const auto it = best_record_map.find(state_key);
+
+  if (it == best_record_map.end()) {
+    best_record_map[state_key] = record;
+    return;
+  }
+
+  auto & existing_record = it->second;
+
+  if (existing_record.signal.elements.empty()) {
+    return;
+  }
+
+  if (confidence > utils::get_min_confidence(existing_record.signal)) {
+    best_record_map[state_key] = record;
+  }
+}
+
 }  // namespace
 
 MultiCameraFusion::MultiCameraFusion(const MultiCameraFusionConfig & config)
@@ -95,9 +157,6 @@ MultiCameraFusion::MultiCameraFusion(const MultiCameraFusionConfig & config)
   traffic_light_id_to_regulatory_ele_id_(
     build_traffic_light_id_to_regulatory_ele_id(config.lanelet_map_ptr))
 {
-  if (config_.use_signal_consistency_check) {
-    signal_validator_ = std::make_unique<SignalValidator>();
-  }
 }
 
 MultiCameraFusionResult MultiCameraFusion::fuse(
@@ -121,22 +180,6 @@ MultiCameraFusionResult MultiCameraFusion::fuse(
 
   result.conflicted_regulatory_element_status = conflicted_regulatory_element_status_;
   return result;
-}
-
-void MultiCameraFusion::convert_output_msg(
-  const std::map<IdType, utils::FusionRecord> & grouped_record_map, NewSignalArrayType & msg_out)
-{
-  msg_out.traffic_light_groups.clear();
-  for (const auto & p : grouped_record_map) {
-    IdType reg_ele_id = p.first;
-    const SignalType & signal = p.second.signal;
-    NewSignalType signal_out;
-    signal_out.traffic_light_group_id = reg_ele_id;
-    for (const auto & ele : signal.elements) {
-      signal_out.elements.push_back(utils::convert_t4_to_autoware(ele));
-    }
-    msg_out.traffic_light_groups.push_back(signal_out);
-  }
 }
 
 void MultiCameraFusion::multi_camera_fusion(
@@ -176,7 +219,7 @@ void MultiCameraFusion::multi_camera_fusion(
         */
         if (
           fused_record_map.find(roi.traffic_light_id) == fused_record_map.end() ||
-          utils::compare_record(record, fused_record_map[roi.traffic_light_id]) >= 0) {
+          utils::has_higher_or_equal_priority(record, fused_record_map[roi.traffic_light_id])) {
           fused_record_map[roi.traffic_light_id] = record;
         }
       }
@@ -278,31 +321,6 @@ void MultiCameraFusion::update_log_odds(
   log_odds_map[state_key] += evidence_log_odds - config_.prior_log_odds;
 }
 
-/**
- * @brief Handles the logic for tracking the best record for a given state.
- */
-void MultiCameraFusion::update_best_record(
-  std::map<StateKey, utils::FusionRecord> & best_record_map, const StateKey & state_key,
-  double confidence, const utils::FusionRecord & record)
-{
-  const auto it = best_record_map.find(state_key);
-
-  if (it == best_record_map.end()) {
-    best_record_map[state_key] = record;
-    return;
-  }
-
-  auto & existing_record = it->second;
-
-  if (existing_record.signal.elements.empty()) {
-    return;
-  }
-
-  if (confidence > utils::get_min_confidence(existing_record.signal)) {
-    best_record_map[state_key] = record;
-  }
-}
-
 void MultiCameraFusion::determine_best_group_state(
   const std::map<IdType, GroupFusionInfo> & group_fusion_info_map,
   std::map<IdType, utils::FusionRecord> & grouped_record_map)
@@ -336,7 +354,7 @@ void MultiCameraFusion::determine_best_group_state(
     // check if conflicts exist among the signals within the same regulatory element id
     for (++log_odds_it; log_odds_it != group_info.accumulated_log_odds.end(); ++log_odds_it) {
       const StateKey & competitor_state = (*log_odds_it).first;
-      conflict_result = signal_validator_->check_conflict(running_state, competitor_state);
+      conflict_result = signal_validator::check_conflict(running_state, competitor_state);
       running_state = conflict_result.common_state_key;
 
       if (conflict_result.conflict_type == ConflictType::CONFLICT) {

--- a/perception/autoware_traffic_light_multi_camera_fusion/src/multi_camera_fusion.cpp
+++ b/perception/autoware_traffic_light_multi_camera_fusion/src/multi_camera_fusion.cpp
@@ -190,7 +190,8 @@ MultiCameraFusion::MultiCameraFusion(const MultiCameraFusionConfig & config)
 }
 
 MultiCameraFusionResult MultiCameraFusion::fuse(
-  const CamInfoType & cam_info, const RoiArrayType & rois, const SignalArrayType & signals)
+  const CamInfoType & cam_info, const RoiArrayType & rois, const SignalArrayType & signals,
+  NewSignalArrayType & output_groups)
 {
   /*
   Insert the received record array to the table.
@@ -206,10 +207,8 @@ MultiCameraFusionResult MultiCameraFusion::fuse(
   GroupFusionResult group_result = group_fusion(fused_record_map);
   result.conflicted_regulatory_element_status = group_result.conflicts;
 
-  NewSignalArrayType msg_out;
-  convert_output_msg(group_result.grouped_record_map, msg_out);
-  msg_out.stamp = cam_info.header.stamp;
-  result.traffic_light_groups = msg_out;
+  convert_output_msg(group_result.grouped_record_map, output_groups);
+  output_groups.stamp = cam_info.header.stamp;
 
   return result;
 }

--- a/perception/autoware_traffic_light_multi_camera_fusion/src/multi_camera_fusion.cpp
+++ b/perception/autoware_traffic_light_multi_camera_fusion/src/multi_camera_fusion.cpp
@@ -20,6 +20,7 @@
 #include <algorithm>
 #include <cmath>
 #include <map>
+#include <set>
 #include <utility>
 #include <vector>
 
@@ -150,7 +151,36 @@ void update_best_record(
   }
 }
 
+/**
+ * @brief Collect the traffic light ids that were observed but are not registered in the map.
+ */
+std::vector<MultiCameraFusion::IdType> find_unmapped_traffic_light_ids(
+  const std::map<MultiCameraFusion::IdType, utils::FusionRecord> & fused_record_map,
+  const std::map<lanelet::Id, std::vector<lanelet::Id>> & traffic_light_id_to_regulatory_ele_id)
+{
+  std::vector<MultiCameraFusion::IdType> unmapped_traffic_light_ids;
+  for (const auto & [traffic_light_id, record] : fused_record_map) {
+    if (
+      traffic_light_id_to_regulatory_ele_id.find(traffic_light_id) ==
+      traffic_light_id_to_regulatory_ele_id.end()) {
+      unmapped_traffic_light_ids.emplace_back(traffic_light_id);
+    }
+  }
+  return unmapped_traffic_light_ids;
+}
+
 }  // namespace
+
+std::map<MultiCameraFusion::IdType, utils::FusionRecord> multi_camera_fusion(
+  std::multiset<utils::FusionRecordArr> & record_arr_set, double message_lifespan);
+
+void update_log_odds(
+  std::map<StateKey, double> & log_odds_map, const StateKey & state_key, double confidence,
+  double prior_log_odds);
+
+void update_group_info_for_element(
+  GroupFusionInfoMap & group_fusion_info_map, const MultiCameraFusion::IdType & reg_ele_id,
+  const utils::FusionRecord & record, double prior_log_odds);
 
 MultiCameraFusion::MultiCameraFusion(const MultiCameraFusionConfig & config)
 : config_(config),
@@ -169,43 +199,47 @@ MultiCameraFusionResult MultiCameraFusion::fuse(
   record_arr_set_.insert(utils::FusionRecordArr{cam_info.header, cam_info, rois, signals});
 
   MultiCameraFusionResult result;
-  std::map<IdType, utils::FusionRecord> fused_record_map, grouped_record_map;
-  multi_camera_fusion(fused_record_map);
-  group_fusion(fused_record_map, grouped_record_map, result.unmapped_traffic_light_ids);
+  std::map<IdType, utils::FusionRecord> fused_record_map =
+    multi_camera_fusion(record_arr_set_, config_.message_lifespan);
+  result.unmapped_traffic_light_ids =
+    find_unmapped_traffic_light_ids(fused_record_map, traffic_light_id_to_regulatory_ele_id_);
+  GroupFusionResult group_result = group_fusion(fused_record_map);
+  result.conflicted_regulatory_element_status = group_result.conflicts;
 
   NewSignalArrayType msg_out;
-  convert_output_msg(grouped_record_map, msg_out);
+  convert_output_msg(group_result.grouped_record_map, msg_out);
   msg_out.stamp = cam_info.header.stamp;
   result.traffic_light_groups = msg_out;
 
-  result.conflicted_regulatory_element_status = conflicted_regulatory_element_status_;
   return result;
 }
 
-void MultiCameraFusion::multi_camera_fusion(
-  std::map<IdType, utils::FusionRecord> & fused_record_map)
+std::map<MultiCameraFusion::IdType, utils::FusionRecord> multi_camera_fusion(
+  std::multiset<utils::FusionRecordArr> & record_arr_set, double message_lifespan)
 {
-  fused_record_map.clear();
-  const rclcpp::Time & newest_stamp(record_arr_set_.rbegin()->header.stamp);
-  for (auto it = record_arr_set_.begin(); it != record_arr_set_.end();) {
+  std::map<MultiCameraFusion::IdType, utils::FusionRecord> fused_record_map;
+  const rclcpp::Time & newest_stamp(record_arr_set.rbegin()->header.stamp);
+  for (auto it = record_arr_set.begin(); it != record_arr_set.end();) {
     /*
     remove all old record arrays whose timestamp difference with newest record is larger than
     threshold
     */
     if (
       (newest_stamp - rclcpp::Time(it->header.stamp)) >
-      rclcpp::Duration::from_seconds(config_.message_lifespan)) {
-      it = record_arr_set_.erase(it);
+      rclcpp::Duration::from_seconds(message_lifespan)) {
+      it = record_arr_set.erase(it);
     } else {
       /*
       generate fused record result with the saved records
       */
       const utils::FusionRecordArr & record_arr = *it;
       for (size_t i = 0; i < record_arr.rois.rois.size(); i++) {
-        const RoiType & roi = record_arr.rois.rois[i];
+        const MultiCameraFusion::RoiType & roi = record_arr.rois.rois[i];
         auto signal_it = std::find_if(
           record_arr.signals.signals.begin(), record_arr.signals.signals.end(),
-          [roi](const SignalType & s1) { return roi.traffic_light_id == s1.traffic_light_id; });
+          [roi](const MultiCameraFusion::SignalType & s1) {
+            return roi.traffic_light_id == s1.traffic_light_id;
+          });
         /*
         failed to find corresponding signal. skip it
         */
@@ -226,48 +260,43 @@ void MultiCameraFusion::multi_camera_fusion(
       it++;
     }
   }
+  return fused_record_map;
 }
 
-void MultiCameraFusion::group_fusion(
-  const std::map<IdType, utils::FusionRecord> & fused_record_map,
-  std::map<IdType, utils::FusionRecord> & grouped_record_map,
-  std::vector<IdType> & unmapped_traffic_light_ids)
+GroupFusionResult MultiCameraFusion::group_fusion(
+  const std::map<IdType, utils::FusionRecord> & fused_record_map)
 {
-  grouped_record_map.clear();
-
   // Stage 1: Accumulate evidence from all fused records
   const std::map<IdType, GroupFusionInfo> group_fusion_info_map =
-    accumulate_group_evidence(fused_record_map, unmapped_traffic_light_ids);
+    accumulate_group_evidence(fused_record_map);
 
   // Stage 2: Determine the best state for each group from the accumulated evidence
-  determine_best_group_state(group_fusion_info_map, grouped_record_map);
+  GroupFusionResult result;
+  result.conflicts = determine_best_group_state(group_fusion_info_map, result.grouped_record_map);
+  return result;
 }
 
 GroupFusionInfoMap MultiCameraFusion::accumulate_group_evidence(
-  const std::map<IdType, utils::FusionRecord> & fused_record_map,
-  std::vector<IdType> & unmapped_traffic_light_ids)
+  const std::map<IdType, utils::FusionRecord> & fused_record_map)
 {
   GroupFusionInfoMap group_fusion_info_map;
-  for (const auto & p : fused_record_map) {
-    process_fused_record(group_fusion_info_map, p.second, unmapped_traffic_light_ids);
+  for (const auto & [traffic_light_id, record] : fused_record_map) {
+    process_fused_record(group_fusion_info_map, record);
   }
   return group_fusion_info_map;
 }
 
 /**
  * @brief Processes a single fused record and updates the group_fusion_info_map.
- * (This function contains the logic from the outer loop)
  */
 void MultiCameraFusion::process_fused_record(
-  GroupFusionInfoMap & group_fusion_info_map, const utils::FusionRecord & record,
-  std::vector<IdType> & unmapped_traffic_light_ids)
+  GroupFusionInfoMap & group_fusion_info_map, const utils::FusionRecord & record)
 {
   const IdType roi_id = record.roi.traffic_light_id;
 
   // Guard Clause 1: Check if traffic light ID is in the map
   const auto it = traffic_light_id_to_regulatory_ele_id_.find(roi_id);
   if (it == traffic_light_id_to_regulatory_ele_id_.end()) {
-    unmapped_traffic_light_ids.emplace_back(roi_id);
     return;
   }
 
@@ -281,16 +310,17 @@ void MultiCameraFusion::process_fused_record(
   // Loop over all regulatory IDs associated with this traffic light
   for (const auto & reg_ele_id : reg_ele_id_vec) {
     // Delegate the innermost logic to another helper
-    update_group_info_for_element(group_fusion_info_map, reg_ele_id, record);
+    update_group_info_for_element(
+      group_fusion_info_map, reg_ele_id, record, config_.prior_log_odds);
   }
 }
 
 /**
  * @brief Updates the map for a single (element, regulatory_id) combination.
  */
-void MultiCameraFusion::update_group_info_for_element(
-  GroupFusionInfoMap & group_fusion_info_map, const IdType & reg_ele_id,
-  const utils::FusionRecord & record) const
+void update_group_info_for_element(
+  GroupFusionInfoMap & group_fusion_info_map, const MultiCameraFusion::IdType & reg_ele_id,
+  const utils::FusionRecord & record, double prior_log_odds)
 {
   StateKey state_key;
   for (const auto & element : record.signal.elements) {
@@ -300,7 +330,7 @@ void MultiCameraFusion::update_group_info_for_element(
   auto & group_info = group_fusion_info_map[reg_ele_id];
 
   // Update Log-Odds
-  update_log_odds(group_info.accumulated_log_odds, state_key, confidence);
+  update_log_odds(group_info.accumulated_log_odds, state_key, confidence, prior_log_odds);
 
   // Update Best Record
   update_best_record(group_info.best_record_for_state, state_key, confidence, record);
@@ -309,8 +339,9 @@ void MultiCameraFusion::update_group_info_for_element(
 /**
  * @brief Handles the log-odds accumulation logic.
  */
-void MultiCameraFusion::update_log_odds(
-  std::map<StateKey, double> & log_odds_map, const StateKey & state_key, double confidence) const
+void update_log_odds(
+  std::map<StateKey, double> & log_odds_map, const StateKey & state_key, double confidence,
+  double prior_log_odds)
 {
   // try_emplace ensures we only add the 0.0 prior (from a 0.5 probability) once.
   log_odds_map.try_emplace(state_key, 0.0);
@@ -318,14 +349,14 @@ void MultiCameraFusion::update_log_odds(
   const double evidence_log_odds = probability_to_log_odds(confidence);
 
   // Accumulate evidence
-  log_odds_map[state_key] += evidence_log_odds - config_.prior_log_odds;
+  log_odds_map[state_key] += evidence_log_odds - prior_log_odds;
 }
 
-void MultiCameraFusion::determine_best_group_state(
+std::vector<ConflictInfo> MultiCameraFusion::determine_best_group_state(
   const std::map<IdType, GroupFusionInfo> & group_fusion_info_map,
-  std::map<IdType, utils::FusionRecord> & grouped_record_map)
+  std::map<IdType, utils::FusionRecord> & grouped_record_map) const
 {
-  conflicted_regulatory_element_status_.clear();
+  std::vector<ConflictInfo> conflicted_regulatory_element_status;
 
   for (const auto & pair : group_fusion_info_map) {
     const IdType reg_ele_id = pair.first;
@@ -409,9 +440,11 @@ void MultiCameraFusion::determine_best_group_state(
     // suppress diagnostics for comparisons with unknown
     if (conflict_result.conflict_type != ConflictType::NO_CONFLICT) {
       // record it for diagnostics
-      conflicted_regulatory_element_status_.push_back({reg_ele_id, conflict_result.conflict_type});
+      conflicted_regulatory_element_status.push_back({reg_ele_id, conflict_result.conflict_type});
     }
   }
+
+  return conflicted_regulatory_element_status;
 }
 
 }  // namespace autoware::traffic_light

--- a/perception/autoware_traffic_light_multi_camera_fusion/src/multi_camera_fusion.cpp
+++ b/perception/autoware_traffic_light_multi_camera_fusion/src/multi_camera_fusion.cpp
@@ -1,0 +1,399 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "multi_camera_fusion.hpp"
+
+#include <autoware_lanelet2_extension/utility/query.hpp>
+#include <rclcpp/time.hpp>
+
+#include <algorithm>
+#include <cmath>
+#include <map>
+#include <memory>
+#include <utility>
+#include <vector>
+
+namespace autoware::traffic_light
+{
+
+namespace
+{
+
+double probability_to_log_odds(double prob)
+{
+  /**
+   * @brief Converts a probability value to log-odds.
+   *
+   * Log-odds is the logarithm of the odds ratio, i.e., log(p / (1-p)).
+   * This function is essential for Bayesian updating in log-space, as it allows
+   * evidence to be additively combined.
+   *
+   * The function handles edge cases where the probability `p` is very close to
+   * 0 or 1. As `p` -> 1, log-odds -> +inf. As `p` -> 0, log-odds -> -inf.
+   * To prevent floating-point divergence (infinity), the input probability is
+   * "clamped" to a safe range slightly away from the boundaries. The bounds
+   * [1e-9, 1.0 - 1e-9] are chosen as a small epsilon to ensure numerical
+   * stability while having a negligible impact on non-extreme probability values.
+   *
+   * @param prob The input probability, expected to be in the range [0.0, 1.0].
+   * @return The corresponding log-odds value.
+   */
+  prob = std::clamp(prob, 1e-9, 1.0 - 1e-9);
+  return std::log(prob / (1.0 - prob));
+}
+
+/**
+ * @brief get the state key that has best log-odds.
+ */
+inline StateKey get_best_state_key(const std::map<StateKey, double> & accumulated_log_odds)
+{
+  auto best_element = std::max_element(
+    accumulated_log_odds.begin(), accumulated_log_odds.end(), compare_state_key_log_odds);
+
+  StateKey best_state_key = best_element->first;
+
+  return best_state_key;
+}
+
+std::map<lanelet::Id, std::vector<lanelet::Id>> build_traffic_light_id_to_regulatory_ele_id(
+  const lanelet::LaneletMapPtr & lanelet_map_ptr)
+{
+  std::map<lanelet::Id, std::vector<lanelet::Id>> traffic_light_id_to_regulatory_ele_id;
+  if (!lanelet_map_ptr) {
+    return traffic_light_id_to_regulatory_ele_id;
+  }
+  lanelet::ConstLanelets all_lanelets = lanelet::utils::query::laneletLayer(lanelet_map_ptr);
+  std::vector<lanelet::AutowareTrafficLightConstPtr> all_lanelet_traffic_lights =
+    lanelet::utils::query::autowareTrafficLights(all_lanelets);
+  for (auto tl_itr = all_lanelet_traffic_lights.begin(); tl_itr != all_lanelet_traffic_lights.end();
+       ++tl_itr) {
+    lanelet::AutowareTrafficLightConstPtr tl = *tl_itr;
+
+    auto lights = tl->trafficLights();
+    for (const auto & light : lights) {
+      traffic_light_id_to_regulatory_ele_id[light.id()].emplace_back(tl->id());
+    }
+  }
+  return traffic_light_id_to_regulatory_ele_id;
+}
+
+}  // namespace
+
+MultiCameraFusion::MultiCameraFusion(const MultiCameraFusionConfig & config)
+: config_(config),
+  traffic_light_id_to_regulatory_ele_id_(
+    build_traffic_light_id_to_regulatory_ele_id(config.lanelet_map_ptr))
+{
+  if (config_.use_signal_consistency_check) {
+    signal_validator_ = std::make_unique<SignalValidator>();
+  }
+}
+
+MultiCameraFusionResult MultiCameraFusion::fuse(
+  const CamInfoType & cam_info, const RoiArrayType & rois, const SignalArrayType & signals)
+{
+  /*
+  Insert the received record array to the table.
+  Attention should be payed that this record array might not have the newest timestamp
+  */
+  record_arr_set_.insert(utils::FusionRecordArr{cam_info.header, cam_info, rois, signals});
+
+  MultiCameraFusionResult result;
+  std::map<IdType, utils::FusionRecord> fused_record_map, grouped_record_map;
+  multi_camera_fusion(fused_record_map);
+  group_fusion(fused_record_map, grouped_record_map, result.unmapped_traffic_light_ids);
+
+  NewSignalArrayType msg_out;
+  convert_output_msg(grouped_record_map, msg_out);
+  msg_out.stamp = cam_info.header.stamp;
+  result.traffic_light_groups = msg_out;
+
+  result.conflicted_regulatory_element_status = conflicted_regulatory_element_status_;
+  return result;
+}
+
+void MultiCameraFusion::convert_output_msg(
+  const std::map<IdType, utils::FusionRecord> & grouped_record_map, NewSignalArrayType & msg_out)
+{
+  msg_out.traffic_light_groups.clear();
+  for (const auto & p : grouped_record_map) {
+    IdType reg_ele_id = p.first;
+    const SignalType & signal = p.second.signal;
+    NewSignalType signal_out;
+    signal_out.traffic_light_group_id = reg_ele_id;
+    for (const auto & ele : signal.elements) {
+      signal_out.elements.push_back(utils::convert_t4_to_autoware(ele));
+    }
+    msg_out.traffic_light_groups.push_back(signal_out);
+  }
+}
+
+void MultiCameraFusion::multi_camera_fusion(
+  std::map<IdType, utils::FusionRecord> & fused_record_map)
+{
+  fused_record_map.clear();
+  const rclcpp::Time & newest_stamp(record_arr_set_.rbegin()->header.stamp);
+  for (auto it = record_arr_set_.begin(); it != record_arr_set_.end();) {
+    /*
+    remove all old record arrays whose timestamp difference with newest record is larger than
+    threshold
+    */
+    if (
+      (newest_stamp - rclcpp::Time(it->header.stamp)) >
+      rclcpp::Duration::from_seconds(config_.message_lifespan)) {
+      it = record_arr_set_.erase(it);
+    } else {
+      /*
+      generate fused record result with the saved records
+      */
+      const utils::FusionRecordArr & record_arr = *it;
+      for (size_t i = 0; i < record_arr.rois.rois.size(); i++) {
+        const RoiType & roi = record_arr.rois.rois[i];
+        auto signal_it = std::find_if(
+          record_arr.signals.signals.begin(), record_arr.signals.signals.end(),
+          [roi](const SignalType & s1) { return roi.traffic_light_id == s1.traffic_light_id; });
+        /*
+        failed to find corresponding signal. skip it
+        */
+        if (signal_it == record_arr.signals.signals.end()) {
+          continue;
+        }
+        utils::FusionRecord record{record_arr.header, record_arr.cam_info, roi, *signal_it};
+        /*
+        if this traffic light is not detected yet or can be updated by higher priority record,
+        update it
+        */
+        if (
+          fused_record_map.find(roi.traffic_light_id) == fused_record_map.end() ||
+          utils::compare_record(record, fused_record_map[roi.traffic_light_id]) >= 0) {
+          fused_record_map[roi.traffic_light_id] = record;
+        }
+      }
+      it++;
+    }
+  }
+}
+
+void MultiCameraFusion::group_fusion(
+  const std::map<IdType, utils::FusionRecord> & fused_record_map,
+  std::map<IdType, utils::FusionRecord> & grouped_record_map,
+  std::vector<IdType> & unmapped_traffic_light_ids)
+{
+  grouped_record_map.clear();
+
+  // Stage 1: Accumulate evidence from all fused records
+  const std::map<IdType, GroupFusionInfo> group_fusion_info_map =
+    accumulate_group_evidence(fused_record_map, unmapped_traffic_light_ids);
+
+  // Stage 2: Determine the best state for each group from the accumulated evidence
+  determine_best_group_state(group_fusion_info_map, grouped_record_map);
+}
+
+GroupFusionInfoMap MultiCameraFusion::accumulate_group_evidence(
+  const std::map<IdType, utils::FusionRecord> & fused_record_map,
+  std::vector<IdType> & unmapped_traffic_light_ids)
+{
+  GroupFusionInfoMap group_fusion_info_map;
+  for (const auto & p : fused_record_map) {
+    process_fused_record(group_fusion_info_map, p.second, unmapped_traffic_light_ids);
+  }
+  return group_fusion_info_map;
+}
+
+/**
+ * @brief Processes a single fused record and updates the group_fusion_info_map.
+ * (This function contains the logic from the outer loop)
+ */
+void MultiCameraFusion::process_fused_record(
+  GroupFusionInfoMap & group_fusion_info_map, const utils::FusionRecord & record,
+  std::vector<IdType> & unmapped_traffic_light_ids)
+{
+  const IdType roi_id = record.roi.traffic_light_id;
+
+  // Guard Clause 1: Check if traffic light ID is in the map
+  const auto it = traffic_light_id_to_regulatory_ele_id_.find(roi_id);
+  if (it == traffic_light_id_to_regulatory_ele_id_.end()) {
+    unmapped_traffic_light_ids.emplace_back(roi_id);
+    return;
+  }
+
+  // Guard Clause 2: Check for elements
+  if (record.signal.elements.empty()) {
+    return;
+  }
+
+  const auto & reg_ele_id_vec = it->second;  // Use the iterator
+
+  // Loop over all regulatory IDs associated with this traffic light
+  for (const auto & reg_ele_id : reg_ele_id_vec) {
+    // Delegate the innermost logic to another helper
+    update_group_info_for_element(group_fusion_info_map, reg_ele_id, record);
+  }
+}
+
+/**
+ * @brief Updates the map for a single (element, regulatory_id) combination.
+ */
+void MultiCameraFusion::update_group_info_for_element(
+  GroupFusionInfoMap & group_fusion_info_map, const IdType & reg_ele_id,
+  const utils::FusionRecord & record) const
+{
+  StateKey state_key;
+  for (const auto & element : record.signal.elements) {
+    state_key.emplace_back(std::make_pair(element.color, element.shape));
+  }
+  const double confidence = utils::get_min_confidence(record.signal);
+  auto & group_info = group_fusion_info_map[reg_ele_id];
+
+  // Update Log-Odds
+  update_log_odds(group_info.accumulated_log_odds, state_key, confidence);
+
+  // Update Best Record
+  update_best_record(group_info.best_record_for_state, state_key, confidence, record);
+}
+
+/**
+ * @brief Handles the log-odds accumulation logic.
+ */
+void MultiCameraFusion::update_log_odds(
+  std::map<StateKey, double> & log_odds_map, const StateKey & state_key, double confidence) const
+{
+  // try_emplace ensures we only add the 0.0 prior (from a 0.5 probability) once.
+  log_odds_map.try_emplace(state_key, 0.0);
+
+  const double evidence_log_odds = probability_to_log_odds(confidence);
+
+  // Accumulate evidence
+  log_odds_map[state_key] += evidence_log_odds - config_.prior_log_odds;
+}
+
+/**
+ * @brief Handles the logic for tracking the best record for a given state.
+ */
+void MultiCameraFusion::update_best_record(
+  std::map<StateKey, utils::FusionRecord> & best_record_map, const StateKey & state_key,
+  double confidence, const utils::FusionRecord & record)
+{
+  const auto it = best_record_map.find(state_key);
+
+  if (it == best_record_map.end()) {
+    best_record_map[state_key] = record;
+    return;
+  }
+
+  auto & existing_record = it->second;
+
+  if (existing_record.signal.elements.empty()) {
+    return;
+  }
+
+  if (confidence > utils::get_min_confidence(existing_record.signal)) {
+    best_record_map[state_key] = record;
+  }
+}
+
+void MultiCameraFusion::determine_best_group_state(
+  const std::map<IdType, GroupFusionInfo> & group_fusion_info_map,
+  std::map<IdType, utils::FusionRecord> & grouped_record_map)
+{
+  conflicted_regulatory_element_status_.clear();
+
+  for (const auto & pair : group_fusion_info_map) {
+    const IdType reg_ele_id = pair.first;
+    const auto & group_info = pair.second;
+
+    if (group_info.accumulated_log_odds.empty()) {
+      continue;
+    }
+
+    if (!config_.use_signal_consistency_check || group_info.accumulated_log_odds.size() == 1) {
+      // use the most probable one (the highest logarithmic odds) as the base
+      const StateKey best_state_key = get_best_state_key(group_info.accumulated_log_odds);
+      grouped_record_map[reg_ele_id] = group_info.best_record_for_state.at(best_state_key);
+
+      continue;
+    }
+
+    // only records with multiple state keys reach here
+    // these indicate conflicts, except when unknown states are present
+
+    auto log_odds_it = group_info.accumulated_log_odds.begin();
+    StateKey running_state = (*log_odds_it).first;
+
+    ConflictStatus conflict_result{ConflictType::PARTIAL_CONFLICT, running_state};
+
+    // check if conflicts exist among the signals within the same regulatory element id
+    for (++log_odds_it; log_odds_it != group_info.accumulated_log_odds.end(); ++log_odds_it) {
+      const StateKey & competitor_state = (*log_odds_it).first;
+      conflict_result = signal_validator_->check_conflict(running_state, competitor_state);
+      running_state = conflict_result.common_state_key;
+
+      if (conflict_result.conflict_type == ConflictType::CONFLICT) {
+        // critical conflict will be overwritten with fail-safe record
+        // we immediately exit the loop
+        break;
+      } else {  // partial conflict
+        if (config_.publish_partial_matched_signal) {
+          continue;
+        } else {
+          break;
+        }
+      }
+    }
+
+    if (
+      conflict_result.conflict_type == ConflictType::CONFLICT ||
+      !config_.publish_partial_matched_signal) {
+      // use a fail-safe record as a fallback for this regulatory element.
+
+      // use the most probable one (the highest logarithmic odds) as the base
+      const StateKey best_state_key = get_best_state_key(group_info.accumulated_log_odds);
+
+      // set the best record that signal is overwritten with fail-safe record
+      grouped_record_map[reg_ele_id] =
+        utils::generate_failsafe_record(group_info.best_record_for_state.at(best_state_key));
+    } else {
+      // partially conflicted and allowed to publish the matched signals
+
+      // rebuild the record based on the matched signals
+      // copy the base data from the best original record, but replace the elements
+      const StateKey best_state_key = get_best_state_key(group_info.accumulated_log_odds);
+      utils::FusionRecord merged_record = group_info.best_record_for_state.at(best_state_key);
+
+      merged_record.signal.elements.clear();
+
+      const double min_confidence =
+        utils::get_min_confidence(group_info.best_record_for_state.at(best_state_key).signal);
+      for (const auto & elem : running_state) {
+        tier4_perception_msgs::msg::TrafficLightElement new_elem;
+        new_elem.color = elem.first;
+        new_elem.shape = elem.second;
+        // keep the min confidence of the base record
+        new_elem.confidence = min_confidence;
+
+        merged_record.signal.elements.push_back(new_elem);
+      }
+
+      grouped_record_map[reg_ele_id] = merged_record;
+    }
+
+    // suppress diagnostics for comparisons with unknown
+    if (conflict_result.conflict_type != ConflictType::NO_CONFLICT) {
+      // record it for diagnostics
+      conflicted_regulatory_element_status_.push_back({reg_ele_id, conflict_result.conflict_type});
+    }
+  }
+}
+
+}  // namespace autoware::traffic_light

--- a/perception/autoware_traffic_light_multi_camera_fusion/src/multi_camera_fusion.cpp
+++ b/perception/autoware_traffic_light_multi_camera_fusion/src/multi_camera_fusion.cpp
@@ -190,8 +190,7 @@ MultiCameraFusion::MultiCameraFusion(const MultiCameraFusionConfig & config)
 }
 
 MultiCameraFusionResult MultiCameraFusion::fuse(
-  const CamInfoType & cam_info, const RoiArrayType & rois, const SignalArrayType & signals,
-  NewSignalArrayType & output_groups)
+  const CamInfoType & cam_info, const RoiArrayType & rois, const SignalArrayType & signals)
 {
   /*
   Insert the received record array to the table.
@@ -207,8 +206,10 @@ MultiCameraFusionResult MultiCameraFusion::fuse(
   GroupFusionResult group_result = group_fusion(fused_record_map);
   result.conflicted_regulatory_element_status = group_result.conflicts;
 
-  convert_output_msg(group_result.grouped_record_map, output_groups);
-  output_groups.stamp = cam_info.header.stamp;
+  NewSignalArrayType msg_out;
+  convert_output_msg(group_result.grouped_record_map, msg_out);
+  msg_out.stamp = cam_info.header.stamp;
+  result.traffic_light_groups = msg_out;
 
   return result;
 }

--- a/perception/autoware_traffic_light_multi_camera_fusion/src/multi_camera_fusion.hpp
+++ b/perception/autoware_traffic_light_multi_camera_fusion/src/multi_camera_fusion.hpp
@@ -51,6 +51,13 @@ struct ConflictInfo
 using GroupFusionInfoMap =
   std::map<tier4_perception_msgs::msg::TrafficLightRoi::_traffic_light_id_type, GroupFusionInfo>;
 
+struct GroupFusionResult
+{
+  std::map<tier4_perception_msgs::msg::TrafficLightRoi::_traffic_light_id_type, utils::FusionRecord>
+    grouped_record_map;
+  std::vector<ConflictInfo> conflicts;
+};
+
 struct MultiCameraFusionConfig
 {
   /*
@@ -97,47 +104,28 @@ public:
     const CamInfoType & cam_info, const RoiArrayType & rois, const SignalArrayType & signals);
 
 private:
-  void multi_camera_fusion(std::map<IdType, utils::FusionRecord> & fused_record_map);
-
-  void group_fusion(
-    const std::map<IdType, utils::FusionRecord> & fused_record_map,
-    std::map<IdType, utils::FusionRecord> & grouped_record_map,
-    std::vector<IdType> & unmapped_traffic_light_ids);
+  GroupFusionResult group_fusion(const std::map<IdType, utils::FusionRecord> & fused_record_map);
 
   /**
    * @brief Accumulates log-odds evidence for each traffic light group from individual fused
    * records.
    */
   GroupFusionInfoMap accumulate_group_evidence(
-    const std::map<IdType, utils::FusionRecord> & fused_record_map,
-    std::vector<IdType> & unmapped_traffic_light_ids);
+    const std::map<IdType, utils::FusionRecord> & fused_record_map);
 
   /**
    * @brief Processes a single fused record and updates the group_fusion_info_map.
    */
   void process_fused_record(
-    GroupFusionInfoMap & group_fusion_info_map, const utils::FusionRecord & record,
-    std::vector<IdType> & unmapped_traffic_light_ids);
-
-  /**
-   * @brief Updates the map for a single (element, regulatory_id) combination.
-   */
-  void update_group_info_for_element(
-    GroupFusionInfoMap & group_fusion_info_map, const IdType & reg_ele_id,
-    const utils::FusionRecord & record) const;
-
-  /**
-   * @brief Handles the log-odds accumulation logic.
-   */
-  void update_log_odds(
-    std::map<StateKey, double> & log_odds_map, const StateKey & state_key, double confidence) const;
+    GroupFusionInfoMap & group_fusion_info_map, const utils::FusionRecord & record);
 
   /**
    * @brief Determines the best state for each group based on accumulated evidence.
+   * @return The conflicts detected during this call. Empty when no conflict is found.
    */
-  void determine_best_group_state(
+  std::vector<ConflictInfo> determine_best_group_state(
     const std::map<IdType, GroupFusionInfo> & group_fusion_info_map,
-    std::map<IdType, utils::FusionRecord> & grouped_record_map);
+    std::map<IdType, utils::FusionRecord> & grouped_record_map) const;
 
   MultiCameraFusionConfig config_{};
   /*
@@ -149,8 +137,6 @@ private:
   Use multiset in case multiple cameras publish images at the exact same time.
   */
   std::multiset<utils::FusionRecordArr> record_arr_set_;
-
-  std::vector<ConflictInfo> conflicted_regulatory_element_status_{};
 };
 
 }  // namespace autoware::traffic_light

--- a/perception/autoware_traffic_light_multi_camera_fusion/src/multi_camera_fusion.hpp
+++ b/perception/autoware_traffic_light_multi_camera_fusion/src/multi_camera_fusion.hpp
@@ -1,0 +1,194 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef MULTI_CAMERA_FUSION_HPP_
+#define MULTI_CAMERA_FUSION_HPP_
+
+#include "signal_validator.hpp"
+#include "traffic_light_multi_camera_fusion_process.hpp"
+#include "types.hpp"
+
+#include <autoware_perception_msgs/msg/traffic_light_group.hpp>
+#include <autoware_perception_msgs/msg/traffic_light_group_array.hpp>
+#include <sensor_msgs/msg/camera_info.hpp>
+#include <tier4_perception_msgs/msg/traffic_light.hpp>
+#include <tier4_perception_msgs/msg/traffic_light_array.hpp>
+#include <tier4_perception_msgs/msg/traffic_light_roi.hpp>
+#include <tier4_perception_msgs/msg/traffic_light_roi_array.hpp>
+
+#include <lanelet2_core/Forward.h>
+
+#include <map>
+#include <memory>
+#include <set>
+#include <utility>
+#include <vector>
+
+namespace autoware::traffic_light
+{
+
+inline bool is_unknown(const StateKey & state_key)
+{
+  return state_key.size() == 1 &&
+         state_key[0].first == tier4_perception_msgs::msg::TrafficLightElement::UNKNOWN;
+}
+
+inline bool compare_state_key_log_odds(
+  const std::pair<StateKey, double> & key1, const std::pair<StateKey, double> & key2)
+{
+  // Ordering rule:
+  // 1. Unknown StateKey is always lower priority
+  // 2. Otherwise, smaller log-odds comes first
+  const bool key1_is_unknown = is_unknown(key1.first);
+  const bool key2_is_unknown = is_unknown(key2.first);
+  if (key1_is_unknown && !key2_is_unknown) {
+    return true;
+  }
+  if (!key1_is_unknown && key2_is_unknown) {
+    return false;
+  }
+  return key1.second < key2.second;
+}
+
+struct GroupFusionInfo
+{
+  std::map<StateKey, double> accumulated_log_odds;
+  std::map<StateKey, utils::FusionRecord> best_record_for_state;
+};
+
+struct ConflictInfo
+{
+  tier4_perception_msgs::msg::TrafficLightRoi::_traffic_light_id_type id;
+  ConflictType conflict_type;
+};
+
+using GroupFusionInfoMap =
+  std::map<tier4_perception_msgs::msg::TrafficLightRoi::_traffic_light_id_type, GroupFusionInfo>;
+
+struct MultiCameraFusionConfig
+{
+  /*
+  For every input message input_m, if the timestamp difference between input_m and the latest
+  message is smaller than message_lifespan, then input_m would be used for the fusion. Otherwise,
+  it would be discarded.
+  */
+  double message_lifespan{1.0};
+  /**
+   * @brief The prior log-odds for a traffic light state.
+   */
+  double prior_log_odds{0.0};
+  bool use_signal_consistency_check{false};
+  bool publish_partial_matched_signal{false};
+  lanelet::LaneletMapPtr lanelet_map_ptr{nullptr};
+};
+
+struct MultiCameraFusionResult
+{
+  autoware_perception_msgs::msg::TrafficLightGroupArray traffic_light_groups;
+  std::vector<ConflictInfo> conflicted_regulatory_element_status;
+  // Traffic light IDs that were observed by a camera but are not registered in the loaded map.
+  // The Node logs a warning for each entry.
+  std::vector<tier4_perception_msgs::msg::TrafficLightRoi::_traffic_light_id_type>
+    unmapped_traffic_light_ids;
+};
+
+class MultiCameraFusion
+{
+public:
+  using CamInfoType = sensor_msgs::msg::CameraInfo;
+  using RoiType = tier4_perception_msgs::msg::TrafficLightRoi;
+  using SignalType = tier4_perception_msgs::msg::TrafficLight;
+  using SignalArrayType = tier4_perception_msgs::msg::TrafficLightArray;
+  using RoiArrayType = tier4_perception_msgs::msg::TrafficLightRoiArray;
+  using IdType = tier4_perception_msgs::msg::TrafficLightRoi::_traffic_light_id_type;
+  using NewSignalType = autoware_perception_msgs::msg::TrafficLightGroup;
+  using NewSignalArrayType = autoware_perception_msgs::msg::TrafficLightGroupArray;
+
+  explicit MultiCameraFusion(const MultiCameraFusionConfig & config);
+  MultiCameraFusion() = default;
+
+  MultiCameraFusionResult fuse(
+    const CamInfoType & cam_info, const RoiArrayType & rois, const SignalArrayType & signals);
+
+private:
+  void multi_camera_fusion(std::map<IdType, utils::FusionRecord> & fused_record_map);
+
+  static void convert_output_msg(
+    const std::map<IdType, utils::FusionRecord> & grouped_record_map, NewSignalArrayType & msg_out);
+
+  void group_fusion(
+    const std::map<IdType, utils::FusionRecord> & fused_record_map,
+    std::map<IdType, utils::FusionRecord> & grouped_record_map,
+    std::vector<IdType> & unmapped_traffic_light_ids);
+
+  /**
+   * @brief Accumulates log-odds evidence for each traffic light group from individual fused
+   * records.
+   */
+  GroupFusionInfoMap accumulate_group_evidence(
+    const std::map<IdType, utils::FusionRecord> & fused_record_map,
+    std::vector<IdType> & unmapped_traffic_light_ids);
+
+  /**
+   * @brief Processes a single fused record and updates the group_fusion_info_map.
+   */
+  void process_fused_record(
+    GroupFusionInfoMap & group_fusion_info_map, const utils::FusionRecord & record,
+    std::vector<IdType> & unmapped_traffic_light_ids);
+
+  /**
+   * @brief Updates the map for a single (element, regulatory_id) combination.
+   */
+  void update_group_info_for_element(
+    GroupFusionInfoMap & group_fusion_info_map, const IdType & reg_ele_id,
+    const utils::FusionRecord & record) const;
+
+  /**
+   * @brief Handles the log-odds accumulation logic.
+   */
+  void update_log_odds(
+    std::map<StateKey, double> & log_odds_map, const StateKey & state_key, double confidence) const;
+
+  /**
+   * @brief Handles the logic for tracking the best record for a given state.
+   */
+  static void update_best_record(
+    std::map<StateKey, utils::FusionRecord> & best_record_map, const StateKey & state_key,
+    double confidence, const utils::FusionRecord & record);
+
+  /**
+   * @brief Determines the best state for each group based on accumulated evidence.
+   */
+  void determine_best_group_state(
+    const std::map<IdType, GroupFusionInfo> & group_fusion_info_map,
+    std::map<IdType, utils::FusionRecord> & grouped_record_map);
+
+  MultiCameraFusionConfig config_{};
+  /*
+  Mapping from traffic light instance id to regulatory element id (group id)
+  */
+  std::map<lanelet::Id, std::vector<lanelet::Id>> traffic_light_id_to_regulatory_ele_id_;
+  /*
+  Store record arrays in increasing timestamp order.
+  Use multiset in case multiple cameras publish images at the exact same time.
+  */
+  std::multiset<utils::FusionRecordArr> record_arr_set_;
+
+  std::unique_ptr<SignalValidator> signal_validator_;
+  std::vector<ConflictInfo> conflicted_regulatory_element_status_{};
+};
+
+}  // namespace autoware::traffic_light
+
+#endif  // MULTI_CAMERA_FUSION_HPP_

--- a/perception/autoware_traffic_light_multi_camera_fusion/src/multi_camera_fusion.hpp
+++ b/perception/autoware_traffic_light_multi_camera_fusion/src/multi_camera_fusion.hpp
@@ -30,36 +30,11 @@
 #include <lanelet2_core/Forward.h>
 
 #include <map>
-#include <memory>
 #include <set>
-#include <utility>
 #include <vector>
 
 namespace autoware::traffic_light
 {
-
-inline bool is_unknown(const StateKey & state_key)
-{
-  return state_key.size() == 1 &&
-         state_key[0].first == tier4_perception_msgs::msg::TrafficLightElement::UNKNOWN;
-}
-
-inline bool compare_state_key_log_odds(
-  const std::pair<StateKey, double> & key1, const std::pair<StateKey, double> & key2)
-{
-  // Ordering rule:
-  // 1. Unknown StateKey is always lower priority
-  // 2. Otherwise, smaller log-odds comes first
-  const bool key1_is_unknown = is_unknown(key1.first);
-  const bool key2_is_unknown = is_unknown(key2.first);
-  if (key1_is_unknown && !key2_is_unknown) {
-    return true;
-  }
-  if (!key1_is_unknown && key2_is_unknown) {
-    return false;
-  }
-  return key1.second < key2.second;
-}
 
 struct GroupFusionInfo
 {
@@ -124,9 +99,6 @@ public:
 private:
   void multi_camera_fusion(std::map<IdType, utils::FusionRecord> & fused_record_map);
 
-  static void convert_output_msg(
-    const std::map<IdType, utils::FusionRecord> & grouped_record_map, NewSignalArrayType & msg_out);
-
   void group_fusion(
     const std::map<IdType, utils::FusionRecord> & fused_record_map,
     std::map<IdType, utils::FusionRecord> & grouped_record_map,
@@ -161,13 +133,6 @@ private:
     std::map<StateKey, double> & log_odds_map, const StateKey & state_key, double confidence) const;
 
   /**
-   * @brief Handles the logic for tracking the best record for a given state.
-   */
-  static void update_best_record(
-    std::map<StateKey, utils::FusionRecord> & best_record_map, const StateKey & state_key,
-    double confidence, const utils::FusionRecord & record);
-
-  /**
    * @brief Determines the best state for each group based on accumulated evidence.
    */
   void determine_best_group_state(
@@ -185,7 +150,6 @@ private:
   */
   std::multiset<utils::FusionRecordArr> record_arr_set_;
 
-  std::unique_ptr<SignalValidator> signal_validator_;
   std::vector<ConflictInfo> conflicted_regulatory_element_status_{};
 };
 

--- a/perception/autoware_traffic_light_multi_camera_fusion/src/multi_camera_fusion.hpp
+++ b/perception/autoware_traffic_light_multi_camera_fusion/src/multi_camera_fusion.hpp
@@ -77,7 +77,6 @@ struct MultiCameraFusionConfig
 
 struct MultiCameraFusionResult
 {
-  autoware_perception_msgs::msg::TrafficLightGroupArray traffic_light_groups;
   std::vector<ConflictInfo> conflicted_regulatory_element_status;
   // Traffic light IDs that were observed by a camera but are not registered in the loaded map.
   // The Node logs a warning for each entry.
@@ -101,7 +100,8 @@ public:
   MultiCameraFusion() = default;
 
   MultiCameraFusionResult fuse(
-    const CamInfoType & cam_info, const RoiArrayType & rois, const SignalArrayType & signals);
+    const CamInfoType & cam_info, const RoiArrayType & rois, const SignalArrayType & signals,
+    NewSignalArrayType & output_groups);
 
 private:
   GroupFusionResult group_fusion(const std::map<IdType, utils::FusionRecord> & fused_record_map);

--- a/perception/autoware_traffic_light_multi_camera_fusion/src/multi_camera_fusion.hpp
+++ b/perception/autoware_traffic_light_multi_camera_fusion/src/multi_camera_fusion.hpp
@@ -77,6 +77,7 @@ struct MultiCameraFusionConfig
 
 struct MultiCameraFusionResult
 {
+  autoware_perception_msgs::msg::TrafficLightGroupArray traffic_light_groups;
   std::vector<ConflictInfo> conflicted_regulatory_element_status;
   // Traffic light IDs that were observed by a camera but are not registered in the loaded map.
   // The Node logs a warning for each entry.
@@ -100,8 +101,7 @@ public:
   MultiCameraFusion() = default;
 
   MultiCameraFusionResult fuse(
-    const CamInfoType & cam_info, const RoiArrayType & rois, const SignalArrayType & signals,
-    NewSignalArrayType & output_groups);
+    const CamInfoType & cam_info, const RoiArrayType & rois, const SignalArrayType & signals);
 
 private:
   GroupFusionResult group_fusion(const std::map<IdType, utils::FusionRecord> & fused_record_map);

--- a/perception/autoware_traffic_light_multi_camera_fusion/src/signal_validator.cpp
+++ b/perception/autoware_traffic_light_multi_camera_fusion/src/signal_validator.cpp
@@ -16,6 +16,8 @@
 
 #include "types.hpp"
 
+#include <tier4_perception_msgs/msg/traffic_light_element.hpp>
+
 #include <utility>
 
 namespace autoware::traffic_light
@@ -71,8 +73,12 @@ inline SignalLUT extract_common_signals(const SignalLUT & lut_a, const SignalLUT
  * @param state_b Second StateKey.
  * @return Conflict status and common signals (StateKey).
  */
-ConflictStatus SignalValidator::check_conflict(const StateKey & state_a, const StateKey & state_b)
+namespace signal_validator
 {
+ConflictStatus check_conflict(const StateKey & state_a, const StateKey & state_b)
+{
+  using TrafficLightElement = tier4_perception_msgs::msg::TrafficLightElement;
+
   // check if states match across signals.
   //
   // NOTE: Currently, identical shape/color pairs (e.g., duplicate entries)
@@ -119,5 +125,6 @@ ConflictStatus SignalValidator::check_conflict(const StateKey & state_a, const S
     }
   }
 }
+}  // namespace signal_validator
 
 }  // namespace autoware::traffic_light

--- a/perception/autoware_traffic_light_multi_camera_fusion/src/signal_validator.cpp
+++ b/perception/autoware_traffic_light_multi_camera_fusion/src/signal_validator.cpp
@@ -22,7 +22,7 @@ namespace autoware::traffic_light
 {
 namespace
 {
-inline StateKey signalLutToStateKey(const SignalLUT & lut)
+inline StateKey signal_lut_to_state_key(const SignalLUT & lut)
 {
   StateKey state_key;
   for (const auto & signal : lut) {
@@ -32,7 +32,7 @@ inline StateKey signalLutToStateKey(const SignalLUT & lut)
   return state_key;
 }
 
-inline SignalLUT createSignalLUT(const StateKey & state_key)
+inline SignalLUT create_signal_lut(const StateKey & state_key)
 {
   SignalLUT signal_lut;
 
@@ -43,7 +43,7 @@ inline SignalLUT createSignalLUT(const StateKey & state_key)
   return signal_lut;
 };
 
-inline SignalLUT extractCommonSignals(const SignalLUT & lut_a, const SignalLUT & lut_b)
+inline SignalLUT extract_common_signals(const SignalLUT & lut_a, const SignalLUT & lut_b)
 {
   SignalLUT common_lut;
 
@@ -71,7 +71,7 @@ inline SignalLUT extractCommonSignals(const SignalLUT & lut_a, const SignalLUT &
  * @param state_b Second StateKey.
  * @return Conflict status and common signals (StateKey).
  */
-ConflictStatus SignalValidator::checkConflict(const StateKey & state_a, const StateKey & state_b)
+ConflictStatus SignalValidator::check_conflict(const StateKey & state_a, const StateKey & state_b)
 {
   // check if states match across signals.
   //
@@ -83,8 +83,8 @@ ConflictStatus SignalValidator::checkConflict(const StateKey & state_a, const St
     return ConflictStatus{ConflictType::NO_CONFLICT, state_a};
   }
 
-  SignalLUT lut_a = createSignalLUT(state_a);
-  SignalLUT lut_b = createSignalLUT(state_b);
+  SignalLUT lut_a = create_signal_lut(state_a);
+  SignalLUT lut_b = create_signal_lut(state_b);
 
   constexpr std::pair<uint8_t, uint8_t> unknown_pair{
     TrafficLightElement::UNKNOWN, TrafficLightElement::UNKNOWN};
@@ -107,8 +107,8 @@ ConflictStatus SignalValidator::checkConflict(const StateKey & state_a, const St
     // however, the returned state key depends on the input order
     return ConflictStatus{ConflictType::NO_CONFLICT, state_a};
   } else {
-    const SignalLUT lut_common = extractCommonSignals(lut_a, lut_b);
-    const StateKey common_state_key = signalLutToStateKey(lut_common);
+    const SignalLUT lut_common = extract_common_signals(lut_a, lut_b);
+    const StateKey common_state_key = signal_lut_to_state_key(lut_common);
 
     // all matching cases are already handled.
     // only need to check for full or partial conflicts.

--- a/perception/autoware_traffic_light_multi_camera_fusion/src/signal_validator.hpp
+++ b/perception/autoware_traffic_light_multi_camera_fusion/src/signal_validator.hpp
@@ -17,8 +17,6 @@
 
 #include "types.hpp"
 
-#include <tier4_perception_msgs/msg/traffic_light.hpp>
-
 #include <unordered_set>
 #include <utility>
 
@@ -48,15 +46,10 @@ struct ConflictStatus
   StateKey common_state_key;
 };
 
-class SignalValidator
+namespace signal_validator
 {
-public:
-  using TrafficLightElement = tier4_perception_msgs::msg::TrafficLightElement;
-
-  static ConflictStatus check_conflict(const StateKey & state_a, const StateKey & state_b);
-
-  StateKey merge_partial_match(const StateKey & state_a, const StateKey & state_b);
-};
+ConflictStatus check_conflict(const StateKey & state_a, const StateKey & state_b);
+}  // namespace signal_validator
 
 }  // namespace autoware::traffic_light
 

--- a/perception/autoware_traffic_light_multi_camera_fusion/src/signal_validator.hpp
+++ b/perception/autoware_traffic_light_multi_camera_fusion/src/signal_validator.hpp
@@ -53,9 +53,9 @@ class SignalValidator
 public:
   using TrafficLightElement = tier4_perception_msgs::msg::TrafficLightElement;
 
-  static ConflictStatus checkConflict(const StateKey & state_a, const StateKey & state_b);
+  static ConflictStatus check_conflict(const StateKey & state_a, const StateKey & state_b);
 
-  StateKey mergePartialMatch(const StateKey & state_a, const StateKey & state_b);
+  StateKey merge_partial_match(const StateKey & state_a, const StateKey & state_b);
 };
 
 }  // namespace autoware::traffic_light

--- a/perception/autoware_traffic_light_multi_camera_fusion/src/traffic_light_multi_camera_fusion_node.cpp
+++ b/perception/autoware_traffic_light_multi_camera_fusion/src/traffic_light_multi_camera_fusion_node.cpp
@@ -32,7 +32,7 @@ namespace autoware::traffic_light
 namespace
 {
 
-double probabilityToLogOdds(double prob)
+double probability_to_log_odds(double prob)
 {
   /**
    * @brief Converts a probability value to log-odds.
@@ -58,10 +58,10 @@ double probabilityToLogOdds(double prob)
 /**
  * @brief get the state key that has best log-odds.
  */
-inline StateKey getBestStatekey(const std::map<StateKey, double> & accumulated_log_odds)
+inline StateKey get_best_state_key(const std::map<StateKey, double> & accumulated_log_odds)
 {
   auto best_element = std::max_element(
-    accumulated_log_odds.begin(), accumulated_log_odds.end(), compareStateKeyLogOdds);
+    accumulated_log_odds.begin(), accumulated_log_odds.end(), compare_state_key_log_odds);
 
   StateKey best_state_key = best_element->first;
 
@@ -102,20 +102,20 @@ MultiCameraFusion::MultiCameraFusion(const rclcpp::NodeOptions & node_options)
         ExactSyncPolicy(10), *(cam_info_subs_.back()), *(roi_subs_.back()),
         *(signal_subs_.back())));
       exact_sync_subs_.back()->registerCallback(
-        std::bind(&MultiCameraFusion::trafficSignalRoiCallback, this, _1, _2, _3));
+        std::bind(&MultiCameraFusion::traffic_signal_roi_callback, this, _1, _2, _3));
     } else {
       approximate_sync_subs_.emplace_back(new ApproximateSync(
         ApproximateSyncPolicy(10), *(cam_info_subs_.back()), *(roi_subs_.back()),
         *(signal_subs_.back())));
       approximate_sync_subs_.back()->registerCallback(
-        std::bind(&MultiCameraFusion::trafficSignalRoiCallback, this, _1, _2, _3));
+        std::bind(&MultiCameraFusion::traffic_signal_roi_callback, this, _1, _2, _3));
     }
   }
 
   map_sub_ = create_subscription<autoware_map_msgs::msg::LaneletMapBin>(
     "~/input/vector_map", rclcpp::QoS{1}.transient_local(),
     [this](const autoware_map_msgs::msg::LaneletMapBin::ConstSharedPtr msg) {
-      this->mapCallback(msg);
+      this->map_callback(msg);
     });
   signal_pub_ = create_publisher<NewSignalArrayType>("~/output/traffic_signals", rclcpp::QoS{1});
 
@@ -127,7 +127,7 @@ MultiCameraFusion::MultiCameraFusion(const rclcpp::NodeOptions & node_options)
   }
 }
 
-void MultiCameraFusion::trafficSignalRoiCallback(
+void MultiCameraFusion::traffic_signal_roi_callback(
   const CamInfoType::ConstSharedPtr cam_info_msg, const RoiArrayType::ConstSharedPtr roi_msg,
   const SignalArrayType::ConstSharedPtr signal_msg)
 {
@@ -140,20 +140,20 @@ void MultiCameraFusion::trafficSignalRoiCallback(
     utils::FusionRecordArr{cam_info_msg->header, *cam_info_msg, *roi_msg, *signal_msg});
 
   std::map<IdType, utils::FusionRecord> fused_record_map, grouped_record_map;
-  multiCameraFusion(fused_record_map);
-  groupFusion(fused_record_map, grouped_record_map);
+  multi_camera_fusion(fused_record_map);
+  group_fusion(fused_record_map, grouped_record_map);
 
   NewSignalArrayType msg_out;
-  convertOutputMsg(grouped_record_map, msg_out);
+  convert_output_msg(grouped_record_map, msg_out);
   msg_out.stamp = cam_info_msg->header.stamp;
   signal_pub_->publish(msg_out);
 
   if (conflicted_regulatory_element_status_.size() > 0) {
-    publishDiagnostics(stamp);
+    publish_diagnostics(stamp);
   }
 }
 
-void MultiCameraFusion::mapCallback(
+void MultiCameraFusion::map_callback(
   const autoware_map_msgs::msg::LaneletMapBin::ConstSharedPtr input_msg)
 {
   lanelet::LaneletMapPtr lanelet_map_ptr = autoware::experimental::lanelet2_utils::remove_const(
@@ -172,7 +172,7 @@ void MultiCameraFusion::mapCallback(
   }
 }
 
-void MultiCameraFusion::convertOutputMsg(
+void MultiCameraFusion::convert_output_msg(
   const std::map<IdType, utils::FusionRecord> & grouped_record_map, NewSignalArrayType & msg_out)
 {
   msg_out.traffic_light_groups.clear();
@@ -182,13 +182,14 @@ void MultiCameraFusion::convertOutputMsg(
     NewSignalType signal_out;
     signal_out.traffic_light_group_id = reg_ele_id;
     for (const auto & ele : signal.elements) {
-      signal_out.elements.push_back(utils::convertT4toAutoware(ele));
+      signal_out.elements.push_back(utils::convert_t4_to_autoware(ele));
     }
     msg_out.traffic_light_groups.push_back(signal_out);
   }
 }
 
-void MultiCameraFusion::multiCameraFusion(std::map<IdType, utils::FusionRecord> & fused_record_map)
+void MultiCameraFusion::multi_camera_fusion(
+  std::map<IdType, utils::FusionRecord> & fused_record_map)
 {
   fused_record_map.clear();
   /*
@@ -231,7 +232,7 @@ void MultiCameraFusion::multiCameraFusion(std::map<IdType, utils::FusionRecord> 
         */
         if (
           fused_record_map.find(roi.traffic_light_id) == fused_record_map.end() ||
-          utils::compareRecord(record, fused_record_map[roi.traffic_light_id]) >= 0) {
+          utils::compare_record(record, fused_record_map[roi.traffic_light_id]) >= 0) {
           fused_record_map[roi.traffic_light_id] = record;
         }
       }
@@ -240,7 +241,7 @@ void MultiCameraFusion::multiCameraFusion(std::map<IdType, utils::FusionRecord> 
   }
 }
 
-void MultiCameraFusion::groupFusion(
+void MultiCameraFusion::group_fusion(
   const std::map<IdType, utils::FusionRecord> & fused_record_map,
   std::map<IdType, utils::FusionRecord> & grouped_record_map)
 {
@@ -248,18 +249,18 @@ void MultiCameraFusion::groupFusion(
 
   // Stage 1: Accumulate evidence from all fused records
   const std::map<IdType, GroupFusionInfo> group_fusion_info_map =
-    accumulateGroupEvidence(fused_record_map);
+    accumulate_group_evidence(fused_record_map);
 
   // Stage 2: Determine the best state for each group from the accumulated evidence
-  determineBestGroupState(group_fusion_info_map, grouped_record_map);
+  determine_best_group_state(group_fusion_info_map, grouped_record_map);
 }
 
-GroupFusionInfoMap MultiCameraFusion::accumulateGroupEvidence(
+GroupFusionInfoMap MultiCameraFusion::accumulate_group_evidence(
   const std::map<IdType, utils::FusionRecord> & fused_record_map)
 {
   GroupFusionInfoMap group_fusion_info_map;
   for (const auto & p : fused_record_map) {
-    processFusedRecord(group_fusion_info_map, p.second);
+    process_fused_record(group_fusion_info_map, p.second);
   }
   return group_fusion_info_map;
 }
@@ -268,7 +269,7 @@ GroupFusionInfoMap MultiCameraFusion::accumulateGroupEvidence(
  * @brief Processes a single fused record and updates the group_fusion_info_map.
  * (This function contains the logic from the outer loop)
  */
-void MultiCameraFusion::processFusedRecord(
+void MultiCameraFusion::process_fused_record(
   GroupFusionInfoMap & group_fusion_info_map, const utils::FusionRecord & record)
 {
   const IdType roi_id = record.roi.traffic_light_id;
@@ -291,14 +292,14 @@ void MultiCameraFusion::processFusedRecord(
   // Loop over all regulatory IDs associated with this traffic light
   for (const auto & reg_ele_id : reg_ele_id_vec) {
     // Delegate the innermost logic to another helper
-    updateGroupInfoForElement(group_fusion_info_map, reg_ele_id, record);
+    update_group_info_for_element(group_fusion_info_map, reg_ele_id, record);
   }
 }
 
 /**
  * @brief Updates the map for a single (element, regulatory_id) combination.
  */
-void MultiCameraFusion::updateGroupInfoForElement(
+void MultiCameraFusion::update_group_info_for_element(
   GroupFusionInfoMap & group_fusion_info_map, const IdType & reg_ele_id,
   const utils::FusionRecord & record)
 {
@@ -306,26 +307,26 @@ void MultiCameraFusion::updateGroupInfoForElement(
   for (const auto & element : record.signal.elements) {
     state_key.emplace_back(std::make_pair(element.color, element.shape));
   }
-  const double confidence = utils::getMinConfidence(record.signal);
+  const double confidence = utils::get_min_confidence(record.signal);
   auto & group_info = group_fusion_info_map[reg_ele_id];
 
   // Update Log-Odds
-  updateLogOdds(group_info.accumulated_log_odds, state_key, confidence);
+  update_log_odds(group_info.accumulated_log_odds, state_key, confidence);
 
   // Update Best Record
-  updateBestRecord(group_info.best_record_for_state, state_key, confidence, record);
+  update_best_record(group_info.best_record_for_state, state_key, confidence, record);
 }
 
 /**
  * @brief Handles the log-odds accumulation logic.
  */
-void MultiCameraFusion::updateLogOdds(
+void MultiCameraFusion::update_log_odds(
   std::map<StateKey, double> & log_odds_map, const StateKey & state_key, double confidence)
 {
   // try_emplace ensures we only add the 0.0 prior (from a 0.5 probability) once.
   log_odds_map.try_emplace(state_key, 0.0);
 
-  const double evidence_log_odds = probabilityToLogOdds(confidence);
+  const double evidence_log_odds = probability_to_log_odds(confidence);
 
   // Accumulate evidence
   log_odds_map[state_key] += evidence_log_odds - prior_log_odds_;
@@ -334,7 +335,7 @@ void MultiCameraFusion::updateLogOdds(
 /**
  * @brief Handles the logic for tracking the best record for a given state.
  */
-void MultiCameraFusion::updateBestRecord(
+void MultiCameraFusion::update_best_record(
   std::map<StateKey, utils::FusionRecord> & best_record_map, const StateKey & state_key,
   double confidence, const utils::FusionRecord & record)
 {
@@ -351,12 +352,12 @@ void MultiCameraFusion::updateBestRecord(
     return;
   }
 
-  if (confidence > utils::getMinConfidence(existing_record.signal)) {
+  if (confidence > utils::get_min_confidence(existing_record.signal)) {
     best_record_map[state_key] = record;
   }
 }
 
-void MultiCameraFusion::determineBestGroupState(
+void MultiCameraFusion::determine_best_group_state(
   const std::map<IdType, GroupFusionInfo> & group_fusion_info_map,
   std::map<IdType, utils::FusionRecord> & grouped_record_map)
 {
@@ -372,7 +373,7 @@ void MultiCameraFusion::determineBestGroupState(
 
     if (!use_signal_consistency_check_ || group_info.accumulated_log_odds.size() == 1) {
       // use the most probable one (the highest logarithmic odds) as the base
-      const StateKey best_state_key = getBestStatekey(group_info.accumulated_log_odds);
+      const StateKey best_state_key = get_best_state_key(group_info.accumulated_log_odds);
       grouped_record_map[reg_ele_id] = group_info.best_record_for_state.at(best_state_key);
 
       continue;
@@ -389,7 +390,7 @@ void MultiCameraFusion::determineBestGroupState(
     // check if conflicts exist among the signals within the same regulatory element id
     for (++log_odds_it; log_odds_it != group_info.accumulated_log_odds.end(); ++log_odds_it) {
       const StateKey & competitor_state = (*log_odds_it).first;
-      conflict_result = signal_validator_->checkConflict(running_state, competitor_state);
+      conflict_result = signal_validator_->check_conflict(running_state, competitor_state);
       running_state = conflict_result.common_state_key;
 
       if (conflict_result.conflict_type == ConflictType::CONFLICT) {
@@ -410,23 +411,23 @@ void MultiCameraFusion::determineBestGroupState(
       // use a fail-safe record as a fallback for this regulatory element.
 
       // use the most probable one (the highest logarithmic odds) as the base
-      const StateKey best_state_key = getBestStatekey(group_info.accumulated_log_odds);
+      const StateKey best_state_key = get_best_state_key(group_info.accumulated_log_odds);
 
       // set the best record that signal is overwritten with fail-safe record
       grouped_record_map[reg_ele_id] =
-        utils::generateFailsafeRecord(group_info.best_record_for_state.at(best_state_key));
+        utils::generate_failsafe_record(group_info.best_record_for_state.at(best_state_key));
     } else {
       // partially conflicted and allowed to publish the matched signals
 
       // rebuild the record based on the matched signals
       // copy the base data from the best original record, but replace the elements
-      const StateKey best_state_key = getBestStatekey(group_info.accumulated_log_odds);
+      const StateKey best_state_key = get_best_state_key(group_info.accumulated_log_odds);
       utils::FusionRecord merged_record = group_info.best_record_for_state.at(best_state_key);
 
       merged_record.signal.elements.clear();
 
       const double min_confidence =
-        utils::getMinConfidence(group_info.best_record_for_state.at(best_state_key).signal);
+        utils::get_min_confidence(group_info.best_record_for_state.at(best_state_key).signal);
       for (const auto & elem : running_state) {
         tier4_perception_msgs::msg::TrafficLightElement new_elem;
         new_elem.color = elem.first;
@@ -448,7 +449,7 @@ void MultiCameraFusion::determineBestGroupState(
   }
 }
 
-void MultiCameraFusion::publishDiagnostics(rclcpp::Time stamp)
+void MultiCameraFusion::publish_diagnostics(rclcpp::Time stamp)
 {
   diagnostics_interface_ptr_->clear();
 

--- a/perception/autoware_traffic_light_multi_camera_fusion/src/traffic_light_multi_camera_fusion_node.cpp
+++ b/perception/autoware_traffic_light_multi_camera_fusion/src/traffic_light_multi_camera_fusion_node.cpp
@@ -19,6 +19,7 @@
 #include <functional>
 #include <memory>
 #include <string>
+#include <utility>
 #include <vector>
 
 namespace autoware::traffic_light
@@ -75,7 +76,8 @@ MultiCameraFusionNode::MultiCameraFusionNode(const rclcpp::NodeOptions & node_op
     [this](const autoware_map_msgs::msg::LaneletMapBin::ConstSharedPtr msg) {
       this->map_callback(msg);
     });
-  signal_pub_ = create_publisher<NewSignalArrayType>("~/output/traffic_signals", rclcpp::QoS{1});
+  signal_pub_ =
+    AUTOWARE_CREATE_PUBLISHER2(NewSignalArrayType, "~/output/traffic_signals", rclcpp::QoS{1});
 
   diagnostics_interface_ptr_ =
     std::make_unique<autoware_utils::DiagnosticsInterface>(this, "traffic light conflict status");
@@ -87,12 +89,14 @@ void MultiCameraFusionNode::traffic_signal_roi_callback(
 {
   rclcpp::Time stamp(roi_msg->header.stamp);
 
-  const MultiCameraFusionResult result = fusion_.fuse(*cam_info_msg, *roi_msg, *signal_msg);
+  auto msg_out = ALLOCATE_OUTPUT_MESSAGE_UNIQUE(signal_pub_);
+  const MultiCameraFusionResult result =
+    fusion_.fuse(*cam_info_msg, *roi_msg, *signal_msg, *msg_out);
   for (const auto & unmapped_id : result.unmapped_traffic_light_ids) {
     RCLCPP_WARN_STREAM(
       get_logger(), "Found Traffic Light Id = " << unmapped_id << " which is not defined in Map");
   }
-  signal_pub_->publish(result.traffic_light_groups);
+  signal_pub_->publish(std::move(msg_out));
 
   if (result.conflicted_regulatory_element_status.size() > 0) {
     publish_diagnostics(result.conflicted_regulatory_element_status, stamp);

--- a/perception/autoware_traffic_light_multi_camera_fusion/src/traffic_light_multi_camera_fusion_node.cpp
+++ b/perception/autoware_traffic_light_multi_camera_fusion/src/traffic_light_multi_camera_fusion_node.cpp
@@ -15,62 +15,16 @@
 #include "traffic_light_multi_camera_fusion_node.hpp"
 
 #include <autoware/lanelet2_utils/conversion.hpp>
-#include <autoware_lanelet2_extension/utility/query.hpp>
 
-#include <algorithm>
 #include <functional>
-#include <map>
 #include <memory>
 #include <string>
-#include <unordered_map>
-#include <utility>
 #include <vector>
 
 namespace autoware::traffic_light
 {
 
-namespace
-{
-
-double probability_to_log_odds(double prob)
-{
-  /**
-   * @brief Converts a probability value to log-odds.
-   *
-   * Log-odds is the logarithm of the odds ratio, i.e., log(p / (1-p)).
-   * This function is essential for Bayesian updating in log-space, as it allows
-   * evidence to be additively combined.
-   *
-   * The function handles edge cases where the probability `p` is very close to
-   * 0 or 1. As `p` -> 1, log-odds -> +inf. As `p` -> 0, log-odds -> -inf.
-   * To prevent floating-point divergence (infinity), the input probability is
-   * "clamped" to a safe range slightly away from the boundaries. The bounds
-   * [1e-9, 1.0 - 1e-9] are chosen as a small epsilon to ensure numerical
-   * stability while having a negligible impact on non-extreme probability values.
-   *
-   * @param prob The input probability, expected to be in the range [0.0, 1.0].
-   * @return The corresponding log-odds value.
-   */
-  prob = std::clamp(prob, 1e-9, 1.0 - 1e-9);
-  return std::log(prob / (1.0 - prob));
-}
-
-/**
- * @brief get the state key that has best log-odds.
- */
-inline StateKey get_best_state_key(const std::map<StateKey, double> & accumulated_log_odds)
-{
-  auto best_element = std::max_element(
-    accumulated_log_odds.begin(), accumulated_log_odds.end(), compare_state_key_log_odds);
-
-  StateKey best_state_key = best_element->first;
-
-  return best_state_key;
-}
-
-}  // namespace
-
-MultiCameraFusion::MultiCameraFusion(const rclcpp::NodeOptions & node_options)
+MultiCameraFusionNode::MultiCameraFusionNode(const rclcpp::NodeOptions & node_options)
 : Node("traffic_light_multi_camera_fusion", node_options)
 {
   using std::placeholders::_1;
@@ -79,13 +33,17 @@ MultiCameraFusion::MultiCameraFusion(const rclcpp::NodeOptions & node_options)
 
   std::vector<std::string> camera_namespaces =
     this->declare_parameter<std::vector<std::string>>("camera_namespaces");
-  is_approximate_sync_ = this->declare_parameter<bool>("approximate_sync");
-  message_lifespan_ = this->declare_parameter<double>("message_lifespan");
-  prior_log_odds_ = this->declare_parameter<double>("prior_log_odds");
+  const bool is_approximate_sync = this->declare_parameter<bool>("approximate_sync");
 
-  use_signal_consistency_check_ = this->declare_parameter<bool>("signal_consistency_check.enable");
-  publish_partial_matched_signal_ =
+  fusion_config_.message_lifespan = this->declare_parameter<double>("message_lifespan");
+  fusion_config_.prior_log_odds = this->declare_parameter<double>("prior_log_odds");
+
+  fusion_config_.use_signal_consistency_check =
+    this->declare_parameter<bool>("signal_consistency_check.enable");
+  fusion_config_.publish_partial_matched_signal =
     this->declare_parameter<bool>("signal_consistency_check.publish_partial_matched_signal");
+
+  fusion_ = MultiCameraFusion(fusion_config_);
 
   for (const std::string & camera_ns : camera_namespaces) {
     std::string signal_topic = camera_ns + "/classification/traffic_signals";
@@ -97,18 +55,18 @@ MultiCameraFusion::MultiCameraFusion(const rclcpp::NodeOptions & node_options)
       this, signal_topic, rclcpp::QoS{1}.get_rmw_qos_profile()));
     cam_info_subs_.emplace_back(new mf::Subscriber<CamInfoType>(
       this, cam_info_topic, rclcpp::SensorDataQoS().get_rmw_qos_profile()));
-    if (is_approximate_sync_ == false) {
+    if (is_approximate_sync == false) {
       exact_sync_subs_.emplace_back(new ExactSync(
         ExactSyncPolicy(10), *(cam_info_subs_.back()), *(roi_subs_.back()),
         *(signal_subs_.back())));
       exact_sync_subs_.back()->registerCallback(
-        std::bind(&MultiCameraFusion::traffic_signal_roi_callback, this, _1, _2, _3));
+        std::bind(&MultiCameraFusionNode::traffic_signal_roi_callback, this, _1, _2, _3));
     } else {
       approximate_sync_subs_.emplace_back(new ApproximateSync(
         ApproximateSyncPolicy(10), *(cam_info_subs_.back()), *(roi_subs_.back()),
         *(signal_subs_.back())));
       approximate_sync_subs_.back()->registerCallback(
-        std::bind(&MultiCameraFusion::traffic_signal_roi_callback, this, _1, _2, _3));
+        std::bind(&MultiCameraFusionNode::traffic_signal_roi_callback, this, _1, _2, _3));
     }
   }
 
@@ -121,340 +79,41 @@ MultiCameraFusion::MultiCameraFusion(const rclcpp::NodeOptions & node_options)
 
   diagnostics_interface_ptr_ =
     std::make_unique<autoware_utils::DiagnosticsInterface>(this, "traffic light conflict status");
-
-  if (use_signal_consistency_check_) {
-    signal_validator_ = std::make_unique<SignalValidator>();
-  }
 }
 
-void MultiCameraFusion::traffic_signal_roi_callback(
+void MultiCameraFusionNode::traffic_signal_roi_callback(
   const CamInfoType::ConstSharedPtr cam_info_msg, const RoiArrayType::ConstSharedPtr roi_msg,
   const SignalArrayType::ConstSharedPtr signal_msg)
 {
   rclcpp::Time stamp(roi_msg->header.stamp);
-  /*
-  Insert the received record array to the table.
-  Attention should be payed that this record array might not have the newest timestamp
-  */
-  record_arr_set_.insert(
-    utils::FusionRecordArr{cam_info_msg->header, *cam_info_msg, *roi_msg, *signal_msg});
 
-  std::map<IdType, utils::FusionRecord> fused_record_map, grouped_record_map;
-  multi_camera_fusion(fused_record_map);
-  group_fusion(fused_record_map, grouped_record_map);
+  const MultiCameraFusionResult result = fusion_.fuse(*cam_info_msg, *roi_msg, *signal_msg);
+  for (const auto & unmapped_id : result.unmapped_traffic_light_ids) {
+    RCLCPP_WARN_STREAM(
+      get_logger(), "Found Traffic Light Id = " << unmapped_id << " which is not defined in Map");
+  }
+  signal_pub_->publish(result.traffic_light_groups);
 
-  NewSignalArrayType msg_out;
-  convert_output_msg(grouped_record_map, msg_out);
-  msg_out.stamp = cam_info_msg->header.stamp;
-  signal_pub_->publish(msg_out);
-
-  if (conflicted_regulatory_element_status_.size() > 0) {
-    publish_diagnostics(stamp);
+  if (result.conflicted_regulatory_element_status.size() > 0) {
+    publish_diagnostics(result.conflicted_regulatory_element_status, stamp);
   }
 }
 
-void MultiCameraFusion::map_callback(
+void MultiCameraFusionNode::map_callback(
   const autoware_map_msgs::msg::LaneletMapBin::ConstSharedPtr input_msg)
 {
-  lanelet::LaneletMapPtr lanelet_map_ptr = autoware::experimental::lanelet2_utils::remove_const(
+  fusion_config_.lanelet_map_ptr = autoware::experimental::lanelet2_utils::remove_const(
     autoware::experimental::lanelet2_utils::from_autoware_map_msgs(*input_msg));
-  lanelet::ConstLanelets all_lanelets = lanelet::utils::query::laneletLayer(lanelet_map_ptr);
-  std::vector<lanelet::AutowareTrafficLightConstPtr> all_lanelet_traffic_lights =
-    lanelet::utils::query::autowareTrafficLights(all_lanelets);
-  for (auto tl_itr = all_lanelet_traffic_lights.begin(); tl_itr != all_lanelet_traffic_lights.end();
-       ++tl_itr) {
-    lanelet::AutowareTrafficLightConstPtr tl = *tl_itr;
-
-    auto lights = tl->trafficLights();
-    for (const auto & light : lights) {
-      traffic_light_id_to_regulatory_ele_id_[light.id()].emplace_back(tl->id());
-    }
-  }
+  fusion_ = MultiCameraFusion(fusion_config_);
 }
 
-void MultiCameraFusion::convert_output_msg(
-  const std::map<IdType, utils::FusionRecord> & grouped_record_map, NewSignalArrayType & msg_out)
-{
-  msg_out.traffic_light_groups.clear();
-  for (const auto & p : grouped_record_map) {
-    IdType reg_ele_id = p.first;
-    const SignalType & signal = p.second.signal;
-    NewSignalType signal_out;
-    signal_out.traffic_light_group_id = reg_ele_id;
-    for (const auto & ele : signal.elements) {
-      signal_out.elements.push_back(utils::convert_t4_to_autoware(ele));
-    }
-    msg_out.traffic_light_groups.push_back(signal_out);
-  }
-}
-
-void MultiCameraFusion::multi_camera_fusion(
-  std::map<IdType, utils::FusionRecord> & fused_record_map)
-{
-  fused_record_map.clear();
-  /*
-  this should not happen. Just in case
-  */
-  if (record_arr_set_.empty()) {
-    RCLCPP_ERROR(get_logger(), "record_arr_set_ is empty! This should not happen");
-    return;
-  }
-  const rclcpp::Time & newest_stamp(record_arr_set_.rbegin()->header.stamp);
-  for (auto it = record_arr_set_.begin(); it != record_arr_set_.end();) {
-    /*
-    remove all old record arrays whose timestamp difference with newest record is larger than
-    threshold
-    */
-    if (
-      (newest_stamp - rclcpp::Time(it->header.stamp)) >
-      rclcpp::Duration::from_seconds(message_lifespan_)) {
-      it = record_arr_set_.erase(it);
-    } else {
-      /*
-      generate fused record result with the saved records
-      */
-      const utils::FusionRecordArr & record_arr = *it;
-      for (size_t i = 0; i < record_arr.rois.rois.size(); i++) {
-        const RoiType & roi = record_arr.rois.rois[i];
-        auto signal_it = std::find_if(
-          record_arr.signals.signals.begin(), record_arr.signals.signals.end(),
-          [roi](const SignalType & s1) { return roi.traffic_light_id == s1.traffic_light_id; });
-        /*
-        failed to find corresponding signal. skip it
-        */
-        if (signal_it == record_arr.signals.signals.end()) {
-          continue;
-        }
-        utils::FusionRecord record{record_arr.header, record_arr.cam_info, roi, *signal_it};
-        /*
-        if this traffic light is not detected yet or can be updated by higher priority record,
-        update it
-        */
-        if (
-          fused_record_map.find(roi.traffic_light_id) == fused_record_map.end() ||
-          utils::compare_record(record, fused_record_map[roi.traffic_light_id]) >= 0) {
-          fused_record_map[roi.traffic_light_id] = record;
-        }
-      }
-      it++;
-    }
-  }
-}
-
-void MultiCameraFusion::group_fusion(
-  const std::map<IdType, utils::FusionRecord> & fused_record_map,
-  std::map<IdType, utils::FusionRecord> & grouped_record_map)
-{
-  grouped_record_map.clear();
-
-  // Stage 1: Accumulate evidence from all fused records
-  const std::map<IdType, GroupFusionInfo> group_fusion_info_map =
-    accumulate_group_evidence(fused_record_map);
-
-  // Stage 2: Determine the best state for each group from the accumulated evidence
-  determine_best_group_state(group_fusion_info_map, grouped_record_map);
-}
-
-GroupFusionInfoMap MultiCameraFusion::accumulate_group_evidence(
-  const std::map<IdType, utils::FusionRecord> & fused_record_map)
-{
-  GroupFusionInfoMap group_fusion_info_map;
-  for (const auto & p : fused_record_map) {
-    process_fused_record(group_fusion_info_map, p.second);
-  }
-  return group_fusion_info_map;
-}
-
-/**
- * @brief Processes a single fused record and updates the group_fusion_info_map.
- * (This function contains the logic from the outer loop)
- */
-void MultiCameraFusion::process_fused_record(
-  GroupFusionInfoMap & group_fusion_info_map, const utils::FusionRecord & record)
-{
-  const IdType roi_id = record.roi.traffic_light_id;
-
-  // Guard Clause 1: Check if traffic light ID is in the map
-  const auto it = traffic_light_id_to_regulatory_ele_id_.find(roi_id);
-  if (it == traffic_light_id_to_regulatory_ele_id_.end()) {
-    RCLCPP_WARN_STREAM(
-      get_logger(), "Found Traffic Light Id = " << roi_id << " which is not defined in Map");
-    return;
-  }
-
-  // Guard Clause 2: Check for elements
-  if (record.signal.elements.empty()) {
-    return;
-  }
-
-  const auto & reg_ele_id_vec = it->second;  // Use the iterator
-
-  // Loop over all regulatory IDs associated with this traffic light
-  for (const auto & reg_ele_id : reg_ele_id_vec) {
-    // Delegate the innermost logic to another helper
-    update_group_info_for_element(group_fusion_info_map, reg_ele_id, record);
-  }
-}
-
-/**
- * @brief Updates the map for a single (element, regulatory_id) combination.
- */
-void MultiCameraFusion::update_group_info_for_element(
-  GroupFusionInfoMap & group_fusion_info_map, const IdType & reg_ele_id,
-  const utils::FusionRecord & record)
-{
-  StateKey state_key;
-  for (const auto & element : record.signal.elements) {
-    state_key.emplace_back(std::make_pair(element.color, element.shape));
-  }
-  const double confidence = utils::get_min_confidence(record.signal);
-  auto & group_info = group_fusion_info_map[reg_ele_id];
-
-  // Update Log-Odds
-  update_log_odds(group_info.accumulated_log_odds, state_key, confidence);
-
-  // Update Best Record
-  update_best_record(group_info.best_record_for_state, state_key, confidence, record);
-}
-
-/**
- * @brief Handles the log-odds accumulation logic.
- */
-void MultiCameraFusion::update_log_odds(
-  std::map<StateKey, double> & log_odds_map, const StateKey & state_key, double confidence)
-{
-  // try_emplace ensures we only add the 0.0 prior (from a 0.5 probability) once.
-  log_odds_map.try_emplace(state_key, 0.0);
-
-  const double evidence_log_odds = probability_to_log_odds(confidence);
-
-  // Accumulate evidence
-  log_odds_map[state_key] += evidence_log_odds - prior_log_odds_;
-}
-
-/**
- * @brief Handles the logic for tracking the best record for a given state.
- */
-void MultiCameraFusion::update_best_record(
-  std::map<StateKey, utils::FusionRecord> & best_record_map, const StateKey & state_key,
-  double confidence, const utils::FusionRecord & record)
-{
-  const auto it = best_record_map.find(state_key);
-
-  if (it == best_record_map.end()) {
-    best_record_map[state_key] = record;
-    return;
-  }
-
-  auto & existing_record = it->second;
-
-  if (existing_record.signal.elements.empty()) {
-    return;
-  }
-
-  if (confidence > utils::get_min_confidence(existing_record.signal)) {
-    best_record_map[state_key] = record;
-  }
-}
-
-void MultiCameraFusion::determine_best_group_state(
-  const std::map<IdType, GroupFusionInfo> & group_fusion_info_map,
-  std::map<IdType, utils::FusionRecord> & grouped_record_map)
-{
-  conflicted_regulatory_element_status_.clear();
-
-  for (const auto & pair : group_fusion_info_map) {
-    const IdType reg_ele_id = pair.first;
-    const auto & group_info = pair.second;
-
-    if (group_info.accumulated_log_odds.empty()) {
-      continue;
-    }
-
-    if (!use_signal_consistency_check_ || group_info.accumulated_log_odds.size() == 1) {
-      // use the most probable one (the highest logarithmic odds) as the base
-      const StateKey best_state_key = get_best_state_key(group_info.accumulated_log_odds);
-      grouped_record_map[reg_ele_id] = group_info.best_record_for_state.at(best_state_key);
-
-      continue;
-    }
-
-    // only records with multiple state keys reach here
-    // these indicate conflicts, except when unknown states are present
-
-    auto log_odds_it = group_info.accumulated_log_odds.begin();
-    StateKey running_state = (*log_odds_it).first;
-
-    ConflictStatus conflict_result{ConflictType::PARTIAL_CONFLICT, running_state};
-
-    // check if conflicts exist among the signals within the same regulatory element id
-    for (++log_odds_it; log_odds_it != group_info.accumulated_log_odds.end(); ++log_odds_it) {
-      const StateKey & competitor_state = (*log_odds_it).first;
-      conflict_result = signal_validator_->check_conflict(running_state, competitor_state);
-      running_state = conflict_result.common_state_key;
-
-      if (conflict_result.conflict_type == ConflictType::CONFLICT) {
-        // critical conflict will be overwritten with fail-safe record
-        // we immediately exit the loop
-        break;
-      } else {  // partial conflict
-        if (publish_partial_matched_signal_) {
-          continue;
-        } else {
-          break;
-        }
-      }
-    }
-
-    if (
-      conflict_result.conflict_type == ConflictType::CONFLICT || !publish_partial_matched_signal_) {
-      // use a fail-safe record as a fallback for this regulatory element.
-
-      // use the most probable one (the highest logarithmic odds) as the base
-      const StateKey best_state_key = get_best_state_key(group_info.accumulated_log_odds);
-
-      // set the best record that signal is overwritten with fail-safe record
-      grouped_record_map[reg_ele_id] =
-        utils::generate_failsafe_record(group_info.best_record_for_state.at(best_state_key));
-    } else {
-      // partially conflicted and allowed to publish the matched signals
-
-      // rebuild the record based on the matched signals
-      // copy the base data from the best original record, but replace the elements
-      const StateKey best_state_key = get_best_state_key(group_info.accumulated_log_odds);
-      utils::FusionRecord merged_record = group_info.best_record_for_state.at(best_state_key);
-
-      merged_record.signal.elements.clear();
-
-      const double min_confidence =
-        utils::get_min_confidence(group_info.best_record_for_state.at(best_state_key).signal);
-      for (const auto & elem : running_state) {
-        tier4_perception_msgs::msg::TrafficLightElement new_elem;
-        new_elem.color = elem.first;
-        new_elem.shape = elem.second;
-        // keep the min confidence of the base record
-        new_elem.confidence = min_confidence;
-
-        merged_record.signal.elements.push_back(new_elem);
-      }
-
-      grouped_record_map[reg_ele_id] = merged_record;
-    }
-
-    // suppress diagnostics for comparisons with unknown
-    if (conflict_result.conflict_type != ConflictType::NO_CONFLICT) {
-      // record it for diagnostics
-      conflicted_regulatory_element_status_.push_back({reg_ele_id, conflict_result.conflict_type});
-    }
-  }
-}
-
-void MultiCameraFusion::publish_diagnostics(rclcpp::Time stamp)
+void MultiCameraFusionNode::publish_diagnostics(
+  const std::vector<ConflictInfo> & conflicted_regulatory_element_status, rclcpp::Time stamp)
 {
   diagnostics_interface_ptr_->clear();
 
   // publish only conflicted RE status
-  for (const auto & conflicted_re : conflicted_regulatory_element_status_) {
+  for (const auto & conflicted_re : conflicted_regulatory_element_status) {
     diagnostics_interface_ptr_->add_key_value(
       std::to_string(static_cast<int64_t>(conflicted_re.id)),
       static_cast<int>(conflicted_re.conflict_type));
@@ -465,10 +124,9 @@ void MultiCameraFusion::publish_diagnostics(rclcpp::Time stamp)
     "Detected traffic light signal conflict in the fusion process.");
 
   diagnostics_interface_ptr_->publish(stamp);
-  conflicted_regulatory_element_status_.clear();
 }
 
 }  // namespace autoware::traffic_light
 
 #include <rclcpp_components/register_node_macro.hpp>
-RCLCPP_COMPONENTS_REGISTER_NODE(autoware::traffic_light::MultiCameraFusion)
+RCLCPP_COMPONENTS_REGISTER_NODE(autoware::traffic_light::MultiCameraFusionNode)

--- a/perception/autoware_traffic_light_multi_camera_fusion/src/traffic_light_multi_camera_fusion_node.cpp
+++ b/perception/autoware_traffic_light_multi_camera_fusion/src/traffic_light_multi_camera_fusion_node.cpp
@@ -19,7 +19,6 @@
 #include <functional>
 #include <memory>
 #include <string>
-#include <utility>
 #include <vector>
 
 namespace autoware::traffic_light
@@ -89,14 +88,12 @@ void MultiCameraFusionNode::traffic_signal_roi_callback(
 {
   rclcpp::Time stamp(roi_msg->header.stamp);
 
-  auto msg_out = ALLOCATE_OUTPUT_MESSAGE_UNIQUE(signal_pub_);
-  const MultiCameraFusionResult result =
-    fusion_.fuse(*cam_info_msg, *roi_msg, *signal_msg, *msg_out);
+  const MultiCameraFusionResult result = fusion_.fuse(*cam_info_msg, *roi_msg, *signal_msg);
   for (const auto & unmapped_id : result.unmapped_traffic_light_ids) {
     RCLCPP_WARN_STREAM(
       get_logger(), "Found Traffic Light Id = " << unmapped_id << " which is not defined in Map");
   }
-  signal_pub_->publish(std::move(msg_out));
+  signal_pub_->publish(result.traffic_light_groups);
 
   if (result.conflicted_regulatory_element_status.size() > 0) {
     publish_diagnostics(result.conflicted_regulatory_element_status, stamp);

--- a/perception/autoware_traffic_light_multi_camera_fusion/src/traffic_light_multi_camera_fusion_node.hpp
+++ b/perception/autoware_traffic_light_multi_camera_fusion/src/traffic_light_multi_camera_fusion_node.hpp
@@ -17,6 +17,7 @@
 
 #include "multi_camera_fusion.hpp"
 
+#include <autoware/agnocast_wrapper/autoware_agnocast_wrapper.hpp>
 #include <autoware_utils/ros/diagnostics_interface.hpp>
 #include <rclcpp/rclcpp.hpp>
 
@@ -81,7 +82,7 @@ private:
   std::vector<std::unique_ptr<ApproximateSync>> approximate_sync_subs_;
   rclcpp::Subscription<autoware_map_msgs::msg::LaneletMapBin>::SharedPtr map_sub_;
 
-  rclcpp::Publisher<NewSignalArrayType>::SharedPtr signal_pub_;
+  AUTOWARE_PUBLISHER_PTR(NewSignalArrayType) signal_pub_;
 
   MultiCameraFusionConfig fusion_config_{};
   MultiCameraFusion fusion_{};

--- a/perception/autoware_traffic_light_multi_camera_fusion/src/traffic_light_multi_camera_fusion_node.hpp
+++ b/perception/autoware_traffic_light_multi_camera_fusion/src/traffic_light_multi_camera_fusion_node.hpp
@@ -48,20 +48,20 @@ namespace autoware::traffic_light
 {
 namespace mf = message_filters;
 
-inline bool isUnknown(const StateKey & state_key)
+inline bool is_unknown(const StateKey & state_key)
 {
   return state_key.size() == 1 &&
          state_key[0].first == tier4_perception_msgs::msg::TrafficLightElement::UNKNOWN;
 }
 
-inline bool compareStateKeyLogOdds(
+inline bool compare_state_key_log_odds(
   const std::pair<StateKey, double> & key1, const std::pair<StateKey, double> & key2)
 {
   // Ordering rule:
   // 1. Unknown StateKey is always lower priority
   // 2. Otherwise, smaller log-odds comes first
-  const bool key1_is_unknown = isUnknown(key1.first);
-  const bool key2_is_unknown = isUnknown(key2.first);
+  const bool key1_is_unknown = is_unknown(key1.first);
+  const bool key2_is_unknown = is_unknown(key2.first);
   if (key1_is_unknown && !key2_is_unknown) {
     return true;
   }
@@ -103,18 +103,18 @@ public:
   explicit MultiCameraFusion(const rclcpp::NodeOptions & node_options);
 
 private:
-  void trafficSignalRoiCallback(
+  void traffic_signal_roi_callback(
     const CamInfoType::ConstSharedPtr cam_info_msg, const RoiArrayType::ConstSharedPtr roi_msg,
     const SignalArrayType::ConstSharedPtr signal_msg);
 
-  void mapCallback(const autoware_map_msgs::msg::LaneletMapBin::ConstSharedPtr input_msg);
+  void map_callback(const autoware_map_msgs::msg::LaneletMapBin::ConstSharedPtr input_msg);
 
-  void multiCameraFusion(std::map<IdType, utils::FusionRecord> & fused_record_map);
+  void multi_camera_fusion(std::map<IdType, utils::FusionRecord> & fused_record_map);
 
-  void convertOutputMsg(
+  void convert_output_msg(
     const std::map<IdType, utils::FusionRecord> & grouped_record_map, NewSignalArrayType & msg_out);
 
-  void groupFusion(
+  void group_fusion(
     const std::map<IdType, utils::FusionRecord> & fused_record_map,
     std::map<IdType, utils::FusionRecord> & grouped_record_map);
 
@@ -122,43 +122,43 @@ private:
    * @brief Accumulates log-odds evidence for each traffic light group from individual fused
    * records.
    */
-  GroupFusionInfoMap accumulateGroupEvidence(
+  GroupFusionInfoMap accumulate_group_evidence(
     const std::map<IdType, utils::FusionRecord> & fused_record_map);
 
   /**
    * @brief Processes a single fused record and updates the group_fusion_info_map.
    */
-  void processFusedRecord(
+  void process_fused_record(
     GroupFusionInfoMap & group_fusion_info_map, const utils::FusionRecord & record);
 
   /**
    * @brief Updates the map for a single (element, regulatory_id) combination.
    */
-  void updateGroupInfoForElement(
+  void update_group_info_for_element(
     GroupFusionInfoMap & group_fusion_info_map, const IdType & reg_ele_id,
     const utils::FusionRecord & record);
 
   /**
    * @brief Handles the log-odds accumulation logic.
    */
-  void updateLogOdds(
+  void update_log_odds(
     std::map<StateKey, double> & log_odds_map, const StateKey & state_key, double confidence);
 
   /**
    * @brief Handles the logic for tracking the best record for a given state.
    */
-  void updateBestRecord(
+  void update_best_record(
     std::map<StateKey, utils::FusionRecord> & best_record_map, const StateKey & state_key,
     double confidence, const utils::FusionRecord & record);
 
   /**
    * @brief Determines the best state for each group based on accumulated evidence.
    */
-  void determineBestGroupState(
+  void determine_best_group_state(
     const std::map<IdType, GroupFusionInfo> & group_fusion_info_map,
     std::map<IdType, utils::FusionRecord> & grouped_record_map);
 
-  void publishDiagnostics(rclcpp::Time stamp);
+  void publish_diagnostics(rclcpp::Time stamp);
 
   using ExactSyncPolicy = mf::sync_policies::ExactTime<CamInfoType, RoiArrayType, SignalArrayType>;
   using ExactSync = mf::Synchronizer<ExactSyncPolicy>;

--- a/perception/autoware_traffic_light_multi_camera_fusion/src/traffic_light_multi_camera_fusion_node.hpp
+++ b/perception/autoware_traffic_light_multi_camera_fusion/src/traffic_light_multi_camera_fusion_node.hpp
@@ -15,9 +15,7 @@
 #ifndef TRAFFIC_LIGHT_MULTI_CAMERA_FUSION_NODE_HPP_
 #define TRAFFIC_LIGHT_MULTI_CAMERA_FUSION_NODE_HPP_
 
-#include "signal_validator.hpp"
-#include "traffic_light_multi_camera_fusion_process.hpp"
-#include "types.hpp"
+#include "multi_camera_fusion.hpp"
 
 #include <autoware_utils/ros/diagnostics_interface.hpp>
 #include <rclcpp/rclcpp.hpp>
@@ -31,16 +29,12 @@
 #include <tier4_perception_msgs/msg/traffic_light_roi.hpp>
 #include <tier4_perception_msgs/msg/traffic_light_roi_array.hpp>
 
-#include <lanelet2_core/Forward.h>
 #include <message_filters/subscriber.h>
 #include <message_filters/sync_policies/approximate_time.h>
 #include <message_filters/sync_policies/exact_time.h>
 #include <message_filters/synchronizer.h>
 
-#include <list>
-#include <map>
 #include <memory>
-#include <set>
 #include <utility>
 #include <vector>
 
@@ -48,45 +42,7 @@ namespace autoware::traffic_light
 {
 namespace mf = message_filters;
 
-inline bool is_unknown(const StateKey & state_key)
-{
-  return state_key.size() == 1 &&
-         state_key[0].first == tier4_perception_msgs::msg::TrafficLightElement::UNKNOWN;
-}
-
-inline bool compare_state_key_log_odds(
-  const std::pair<StateKey, double> & key1, const std::pair<StateKey, double> & key2)
-{
-  // Ordering rule:
-  // 1. Unknown StateKey is always lower priority
-  // 2. Otherwise, smaller log-odds comes first
-  const bool key1_is_unknown = is_unknown(key1.first);
-  const bool key2_is_unknown = is_unknown(key2.first);
-  if (key1_is_unknown && !key2_is_unknown) {
-    return true;
-  }
-  if (!key1_is_unknown && key2_is_unknown) {
-    return false;
-  }
-  return key1.second < key2.second;
-}
-
-struct GroupFusionInfo
-{
-  std::map<StateKey, double> accumulated_log_odds;
-  std::map<StateKey, utils::FusionRecord> best_record_for_state;
-};
-
-struct ConflictInfo
-{
-  tier4_perception_msgs::msg::TrafficLightRoi::_traffic_light_id_type id;
-  ConflictType conflict_type;
-};
-
-using GroupFusionInfoMap =
-  std::map<tier4_perception_msgs::msg::TrafficLightRoi::_traffic_light_id_type, GroupFusionInfo>;
-
-class MultiCameraFusion : public rclcpp::Node
+class MultiCameraFusionNode : public rclcpp::Node
 {
 public:
   using CamInfoType = sensor_msgs::msg::CameraInfo;
@@ -100,7 +56,7 @@ public:
 
   using RecordArrayType = std::pair<RoiArrayType, SignalArrayType>;
 
-  explicit MultiCameraFusion(const rclcpp::NodeOptions & node_options);
+  explicit MultiCameraFusionNode(const rclcpp::NodeOptions & node_options);
 
 private:
   void traffic_signal_roi_callback(
@@ -109,56 +65,8 @@ private:
 
   void map_callback(const autoware_map_msgs::msg::LaneletMapBin::ConstSharedPtr input_msg);
 
-  void multi_camera_fusion(std::map<IdType, utils::FusionRecord> & fused_record_map);
-
-  void convert_output_msg(
-    const std::map<IdType, utils::FusionRecord> & grouped_record_map, NewSignalArrayType & msg_out);
-
-  void group_fusion(
-    const std::map<IdType, utils::FusionRecord> & fused_record_map,
-    std::map<IdType, utils::FusionRecord> & grouped_record_map);
-
-  /**
-   * @brief Accumulates log-odds evidence for each traffic light group from individual fused
-   * records.
-   */
-  GroupFusionInfoMap accumulate_group_evidence(
-    const std::map<IdType, utils::FusionRecord> & fused_record_map);
-
-  /**
-   * @brief Processes a single fused record and updates the group_fusion_info_map.
-   */
-  void process_fused_record(
-    GroupFusionInfoMap & group_fusion_info_map, const utils::FusionRecord & record);
-
-  /**
-   * @brief Updates the map for a single (element, regulatory_id) combination.
-   */
-  void update_group_info_for_element(
-    GroupFusionInfoMap & group_fusion_info_map, const IdType & reg_ele_id,
-    const utils::FusionRecord & record);
-
-  /**
-   * @brief Handles the log-odds accumulation logic.
-   */
-  void update_log_odds(
-    std::map<StateKey, double> & log_odds_map, const StateKey & state_key, double confidence);
-
-  /**
-   * @brief Handles the logic for tracking the best record for a given state.
-   */
-  void update_best_record(
-    std::map<StateKey, utils::FusionRecord> & best_record_map, const StateKey & state_key,
-    double confidence, const utils::FusionRecord & record);
-
-  /**
-   * @brief Determines the best state for each group based on accumulated evidence.
-   */
-  void determine_best_group_state(
-    const std::map<IdType, GroupFusionInfo> & group_fusion_info_map,
-    std::map<IdType, utils::FusionRecord> & grouped_record_map);
-
-  void publish_diagnostics(rclcpp::Time stamp);
+  void publish_diagnostics(
+    const std::vector<ConflictInfo> & conflicted_regulatory_element_status, rclcpp::Time stamp);
 
   using ExactSyncPolicy = mf::sync_policies::ExactTime<CamInfoType, RoiArrayType, SignalArrayType>;
   using ExactSync = mf::Synchronizer<ExactSyncPolicy>;
@@ -174,31 +82,9 @@ private:
   rclcpp::Subscription<autoware_map_msgs::msg::LaneletMapBin>::SharedPtr map_sub_;
 
   rclcpp::Publisher<NewSignalArrayType>::SharedPtr signal_pub_;
-  /*
-  Mapping from traffic light instance id to regulatory element id (group id)
-  */
-  std::map<lanelet::Id, std::vector<lanelet::Id>> traffic_light_id_to_regulatory_ele_id_;
-  /*
-  Store record arrays in increasing timestamp order.
-  Use multiset in case multiple cameras publish images at the exact same time.
-  */
-  std::multiset<utils::FusionRecordArr> record_arr_set_;
-  bool is_approximate_sync_;
-  /*
-  For every input message input_m, if the timestamp difference between input_m and the latest
-  message is smaller than message_lifespan_, then input_m would be used for the fusion. Otherwise,
-  it would be discarded.
-  */
-  double message_lifespan_;
-  /**
-   * @brief The prior log-odds for a traffic light state.
-   */
-  double prior_log_odds_;
-  bool use_signal_consistency_check_;
-  bool publish_partial_matched_signal_;
 
-  std::unique_ptr<SignalValidator> signal_validator_;
-  std::vector<ConflictInfo> conflicted_regulatory_element_status_{};
+  MultiCameraFusionConfig fusion_config_{};
+  MultiCameraFusion fusion_{};
 
   std::unique_ptr<autoware_utils::DiagnosticsInterface> diagnostics_interface_ptr_;
 };

--- a/perception/autoware_traffic_light_multi_camera_fusion/src/traffic_light_multi_camera_fusion_process.cpp
+++ b/perception/autoware_traffic_light_multi_camera_fusion/src/traffic_light_multi_camera_fusion_process.cpp
@@ -73,7 +73,7 @@ const std::unordered_map<
      {tier4_perception_msgs::msg::TrafficLightElement::FLASHING,
       autoware_perception_msgs::msg::TrafficLightElement::FLASHING}});
 
-double getMinConfidence(const tier4_perception_msgs::msg::TrafficLight & signal)
+double get_min_confidence(const tier4_perception_msgs::msg::TrafficLight & signal)
 {
   // Normally, we should check whether the elements are empty,
   // but we already know they are not, so we skip the check here
@@ -83,7 +83,7 @@ double getMinConfidence(const tier4_perception_msgs::msg::TrafficLight & signal)
     ->confidence;
 }
 
-int compareRecord(const FusionRecord & r1, const FusionRecord & r2)
+int compare_record(const FusionRecord & r1, const FusionRecord & r2)
 {
   /*
   r1 will be checked
@@ -100,8 +100,8 @@ int compareRecord(const FusionRecord & r1, const FusionRecord & r2)
   if (r1.header.frame_id == r2.header.frame_id && std::abs(t1 - t2) >= dt_thres) {
     return t1 < t2 ? -1 : 1;
   }
-  bool r1_is_unknown = isUnknown(r1.signal);
-  bool r2_is_unknown = isUnknown(r2.signal);
+  bool r1_is_unknown = is_unknown(r1.signal);
+  bool r2_is_unknown = is_unknown(r2.signal);
   /*
   if both are unknown, they are of the same priority
   */
@@ -113,18 +113,18 @@ int compareRecord(const FusionRecord & r1, const FusionRecord & r2)
     */
     return r1_is_unknown ? -1 : 1;
   }
-  int visible_score_1 = calVisibleScore(r1);
-  int visible_score_2 = calVisibleScore(r2);
+  int visible_score_1 = cal_visible_score(r1);
+  int visible_score_2 = cal_visible_score(r2);
   if (visible_score_1 == visible_score_2) {
-    double confidence_1 = getMinConfidence(r1.signal);
-    double confidence_2 = getMinConfidence(r2.signal);
+    double confidence_1 = get_min_confidence(r1.signal);
+    double confidence_2 = get_min_confidence(r2.signal);
     return confidence_1 < confidence_2 ? -1 : 1;
   } else {
     return visible_score_1 < visible_score_2 ? -1 : 1;
   }
 }
 
-autoware_perception_msgs::msg::TrafficLightElement convertT4toAutoware(
+autoware_perception_msgs::msg::TrafficLightElement convert_t4_to_autoware(
   const tier4_perception_msgs::msg::TrafficLightElement & input)
 {
   // clang-format on
@@ -140,7 +140,7 @@ autoware_perception_msgs::msg::TrafficLightElement convertT4toAutoware(
   return output;
 }
 
-int calVisibleScore(const FusionRecord & record)
+int cal_visible_score(const FusionRecord & record)
 {
   const uint32_t boundary = 5;
   uint32_t x1 = record.roi.roi.x_offset;
@@ -156,7 +156,7 @@ int calVisibleScore(const FusionRecord & record)
   }
 }
 
-FusionRecord generateFailsafeRecord(FusionRecord base_record)
+FusionRecord generate_failsafe_record(FusionRecord base_record)
 {
   // return unknown record for a fail safe
   FusionRecord fail_safe_signal;

--- a/perception/autoware_traffic_light_multi_camera_fusion/src/traffic_light_multi_camera_fusion_process.cpp
+++ b/perception/autoware_traffic_light_multi_camera_fusion/src/traffic_light_multi_camera_fusion_process.cpp
@@ -15,7 +15,7 @@
 #include "traffic_light_multi_camera_fusion_process.hpp"
 
 #include <autoware/traffic_light_utils/traffic_light_utils.hpp>
-#include <rclcpp/rclcpp.hpp>
+#include <rclcpp/time.hpp>
 
 #include <unordered_map>
 
@@ -83,45 +83,45 @@ double get_min_confidence(const tier4_perception_msgs::msg::TrafficLight & signa
     ->confidence;
 }
 
-int compare_record(const FusionRecord & r1, const FusionRecord & r2)
+bool has_higher_or_equal_priority(const FusionRecord & candidate, const FusionRecord & existing)
 {
   /*
-  r1 will be checked
-  return 1 if r1 is better than r2
-  return -1 if r1 is worse than r2
-  return 0 if r1 is equal to r2
+  Records are ranked by a fixed priority order. Ties favor the candidate so that a
+  newly arrived record wins over an equally-ranked existing one.
   */
-  /*
-  if both records are from the same sensor but different stamp, trust the latest one
-  */
-  double t1 = rclcpp::Time(r1.header.stamp).seconds();
-  double t2 = rclcpp::Time(r2.header.stamp).seconds();
+
+  // 1. records from the same camera are ranked by timestamp; trust the latest one
+  const double candidate_time = rclcpp::Time(candidate.header.stamp).seconds();
+  const double existing_time = rclcpp::Time(existing.header.stamp).seconds();
   const double dt_thres = 1e-3;
-  if (r1.header.frame_id == r2.header.frame_id && std::abs(t1 - t2) >= dt_thres) {
-    return t1 < t2 ? -1 : 1;
+  if (
+    candidate.header.frame_id == existing.header.frame_id &&
+    std::abs(candidate_time - existing_time) >= dt_thres) {
+    return candidate_time >= existing_time;
   }
-  bool r1_is_unknown = is_unknown(r1.signal);
-  bool r2_is_unknown = is_unknown(r2.signal);
-  /*
-  if both are unknown, they are of the same priority
-  */
-  if (r1_is_unknown && r2_is_unknown) {
-    return 0;
-  } else if (r1_is_unknown ^ r2_is_unknown) {
-    /*
-    if either is unknown, the unknown is of lower priority
-    */
-    return r1_is_unknown ? -1 : 1;
+
+  // 2. a recognized signal outranks an unknown one
+  const bool candidate_is_unknown = is_signal_unknown(candidate.signal);
+  const bool existing_is_unknown = is_signal_unknown(existing.signal);
+  if (candidate_is_unknown && existing_is_unknown) {
+    return true;  // both unknown -> equal priority (favor the candidate)
   }
-  int visible_score_1 = cal_visible_score(r1);
-  int visible_score_2 = cal_visible_score(r2);
-  if (visible_score_1 == visible_score_2) {
-    double confidence_1 = get_min_confidence(r1.signal);
-    double confidence_2 = get_min_confidence(r2.signal);
-    return confidence_1 < confidence_2 ? -1 : 1;
-  } else {
-    return visible_score_1 < visible_score_2 ? -1 : 1;
+  if (candidate_is_unknown) {
+    return false;  // only the candidate is unknown -> it loses
   }
+  if (existing_is_unknown) {
+    return true;  // only the existing record is unknown -> the candidate wins
+  }
+
+  // 3. a fully visible signal outranks a truncated one
+  const bool candidate_is_visible = is_fully_visible(candidate);
+  const bool existing_is_visible = is_fully_visible(existing);
+  if (candidate_is_visible != existing_is_visible) {
+    return candidate_is_visible;
+  }
+
+  // 4. otherwise the higher confidence wins
+  return get_min_confidence(candidate.signal) >= get_min_confidence(existing.signal);
 }
 
 autoware_perception_msgs::msg::TrafficLightElement convert_t4_to_autoware(
@@ -140,20 +140,16 @@ autoware_perception_msgs::msg::TrafficLightElement convert_t4_to_autoware(
   return output;
 }
 
-int cal_visible_score(const FusionRecord & record)
+bool is_fully_visible(const FusionRecord & record)
 {
   const uint32_t boundary = 5;
-  uint32_t x1 = record.roi.roi.x_offset;
-  uint32_t x2 = record.roi.roi.x_offset + record.roi.roi.width;
-  uint32_t y1 = record.roi.roi.y_offset;
-  uint32_t y2 = record.roi.roi.y_offset + record.roi.roi.height;
-  if (
-    x1 <= boundary || (record.cam_info.width - x2) <= boundary || y1 <= boundary ||
-    (record.cam_info.height - y2) <= boundary) {
-    return 0;
-  } else {
-    return 1;
-  }
+  const uint32_t x1 = record.roi.roi.x_offset;
+  const uint32_t x2 = record.roi.roi.x_offset + record.roi.roi.width;
+  const uint32_t y1 = record.roi.roi.y_offset;
+  const uint32_t y2 = record.roi.roi.y_offset + record.roi.roi.height;
+  const bool is_truncated = x1 <= boundary || (record.cam_info.width - x2) <= boundary ||
+                            y1 <= boundary || (record.cam_info.height - y2) <= boundary;
+  return !is_truncated;
 }
 
 FusionRecord generate_failsafe_record(FusionRecord base_record)

--- a/perception/autoware_traffic_light_multi_camera_fusion/src/traffic_light_multi_camera_fusion_process.hpp
+++ b/perception/autoware_traffic_light_multi_camera_fusion/src/traffic_light_multi_camera_fusion_process.hpp
@@ -53,7 +53,7 @@ struct FusionRecordArr
   }
 };
 
-inline bool is_unknown(const tier4_perception_msgs::msg::TrafficLight & signal)
+inline bool is_signal_unknown(const tier4_perception_msgs::msg::TrafficLight & signal)
 {
   return signal.elements.size() == 1 &&
          signal.elements[0].color == tier4_perception_msgs::msg::TrafficLightElement::UNKNOWN &&
@@ -67,19 +67,32 @@ V at_or(const std::unordered_map<K, V> & map, const K & key, const V & value)
 }
 
 double get_min_confidence(const tier4_perception_msgs::msg::TrafficLight & signal);
-int compare_record(const FusionRecord & r1, const FusionRecord & r2);
+
+/**
+ * @brief Decide whether `candidate` should replace `existing` as the fused result.
+ *
+ * Records are ranked by a fixed priority order (timestamp for the same camera, then
+ * recognized-over-unknown, then visibility, then confidence). Ties favor the candidate
+ * so that a newly arrived record wins over an equally-ranked existing one.
+ *
+ * @param candidate   newly arrived record
+ * @param existing    record currently held as the best for this traffic light
+ * @return true if the candidate has a higher or equal priority than the existing record
+ */
+bool has_higher_or_equal_priority(const FusionRecord & candidate, const FusionRecord & existing);
 
 autoware_perception_msgs::msg::TrafficLightElement convert_t4_to_autoware(
   const tier4_perception_msgs::msg::TrafficLightElement & input);
 
 /**
- * @brief Currently the visible score only considers the truncation.
- * If the detection roi is very close to the image boundary, it would be considered as truncated.
+ * @brief Check whether the detection roi is fully visible, i.e. not truncated by the image
+ * boundary. If the detection roi is very close to the image boundary, it is considered as
+ * truncated.
  *
  * @param record    fusion record
- * @return 0 if traffic light is truncated, otherwise 1
+ * @return true if the traffic light is fully visible, false if truncated
  */
-int cal_visible_score(const FusionRecord & record);
+bool is_fully_visible(const FusionRecord & record);
 FusionRecord generate_failsafe_record(FusionRecord base_record);
 
 }  // namespace utils

--- a/perception/autoware_traffic_light_multi_camera_fusion/src/traffic_light_multi_camera_fusion_process.hpp
+++ b/perception/autoware_traffic_light_multi_camera_fusion/src/traffic_light_multi_camera_fusion_process.hpp
@@ -53,7 +53,7 @@ struct FusionRecordArr
   }
 };
 
-inline bool isUnknown(const tier4_perception_msgs::msg::TrafficLight & signal)
+inline bool is_unknown(const tier4_perception_msgs::msg::TrafficLight & signal)
 {
   return signal.elements.size() == 1 &&
          signal.elements[0].color == tier4_perception_msgs::msg::TrafficLightElement::UNKNOWN &&
@@ -66,10 +66,10 @@ V at_or(const std::unordered_map<K, V> & map, const K & key, const V & value)
   return map.count(key) ? map.at(key) : value;
 }
 
-double getMinConfidence(const tier4_perception_msgs::msg::TrafficLight & signal);
-int compareRecord(const FusionRecord & r1, const FusionRecord & r2);
+double get_min_confidence(const tier4_perception_msgs::msg::TrafficLight & signal);
+int compare_record(const FusionRecord & r1, const FusionRecord & r2);
 
-autoware_perception_msgs::msg::TrafficLightElement convertT4toAutoware(
+autoware_perception_msgs::msg::TrafficLightElement convert_t4_to_autoware(
   const tier4_perception_msgs::msg::TrafficLightElement & input);
 
 /**
@@ -79,8 +79,8 @@ autoware_perception_msgs::msg::TrafficLightElement convertT4toAutoware(
  * @param record    fusion record
  * @return 0 if traffic light is truncated, otherwise 1
  */
-int calVisibleScore(const FusionRecord & record);
-FusionRecord generateFailsafeRecord(FusionRecord base_record);
+int cal_visible_score(const FusionRecord & record);
+FusionRecord generate_failsafe_record(FusionRecord base_record);
 
 }  // namespace utils
 }  // namespace autoware::traffic_light

--- a/perception/autoware_traffic_light_multi_camera_fusion/test/test_multi_camera_fusion.cpp
+++ b/perception/autoware_traffic_light_multi_camera_fusion/test/test_multi_camera_fusion.cpp
@@ -142,7 +142,7 @@ TrafficLightRoiArray make_roi_array(
   return roi_array;
 }
 
-// ROI placed against the top-left image boundary so cal_visible_score returns 0.
+// ROI placed against the top-left image boundary so is_fully_visible returns false.
 TrafficLightRoiArray make_truncated_roi_array(
   const rclcpp::Time & stamp, const std::string & frame_id, lanelet::Id traffic_light_id)
 {
@@ -174,7 +174,7 @@ TrafficLight make_signal(lanelet::Id traffic_light_id, uint8_t color, float conf
   return signal;
 }
 
-// Matches utils::is_unknown: a single element whose color and shape are both UNKNOWN.
+// Matches utils::is_signal_unknown: a single element whose color and shape are both UNKNOWN.
 TrafficLight make_unknown_signal(lanelet::Id traffic_light_id)
 {
   T4Element element;
@@ -453,9 +453,9 @@ TEST(MultiCameraFusionFuse, TruncatedRoiHasLowerPriorityThanCenteredRoi)
 {
   // Arrange
   // Two cameras observe the same traffic_light_id. camera0 reports a truncated ROI
-  // (visible_score=0) with the higher confidence; camera1 reports a centered ROI
-  // (visible_score=1) with the lower confidence. compare_record's visibility check ranks above the
-  // confidence check, so camera1's record is selected and the fused output is RED.
+  // (truncated) with the higher confidence; camera1 reports a centered ROI
+  // (fully visible) with the lower confidence. has_higher_or_equal_priority's visibility check
+  // ranks above the confidence check, so camera1's record is selected and the fused output is RED.
   MultiCameraFusion fusion(make_default_config());
   const rclcpp::Time stamp(100, 0);
   const auto truncated_camera_info = make_camera_info(stamp, "camera0");
@@ -478,8 +478,8 @@ TEST(MultiCameraFusionFuse, UnknownSignalLosesToValidSignalForSameTrafficLightId
 {
   // Arrange
   // Two cameras observe the same traffic_light_id. camera0 reports an UNKNOWN signal;
-  // camera1 reports GREEN. compare_record's unknown check drops the unknown record, so the
-  // fused output reflects camera1.
+  // camera1 reports GREEN. has_higher_or_equal_priority's unknown check drops the unknown record,
+  // so the fused output reflects camera1.
   MultiCameraFusion fusion(make_default_config());
   const auto unknown_input =
     make_fusion_input("camera0", make_unknown_signal(LEFT_TRAFFIC_LIGHT_ID));
@@ -499,8 +499,9 @@ TEST(MultiCameraFusionFuse, NewerTimestampWinsForSameFrameIdAndTrafficLightId)
 {
   // Arrange
   // The same camera publishes two observations of the same traffic_light_id within the lifespan.
-  // compare_record's first priority (same frame_id with timestamps differing by >= 1 ms) prefers
-  // the newer record regardless of confidence, so the later RED supersedes the earlier GREEN.
+  // has_higher_or_equal_priority's first priority (same frame_id with timestamps differing by >= 1
+  // ms) prefers the newer record regardless of confidence, so the later RED supersedes the earlier
+  // GREEN.
   MultiCameraFusion fusion(make_default_config());
   const std::string frame_id = "camera0";
   const auto earlier_input = make_fusion_input(
@@ -518,12 +519,12 @@ TEST(MultiCameraFusionFuse, NewerTimestampWinsForSameFrameIdAndTrafficLightId)
   expect_single_fused_color(result, TrafficLightElement::RED);
 }
 
-TEST(MultiCameraFusionFuse, HigherConfidenceWinsWhenVisibleScoreTiesForSameTrafficLightId)
+TEST(MultiCameraFusionFuse, HigherConfidenceWinsWhenBothFullyVisibleForSameTrafficLightId)
 {
   // Arrange
-  // Two cameras observe the same traffic_light_id with centered ROIs (visible_score=1 each).
-  // compare_record falls through to its last priority — the confidence comparison — and selects
-  // the higher-confidence RED over the lower-confidence GREEN.
+  // Two cameras observe the same traffic_light_id with centered ROIs (fully visible each).
+  // has_higher_or_equal_priority falls through to its last priority — the confidence
+  // comparison — and selects the higher-confidence RED over the lower-confidence GREEN.
   MultiCameraFusion fusion(make_default_config());
   const auto low_confidence_input =
     make_fusion_input("camera0", make_signal(LEFT_TRAFFIC_LIGHT_ID, T4Element::GREEN, 0.5f));
@@ -572,13 +573,14 @@ TEST(MultiCameraFusionFuse, PartialConflictWithPartialMatchEnabledPublishesCommo
 TEST(MultiCameraFusionFuse, MinElementConfidenceDeterminesWinnerForMultiElementSignals)
 {
   // Arrange
-  // Two cameras observe the same traffic_light_id with centered ROIs (visible_score tied at 1).
+  // Two cameras observe the same traffic_light_id with centered ROIs (both fully visible).
   // Each signal has CIRCLE + LEFT_ARROW with differing per-element confidences:
   //   camera0: {CIRCLE 0.8, LEFT_ARROW 0.8}  -> min = 0.8
   //   camera1: {CIRCLE 0.9, LEFT_ARROW 0.3}  -> min = 0.3
-  // compare_record falls through to the confidence check, which uses utils::get_min_confidence.
-  // With min-aggregation, camera0 wins (0.8 > 0.3); with max-aggregation, camera1 would win
-  // (0.9 > 0.8). The output's preserved per-element confidences distinguish the two cases.
+  // has_higher_or_equal_priority falls through to the confidence check, which uses
+  // utils::get_min_confidence. With min-aggregation, camera0 wins (0.8 > 0.3); with
+  // max-aggregation, camera1 would win (0.9 > 0.8). The output's preserved per-element confidences
+  // distinguish the two cases.
   MultiCameraFusion fusion(make_default_config());
   const auto input0 = make_fusion_input(
     "camera0", make_signal_with_left_arrow(LEFT_TRAFFIC_LIGHT_ID, T4Element::GREEN, 0.8f, 0.8f));

--- a/perception/autoware_traffic_light_multi_camera_fusion/test/test_multi_camera_fusion.cpp
+++ b/perception/autoware_traffic_light_multi_camera_fusion/test/test_multi_camera_fusion.cpp
@@ -1,0 +1,621 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "../src/multi_camera_fusion.hpp"
+
+#include <autoware_lanelet2_extension/regulatory_elements/autoware_traffic_light.hpp>
+#include <rclcpp/time.hpp>
+
+#include <autoware_perception_msgs/msg/traffic_light_element.hpp>
+#include <sensor_msgs/msg/camera_info.hpp>
+#include <tier4_perception_msgs/msg/traffic_light.hpp>
+#include <tier4_perception_msgs/msg/traffic_light_array.hpp>
+#include <tier4_perception_msgs/msg/traffic_light_element.hpp>
+#include <tier4_perception_msgs/msg/traffic_light_roi.hpp>
+#include <tier4_perception_msgs/msg/traffic_light_roi_array.hpp>
+
+#include <gtest/gtest.h>
+#include <lanelet2_core/LaneletMap.h>
+#include <lanelet2_core/primitives/Lanelet.h>
+#include <lanelet2_core/primitives/LineString.h>
+#include <lanelet2_core/primitives/Point.h>
+
+#include <memory>
+#include <string>
+
+namespace
+{
+using autoware::traffic_light::ConflictType;
+using autoware::traffic_light::MultiCameraFusion;
+using autoware::traffic_light::MultiCameraFusionConfig;
+using autoware::traffic_light::MultiCameraFusionResult;
+using autoware_perception_msgs::msg::TrafficLightElement;
+using sensor_msgs::msg::CameraInfo;
+using tier4_perception_msgs::msg::TrafficLight;
+using tier4_perception_msgs::msg::TrafficLightArray;
+using tier4_perception_msgs::msg::TrafficLightRoi;
+using tier4_perception_msgs::msg::TrafficLightRoiArray;
+
+using T4Element = tier4_perception_msgs::msg::TrafficLightElement;
+
+// IDs used by the lanelet map fixture. LEFT and RIGHT traffic-light line strings are bound to a
+// single regulatory element so that group fusion aggregates evidence from both into one group.
+constexpr lanelet::Id LEFT_TRAFFIC_LIGHT_ID = 11;
+constexpr lanelet::Id RIGHT_TRAFFIC_LIGHT_ID = 12;
+constexpr lanelet::Id REGULATORY_ELEMENT_ID = 100;
+constexpr lanelet::Id UNMAPPED_TRAFFIC_LIGHT_ID = 999;
+
+constexpr uint32_t CAMERA_IMAGE_WIDTH = 1440;
+constexpr uint32_t CAMERA_IMAGE_HEIGHT = 1080;
+
+// ROI placed safely inside the image so the visibility score equals 1.
+constexpr uint32_t ROI_X_OFFSET = 100;
+constexpr uint32_t ROI_Y_OFFSET = 100;
+constexpr uint32_t ROI_WIDTH = 100;
+constexpr uint32_t ROI_HEIGHT = 100;
+
+lanelet::LaneletMapPtr make_lanelet_map_with_two_traffic_lights()
+{
+  lanelet::Point3d road_left_start(1, 0.0, 2.0, 0.0);
+  lanelet::Point3d road_left_end(2, 30.0, 2.0, 0.0);
+  lanelet::Point3d road_right_start(3, 0.0, -2.0, 0.0);
+  lanelet::Point3d road_right_end(4, 30.0, -2.0, 0.0);
+  lanelet::LineString3d road_left(5, {road_left_start, road_left_end});
+  lanelet::LineString3d road_right(6, {road_right_start, road_right_end});
+
+  auto road_lanelet = lanelet::Lanelet(1000, road_left, road_right);
+  road_lanelet.attributes()[lanelet::AttributeName::Subtype] = lanelet::AttributeValueString::Road;
+
+  lanelet::Point3d left_traffic_light_left_end(7, 19.5, 0.5, 3.5);
+  lanelet::Point3d left_traffic_light_right_end(8, 19.5, -0.5, 3.5);
+  lanelet::LineString3d left_traffic_light(
+    LEFT_TRAFFIC_LIGHT_ID, {left_traffic_light_left_end, left_traffic_light_right_end});
+  left_traffic_light.attributes()["subtype"] = "red_yellow_green";
+  left_traffic_light.attributes()["height"] = "1.0";
+
+  lanelet::Point3d right_traffic_light_left_end(9, 20.5, 0.5, 3.5);
+  lanelet::Point3d right_traffic_light_right_end(10, 20.5, -0.5, 3.5);
+  lanelet::LineString3d right_traffic_light(
+    RIGHT_TRAFFIC_LIGHT_ID, {right_traffic_light_left_end, right_traffic_light_right_end});
+  right_traffic_light.attributes()["subtype"] = "red_yellow_green";
+  right_traffic_light.attributes()["height"] = "1.0";
+
+  auto traffic_light_regulatory_element = lanelet::autoware::AutowareTrafficLight::make(
+    REGULATORY_ELEMENT_ID, lanelet::AttributeMap(), {left_traffic_light, right_traffic_light});
+  road_lanelet.addRegulatoryElement(traffic_light_regulatory_element);
+
+  auto lanelet_map = std::make_shared<lanelet::LaneletMap>();
+  lanelet_map->add(road_lanelet);
+  return lanelet_map;
+}
+
+MultiCameraFusionConfig make_default_config()
+{
+  MultiCameraFusionConfig config;
+  config.message_lifespan = 1.0;
+  config.prior_log_odds = 0.0;
+  config.use_signal_consistency_check = false;
+  config.publish_partial_matched_signal = false;
+  config.lanelet_map_ptr = make_lanelet_map_with_two_traffic_lights();
+  return config;
+}
+
+CameraInfo make_camera_info(const rclcpp::Time & stamp, const std::string & frame_id)
+{
+  CameraInfo camera_info;
+  camera_info.header.stamp = stamp;
+  camera_info.header.frame_id = frame_id;
+  camera_info.width = CAMERA_IMAGE_WIDTH;
+  camera_info.height = CAMERA_IMAGE_HEIGHT;
+  return camera_info;
+}
+
+TrafficLightRoi make_roi(lanelet::Id traffic_light_id)
+{
+  TrafficLightRoi roi;
+  roi.traffic_light_id = traffic_light_id;
+  roi.roi.x_offset = ROI_X_OFFSET;
+  roi.roi.y_offset = ROI_Y_OFFSET;
+  roi.roi.width = ROI_WIDTH;
+  roi.roi.height = ROI_HEIGHT;
+  return roi;
+}
+
+TrafficLightRoiArray make_roi_array(
+  const rclcpp::Time & stamp, const std::string & frame_id, lanelet::Id traffic_light_id)
+{
+  TrafficLightRoiArray roi_array;
+  roi_array.header.stamp = stamp;
+  roi_array.header.frame_id = frame_id;
+  roi_array.rois.push_back(make_roi(traffic_light_id));
+  return roi_array;
+}
+
+// ROI placed against the top-left image boundary so cal_visible_score returns 0.
+TrafficLightRoiArray make_truncated_roi_array(
+  const rclcpp::Time & stamp, const std::string & frame_id, lanelet::Id traffic_light_id)
+{
+  TrafficLightRoi roi;
+  roi.traffic_light_id = traffic_light_id;
+  roi.roi.x_offset = 0;
+  roi.roi.y_offset = 0;
+  roi.roi.width = ROI_WIDTH;
+  roi.roi.height = ROI_HEIGHT;
+
+  TrafficLightRoiArray roi_array;
+  roi_array.header.stamp = stamp;
+  roi_array.header.frame_id = frame_id;
+  roi_array.rois.push_back(roi);
+  return roi_array;
+}
+
+TrafficLight make_signal(lanelet::Id traffic_light_id, uint8_t color, float confidence)
+{
+  T4Element element;
+  element.color = color;
+  element.shape = T4Element::CIRCLE;
+  element.status = T4Element::SOLID_ON;
+  element.confidence = confidence;
+
+  TrafficLight signal;
+  signal.traffic_light_id = traffic_light_id;
+  signal.elements.push_back(element);
+  return signal;
+}
+
+// Matches utils::is_unknown: a single element whose color and shape are both UNKNOWN.
+TrafficLight make_unknown_signal(lanelet::Id traffic_light_id)
+{
+  T4Element element;
+  element.color = T4Element::UNKNOWN;
+  element.shape = T4Element::UNKNOWN;
+  element.status = T4Element::SOLID_ON;
+  element.confidence = 0.0f;
+
+  TrafficLight signal;
+  signal.traffic_light_id = traffic_light_id;
+  signal.elements.push_back(element);
+  return signal;
+}
+
+TrafficLight make_signal_with_left_arrow(
+  lanelet::Id traffic_light_id, uint8_t color, float circle_confidence, float arrow_confidence)
+{
+  TrafficLight signal = make_signal(traffic_light_id, color, circle_confidence);
+  T4Element arrow_element;
+  arrow_element.color = color;
+  arrow_element.shape = T4Element::LEFT_ARROW;
+  arrow_element.status = T4Element::SOLID_ON;
+  arrow_element.confidence = arrow_confidence;
+  signal.elements.push_back(arrow_element);
+  return signal;
+}
+
+TrafficLightArray make_signal_array(
+  const rclcpp::Time & stamp, const std::string & frame_id, const TrafficLight & signal)
+{
+  TrafficLightArray signal_array;
+  signal_array.header.stamp = stamp;
+  signal_array.header.frame_id = frame_id;
+  signal_array.signals.push_back(signal);
+  return signal_array;
+}
+
+struct FusionInput
+{
+  CameraInfo camera_info;
+  TrafficLightRoiArray roi_array;
+  TrafficLightArray signal_array;
+};
+
+FusionInput make_fusion_input(
+  const std::string & frame_id, const TrafficLight & signal,
+  const rclcpp::Time & stamp = rclcpp::Time(0, 0))
+{
+  return FusionInput{
+    make_camera_info(stamp, frame_id), make_roi_array(stamp, frame_id, signal.traffic_light_id),
+    make_signal_array(stamp, frame_id, signal)};
+}
+
+void expect_single_fused_color(const MultiCameraFusionResult & result, uint8_t expected_color)
+{
+  ASSERT_EQ(result.traffic_light_groups.traffic_light_groups.size(), 1u);
+  const auto & group = result.traffic_light_groups.traffic_light_groups.front();
+  ASSERT_EQ(group.elements.size(), 1u);
+  EXPECT_EQ(group.elements.front().color, expected_color);
+}
+
+void expect_single_fused_color_and_shape(
+  const MultiCameraFusionResult & result, uint8_t expected_color, uint8_t expected_shape)
+{
+  ASSERT_EQ(result.traffic_light_groups.traffic_light_groups.size(), 1u);
+  const auto & group = result.traffic_light_groups.traffic_light_groups.front();
+  ASSERT_EQ(group.elements.size(), 1u);
+  EXPECT_EQ(group.elements.front().color, expected_color);
+  EXPECT_EQ(group.elements.front().shape, expected_shape);
+}
+
+void expect_single_conflict_status(
+  const MultiCameraFusionResult & result, ConflictType expected_conflict_type)
+{
+  ASSERT_EQ(result.conflicted_regulatory_element_status.size(), 1u);
+  EXPECT_EQ(
+    result.conflicted_regulatory_element_status.front().conflict_type, expected_conflict_type);
+}
+
+void expect_element_confidence(
+  const MultiCameraFusionResult & result, size_t element_index, float expected_confidence)
+{
+  ASSERT_EQ(result.traffic_light_groups.traffic_light_groups.size(), 1u);
+  const auto & group = result.traffic_light_groups.traffic_light_groups.front();
+  ASSERT_LT(element_index, group.elements.size());
+  EXPECT_FLOAT_EQ(group.elements[element_index].confidence, expected_confidence);
+}
+
+}  // namespace
+
+TEST(MultiCameraFusionFuse, SingleCameraSingleLightOutputsGroupWithMappedRegulatoryId)
+{
+  // Arrange
+  MultiCameraFusion fusion(make_default_config());
+  const auto input =
+    make_fusion_input("camera0", make_signal(LEFT_TRAFFIC_LIGHT_ID, T4Element::GREEN, 0.9f));
+
+  // Act
+  const auto result = fusion.fuse(input.camera_info, input.roi_array, input.signal_array);
+
+  // Assert
+  ASSERT_EQ(result.traffic_light_groups.traffic_light_groups.size(), 1u);
+  const auto & group = result.traffic_light_groups.traffic_light_groups.front();
+  EXPECT_EQ(group.traffic_light_group_id, REGULATORY_ELEMENT_ID);
+  ASSERT_EQ(group.elements.size(), 1u);
+  EXPECT_EQ(group.elements.front().color, TrafficLightElement::GREEN);
+  EXPECT_EQ(group.elements.front().shape, TrafficLightElement::CIRCLE);
+  EXPECT_TRUE(result.unmapped_traffic_light_ids.empty());
+}
+
+TEST(MultiCameraFusionFuse, EmptyRoiArrayProducesEmptyTrafficLightGroups)
+{
+  // Arrange
+  MultiCameraFusion fusion(make_default_config());
+  const rclcpp::Time stamp(100, 0);
+  const std::string frame_id = "camera0";
+  TrafficLightRoiArray empty_rois;
+  empty_rois.header.stamp = stamp;
+  empty_rois.header.frame_id = frame_id;
+  TrafficLightArray empty_signals;
+  empty_signals.header.stamp = stamp;
+  empty_signals.header.frame_id = frame_id;
+
+  // Act
+  const auto result = fusion.fuse(make_camera_info(stamp, frame_id), empty_rois, empty_signals);
+
+  // Assert
+  EXPECT_TRUE(result.traffic_light_groups.traffic_light_groups.empty());
+  EXPECT_TRUE(result.unmapped_traffic_light_ids.empty());
+}
+
+TEST(MultiCameraFusionFuse, UnknownTrafficLightIdIsRecordedAsUnmapped)
+{
+  // Arrange
+  MultiCameraFusion fusion(make_default_config());
+  const auto input =
+    make_fusion_input("camera0", make_signal(UNMAPPED_TRAFFIC_LIGHT_ID, T4Element::GREEN, 0.9f));
+
+  // Act
+  const auto result = fusion.fuse(input.camera_info, input.roi_array, input.signal_array);
+
+  // Assert
+  EXPECT_TRUE(result.traffic_light_groups.traffic_light_groups.empty());
+  ASSERT_EQ(result.unmapped_traffic_light_ids.size(), 1u);
+  EXPECT_EQ(result.unmapped_traffic_light_ids.front(), UNMAPPED_TRAFFIC_LIGHT_ID);
+}
+
+TEST(MultiCameraFusionFuse, RoiWithoutMatchingSignalIsIgnored)
+{
+  // Arrange
+  MultiCameraFusion fusion(make_default_config());
+  const rclcpp::Time stamp(100, 0);
+  const std::string frame_id = "camera0";
+
+  // signal id does not match the roi id -> the roi cannot be paired with a signal
+  TrafficLightArray mismatched_signals =
+    make_signal_array(stamp, frame_id, make_signal(RIGHT_TRAFFIC_LIGHT_ID, T4Element::GREEN, 0.9f));
+
+  // Act
+  const auto result = fusion.fuse(
+    make_camera_info(stamp, frame_id), make_roi_array(stamp, frame_id, LEFT_TRAFFIC_LIGHT_ID),
+    mismatched_signals);
+
+  // Assert
+  EXPECT_TRUE(result.traffic_light_groups.traffic_light_groups.empty());
+}
+
+TEST(MultiCameraFusionFuse, HigherConfidenceColorIsSelectedAcrossTwoLights)
+{
+  // Arrange
+  // Two traffic lights belong to the same regulatory element. When their colors disagree,
+  // the color reported with the higher confidence (GREEN at 0.9 vs RED at 0.6) is selected.
+  MultiCameraFusion fusion(make_default_config());
+  const auto input0 =
+    make_fusion_input("camera0", make_signal(LEFT_TRAFFIC_LIGHT_ID, T4Element::RED, 0.6f));
+  const auto input1 =
+    make_fusion_input("camera1", make_signal(RIGHT_TRAFFIC_LIGHT_ID, T4Element::GREEN, 0.9f));
+
+  // Act
+  fusion.fuse(input0.camera_info, input0.roi_array, input0.signal_array);
+  const auto result = fusion.fuse(input1.camera_info, input1.roi_array, input1.signal_array);
+
+  // Assert
+  expect_single_fused_color(result, TrafficLightElement::GREEN);
+}
+
+TEST(MultiCameraFusionFuse, RecordOlderThanMessageLifespanIsDiscarded)
+{
+  // Arrange
+  // message_lifespan=1.0s. First record at t=100s, second at t=102s.
+  // Difference (2s) exceeds the lifespan, so the first record is purged before group fusion.
+  auto config = make_default_config();
+  config.message_lifespan = 1.0;
+  MultiCameraFusion fusion(config);
+  const auto input0 = make_fusion_input(
+    "camera0", make_signal(LEFT_TRAFFIC_LIGHT_ID, T4Element::GREEN, 0.9f), rclcpp::Time(100, 0));
+  const auto input1 = make_fusion_input(
+    "camera1", make_signal(RIGHT_TRAFFIC_LIGHT_ID, T4Element::RED, 0.6f), rclcpp::Time(102, 0));
+
+  // Act
+  fusion.fuse(input0.camera_info, input0.roi_array, input0.signal_array);
+  const auto result = fusion.fuse(input1.camera_info, input1.roi_array, input1.signal_array);
+
+  // Assert
+  // Only the second record contributes -> single light, RED color.
+  expect_single_fused_color(result, TrafficLightElement::RED);
+}
+
+TEST(MultiCameraFusionFuse, RecordWithinMessageLifespanIsKeptAndAccumulated)
+{
+  // Arrange
+  // message_lifespan=2.0s, records at t=100s and t=101s. Both records remain.
+  auto config = make_default_config();
+  config.message_lifespan = 2.0;
+  MultiCameraFusion fusion(config);
+  const auto input0 = make_fusion_input(
+    "camera0", make_signal(LEFT_TRAFFIC_LIGHT_ID, T4Element::GREEN, 0.9f), rclcpp::Time(100, 0));
+  const auto input1 = make_fusion_input(
+    "camera1", make_signal(RIGHT_TRAFFIC_LIGHT_ID, T4Element::GREEN, 0.7f), rclcpp::Time(101, 0));
+
+  // Act
+  fusion.fuse(input0.camera_info, input0.roi_array, input0.signal_array);
+  const auto result = fusion.fuse(input1.camera_info, input1.roi_array, input1.signal_array);
+
+  // Assert
+  // Both records aggregate into a single group (same regulatory element) with color GREEN.
+  expect_single_fused_color(result, TrafficLightElement::GREEN);
+}
+
+TEST(MultiCameraFusionFuse, ConsistencyCheckWithSameColorOutputsNoConflict)
+{
+  // Arrange
+  auto config = make_default_config();
+  config.use_signal_consistency_check = true;
+  MultiCameraFusion fusion(config);
+  const auto input0 =
+    make_fusion_input("camera0", make_signal(LEFT_TRAFFIC_LIGHT_ID, T4Element::GREEN, 0.9f));
+  const auto input1 =
+    make_fusion_input("camera1", make_signal(RIGHT_TRAFFIC_LIGHT_ID, T4Element::GREEN, 0.9f));
+
+  // Act
+  fusion.fuse(input0.camera_info, input0.roi_array, input0.signal_array);
+  const auto result = fusion.fuse(input1.camera_info, input1.roi_array, input1.signal_array);
+
+  // Assert
+  expect_single_fused_color(result, TrafficLightElement::GREEN);
+  EXPECT_TRUE(result.conflicted_regulatory_element_status.empty());
+}
+
+TEST(MultiCameraFusionFuse, ConsistencyCheckWithConflictingColorsOutputsUnknownFailsafe)
+{
+  // Arrange
+  // Both cameras see the same regulatory element with different colors (no shared state).
+  // With consistency_check enabled and partial_match publishing disabled, the result is a
+  // fail-safe UNKNOWN group and the conflict is recorded as CONFLICT.
+  auto config = make_default_config();
+  config.use_signal_consistency_check = true;
+  config.publish_partial_matched_signal = false;
+  MultiCameraFusion fusion(config);
+  const auto input0 =
+    make_fusion_input("camera0", make_signal(LEFT_TRAFFIC_LIGHT_ID, T4Element::RED, 0.9f));
+  const auto input1 =
+    make_fusion_input("camera1", make_signal(RIGHT_TRAFFIC_LIGHT_ID, T4Element::GREEN, 0.9f));
+
+  // Act
+  fusion.fuse(input0.camera_info, input0.roi_array, input0.signal_array);
+  const auto result = fusion.fuse(input1.camera_info, input1.roi_array, input1.signal_array);
+
+  // Assert
+  expect_single_fused_color_and_shape(
+    result, TrafficLightElement::UNKNOWN, TrafficLightElement::UNKNOWN);
+  expect_single_conflict_status(result, ConflictType::CONFLICT);
+}
+
+TEST(MultiCameraFusionFuse, TruncatedRoiHasLowerPriorityThanCenteredRoi)
+{
+  // Arrange
+  // Two cameras observe the same traffic_light_id. camera0 reports a truncated ROI
+  // (visible_score=0) with the higher confidence; camera1 reports a centered ROI
+  // (visible_score=1) with the lower confidence. compare_record's visibility check ranks above the
+  // confidence check, so camera1's record is selected and the fused output is RED.
+  MultiCameraFusion fusion(make_default_config());
+  const rclcpp::Time stamp(100, 0);
+  const auto truncated_camera_info = make_camera_info(stamp, "camera0");
+  const auto truncated_rois = make_truncated_roi_array(stamp, "camera0", LEFT_TRAFFIC_LIGHT_ID);
+  const auto truncated_signals =
+    make_signal_array(stamp, "camera0", make_signal(LEFT_TRAFFIC_LIGHT_ID, T4Element::GREEN, 0.9f));
+  const auto centered_input =
+    make_fusion_input("camera1", make_signal(LEFT_TRAFFIC_LIGHT_ID, T4Element::RED, 0.6f), stamp);
+
+  // Act
+  fusion.fuse(truncated_camera_info, truncated_rois, truncated_signals);
+  const auto result =
+    fusion.fuse(centered_input.camera_info, centered_input.roi_array, centered_input.signal_array);
+
+  // Assert
+  expect_single_fused_color(result, TrafficLightElement::RED);
+}
+
+TEST(MultiCameraFusionFuse, UnknownSignalLosesToValidSignalForSameTrafficLightId)
+{
+  // Arrange
+  // Two cameras observe the same traffic_light_id. camera0 reports an UNKNOWN signal;
+  // camera1 reports GREEN. compare_record's unknown check drops the unknown record, so the
+  // fused output reflects camera1.
+  MultiCameraFusion fusion(make_default_config());
+  const auto unknown_input =
+    make_fusion_input("camera0", make_unknown_signal(LEFT_TRAFFIC_LIGHT_ID));
+  const auto valid_input =
+    make_fusion_input("camera1", make_signal(LEFT_TRAFFIC_LIGHT_ID, T4Element::GREEN, 0.8f));
+
+  // Act
+  fusion.fuse(unknown_input.camera_info, unknown_input.roi_array, unknown_input.signal_array);
+  const auto result =
+    fusion.fuse(valid_input.camera_info, valid_input.roi_array, valid_input.signal_array);
+
+  // Assert
+  expect_single_fused_color(result, TrafficLightElement::GREEN);
+}
+
+TEST(MultiCameraFusionFuse, NewerTimestampWinsForSameFrameIdAndTrafficLightId)
+{
+  // Arrange
+  // The same camera publishes two observations of the same traffic_light_id within the lifespan.
+  // compare_record's first priority (same frame_id with timestamps differing by >= 1 ms) prefers
+  // the newer record regardless of confidence, so the later RED supersedes the earlier GREEN.
+  MultiCameraFusion fusion(make_default_config());
+  const std::string frame_id = "camera0";
+  const auto earlier_input = make_fusion_input(
+    frame_id, make_signal(LEFT_TRAFFIC_LIGHT_ID, T4Element::GREEN, 0.9f), rclcpp::Time(100, 0));
+  const auto later_input = make_fusion_input(
+    frame_id, make_signal(LEFT_TRAFFIC_LIGHT_ID, T4Element::RED, 0.4f),
+    rclcpp::Time(100, 500000000));
+
+  // Act
+  fusion.fuse(earlier_input.camera_info, earlier_input.roi_array, earlier_input.signal_array);
+  const auto result =
+    fusion.fuse(later_input.camera_info, later_input.roi_array, later_input.signal_array);
+
+  // Assert
+  expect_single_fused_color(result, TrafficLightElement::RED);
+}
+
+TEST(MultiCameraFusionFuse, HigherConfidenceWinsWhenVisibleScoreTiesForSameTrafficLightId)
+{
+  // Arrange
+  // Two cameras observe the same traffic_light_id with centered ROIs (visible_score=1 each).
+  // compare_record falls through to its last priority — the confidence comparison — and selects
+  // the higher-confidence RED over the lower-confidence GREEN.
+  MultiCameraFusion fusion(make_default_config());
+  const auto low_confidence_input =
+    make_fusion_input("camera0", make_signal(LEFT_TRAFFIC_LIGHT_ID, T4Element::GREEN, 0.5f));
+  const auto high_confidence_input =
+    make_fusion_input("camera1", make_signal(LEFT_TRAFFIC_LIGHT_ID, T4Element::RED, 0.9f));
+
+  // Act
+  fusion.fuse(
+    low_confidence_input.camera_info, low_confidence_input.roi_array,
+    low_confidence_input.signal_array);
+  const auto result = fusion.fuse(
+    high_confidence_input.camera_info, high_confidence_input.roi_array,
+    high_confidence_input.signal_array);
+
+  // Assert
+  expect_single_fused_color(result, TrafficLightElement::RED);
+}
+
+TEST(MultiCameraFusionFuse, PartialConflictWithPartialMatchEnabledPublishesCommonState)
+{
+  // Arrange
+  // Two traffic lights in the same regulatory element report partially-overlapping states:
+  //   LEFT  -> [(RED, CIRCLE)]
+  //   RIGHT -> [(RED, CIRCLE), (RED, LEFT_ARROW)]
+  // With consistency_check enabled and partial-match publishing enabled, the merged output keeps
+  // only the common (RED, CIRCLE) element and the conflict is reported as PARTIAL_CONFLICT.
+  auto config = make_default_config();
+  config.use_signal_consistency_check = true;
+  config.publish_partial_matched_signal = true;
+  MultiCameraFusion fusion(config);
+  const auto input0 =
+    make_fusion_input("camera0", make_signal(LEFT_TRAFFIC_LIGHT_ID, T4Element::RED, 0.9f));
+  const auto input1 = make_fusion_input(
+    "camera1", make_signal_with_left_arrow(RIGHT_TRAFFIC_LIGHT_ID, T4Element::RED, 0.9f, 0.9f));
+
+  // Act
+  fusion.fuse(input0.camera_info, input0.roi_array, input0.signal_array);
+  const auto result = fusion.fuse(input1.camera_info, input1.roi_array, input1.signal_array);
+
+  // Assert
+  expect_single_fused_color_and_shape(
+    result, TrafficLightElement::RED, TrafficLightElement::CIRCLE);
+  expect_single_conflict_status(result, ConflictType::PARTIAL_CONFLICT);
+}
+
+TEST(MultiCameraFusionFuse, MinElementConfidenceDeterminesWinnerForMultiElementSignals)
+{
+  // Arrange
+  // Two cameras observe the same traffic_light_id with centered ROIs (visible_score tied at 1).
+  // Each signal has CIRCLE + LEFT_ARROW with differing per-element confidences:
+  //   camera0: {CIRCLE 0.8, LEFT_ARROW 0.8}  -> min = 0.8
+  //   camera1: {CIRCLE 0.9, LEFT_ARROW 0.3}  -> min = 0.3
+  // compare_record falls through to the confidence check, which uses utils::get_min_confidence.
+  // With min-aggregation, camera0 wins (0.8 > 0.3); with max-aggregation, camera1 would win
+  // (0.9 > 0.8). The output's preserved per-element confidences distinguish the two cases.
+  MultiCameraFusion fusion(make_default_config());
+  const auto input0 = make_fusion_input(
+    "camera0", make_signal_with_left_arrow(LEFT_TRAFFIC_LIGHT_ID, T4Element::GREEN, 0.8f, 0.8f));
+  const auto input1 = make_fusion_input(
+    "camera1", make_signal_with_left_arrow(LEFT_TRAFFIC_LIGHT_ID, T4Element::GREEN, 0.9f, 0.3f));
+
+  // Act
+  fusion.fuse(input0.camera_info, input0.roi_array, input0.signal_array);
+  const auto result = fusion.fuse(input1.camera_info, input1.roi_array, input1.signal_array);
+
+  // Assert
+  // camera0 wins -> output preserves camera0's per-element confidences (0.8 each).
+  expect_element_confidence(result, 0, 0.8f);
+  expect_element_confidence(result, 1, 0.8f);
+}
+
+TEST(MultiCameraFusionFuse, PartialConflictWithPartialMatchDisabledPublishesFailsafe)
+{
+  // Arrange
+  // Same partial-overlap setup as the previous test, but with partial-match publishing disabled.
+  // The fused output is replaced with a fail-safe UNKNOWN element, and the conflict is still
+  // reported as PARTIAL_CONFLICT (not CONFLICT).
+  auto config = make_default_config();
+  config.use_signal_consistency_check = true;
+  config.publish_partial_matched_signal = false;
+  MultiCameraFusion fusion(config);
+  const auto input0 =
+    make_fusion_input("camera0", make_signal(LEFT_TRAFFIC_LIGHT_ID, T4Element::RED, 0.9f));
+  const auto input1 = make_fusion_input(
+    "camera1", make_signal_with_left_arrow(RIGHT_TRAFFIC_LIGHT_ID, T4Element::RED, 0.9f, 0.9f));
+
+  // Act
+  fusion.fuse(input0.camera_info, input0.roi_array, input0.signal_array);
+  const auto result = fusion.fuse(input1.camera_info, input1.roi_array, input1.signal_array);
+
+  // Assert
+  expect_single_fused_color_and_shape(
+    result, TrafficLightElement::UNKNOWN, TrafficLightElement::UNKNOWN);
+  expect_single_conflict_status(result, ConflictType::PARTIAL_CONFLICT);
+}

--- a/perception/autoware_traffic_light_multi_camera_fusion/test/test_multi_camera_fusion.cpp
+++ b/perception/autoware_traffic_light_multi_camera_fusion/test/test_multi_camera_fusion.cpp
@@ -33,6 +33,7 @@
 
 #include <memory>
 #include <string>
+#include <vector>
 
 namespace
 {
@@ -41,6 +42,7 @@ using autoware::traffic_light::MultiCameraFusion;
 using autoware::traffic_light::MultiCameraFusionConfig;
 using autoware::traffic_light::MultiCameraFusionResult;
 using autoware_perception_msgs::msg::TrafficLightElement;
+using autoware_perception_msgs::msg::TrafficLightGroupArray;
 using sensor_msgs::msg::CameraInfo;
 using tier4_perception_msgs::msg::TrafficLight;
 using tier4_perception_msgs::msg::TrafficLightArray;
@@ -228,19 +230,19 @@ FusionInput make_fusion_input(
     make_signal_array(stamp, frame_id, signal)};
 }
 
-void expect_single_fused_color(const MultiCameraFusionResult & result, uint8_t expected_color)
+void expect_single_fused_color(const TrafficLightGroupArray & groups, uint8_t expected_color)
 {
-  ASSERT_EQ(result.traffic_light_groups.traffic_light_groups.size(), 1u);
-  const auto & group = result.traffic_light_groups.traffic_light_groups.front();
+  ASSERT_EQ(groups.traffic_light_groups.size(), 1u);
+  const auto & group = groups.traffic_light_groups.front();
   ASSERT_EQ(group.elements.size(), 1u);
   EXPECT_EQ(group.elements.front().color, expected_color);
 }
 
 void expect_single_fused_color_and_shape(
-  const MultiCameraFusionResult & result, uint8_t expected_color, uint8_t expected_shape)
+  const TrafficLightGroupArray & groups, uint8_t expected_color, uint8_t expected_shape)
 {
-  ASSERT_EQ(result.traffic_light_groups.traffic_light_groups.size(), 1u);
-  const auto & group = result.traffic_light_groups.traffic_light_groups.front();
+  ASSERT_EQ(groups.traffic_light_groups.size(), 1u);
+  const auto & group = groups.traffic_light_groups.front();
   ASSERT_EQ(group.elements.size(), 1u);
   EXPECT_EQ(group.elements.front().color, expected_color);
   EXPECT_EQ(group.elements.front().shape, expected_shape);
@@ -255,10 +257,10 @@ void expect_single_conflict_status(
 }
 
 void expect_element_confidence(
-  const MultiCameraFusionResult & result, size_t element_index, float expected_confidence)
+  const TrafficLightGroupArray & groups, size_t element_index, float expected_confidence)
 {
-  ASSERT_EQ(result.traffic_light_groups.traffic_light_groups.size(), 1u);
-  const auto & group = result.traffic_light_groups.traffic_light_groups.front();
+  ASSERT_EQ(groups.traffic_light_groups.size(), 1u);
+  const auto & group = groups.traffic_light_groups.front();
   ASSERT_LT(element_index, group.elements.size());
   EXPECT_FLOAT_EQ(group.elements[element_index].confidence, expected_confidence);
 }
@@ -273,11 +275,12 @@ TEST(MultiCameraFusionFuse, SingleCameraSingleLightOutputsGroupWithMappedRegulat
     make_fusion_input("camera0", make_signal(LEFT_TRAFFIC_LIGHT_ID, T4Element::GREEN, 0.9f));
 
   // Act
-  const auto result = fusion.fuse(input.camera_info, input.roi_array, input.signal_array);
+  TrafficLightGroupArray groups;
+  const auto result = fusion.fuse(input.camera_info, input.roi_array, input.signal_array, groups);
 
   // Assert
-  ASSERT_EQ(result.traffic_light_groups.traffic_light_groups.size(), 1u);
-  const auto & group = result.traffic_light_groups.traffic_light_groups.front();
+  ASSERT_EQ(groups.traffic_light_groups.size(), 1u);
+  const auto & group = groups.traffic_light_groups.front();
   EXPECT_EQ(group.traffic_light_group_id, REGULATORY_ELEMENT_ID);
   ASSERT_EQ(group.elements.size(), 1u);
   EXPECT_EQ(group.elements.front().color, TrafficLightElement::GREEN);
@@ -299,10 +302,12 @@ TEST(MultiCameraFusionFuse, EmptyRoiArrayProducesEmptyTrafficLightGroups)
   empty_signals.header.frame_id = frame_id;
 
   // Act
-  const auto result = fusion.fuse(make_camera_info(stamp, frame_id), empty_rois, empty_signals);
+  TrafficLightGroupArray groups;
+  const auto result =
+    fusion.fuse(make_camera_info(stamp, frame_id), empty_rois, empty_signals, groups);
 
   // Assert
-  EXPECT_TRUE(result.traffic_light_groups.traffic_light_groups.empty());
+  EXPECT_TRUE(groups.traffic_light_groups.empty());
   EXPECT_TRUE(result.unmapped_traffic_light_ids.empty());
 }
 
@@ -314,10 +319,11 @@ TEST(MultiCameraFusionFuse, UnknownTrafficLightIdIsRecordedAsUnmapped)
     make_fusion_input("camera0", make_signal(UNMAPPED_TRAFFIC_LIGHT_ID, T4Element::GREEN, 0.9f));
 
   // Act
-  const auto result = fusion.fuse(input.camera_info, input.roi_array, input.signal_array);
+  TrafficLightGroupArray groups;
+  const auto result = fusion.fuse(input.camera_info, input.roi_array, input.signal_array, groups);
 
   // Assert
-  EXPECT_TRUE(result.traffic_light_groups.traffic_light_groups.empty());
+  EXPECT_TRUE(groups.traffic_light_groups.empty());
   ASSERT_EQ(result.unmapped_traffic_light_ids.size(), 1u);
   EXPECT_EQ(result.unmapped_traffic_light_ids.front(), UNMAPPED_TRAFFIC_LIGHT_ID);
 }
@@ -334,12 +340,13 @@ TEST(MultiCameraFusionFuse, RoiWithoutMatchingSignalIsIgnored)
     make_signal_array(stamp, frame_id, make_signal(RIGHT_TRAFFIC_LIGHT_ID, T4Element::GREEN, 0.9f));
 
   // Act
-  const auto result = fusion.fuse(
+  TrafficLightGroupArray groups;
+  fusion.fuse(
     make_camera_info(stamp, frame_id), make_roi_array(stamp, frame_id, LEFT_TRAFFIC_LIGHT_ID),
-    mismatched_signals);
+    mismatched_signals, groups);
 
   // Assert
-  EXPECT_TRUE(result.traffic_light_groups.traffic_light_groups.empty());
+  EXPECT_TRUE(groups.traffic_light_groups.empty());
 }
 
 TEST(MultiCameraFusionFuse, HigherConfidenceColorIsSelectedAcrossTwoLights)
@@ -354,11 +361,12 @@ TEST(MultiCameraFusionFuse, HigherConfidenceColorIsSelectedAcrossTwoLights)
     make_fusion_input("camera1", make_signal(RIGHT_TRAFFIC_LIGHT_ID, T4Element::GREEN, 0.9f));
 
   // Act
-  fusion.fuse(input0.camera_info, input0.roi_array, input0.signal_array);
-  const auto result = fusion.fuse(input1.camera_info, input1.roi_array, input1.signal_array);
+  TrafficLightGroupArray groups;
+  fusion.fuse(input0.camera_info, input0.roi_array, input0.signal_array, groups);
+  fusion.fuse(input1.camera_info, input1.roi_array, input1.signal_array, groups);
 
   // Assert
-  expect_single_fused_color(result, TrafficLightElement::GREEN);
+  expect_single_fused_color(groups, TrafficLightElement::GREEN);
 }
 
 TEST(MultiCameraFusionFuse, RecordOlderThanMessageLifespanIsDiscarded)
@@ -375,12 +383,13 @@ TEST(MultiCameraFusionFuse, RecordOlderThanMessageLifespanIsDiscarded)
     "camera1", make_signal(RIGHT_TRAFFIC_LIGHT_ID, T4Element::RED, 0.6f), rclcpp::Time(102, 0));
 
   // Act
-  fusion.fuse(input0.camera_info, input0.roi_array, input0.signal_array);
-  const auto result = fusion.fuse(input1.camera_info, input1.roi_array, input1.signal_array);
+  TrafficLightGroupArray groups;
+  fusion.fuse(input0.camera_info, input0.roi_array, input0.signal_array, groups);
+  fusion.fuse(input1.camera_info, input1.roi_array, input1.signal_array, groups);
 
   // Assert
   // Only the second record contributes -> single light, RED color.
-  expect_single_fused_color(result, TrafficLightElement::RED);
+  expect_single_fused_color(groups, TrafficLightElement::RED);
 }
 
 TEST(MultiCameraFusionFuse, RecordWithinMessageLifespanIsKeptAndAccumulated)
@@ -396,12 +405,13 @@ TEST(MultiCameraFusionFuse, RecordWithinMessageLifespanIsKeptAndAccumulated)
     "camera1", make_signal(RIGHT_TRAFFIC_LIGHT_ID, T4Element::GREEN, 0.7f), rclcpp::Time(101, 0));
 
   // Act
-  fusion.fuse(input0.camera_info, input0.roi_array, input0.signal_array);
-  const auto result = fusion.fuse(input1.camera_info, input1.roi_array, input1.signal_array);
+  TrafficLightGroupArray groups;
+  fusion.fuse(input0.camera_info, input0.roi_array, input0.signal_array, groups);
+  fusion.fuse(input1.camera_info, input1.roi_array, input1.signal_array, groups);
 
   // Assert
   // Both records aggregate into a single group (same regulatory element) with color GREEN.
-  expect_single_fused_color(result, TrafficLightElement::GREEN);
+  expect_single_fused_color(groups, TrafficLightElement::GREEN);
 }
 
 TEST(MultiCameraFusionFuse, ConsistencyCheckWithSameColorOutputsNoConflict)
@@ -416,11 +426,13 @@ TEST(MultiCameraFusionFuse, ConsistencyCheckWithSameColorOutputsNoConflict)
     make_fusion_input("camera1", make_signal(RIGHT_TRAFFIC_LIGHT_ID, T4Element::GREEN, 0.9f));
 
   // Act
-  fusion.fuse(input0.camera_info, input0.roi_array, input0.signal_array);
-  const auto result = fusion.fuse(input1.camera_info, input1.roi_array, input1.signal_array);
+  TrafficLightGroupArray groups;
+  fusion.fuse(input0.camera_info, input0.roi_array, input0.signal_array, groups);
+  const auto result =
+    fusion.fuse(input1.camera_info, input1.roi_array, input1.signal_array, groups);
 
   // Assert
-  expect_single_fused_color(result, TrafficLightElement::GREEN);
+  expect_single_fused_color(groups, TrafficLightElement::GREEN);
   EXPECT_TRUE(result.conflicted_regulatory_element_status.empty());
 }
 
@@ -440,12 +452,14 @@ TEST(MultiCameraFusionFuse, ConsistencyCheckWithConflictingColorsOutputsUnknownF
     make_fusion_input("camera1", make_signal(RIGHT_TRAFFIC_LIGHT_ID, T4Element::GREEN, 0.9f));
 
   // Act
-  fusion.fuse(input0.camera_info, input0.roi_array, input0.signal_array);
-  const auto result = fusion.fuse(input1.camera_info, input1.roi_array, input1.signal_array);
+  TrafficLightGroupArray groups;
+  fusion.fuse(input0.camera_info, input0.roi_array, input0.signal_array, groups);
+  const auto result =
+    fusion.fuse(input1.camera_info, input1.roi_array, input1.signal_array, groups);
 
   // Assert
   expect_single_fused_color_and_shape(
-    result, TrafficLightElement::UNKNOWN, TrafficLightElement::UNKNOWN);
+    groups, TrafficLightElement::UNKNOWN, TrafficLightElement::UNKNOWN);
   expect_single_conflict_status(result, ConflictType::CONFLICT);
 }
 
@@ -466,12 +480,13 @@ TEST(MultiCameraFusionFuse, TruncatedRoiHasLowerPriorityThanCenteredRoi)
     make_fusion_input("camera1", make_signal(LEFT_TRAFFIC_LIGHT_ID, T4Element::RED, 0.6f), stamp);
 
   // Act
-  fusion.fuse(truncated_camera_info, truncated_rois, truncated_signals);
-  const auto result =
-    fusion.fuse(centered_input.camera_info, centered_input.roi_array, centered_input.signal_array);
+  TrafficLightGroupArray groups;
+  fusion.fuse(truncated_camera_info, truncated_rois, truncated_signals, groups);
+  fusion.fuse(
+    centered_input.camera_info, centered_input.roi_array, centered_input.signal_array, groups);
 
   // Assert
-  expect_single_fused_color(result, TrafficLightElement::RED);
+  expect_single_fused_color(groups, TrafficLightElement::RED);
 }
 
 TEST(MultiCameraFusionFuse, UnknownSignalLosesToValidSignalForSameTrafficLightId)
@@ -487,12 +502,13 @@ TEST(MultiCameraFusionFuse, UnknownSignalLosesToValidSignalForSameTrafficLightId
     make_fusion_input("camera1", make_signal(LEFT_TRAFFIC_LIGHT_ID, T4Element::GREEN, 0.8f));
 
   // Act
-  fusion.fuse(unknown_input.camera_info, unknown_input.roi_array, unknown_input.signal_array);
-  const auto result =
-    fusion.fuse(valid_input.camera_info, valid_input.roi_array, valid_input.signal_array);
+  TrafficLightGroupArray groups;
+  fusion.fuse(
+    unknown_input.camera_info, unknown_input.roi_array, unknown_input.signal_array, groups);
+  fusion.fuse(valid_input.camera_info, valid_input.roi_array, valid_input.signal_array, groups);
 
   // Assert
-  expect_single_fused_color(result, TrafficLightElement::GREEN);
+  expect_single_fused_color(groups, TrafficLightElement::GREEN);
 }
 
 TEST(MultiCameraFusionFuse, NewerTimestampWinsForSameFrameIdAndTrafficLightId)
@@ -511,12 +527,13 @@ TEST(MultiCameraFusionFuse, NewerTimestampWinsForSameFrameIdAndTrafficLightId)
     rclcpp::Time(100, 500000000));
 
   // Act
-  fusion.fuse(earlier_input.camera_info, earlier_input.roi_array, earlier_input.signal_array);
-  const auto result =
-    fusion.fuse(later_input.camera_info, later_input.roi_array, later_input.signal_array);
+  TrafficLightGroupArray groups;
+  fusion.fuse(
+    earlier_input.camera_info, earlier_input.roi_array, earlier_input.signal_array, groups);
+  fusion.fuse(later_input.camera_info, later_input.roi_array, later_input.signal_array, groups);
 
   // Assert
-  expect_single_fused_color(result, TrafficLightElement::RED);
+  expect_single_fused_color(groups, TrafficLightElement::RED);
 }
 
 TEST(MultiCameraFusionFuse, HigherConfidenceWinsWhenBothFullyVisibleForSameTrafficLightId)
@@ -532,15 +549,16 @@ TEST(MultiCameraFusionFuse, HigherConfidenceWinsWhenBothFullyVisibleForSameTraff
     make_fusion_input("camera1", make_signal(LEFT_TRAFFIC_LIGHT_ID, T4Element::RED, 0.9f));
 
   // Act
+  TrafficLightGroupArray groups;
   fusion.fuse(
     low_confidence_input.camera_info, low_confidence_input.roi_array,
-    low_confidence_input.signal_array);
-  const auto result = fusion.fuse(
+    low_confidence_input.signal_array, groups);
+  fusion.fuse(
     high_confidence_input.camera_info, high_confidence_input.roi_array,
-    high_confidence_input.signal_array);
+    high_confidence_input.signal_array, groups);
 
   // Assert
-  expect_single_fused_color(result, TrafficLightElement::RED);
+  expect_single_fused_color(groups, TrafficLightElement::RED);
 }
 
 TEST(MultiCameraFusionFuse, PartialConflictWithPartialMatchEnabledPublishesCommonState)
@@ -561,12 +579,14 @@ TEST(MultiCameraFusionFuse, PartialConflictWithPartialMatchEnabledPublishesCommo
     "camera1", make_signal_with_left_arrow(RIGHT_TRAFFIC_LIGHT_ID, T4Element::RED, 0.9f, 0.9f));
 
   // Act
-  fusion.fuse(input0.camera_info, input0.roi_array, input0.signal_array);
-  const auto result = fusion.fuse(input1.camera_info, input1.roi_array, input1.signal_array);
+  TrafficLightGroupArray groups;
+  fusion.fuse(input0.camera_info, input0.roi_array, input0.signal_array, groups);
+  const auto result =
+    fusion.fuse(input1.camera_info, input1.roi_array, input1.signal_array, groups);
 
   // Assert
   expect_single_fused_color_and_shape(
-    result, TrafficLightElement::RED, TrafficLightElement::CIRCLE);
+    groups, TrafficLightElement::RED, TrafficLightElement::CIRCLE);
   expect_single_conflict_status(result, ConflictType::PARTIAL_CONFLICT);
 }
 
@@ -588,13 +608,14 @@ TEST(MultiCameraFusionFuse, MinElementConfidenceDeterminesWinnerForMultiElementS
     "camera1", make_signal_with_left_arrow(LEFT_TRAFFIC_LIGHT_ID, T4Element::GREEN, 0.9f, 0.3f));
 
   // Act
-  fusion.fuse(input0.camera_info, input0.roi_array, input0.signal_array);
-  const auto result = fusion.fuse(input1.camera_info, input1.roi_array, input1.signal_array);
+  TrafficLightGroupArray groups;
+  fusion.fuse(input0.camera_info, input0.roi_array, input0.signal_array, groups);
+  fusion.fuse(input1.camera_info, input1.roi_array, input1.signal_array, groups);
 
   // Assert
   // camera0 wins -> output preserves camera0's per-element confidences (0.8 each).
-  expect_element_confidence(result, 0, 0.8f);
-  expect_element_confidence(result, 1, 0.8f);
+  expect_element_confidence(groups, 0, 0.8f);
+  expect_element_confidence(groups, 1, 0.8f);
 }
 
 TEST(MultiCameraFusionFuse, PartialConflictWithPartialMatchDisabledPublishesFailsafe)
@@ -613,11 +634,13 @@ TEST(MultiCameraFusionFuse, PartialConflictWithPartialMatchDisabledPublishesFail
     "camera1", make_signal_with_left_arrow(RIGHT_TRAFFIC_LIGHT_ID, T4Element::RED, 0.9f, 0.9f));
 
   // Act
-  fusion.fuse(input0.camera_info, input0.roi_array, input0.signal_array);
-  const auto result = fusion.fuse(input1.camera_info, input1.roi_array, input1.signal_array);
+  TrafficLightGroupArray groups;
+  fusion.fuse(input0.camera_info, input0.roi_array, input0.signal_array, groups);
+  const auto result =
+    fusion.fuse(input1.camera_info, input1.roi_array, input1.signal_array, groups);
 
   // Assert
   expect_single_fused_color_and_shape(
-    result, TrafficLightElement::UNKNOWN, TrafficLightElement::UNKNOWN);
+    groups, TrafficLightElement::UNKNOWN, TrafficLightElement::UNKNOWN);
   expect_single_conflict_status(result, ConflictType::PARTIAL_CONFLICT);
 }

--- a/perception/autoware_traffic_light_multi_camera_fusion/test/test_multi_camera_fusion.cpp
+++ b/perception/autoware_traffic_light_multi_camera_fusion/test/test_multi_camera_fusion.cpp
@@ -33,7 +33,6 @@
 
 #include <memory>
 #include <string>
-#include <vector>
 
 namespace
 {
@@ -42,7 +41,6 @@ using autoware::traffic_light::MultiCameraFusion;
 using autoware::traffic_light::MultiCameraFusionConfig;
 using autoware::traffic_light::MultiCameraFusionResult;
 using autoware_perception_msgs::msg::TrafficLightElement;
-using autoware_perception_msgs::msg::TrafficLightGroupArray;
 using sensor_msgs::msg::CameraInfo;
 using tier4_perception_msgs::msg::TrafficLight;
 using tier4_perception_msgs::msg::TrafficLightArray;
@@ -230,19 +228,19 @@ FusionInput make_fusion_input(
     make_signal_array(stamp, frame_id, signal)};
 }
 
-void expect_single_fused_color(const TrafficLightGroupArray & groups, uint8_t expected_color)
+void expect_single_fused_color(const MultiCameraFusionResult & result, uint8_t expected_color)
 {
-  ASSERT_EQ(groups.traffic_light_groups.size(), 1u);
-  const auto & group = groups.traffic_light_groups.front();
+  ASSERT_EQ(result.traffic_light_groups.traffic_light_groups.size(), 1u);
+  const auto & group = result.traffic_light_groups.traffic_light_groups.front();
   ASSERT_EQ(group.elements.size(), 1u);
   EXPECT_EQ(group.elements.front().color, expected_color);
 }
 
 void expect_single_fused_color_and_shape(
-  const TrafficLightGroupArray & groups, uint8_t expected_color, uint8_t expected_shape)
+  const MultiCameraFusionResult & result, uint8_t expected_color, uint8_t expected_shape)
 {
-  ASSERT_EQ(groups.traffic_light_groups.size(), 1u);
-  const auto & group = groups.traffic_light_groups.front();
+  ASSERT_EQ(result.traffic_light_groups.traffic_light_groups.size(), 1u);
+  const auto & group = result.traffic_light_groups.traffic_light_groups.front();
   ASSERT_EQ(group.elements.size(), 1u);
   EXPECT_EQ(group.elements.front().color, expected_color);
   EXPECT_EQ(group.elements.front().shape, expected_shape);
@@ -257,10 +255,10 @@ void expect_single_conflict_status(
 }
 
 void expect_element_confidence(
-  const TrafficLightGroupArray & groups, size_t element_index, float expected_confidence)
+  const MultiCameraFusionResult & result, size_t element_index, float expected_confidence)
 {
-  ASSERT_EQ(groups.traffic_light_groups.size(), 1u);
-  const auto & group = groups.traffic_light_groups.front();
+  ASSERT_EQ(result.traffic_light_groups.traffic_light_groups.size(), 1u);
+  const auto & group = result.traffic_light_groups.traffic_light_groups.front();
   ASSERT_LT(element_index, group.elements.size());
   EXPECT_FLOAT_EQ(group.elements[element_index].confidence, expected_confidence);
 }
@@ -275,12 +273,11 @@ TEST(MultiCameraFusionFuse, SingleCameraSingleLightOutputsGroupWithMappedRegulat
     make_fusion_input("camera0", make_signal(LEFT_TRAFFIC_LIGHT_ID, T4Element::GREEN, 0.9f));
 
   // Act
-  TrafficLightGroupArray groups;
-  const auto result = fusion.fuse(input.camera_info, input.roi_array, input.signal_array, groups);
+  const auto result = fusion.fuse(input.camera_info, input.roi_array, input.signal_array);
 
   // Assert
-  ASSERT_EQ(groups.traffic_light_groups.size(), 1u);
-  const auto & group = groups.traffic_light_groups.front();
+  ASSERT_EQ(result.traffic_light_groups.traffic_light_groups.size(), 1u);
+  const auto & group = result.traffic_light_groups.traffic_light_groups.front();
   EXPECT_EQ(group.traffic_light_group_id, REGULATORY_ELEMENT_ID);
   ASSERT_EQ(group.elements.size(), 1u);
   EXPECT_EQ(group.elements.front().color, TrafficLightElement::GREEN);
@@ -302,12 +299,10 @@ TEST(MultiCameraFusionFuse, EmptyRoiArrayProducesEmptyTrafficLightGroups)
   empty_signals.header.frame_id = frame_id;
 
   // Act
-  TrafficLightGroupArray groups;
-  const auto result =
-    fusion.fuse(make_camera_info(stamp, frame_id), empty_rois, empty_signals, groups);
+  const auto result = fusion.fuse(make_camera_info(stamp, frame_id), empty_rois, empty_signals);
 
   // Assert
-  EXPECT_TRUE(groups.traffic_light_groups.empty());
+  EXPECT_TRUE(result.traffic_light_groups.traffic_light_groups.empty());
   EXPECT_TRUE(result.unmapped_traffic_light_ids.empty());
 }
 
@@ -319,11 +314,10 @@ TEST(MultiCameraFusionFuse, UnknownTrafficLightIdIsRecordedAsUnmapped)
     make_fusion_input("camera0", make_signal(UNMAPPED_TRAFFIC_LIGHT_ID, T4Element::GREEN, 0.9f));
 
   // Act
-  TrafficLightGroupArray groups;
-  const auto result = fusion.fuse(input.camera_info, input.roi_array, input.signal_array, groups);
+  const auto result = fusion.fuse(input.camera_info, input.roi_array, input.signal_array);
 
   // Assert
-  EXPECT_TRUE(groups.traffic_light_groups.empty());
+  EXPECT_TRUE(result.traffic_light_groups.traffic_light_groups.empty());
   ASSERT_EQ(result.unmapped_traffic_light_ids.size(), 1u);
   EXPECT_EQ(result.unmapped_traffic_light_ids.front(), UNMAPPED_TRAFFIC_LIGHT_ID);
 }
@@ -340,13 +334,12 @@ TEST(MultiCameraFusionFuse, RoiWithoutMatchingSignalIsIgnored)
     make_signal_array(stamp, frame_id, make_signal(RIGHT_TRAFFIC_LIGHT_ID, T4Element::GREEN, 0.9f));
 
   // Act
-  TrafficLightGroupArray groups;
-  fusion.fuse(
+  const auto result = fusion.fuse(
     make_camera_info(stamp, frame_id), make_roi_array(stamp, frame_id, LEFT_TRAFFIC_LIGHT_ID),
-    mismatched_signals, groups);
+    mismatched_signals);
 
   // Assert
-  EXPECT_TRUE(groups.traffic_light_groups.empty());
+  EXPECT_TRUE(result.traffic_light_groups.traffic_light_groups.empty());
 }
 
 TEST(MultiCameraFusionFuse, HigherConfidenceColorIsSelectedAcrossTwoLights)
@@ -361,12 +354,11 @@ TEST(MultiCameraFusionFuse, HigherConfidenceColorIsSelectedAcrossTwoLights)
     make_fusion_input("camera1", make_signal(RIGHT_TRAFFIC_LIGHT_ID, T4Element::GREEN, 0.9f));
 
   // Act
-  TrafficLightGroupArray groups;
-  fusion.fuse(input0.camera_info, input0.roi_array, input0.signal_array, groups);
-  fusion.fuse(input1.camera_info, input1.roi_array, input1.signal_array, groups);
+  fusion.fuse(input0.camera_info, input0.roi_array, input0.signal_array);
+  const auto result = fusion.fuse(input1.camera_info, input1.roi_array, input1.signal_array);
 
   // Assert
-  expect_single_fused_color(groups, TrafficLightElement::GREEN);
+  expect_single_fused_color(result, TrafficLightElement::GREEN);
 }
 
 TEST(MultiCameraFusionFuse, RecordOlderThanMessageLifespanIsDiscarded)
@@ -383,13 +375,12 @@ TEST(MultiCameraFusionFuse, RecordOlderThanMessageLifespanIsDiscarded)
     "camera1", make_signal(RIGHT_TRAFFIC_LIGHT_ID, T4Element::RED, 0.6f), rclcpp::Time(102, 0));
 
   // Act
-  TrafficLightGroupArray groups;
-  fusion.fuse(input0.camera_info, input0.roi_array, input0.signal_array, groups);
-  fusion.fuse(input1.camera_info, input1.roi_array, input1.signal_array, groups);
+  fusion.fuse(input0.camera_info, input0.roi_array, input0.signal_array);
+  const auto result = fusion.fuse(input1.camera_info, input1.roi_array, input1.signal_array);
 
   // Assert
   // Only the second record contributes -> single light, RED color.
-  expect_single_fused_color(groups, TrafficLightElement::RED);
+  expect_single_fused_color(result, TrafficLightElement::RED);
 }
 
 TEST(MultiCameraFusionFuse, RecordWithinMessageLifespanIsKeptAndAccumulated)
@@ -405,13 +396,12 @@ TEST(MultiCameraFusionFuse, RecordWithinMessageLifespanIsKeptAndAccumulated)
     "camera1", make_signal(RIGHT_TRAFFIC_LIGHT_ID, T4Element::GREEN, 0.7f), rclcpp::Time(101, 0));
 
   // Act
-  TrafficLightGroupArray groups;
-  fusion.fuse(input0.camera_info, input0.roi_array, input0.signal_array, groups);
-  fusion.fuse(input1.camera_info, input1.roi_array, input1.signal_array, groups);
+  fusion.fuse(input0.camera_info, input0.roi_array, input0.signal_array);
+  const auto result = fusion.fuse(input1.camera_info, input1.roi_array, input1.signal_array);
 
   // Assert
   // Both records aggregate into a single group (same regulatory element) with color GREEN.
-  expect_single_fused_color(groups, TrafficLightElement::GREEN);
+  expect_single_fused_color(result, TrafficLightElement::GREEN);
 }
 
 TEST(MultiCameraFusionFuse, ConsistencyCheckWithSameColorOutputsNoConflict)
@@ -426,13 +416,11 @@ TEST(MultiCameraFusionFuse, ConsistencyCheckWithSameColorOutputsNoConflict)
     make_fusion_input("camera1", make_signal(RIGHT_TRAFFIC_LIGHT_ID, T4Element::GREEN, 0.9f));
 
   // Act
-  TrafficLightGroupArray groups;
-  fusion.fuse(input0.camera_info, input0.roi_array, input0.signal_array, groups);
-  const auto result =
-    fusion.fuse(input1.camera_info, input1.roi_array, input1.signal_array, groups);
+  fusion.fuse(input0.camera_info, input0.roi_array, input0.signal_array);
+  const auto result = fusion.fuse(input1.camera_info, input1.roi_array, input1.signal_array);
 
   // Assert
-  expect_single_fused_color(groups, TrafficLightElement::GREEN);
+  expect_single_fused_color(result, TrafficLightElement::GREEN);
   EXPECT_TRUE(result.conflicted_regulatory_element_status.empty());
 }
 
@@ -452,14 +440,12 @@ TEST(MultiCameraFusionFuse, ConsistencyCheckWithConflictingColorsOutputsUnknownF
     make_fusion_input("camera1", make_signal(RIGHT_TRAFFIC_LIGHT_ID, T4Element::GREEN, 0.9f));
 
   // Act
-  TrafficLightGroupArray groups;
-  fusion.fuse(input0.camera_info, input0.roi_array, input0.signal_array, groups);
-  const auto result =
-    fusion.fuse(input1.camera_info, input1.roi_array, input1.signal_array, groups);
+  fusion.fuse(input0.camera_info, input0.roi_array, input0.signal_array);
+  const auto result = fusion.fuse(input1.camera_info, input1.roi_array, input1.signal_array);
 
   // Assert
   expect_single_fused_color_and_shape(
-    groups, TrafficLightElement::UNKNOWN, TrafficLightElement::UNKNOWN);
+    result, TrafficLightElement::UNKNOWN, TrafficLightElement::UNKNOWN);
   expect_single_conflict_status(result, ConflictType::CONFLICT);
 }
 
@@ -480,13 +466,12 @@ TEST(MultiCameraFusionFuse, TruncatedRoiHasLowerPriorityThanCenteredRoi)
     make_fusion_input("camera1", make_signal(LEFT_TRAFFIC_LIGHT_ID, T4Element::RED, 0.6f), stamp);
 
   // Act
-  TrafficLightGroupArray groups;
-  fusion.fuse(truncated_camera_info, truncated_rois, truncated_signals, groups);
-  fusion.fuse(
-    centered_input.camera_info, centered_input.roi_array, centered_input.signal_array, groups);
+  fusion.fuse(truncated_camera_info, truncated_rois, truncated_signals);
+  const auto result =
+    fusion.fuse(centered_input.camera_info, centered_input.roi_array, centered_input.signal_array);
 
   // Assert
-  expect_single_fused_color(groups, TrafficLightElement::RED);
+  expect_single_fused_color(result, TrafficLightElement::RED);
 }
 
 TEST(MultiCameraFusionFuse, UnknownSignalLosesToValidSignalForSameTrafficLightId)
@@ -502,13 +487,12 @@ TEST(MultiCameraFusionFuse, UnknownSignalLosesToValidSignalForSameTrafficLightId
     make_fusion_input("camera1", make_signal(LEFT_TRAFFIC_LIGHT_ID, T4Element::GREEN, 0.8f));
 
   // Act
-  TrafficLightGroupArray groups;
-  fusion.fuse(
-    unknown_input.camera_info, unknown_input.roi_array, unknown_input.signal_array, groups);
-  fusion.fuse(valid_input.camera_info, valid_input.roi_array, valid_input.signal_array, groups);
+  fusion.fuse(unknown_input.camera_info, unknown_input.roi_array, unknown_input.signal_array);
+  const auto result =
+    fusion.fuse(valid_input.camera_info, valid_input.roi_array, valid_input.signal_array);
 
   // Assert
-  expect_single_fused_color(groups, TrafficLightElement::GREEN);
+  expect_single_fused_color(result, TrafficLightElement::GREEN);
 }
 
 TEST(MultiCameraFusionFuse, NewerTimestampWinsForSameFrameIdAndTrafficLightId)
@@ -527,13 +511,12 @@ TEST(MultiCameraFusionFuse, NewerTimestampWinsForSameFrameIdAndTrafficLightId)
     rclcpp::Time(100, 500000000));
 
   // Act
-  TrafficLightGroupArray groups;
-  fusion.fuse(
-    earlier_input.camera_info, earlier_input.roi_array, earlier_input.signal_array, groups);
-  fusion.fuse(later_input.camera_info, later_input.roi_array, later_input.signal_array, groups);
+  fusion.fuse(earlier_input.camera_info, earlier_input.roi_array, earlier_input.signal_array);
+  const auto result =
+    fusion.fuse(later_input.camera_info, later_input.roi_array, later_input.signal_array);
 
   // Assert
-  expect_single_fused_color(groups, TrafficLightElement::RED);
+  expect_single_fused_color(result, TrafficLightElement::RED);
 }
 
 TEST(MultiCameraFusionFuse, HigherConfidenceWinsWhenBothFullyVisibleForSameTrafficLightId)
@@ -549,16 +532,15 @@ TEST(MultiCameraFusionFuse, HigherConfidenceWinsWhenBothFullyVisibleForSameTraff
     make_fusion_input("camera1", make_signal(LEFT_TRAFFIC_LIGHT_ID, T4Element::RED, 0.9f));
 
   // Act
-  TrafficLightGroupArray groups;
   fusion.fuse(
     low_confidence_input.camera_info, low_confidence_input.roi_array,
-    low_confidence_input.signal_array, groups);
-  fusion.fuse(
+    low_confidence_input.signal_array);
+  const auto result = fusion.fuse(
     high_confidence_input.camera_info, high_confidence_input.roi_array,
-    high_confidence_input.signal_array, groups);
+    high_confidence_input.signal_array);
 
   // Assert
-  expect_single_fused_color(groups, TrafficLightElement::RED);
+  expect_single_fused_color(result, TrafficLightElement::RED);
 }
 
 TEST(MultiCameraFusionFuse, PartialConflictWithPartialMatchEnabledPublishesCommonState)
@@ -579,14 +561,12 @@ TEST(MultiCameraFusionFuse, PartialConflictWithPartialMatchEnabledPublishesCommo
     "camera1", make_signal_with_left_arrow(RIGHT_TRAFFIC_LIGHT_ID, T4Element::RED, 0.9f, 0.9f));
 
   // Act
-  TrafficLightGroupArray groups;
-  fusion.fuse(input0.camera_info, input0.roi_array, input0.signal_array, groups);
-  const auto result =
-    fusion.fuse(input1.camera_info, input1.roi_array, input1.signal_array, groups);
+  fusion.fuse(input0.camera_info, input0.roi_array, input0.signal_array);
+  const auto result = fusion.fuse(input1.camera_info, input1.roi_array, input1.signal_array);
 
   // Assert
   expect_single_fused_color_and_shape(
-    groups, TrafficLightElement::RED, TrafficLightElement::CIRCLE);
+    result, TrafficLightElement::RED, TrafficLightElement::CIRCLE);
   expect_single_conflict_status(result, ConflictType::PARTIAL_CONFLICT);
 }
 
@@ -608,14 +588,13 @@ TEST(MultiCameraFusionFuse, MinElementConfidenceDeterminesWinnerForMultiElementS
     "camera1", make_signal_with_left_arrow(LEFT_TRAFFIC_LIGHT_ID, T4Element::GREEN, 0.9f, 0.3f));
 
   // Act
-  TrafficLightGroupArray groups;
-  fusion.fuse(input0.camera_info, input0.roi_array, input0.signal_array, groups);
-  fusion.fuse(input1.camera_info, input1.roi_array, input1.signal_array, groups);
+  fusion.fuse(input0.camera_info, input0.roi_array, input0.signal_array);
+  const auto result = fusion.fuse(input1.camera_info, input1.roi_array, input1.signal_array);
 
   // Assert
   // camera0 wins -> output preserves camera0's per-element confidences (0.8 each).
-  expect_element_confidence(groups, 0, 0.8f);
-  expect_element_confidence(groups, 1, 0.8f);
+  expect_element_confidence(result, 0, 0.8f);
+  expect_element_confidence(result, 1, 0.8f);
 }
 
 TEST(MultiCameraFusionFuse, PartialConflictWithPartialMatchDisabledPublishesFailsafe)
@@ -634,13 +613,11 @@ TEST(MultiCameraFusionFuse, PartialConflictWithPartialMatchDisabledPublishesFail
     "camera1", make_signal_with_left_arrow(RIGHT_TRAFFIC_LIGHT_ID, T4Element::RED, 0.9f, 0.9f));
 
   // Act
-  TrafficLightGroupArray groups;
-  fusion.fuse(input0.camera_info, input0.roi_array, input0.signal_array, groups);
-  const auto result =
-    fusion.fuse(input1.camera_info, input1.roi_array, input1.signal_array, groups);
+  fusion.fuse(input0.camera_info, input0.roi_array, input0.signal_array);
+  const auto result = fusion.fuse(input1.camera_info, input1.roi_array, input1.signal_array);
 
   // Assert
   expect_single_fused_color_and_shape(
-    groups, TrafficLightElement::UNKNOWN, TrafficLightElement::UNKNOWN);
+    result, TrafficLightElement::UNKNOWN, TrafficLightElement::UNKNOWN);
   expect_single_conflict_status(result, ConflictType::PARTIAL_CONFLICT);
 }

--- a/perception/autoware_traffic_light_multi_camera_fusion/test/test_signal_validator.cpp
+++ b/perception/autoware_traffic_light_multi_camera_fusion/test/test_signal_validator.cpp
@@ -21,27 +21,21 @@
 
 using autoware::traffic_light::ConflictStatus;
 using autoware::traffic_light::ConflictType;
-using autoware::traffic_light::SignalValidator;
 using autoware::traffic_light::StateKey;
+using autoware::traffic_light::signal_validator::check_conflict;
 using tier4_perception_msgs::msg::TrafficLightElement;
-
-class SignalValidatorCheckConflict : public ::testing::Test
-{
-protected:
-  SignalValidator validator;
-};
 
 // ----------------------------------------------------------------------------
 // test checkMismatchLogic
 //  basic rules
 
 // same color and shape: no conflict
-TEST_F(SignalValidatorCheckConflict, RedCircle_RedCircle)
+TEST(CheckConflict, RedCircle_RedCircle)
 {
   StateKey input_a = {{TrafficLightElement::RED, TrafficLightElement::CIRCLE}};
   StateKey input_b = {{TrafficLightElement::RED, TrafficLightElement::CIRCLE}};
 
-  ConflictStatus result = validator.check_conflict(input_a, input_b);
+  ConflictStatus result = check_conflict(input_a, input_b);
 
   // output expectations
   ConflictType expected_conflict_type = ConflictType::NO_CONFLICT;
@@ -53,12 +47,12 @@ TEST_F(SignalValidatorCheckConflict, RedCircle_RedCircle)
 
 // different color and same shape
 // -> critical conflict
-TEST_F(SignalValidatorCheckConflict, RedCircle_GreenCircle)
+TEST(CheckConflict, RedCircle_GreenCircle)
 {
   StateKey input_a = {{TrafficLightElement::RED, TrafficLightElement::CIRCLE}};
   StateKey input_b = {{TrafficLightElement::GREEN, TrafficLightElement::CIRCLE}};
 
-  ConflictStatus result = validator.check_conflict(input_a, input_b);
+  ConflictStatus result = check_conflict(input_a, input_b);
 
   // output expectations
   ConflictType expected_conflict_type = ConflictType::CONFLICT;
@@ -71,12 +65,12 @@ TEST_F(SignalValidatorCheckConflict, RedCircle_GreenCircle)
 // check swapped input
 // different colors and same shape
 // -> critical conflict
-TEST_F(SignalValidatorCheckConflict, GreenCircle_RedCircle)
+TEST(CheckConflict, GreenCircle_RedCircle)
 {
   StateKey input_a = {{TrafficLightElement::GREEN, TrafficLightElement::CIRCLE}};
   StateKey input_b = {{TrafficLightElement::RED, TrafficLightElement::CIRCLE}};
 
-  ConflictStatus result = validator.check_conflict(input_a, input_b);
+  ConflictStatus result = check_conflict(input_a, input_b);
 
   // output expectations
   ConflictType expected_conflict_type = ConflictType::CONFLICT;
@@ -88,7 +82,7 @@ TEST_F(SignalValidatorCheckConflict, GreenCircle_RedCircle)
 
 // same colors and shapes with circles and arrows
 // -> no conflict
-TEST_F(SignalValidatorCheckConflict, RedCircleGreenLeftarrow_RedCircleGreenLeftarrow)
+TEST(CheckConflict, RedCircleGreenLeftarrow_RedCircleGreenLeftarrow)
 {
   StateKey input_a = {
     {TrafficLightElement::RED, TrafficLightElement::CIRCLE},
@@ -97,7 +91,7 @@ TEST_F(SignalValidatorCheckConflict, RedCircleGreenLeftarrow_RedCircleGreenLefta
     {TrafficLightElement::RED, TrafficLightElement::CIRCLE},
     {TrafficLightElement::GREEN, TrafficLightElement::LEFT_ARROW}};
 
-  ConflictStatus result = validator.check_conflict(input_a, input_b);
+  ConflictStatus result = check_conflict(input_a, input_b);
 
   // output expectations
   ConflictType expected_conflict_type = ConflictType::NO_CONFLICT;
@@ -111,7 +105,7 @@ TEST_F(SignalValidatorCheckConflict, RedCircleGreenLeftarrow_RedCircleGreenLefta
 
 // same color for circles, and multiple matched arrows
 // -> no conflict
-TEST_F(SignalValidatorCheckConflict, RedCircleMultipleMatchedArrows_RedCircleMultipleMatchedArrows)
+TEST(CheckConflict, RedCircleMultipleMatchedArrows_RedCircleMultipleMatchedArrows)
 {
   StateKey input_a = {
     {TrafficLightElement::RED, TrafficLightElement::CIRCLE},
@@ -126,7 +120,7 @@ TEST_F(SignalValidatorCheckConflict, RedCircleMultipleMatchedArrows_RedCircleMul
     {TrafficLightElement::GREEN, TrafficLightElement::RIGHT_ARROW},
     {TrafficLightElement::GREEN, TrafficLightElement::DOWN_LEFT_ARROW}};
 
-  ConflictStatus result = validator.check_conflict(input_a, input_b);
+  ConflictStatus result = check_conflict(input_a, input_b);
 
   // output expectations
   ConflictType expected_conflict_type = ConflictType::NO_CONFLICT;
@@ -143,7 +137,7 @@ TEST_F(SignalValidatorCheckConflict, RedCircleMultipleMatchedArrows_RedCircleMul
 
 // different colors for circles, same color for arrows
 // -> partial conflict
-TEST_F(SignalValidatorCheckConflict, RedCircleGreenLeftarrow_GreenCircleGreenLeftarrow)
+TEST(CheckConflict, RedCircleGreenLeftarrow_GreenCircleGreenLeftarrow)
 {
   StateKey input_a = {
     {TrafficLightElement::RED, TrafficLightElement::CIRCLE},
@@ -154,7 +148,7 @@ TEST_F(SignalValidatorCheckConflict, RedCircleGreenLeftarrow_GreenCircleGreenLef
     {TrafficLightElement::GREEN, TrafficLightElement::LEFT_ARROW},
   };
 
-  ConflictStatus result = validator.check_conflict(input_a, input_b);
+  ConflictStatus result = check_conflict(input_a, input_b);
 
   // output expectations
   ConflictType expected_conflict_type = ConflictType::PARTIAL_CONFLICT;
@@ -167,7 +161,7 @@ TEST_F(SignalValidatorCheckConflict, RedCircleGreenLeftarrow_GreenCircleGreenLef
 
 // same color for circles, different colors for arrows
 // -> partial conflict
-TEST_F(SignalValidatorCheckConflict, RedCircleGreenLeftarrow_RedCircleRedLeftarrow)
+TEST(CheckConflict, RedCircleGreenLeftarrow_RedCircleRedLeftarrow)
 {
   StateKey input_a = {
     {TrafficLightElement::RED, TrafficLightElement::CIRCLE},
@@ -178,7 +172,7 @@ TEST_F(SignalValidatorCheckConflict, RedCircleGreenLeftarrow_RedCircleRedLeftarr
     {TrafficLightElement::RED, TrafficLightElement::LEFT_ARROW},
   };
 
-  ConflictStatus result = validator.check_conflict(input_a, input_b);
+  ConflictStatus result = check_conflict(input_a, input_b);
 
   // output expectations
   ConflictType expected_conflict_type = ConflictType::PARTIAL_CONFLICT;
@@ -190,7 +184,7 @@ TEST_F(SignalValidatorCheckConflict, RedCircleGreenLeftarrow_RedCircleRedLeftarr
 
 // same color for circles, different colors for arrows
 // -> partial conflict
-TEST_F(SignalValidatorCheckConflict, GreenLeftarrowRedCircle_RedCircle)
+TEST(CheckConflict, GreenLeftarrowRedCircle_RedCircle)
 {
   StateKey input_a = {
     {TrafficLightElement::GREEN, TrafficLightElement::LEFT_ARROW},
@@ -199,7 +193,7 @@ TEST_F(SignalValidatorCheckConflict, GreenLeftarrowRedCircle_RedCircle)
     {TrafficLightElement::RED, TrafficLightElement::CIRCLE},
   };
 
-  ConflictStatus result = validator.check_conflict(input_a, input_b);
+  ConflictStatus result = check_conflict(input_a, input_b);
 
   // output expectations
   ConflictType expected_conflict_type = ConflictType::PARTIAL_CONFLICT;
@@ -211,7 +205,7 @@ TEST_F(SignalValidatorCheckConflict, GreenLeftarrowRedCircle_RedCircle)
 
 // same color for circles, different colors for arrows (swapped input)
 // -> partial conflict
-TEST_F(SignalValidatorCheckConflict, RedCircle_GreenLeftarrowRedCircle)
+TEST(CheckConflict, RedCircle_GreenLeftarrowRedCircle)
 {
   StateKey input_a = {
     {TrafficLightElement::RED, TrafficLightElement::CIRCLE},
@@ -220,7 +214,7 @@ TEST_F(SignalValidatorCheckConflict, RedCircle_GreenLeftarrowRedCircle)
     {TrafficLightElement::GREEN, TrafficLightElement::LEFT_ARROW},
     {TrafficLightElement::RED, TrafficLightElement::CIRCLE}};
 
-  ConflictStatus result = validator.check_conflict(input_a, input_b);
+  ConflictStatus result = check_conflict(input_a, input_b);
 
   // output expectations
   ConflictType expected_conflict_type = ConflictType::PARTIAL_CONFLICT;
@@ -232,7 +226,7 @@ TEST_F(SignalValidatorCheckConflict, RedCircle_GreenLeftarrowRedCircle)
 
 // same color for circles, and multiple matched arrows and single mismatched arrow
 // -> partial conflict
-TEST_F(SignalValidatorCheckConflict, RedCircleMultipleArrows_RedCircleMultipleArrows_ArrowMismatch)
+TEST(CheckConflict, RedCircleMultipleArrows_RedCircleMultipleArrows_ArrowMismatch)
 {
   StateKey input_a = {
     {TrafficLightElement::RED, TrafficLightElement::CIRCLE},
@@ -247,7 +241,7 @@ TEST_F(SignalValidatorCheckConflict, RedCircleMultipleArrows_RedCircleMultipleAr
     {TrafficLightElement::GREEN, TrafficLightElement::RIGHT_ARROW},
     {TrafficLightElement::GREEN, TrafficLightElement::DOWN_ARROW}};
 
-  ConflictStatus result = validator.check_conflict(input_a, input_b);
+  ConflictStatus result = check_conflict(input_a, input_b);
 
   // output expectations
   ConflictType expected_conflict_type = ConflictType::PARTIAL_CONFLICT;
@@ -264,14 +258,14 @@ TEST_F(SignalValidatorCheckConflict, RedCircleMultipleArrows_RedCircleMultipleAr
 // ------------------------------------------
 // test circle with arrow and only arrow
 // -> critical conflict
-TEST_F(SignalValidatorCheckConflict, RedCircleGreendownarrow_GreenUparrow)
+TEST(CheckConflict, RedCircleGreendownarrow_GreenUparrow)
 {
   StateKey input_a = {
     {TrafficLightElement::RED, TrafficLightElement::CIRCLE},
     {TrafficLightElement::GREEN, TrafficLightElement::DOWN_ARROW}};
   StateKey input_b = {{TrafficLightElement::GREEN, TrafficLightElement::UP_ARROW}};
 
-  ConflictStatus result = validator.check_conflict(input_a, input_b);
+  ConflictStatus result = check_conflict(input_a, input_b);
 
   // output expectations
   ConflictType expected_conflict_type = ConflictType::CONFLICT;
@@ -286,12 +280,12 @@ TEST_F(SignalValidatorCheckConflict, RedCircleGreendownarrow_GreenUparrow)
 
 // same signal
 // -> no conflict
-TEST_F(SignalValidatorCheckConflict, WhiteCross_WhiteCross)
+TEST(CheckConflict, WhiteCross_WhiteCross)
 {
   StateKey input_a = {{TrafficLightElement::WHITE, TrafficLightElement::CROSS}};
   StateKey input_b = {{TrafficLightElement::WHITE, TrafficLightElement::CROSS}};
 
-  ConflictStatus result = validator.check_conflict(input_a, input_b);
+  ConflictStatus result = check_conflict(input_a, input_b);
 
   // output expectations
   ConflictType expected_conflict_type = ConflictType::NO_CONFLICT;
@@ -303,12 +297,12 @@ TEST_F(SignalValidatorCheckConflict, WhiteCross_WhiteCross)
 
 // different signal
 // -> critical conflict
-TEST_F(SignalValidatorCheckConflict, WhiteCross_WhiteCIRCLE)
+TEST(CheckConflict, WhiteCross_WhiteCIRCLE)
 {
   StateKey input_a = {{TrafficLightElement::WHITE, TrafficLightElement::CROSS}};
   StateKey input_b = {{TrafficLightElement::WHITE, TrafficLightElement::CIRCLE}};
 
-  ConflictStatus result = validator.check_conflict(input_a, input_b);
+  ConflictStatus result = check_conflict(input_a, input_b);
 
   // output expectations
   ConflictType expected_conflict_type = ConflictType::CONFLICT;
@@ -320,14 +314,14 @@ TEST_F(SignalValidatorCheckConflict, WhiteCross_WhiteCIRCLE)
 
 // same cross signal and different arrow signal
 // -> critical conflict
-TEST_F(SignalValidatorCheckConflict, AmberCross_AmberCrossGreenUparrow)
+TEST(CheckConflict, AmberCross_AmberCrossGreenUparrow)
 {
   StateKey input_a = {{TrafficLightElement::AMBER, TrafficLightElement::CROSS}};
   StateKey input_b = {
     {TrafficLightElement::AMBER, TrafficLightElement::CROSS},
     {TrafficLightElement::GREEN, TrafficLightElement::UP_ARROW}};
 
-  ConflictStatus result = validator.check_conflict(input_a, input_b);
+  ConflictStatus result = check_conflict(input_a, input_b);
 
   // output expectations
   ConflictType expected_conflict_type = ConflictType::PARTIAL_CONFLICT;
@@ -338,7 +332,7 @@ TEST_F(SignalValidatorCheckConflict, AmberCross_AmberCrossGreenUparrow)
 }
 
 // inputs totally mismatch
-TEST_F(SignalValidatorCheckConflict, AllMismatch)
+TEST(CheckConflict, AllMismatch)
 {
   StateKey input_a = {
     {TrafficLightElement::RED, TrafficLightElement::CIRCLE},
@@ -348,7 +342,7 @@ TEST_F(SignalValidatorCheckConflict, AllMismatch)
     {TrafficLightElement::GREEN, TrafficLightElement::LEFT_ARROW},
   };
 
-  ConflictStatus result = validator.check_conflict(input_a, input_b);
+  ConflictStatus result = check_conflict(input_a, input_b);
 
   StateKey expected_common_state_key = {};
 
@@ -361,12 +355,12 @@ TEST_F(SignalValidatorCheckConflict, AllMismatch)
 
 // same color and shape for arrows
 // -> no conflict
-TEST_F(SignalValidatorCheckConflict, GreenUparrow_GreenUparrow)
+TEST(CheckConflict, GreenUparrow_GreenUparrow)
 {
   StateKey input_a = {{TrafficLightElement::GREEN, TrafficLightElement::UP_ARROW}};
   StateKey input_b = {{TrafficLightElement::GREEN, TrafficLightElement::UP_ARROW}};
 
-  ConflictStatus result = validator.check_conflict(input_a, input_b);
+  ConflictStatus result = check_conflict(input_a, input_b);
 
   // output expectations
   ConflictType expected_conflict_type = ConflictType::NO_CONFLICT;
@@ -379,7 +373,7 @@ TEST_F(SignalValidatorCheckConflict, GreenUparrow_GreenUparrow)
 
 // same colors and shapes for arrows
 // -> no conflict
-TEST_F(SignalValidatorCheckConflict, GreenUparrowGreenRightarrow_GreenUparrowGreenRightarrow)
+TEST(CheckConflict, GreenUparrowGreenRightarrow_GreenUparrowGreenRightarrow)
 {
   StateKey input_a = {
     {TrafficLightElement::GREEN, TrafficLightElement::UP_ARROW},
@@ -388,7 +382,7 @@ TEST_F(SignalValidatorCheckConflict, GreenUparrowGreenRightarrow_GreenUparrowGre
     {TrafficLightElement::GREEN, TrafficLightElement::UP_ARROW},
     {TrafficLightElement::GREEN, TrafficLightElement::RIGHT_ARROW}};
 
-  ConflictStatus result = validator.check_conflict(input_a, input_b);
+  ConflictStatus result = check_conflict(input_a, input_b);
 
   // output expectations
   ConflictType expected_conflict_type = ConflictType::NO_CONFLICT;
@@ -402,12 +396,12 @@ TEST_F(SignalValidatorCheckConflict, GreenUparrowGreenRightarrow_GreenUparrowGre
 
 // different colors and same shape for arrows
 // -> critical conflict
-TEST_F(SignalValidatorCheckConflict, RedUparrow_GreenUparrow)
+TEST(CheckConflict, RedUparrow_GreenUparrow)
 {
   StateKey input_a = {{TrafficLightElement::RED, TrafficLightElement::UP_ARROW}};
   StateKey input_b = {{TrafficLightElement::GREEN, TrafficLightElement::UP_ARROW}};
 
-  ConflictStatus result = validator.check_conflict(input_a, input_b);
+  ConflictStatus result = check_conflict(input_a, input_b);
 
   // output expectations
   ConflictType expected_conflict_type = ConflictType::CONFLICT;
@@ -419,12 +413,12 @@ TEST_F(SignalValidatorCheckConflict, RedUparrow_GreenUparrow)
 
 // same color and different shapes for arrows
 // -> critical conflict
-TEST_F(SignalValidatorCheckConflict, RedUparrow_RedDownleftarrow)
+TEST(CheckConflict, RedUparrow_RedDownleftarrow)
 {
   StateKey input_a = {{TrafficLightElement::RED, TrafficLightElement::UP_ARROW}};
   StateKey input_b = {{TrafficLightElement::RED, TrafficLightElement::DOWN_LEFT_ARROW}};
 
-  ConflictStatus result = validator.check_conflict(input_a, input_b);
+  ConflictStatus result = check_conflict(input_a, input_b);
 
   // output expectations
   ConflictType expected_conflict_type = ConflictType::CONFLICT;
@@ -436,14 +430,14 @@ TEST_F(SignalValidatorCheckConflict, RedUparrow_RedDownleftarrow)
 
 // same color and different shapes for arrows
 // -> critical conflict
-TEST_F(SignalValidatorCheckConflict, RedUparrowRedDownleftarrow_RedDownleftarrow)
+TEST(CheckConflict, RedUparrowRedDownleftarrow_RedDownleftarrow)
 {
   StateKey input_a = {
     {TrafficLightElement::RED, TrafficLightElement::UP_ARROW},
     {TrafficLightElement::RED, TrafficLightElement::DOWN_LEFT_ARROW}};
   StateKey input_b = {{TrafficLightElement::RED, TrafficLightElement::DOWN_LEFT_ARROW}};
 
-  ConflictStatus result = validator.check_conflict(input_a, input_b);
+  ConflictStatus result = check_conflict(input_a, input_b);
 
   // output expectations
   ConflictType expected_conflict_type = ConflictType::PARTIAL_CONFLICT;
@@ -456,14 +450,14 @@ TEST_F(SignalValidatorCheckConflict, RedUparrowRedDownleftarrow_RedDownleftarrow
 
 // same color and different shapes for arrows (swapped input)
 // -> critical conflict
-TEST_F(SignalValidatorCheckConflict, RedDownleftarrow_RedUparrowRedDownleftarrow)
+TEST(CheckConflict, RedDownleftarrow_RedUparrowRedDownleftarrow)
 {
   StateKey input_a = {{TrafficLightElement::RED, TrafficLightElement::DOWN_LEFT_ARROW}};
   StateKey input_b = {
     {TrafficLightElement::RED, TrafficLightElement::UP_ARROW},
     {TrafficLightElement::RED, TrafficLightElement::DOWN_LEFT_ARROW}};
 
-  ConflictStatus result = validator.check_conflict(input_a, input_b);
+  ConflictStatus result = check_conflict(input_a, input_b);
 
   // output expectations
   ConflictType expected_conflict_type = ConflictType::PARTIAL_CONFLICT;
@@ -479,12 +473,12 @@ TEST_F(SignalValidatorCheckConflict, RedDownleftarrow_RedUparrowRedDownleftarrow
 
 // unknown input
 // -> no conflict (unknown should be treated as invalid detection)
-TEST_F(SignalValidatorCheckConflict, RedCircle_Unknown)
+TEST(CheckConflict, RedCircle_Unknown)
 {
   StateKey input_a = {{TrafficLightElement::RED, TrafficLightElement::CIRCLE}};
   StateKey input_b = {{TrafficLightElement::UNKNOWN, TrafficLightElement::UNKNOWN}};
 
-  ConflictStatus result = validator.check_conflict(input_a, input_b);
+  ConflictStatus result = check_conflict(input_a, input_b);
 
   // output expectations
   ConflictType expected_conflict_type = ConflictType::NO_CONFLICT;
@@ -496,12 +490,12 @@ TEST_F(SignalValidatorCheckConflict, RedCircle_Unknown)
 
 // unknown input
 // -> no conflict (unknown should be treated as invalid detection)
-TEST_F(SignalValidatorCheckConflict, RedUparrow_Unknown)
+TEST(CheckConflict, RedUparrow_Unknown)
 {
   StateKey input_a = {{TrafficLightElement::RED, TrafficLightElement::UP_ARROW}};
   StateKey input_b = {{TrafficLightElement::UNKNOWN, TrafficLightElement::UNKNOWN}};
 
-  ConflictStatus result = validator.check_conflict(input_a, input_b);
+  ConflictStatus result = check_conflict(input_a, input_b);
 
   // output expectations
   ConflictType expected_conflict_type = ConflictType::NO_CONFLICT;
@@ -513,12 +507,12 @@ TEST_F(SignalValidatorCheckConflict, RedUparrow_Unknown)
 
 // both unknown inputs
 // -> no conflict (unknown should be treated as invalid detection)
-TEST_F(SignalValidatorCheckConflict, Unknown_Unknown)
+TEST(CheckConflict, Unknown_Unknown)
 {
   StateKey input_a = {{TrafficLightElement::UNKNOWN, TrafficLightElement::UNKNOWN}};
   StateKey input_b = {{TrafficLightElement::UNKNOWN, TrafficLightElement::UNKNOWN}};
 
-  ConflictStatus result = validator.check_conflict(input_a, input_b);
+  ConflictStatus result = check_conflict(input_a, input_b);
 
   // output expectations
   ConflictType expected_conflict_type = ConflictType::NO_CONFLICT;
@@ -531,12 +525,12 @@ TEST_F(SignalValidatorCheckConflict, Unknown_Unknown)
 
 // missing input
 // -> no conflict
-TEST_F(SignalValidatorCheckConflict, RedCircle_NoDetection)
+TEST(CheckConflict, RedCircle_NoDetection)
 {
   StateKey input_a = {{TrafficLightElement::RED, TrafficLightElement::CIRCLE}};
   StateKey input_b = {};
 
-  ConflictStatus result = validator.check_conflict(input_a, input_b);
+  ConflictStatus result = check_conflict(input_a, input_b);
 
   // output expectations
   ConflictType expected_conflict_type = ConflictType::NO_CONFLICT;
@@ -548,12 +542,12 @@ TEST_F(SignalValidatorCheckConflict, RedCircle_NoDetection)
 
 // missing input (swapped input)
 // -> no conflict
-TEST_F(SignalValidatorCheckConflict, NoDetection_RedCircle)
+TEST(CheckConflict, NoDetection_RedCircle)
 {
   StateKey input_a = {};
   StateKey input_b = {{TrafficLightElement::RED, TrafficLightElement::CIRCLE}};
 
-  ConflictStatus result = validator.check_conflict(input_a, input_b);
+  ConflictStatus result = check_conflict(input_a, input_b);
 
   // output expectations
   ConflictType expected_conflict_type = ConflictType::NO_CONFLICT;
@@ -565,12 +559,12 @@ TEST_F(SignalValidatorCheckConflict, NoDetection_RedCircle)
 
 // missing input with arrow
 // -> no conflict
-TEST_F(SignalValidatorCheckConflict, RedUparrow_NoDetection)
+TEST(CheckConflict, RedUparrow_NoDetection)
 {
   StateKey input_a = {{TrafficLightElement::RED, TrafficLightElement::UP_ARROW}};
   StateKey input_b = {};
 
-  ConflictStatus result = validator.check_conflict(input_a, input_b);
+  ConflictStatus result = check_conflict(input_a, input_b);
 
   // output expectations
   ConflictType expected_conflict_type = ConflictType::NO_CONFLICT;
@@ -582,14 +576,14 @@ TEST_F(SignalValidatorCheckConflict, RedUparrow_NoDetection)
 
 // inputs with unknown and missing
 // -> no conflict
-TEST_F(SignalValidatorCheckConflict, Unknown_NoDetection)
+TEST(CheckConflict, Unknown_NoDetection)
 {
   StateKey input_a = {{TrafficLightElement::UNKNOWN, TrafficLightElement::UNKNOWN}};
   StateKey input_b = {};
 
   // unknown and missing inputs will be treated as same,
   // but the returned state key depend on the input order
-  ConflictStatus result = validator.check_conflict(input_a, input_b);
+  ConflictStatus result = check_conflict(input_a, input_b);
 
   // output expectations
   ConflictType expected_conflict_type = ConflictType::NO_CONFLICT;
@@ -602,14 +596,14 @@ TEST_F(SignalValidatorCheckConflict, Unknown_NoDetection)
 
 // inputs with unknown and missing (swapped input)
 // -> no conflict
-TEST_F(SignalValidatorCheckConflict, NoDetection_Unknown)
+TEST(CheckConflict, NoDetection_Unknown)
 {
   StateKey input_a = {};
   StateKey input_b = {{TrafficLightElement::UNKNOWN, TrafficLightElement::UNKNOWN}};
 
   // unknown and missing inputs will be treated as same,
   // but the returned state key depend on the input order
-  ConflictStatus result = validator.check_conflict(input_a, input_b);
+  ConflictStatus result = check_conflict(input_a, input_b);
 
   // output expectations
   ConflictType expected_conflict_type = ConflictType::NO_CONFLICT;
@@ -624,14 +618,14 @@ TEST_F(SignalValidatorCheckConflict, NoDetection_Unknown)
 
 // duplicated circle signal input
 // -> partial conflict
-TEST_F(SignalValidatorCheckConflict, RedCircleRedCircle_RedCircle)
+TEST(CheckConflict, RedCircleRedCircle_RedCircle)
 {
   StateKey input_a = {
     {TrafficLightElement::RED, TrafficLightElement::CIRCLE},
     {TrafficLightElement::RED, TrafficLightElement::CIRCLE}};
   StateKey input_b = {{TrafficLightElement::RED, TrafficLightElement::CIRCLE}};
 
-  ConflictStatus result = validator.check_conflict(input_a, input_b);
+  ConflictStatus result = check_conflict(input_a, input_b);
 
   // output expectations
   ConflictType expected_conflict_type = ConflictType::PARTIAL_CONFLICT;
@@ -643,14 +637,14 @@ TEST_F(SignalValidatorCheckConflict, RedCircleRedCircle_RedCircle)
 
 // mutiple same shape signal input
 // -> partial conflict
-TEST_F(SignalValidatorCheckConflict, RedCircleGreenCircle_RedCircle)
+TEST(CheckConflict, RedCircleGreenCircle_RedCircle)
 {
   StateKey input_a = {
     {TrafficLightElement::RED, TrafficLightElement::CIRCLE},
     {TrafficLightElement::GREEN, TrafficLightElement::CIRCLE}};
   StateKey input_b = {{TrafficLightElement::RED, TrafficLightElement::CIRCLE}};
 
-  ConflictStatus result = validator.check_conflict(input_a, input_b);
+  ConflictStatus result = check_conflict(input_a, input_b);
 
   // output expectations
   ConflictType expected_conflict_type = ConflictType::PARTIAL_CONFLICT;
@@ -662,9 +656,7 @@ TEST_F(SignalValidatorCheckConflict, RedCircleGreenCircle_RedCircle)
 
 // duplicated arrow signal input
 // -> no conflict
-TEST_F(
-  SignalValidatorCheckConflict,
-  RedCircleGreenDownrightarrow_RedCircleGreenDownrightarrowGreenDownrightarrow)
+TEST(CheckConflict, RedCircleGreenDownrightarrow_RedCircleGreenDownrightarrowGreenDownrightarrow)
 {
   StateKey input_a = {
     {TrafficLightElement::RED, TrafficLightElement::CIRCLE},
@@ -674,7 +666,7 @@ TEST_F(
     {TrafficLightElement::GREEN, TrafficLightElement::DOWN_RIGHT_ARROW},
     {TrafficLightElement::GREEN, TrafficLightElement::DOWN_RIGHT_ARROW}};
 
-  ConflictStatus result = validator.check_conflict(input_a, input_b);
+  ConflictStatus result = check_conflict(input_a, input_b);
 
   // output expectations
   ConflictType expected_conflict_type = ConflictType::PARTIAL_CONFLICT;
@@ -691,12 +683,12 @@ TEST_F(
 
 // input_b is empty
 // empty input will treated as unknown prediction
-TEST_F(SignalValidatorCheckConflict, EmptyInputs_1)
+TEST(CheckConflict, EmptyInputs_1)
 {
   StateKey input_a = {{TrafficLightElement::RED, TrafficLightElement::CIRCLE}};
   StateKey input_b = {};
 
-  ConflictStatus result = validator.check_conflict(input_a, input_b);
+  ConflictStatus result = check_conflict(input_a, input_b);
 
   // output expectations
   ConflictType expected_conflict_type = ConflictType::NO_CONFLICT;
@@ -708,12 +700,12 @@ TEST_F(SignalValidatorCheckConflict, EmptyInputs_1)
 
 // input_a is empty
 // empty input will treated as unknown prediction
-TEST_F(SignalValidatorCheckConflict, EmptyInputs_2)
+TEST(CheckConflict, EmptyInputs_2)
 {
   StateKey input_a = {};
   StateKey input_b = {{TrafficLightElement::RED, TrafficLightElement::CIRCLE}};
 
-  ConflictStatus result = validator.check_conflict(input_a, input_b);
+  ConflictStatus result = check_conflict(input_a, input_b);
 
   // output expectations
   ConflictType expected_conflict_type = ConflictType::NO_CONFLICT;
@@ -724,12 +716,12 @@ TEST_F(SignalValidatorCheckConflict, EmptyInputs_2)
 }
 
 // both are empty
-TEST_F(SignalValidatorCheckConflict, EmptyInputs_3)
+TEST(CheckConflict, EmptyInputs_3)
 {
   StateKey input_a = {};
   StateKey input_b = {};
 
-  ConflictStatus result = validator.check_conflict(input_a, input_b);
+  ConflictStatus result = check_conflict(input_a, input_b);
 
   // output expectations
   ConflictType expected_conflict_type = ConflictType::NO_CONFLICT;

--- a/perception/autoware_traffic_light_multi_camera_fusion/test/test_signal_validator.cpp
+++ b/perception/autoware_traffic_light_multi_camera_fusion/test/test_signal_validator.cpp
@@ -41,7 +41,7 @@ TEST_F(SignalValidatorCheckConflict, RedCircle_RedCircle)
   StateKey input_a = {{TrafficLightElement::RED, TrafficLightElement::CIRCLE}};
   StateKey input_b = {{TrafficLightElement::RED, TrafficLightElement::CIRCLE}};
 
-  ConflictStatus result = validator.checkConflict(input_a, input_b);
+  ConflictStatus result = validator.check_conflict(input_a, input_b);
 
   // output expectations
   ConflictType expected_conflict_type = ConflictType::NO_CONFLICT;
@@ -58,7 +58,7 @@ TEST_F(SignalValidatorCheckConflict, RedCircle_GreenCircle)
   StateKey input_a = {{TrafficLightElement::RED, TrafficLightElement::CIRCLE}};
   StateKey input_b = {{TrafficLightElement::GREEN, TrafficLightElement::CIRCLE}};
 
-  ConflictStatus result = validator.checkConflict(input_a, input_b);
+  ConflictStatus result = validator.check_conflict(input_a, input_b);
 
   // output expectations
   ConflictType expected_conflict_type = ConflictType::CONFLICT;
@@ -76,7 +76,7 @@ TEST_F(SignalValidatorCheckConflict, GreenCircle_RedCircle)
   StateKey input_a = {{TrafficLightElement::GREEN, TrafficLightElement::CIRCLE}};
   StateKey input_b = {{TrafficLightElement::RED, TrafficLightElement::CIRCLE}};
 
-  ConflictStatus result = validator.checkConflict(input_a, input_b);
+  ConflictStatus result = validator.check_conflict(input_a, input_b);
 
   // output expectations
   ConflictType expected_conflict_type = ConflictType::CONFLICT;
@@ -97,7 +97,7 @@ TEST_F(SignalValidatorCheckConflict, RedCircleGreenLeftarrow_RedCircleGreenLefta
     {TrafficLightElement::RED, TrafficLightElement::CIRCLE},
     {TrafficLightElement::GREEN, TrafficLightElement::LEFT_ARROW}};
 
-  ConflictStatus result = validator.checkConflict(input_a, input_b);
+  ConflictStatus result = validator.check_conflict(input_a, input_b);
 
   // output expectations
   ConflictType expected_conflict_type = ConflictType::NO_CONFLICT;
@@ -126,7 +126,7 @@ TEST_F(SignalValidatorCheckConflict, RedCircleMultipleMatchedArrows_RedCircleMul
     {TrafficLightElement::GREEN, TrafficLightElement::RIGHT_ARROW},
     {TrafficLightElement::GREEN, TrafficLightElement::DOWN_LEFT_ARROW}};
 
-  ConflictStatus result = validator.checkConflict(input_a, input_b);
+  ConflictStatus result = validator.check_conflict(input_a, input_b);
 
   // output expectations
   ConflictType expected_conflict_type = ConflictType::NO_CONFLICT;
@@ -154,7 +154,7 @@ TEST_F(SignalValidatorCheckConflict, RedCircleGreenLeftarrow_GreenCircleGreenLef
     {TrafficLightElement::GREEN, TrafficLightElement::LEFT_ARROW},
   };
 
-  ConflictStatus result = validator.checkConflict(input_a, input_b);
+  ConflictStatus result = validator.check_conflict(input_a, input_b);
 
   // output expectations
   ConflictType expected_conflict_type = ConflictType::PARTIAL_CONFLICT;
@@ -178,7 +178,7 @@ TEST_F(SignalValidatorCheckConflict, RedCircleGreenLeftarrow_RedCircleRedLeftarr
     {TrafficLightElement::RED, TrafficLightElement::LEFT_ARROW},
   };
 
-  ConflictStatus result = validator.checkConflict(input_a, input_b);
+  ConflictStatus result = validator.check_conflict(input_a, input_b);
 
   // output expectations
   ConflictType expected_conflict_type = ConflictType::PARTIAL_CONFLICT;
@@ -199,7 +199,7 @@ TEST_F(SignalValidatorCheckConflict, GreenLeftarrowRedCircle_RedCircle)
     {TrafficLightElement::RED, TrafficLightElement::CIRCLE},
   };
 
-  ConflictStatus result = validator.checkConflict(input_a, input_b);
+  ConflictStatus result = validator.check_conflict(input_a, input_b);
 
   // output expectations
   ConflictType expected_conflict_type = ConflictType::PARTIAL_CONFLICT;
@@ -220,7 +220,7 @@ TEST_F(SignalValidatorCheckConflict, RedCircle_GreenLeftarrowRedCircle)
     {TrafficLightElement::GREEN, TrafficLightElement::LEFT_ARROW},
     {TrafficLightElement::RED, TrafficLightElement::CIRCLE}};
 
-  ConflictStatus result = validator.checkConflict(input_a, input_b);
+  ConflictStatus result = validator.check_conflict(input_a, input_b);
 
   // output expectations
   ConflictType expected_conflict_type = ConflictType::PARTIAL_CONFLICT;
@@ -247,7 +247,7 @@ TEST_F(SignalValidatorCheckConflict, RedCircleMultipleArrows_RedCircleMultipleAr
     {TrafficLightElement::GREEN, TrafficLightElement::RIGHT_ARROW},
     {TrafficLightElement::GREEN, TrafficLightElement::DOWN_ARROW}};
 
-  ConflictStatus result = validator.checkConflict(input_a, input_b);
+  ConflictStatus result = validator.check_conflict(input_a, input_b);
 
   // output expectations
   ConflictType expected_conflict_type = ConflictType::PARTIAL_CONFLICT;
@@ -271,7 +271,7 @@ TEST_F(SignalValidatorCheckConflict, RedCircleGreendownarrow_GreenUparrow)
     {TrafficLightElement::GREEN, TrafficLightElement::DOWN_ARROW}};
   StateKey input_b = {{TrafficLightElement::GREEN, TrafficLightElement::UP_ARROW}};
 
-  ConflictStatus result = validator.checkConflict(input_a, input_b);
+  ConflictStatus result = validator.check_conflict(input_a, input_b);
 
   // output expectations
   ConflictType expected_conflict_type = ConflictType::CONFLICT;
@@ -291,7 +291,7 @@ TEST_F(SignalValidatorCheckConflict, WhiteCross_WhiteCross)
   StateKey input_a = {{TrafficLightElement::WHITE, TrafficLightElement::CROSS}};
   StateKey input_b = {{TrafficLightElement::WHITE, TrafficLightElement::CROSS}};
 
-  ConflictStatus result = validator.checkConflict(input_a, input_b);
+  ConflictStatus result = validator.check_conflict(input_a, input_b);
 
   // output expectations
   ConflictType expected_conflict_type = ConflictType::NO_CONFLICT;
@@ -308,7 +308,7 @@ TEST_F(SignalValidatorCheckConflict, WhiteCross_WhiteCIRCLE)
   StateKey input_a = {{TrafficLightElement::WHITE, TrafficLightElement::CROSS}};
   StateKey input_b = {{TrafficLightElement::WHITE, TrafficLightElement::CIRCLE}};
 
-  ConflictStatus result = validator.checkConflict(input_a, input_b);
+  ConflictStatus result = validator.check_conflict(input_a, input_b);
 
   // output expectations
   ConflictType expected_conflict_type = ConflictType::CONFLICT;
@@ -327,7 +327,7 @@ TEST_F(SignalValidatorCheckConflict, AmberCross_AmberCrossGreenUparrow)
     {TrafficLightElement::AMBER, TrafficLightElement::CROSS},
     {TrafficLightElement::GREEN, TrafficLightElement::UP_ARROW}};
 
-  ConflictStatus result = validator.checkConflict(input_a, input_b);
+  ConflictStatus result = validator.check_conflict(input_a, input_b);
 
   // output expectations
   ConflictType expected_conflict_type = ConflictType::PARTIAL_CONFLICT;
@@ -348,7 +348,7 @@ TEST_F(SignalValidatorCheckConflict, AllMismatch)
     {TrafficLightElement::GREEN, TrafficLightElement::LEFT_ARROW},
   };
 
-  ConflictStatus result = validator.checkConflict(input_a, input_b);
+  ConflictStatus result = validator.check_conflict(input_a, input_b);
 
   StateKey expected_common_state_key = {};
 
@@ -366,7 +366,7 @@ TEST_F(SignalValidatorCheckConflict, GreenUparrow_GreenUparrow)
   StateKey input_a = {{TrafficLightElement::GREEN, TrafficLightElement::UP_ARROW}};
   StateKey input_b = {{TrafficLightElement::GREEN, TrafficLightElement::UP_ARROW}};
 
-  ConflictStatus result = validator.checkConflict(input_a, input_b);
+  ConflictStatus result = validator.check_conflict(input_a, input_b);
 
   // output expectations
   ConflictType expected_conflict_type = ConflictType::NO_CONFLICT;
@@ -388,7 +388,7 @@ TEST_F(SignalValidatorCheckConflict, GreenUparrowGreenRightarrow_GreenUparrowGre
     {TrafficLightElement::GREEN, TrafficLightElement::UP_ARROW},
     {TrafficLightElement::GREEN, TrafficLightElement::RIGHT_ARROW}};
 
-  ConflictStatus result = validator.checkConflict(input_a, input_b);
+  ConflictStatus result = validator.check_conflict(input_a, input_b);
 
   // output expectations
   ConflictType expected_conflict_type = ConflictType::NO_CONFLICT;
@@ -407,7 +407,7 @@ TEST_F(SignalValidatorCheckConflict, RedUparrow_GreenUparrow)
   StateKey input_a = {{TrafficLightElement::RED, TrafficLightElement::UP_ARROW}};
   StateKey input_b = {{TrafficLightElement::GREEN, TrafficLightElement::UP_ARROW}};
 
-  ConflictStatus result = validator.checkConflict(input_a, input_b);
+  ConflictStatus result = validator.check_conflict(input_a, input_b);
 
   // output expectations
   ConflictType expected_conflict_type = ConflictType::CONFLICT;
@@ -424,7 +424,7 @@ TEST_F(SignalValidatorCheckConflict, RedUparrow_RedDownleftarrow)
   StateKey input_a = {{TrafficLightElement::RED, TrafficLightElement::UP_ARROW}};
   StateKey input_b = {{TrafficLightElement::RED, TrafficLightElement::DOWN_LEFT_ARROW}};
 
-  ConflictStatus result = validator.checkConflict(input_a, input_b);
+  ConflictStatus result = validator.check_conflict(input_a, input_b);
 
   // output expectations
   ConflictType expected_conflict_type = ConflictType::CONFLICT;
@@ -443,7 +443,7 @@ TEST_F(SignalValidatorCheckConflict, RedUparrowRedDownleftarrow_RedDownleftarrow
     {TrafficLightElement::RED, TrafficLightElement::DOWN_LEFT_ARROW}};
   StateKey input_b = {{TrafficLightElement::RED, TrafficLightElement::DOWN_LEFT_ARROW}};
 
-  ConflictStatus result = validator.checkConflict(input_a, input_b);
+  ConflictStatus result = validator.check_conflict(input_a, input_b);
 
   // output expectations
   ConflictType expected_conflict_type = ConflictType::PARTIAL_CONFLICT;
@@ -463,7 +463,7 @@ TEST_F(SignalValidatorCheckConflict, RedDownleftarrow_RedUparrowRedDownleftarrow
     {TrafficLightElement::RED, TrafficLightElement::UP_ARROW},
     {TrafficLightElement::RED, TrafficLightElement::DOWN_LEFT_ARROW}};
 
-  ConflictStatus result = validator.checkConflict(input_a, input_b);
+  ConflictStatus result = validator.check_conflict(input_a, input_b);
 
   // output expectations
   ConflictType expected_conflict_type = ConflictType::PARTIAL_CONFLICT;
@@ -484,7 +484,7 @@ TEST_F(SignalValidatorCheckConflict, RedCircle_Unknown)
   StateKey input_a = {{TrafficLightElement::RED, TrafficLightElement::CIRCLE}};
   StateKey input_b = {{TrafficLightElement::UNKNOWN, TrafficLightElement::UNKNOWN}};
 
-  ConflictStatus result = validator.checkConflict(input_a, input_b);
+  ConflictStatus result = validator.check_conflict(input_a, input_b);
 
   // output expectations
   ConflictType expected_conflict_type = ConflictType::NO_CONFLICT;
@@ -501,7 +501,7 @@ TEST_F(SignalValidatorCheckConflict, RedUparrow_Unknown)
   StateKey input_a = {{TrafficLightElement::RED, TrafficLightElement::UP_ARROW}};
   StateKey input_b = {{TrafficLightElement::UNKNOWN, TrafficLightElement::UNKNOWN}};
 
-  ConflictStatus result = validator.checkConflict(input_a, input_b);
+  ConflictStatus result = validator.check_conflict(input_a, input_b);
 
   // output expectations
   ConflictType expected_conflict_type = ConflictType::NO_CONFLICT;
@@ -518,7 +518,7 @@ TEST_F(SignalValidatorCheckConflict, Unknown_Unknown)
   StateKey input_a = {{TrafficLightElement::UNKNOWN, TrafficLightElement::UNKNOWN}};
   StateKey input_b = {{TrafficLightElement::UNKNOWN, TrafficLightElement::UNKNOWN}};
 
-  ConflictStatus result = validator.checkConflict(input_a, input_b);
+  ConflictStatus result = validator.check_conflict(input_a, input_b);
 
   // output expectations
   ConflictType expected_conflict_type = ConflictType::NO_CONFLICT;
@@ -536,7 +536,7 @@ TEST_F(SignalValidatorCheckConflict, RedCircle_NoDetection)
   StateKey input_a = {{TrafficLightElement::RED, TrafficLightElement::CIRCLE}};
   StateKey input_b = {};
 
-  ConflictStatus result = validator.checkConflict(input_a, input_b);
+  ConflictStatus result = validator.check_conflict(input_a, input_b);
 
   // output expectations
   ConflictType expected_conflict_type = ConflictType::NO_CONFLICT;
@@ -553,7 +553,7 @@ TEST_F(SignalValidatorCheckConflict, NoDetection_RedCircle)
   StateKey input_a = {};
   StateKey input_b = {{TrafficLightElement::RED, TrafficLightElement::CIRCLE}};
 
-  ConflictStatus result = validator.checkConflict(input_a, input_b);
+  ConflictStatus result = validator.check_conflict(input_a, input_b);
 
   // output expectations
   ConflictType expected_conflict_type = ConflictType::NO_CONFLICT;
@@ -570,7 +570,7 @@ TEST_F(SignalValidatorCheckConflict, RedUparrow_NoDetection)
   StateKey input_a = {{TrafficLightElement::RED, TrafficLightElement::UP_ARROW}};
   StateKey input_b = {};
 
-  ConflictStatus result = validator.checkConflict(input_a, input_b);
+  ConflictStatus result = validator.check_conflict(input_a, input_b);
 
   // output expectations
   ConflictType expected_conflict_type = ConflictType::NO_CONFLICT;
@@ -589,7 +589,7 @@ TEST_F(SignalValidatorCheckConflict, Unknown_NoDetection)
 
   // unknown and missing inputs will be treated as same,
   // but the returned state key depend on the input order
-  ConflictStatus result = validator.checkConflict(input_a, input_b);
+  ConflictStatus result = validator.check_conflict(input_a, input_b);
 
   // output expectations
   ConflictType expected_conflict_type = ConflictType::NO_CONFLICT;
@@ -609,7 +609,7 @@ TEST_F(SignalValidatorCheckConflict, NoDetection_Unknown)
 
   // unknown and missing inputs will be treated as same,
   // but the returned state key depend on the input order
-  ConflictStatus result = validator.checkConflict(input_a, input_b);
+  ConflictStatus result = validator.check_conflict(input_a, input_b);
 
   // output expectations
   ConflictType expected_conflict_type = ConflictType::NO_CONFLICT;
@@ -631,7 +631,7 @@ TEST_F(SignalValidatorCheckConflict, RedCircleRedCircle_RedCircle)
     {TrafficLightElement::RED, TrafficLightElement::CIRCLE}};
   StateKey input_b = {{TrafficLightElement::RED, TrafficLightElement::CIRCLE}};
 
-  ConflictStatus result = validator.checkConflict(input_a, input_b);
+  ConflictStatus result = validator.check_conflict(input_a, input_b);
 
   // output expectations
   ConflictType expected_conflict_type = ConflictType::PARTIAL_CONFLICT;
@@ -650,7 +650,7 @@ TEST_F(SignalValidatorCheckConflict, RedCircleGreenCircle_RedCircle)
     {TrafficLightElement::GREEN, TrafficLightElement::CIRCLE}};
   StateKey input_b = {{TrafficLightElement::RED, TrafficLightElement::CIRCLE}};
 
-  ConflictStatus result = validator.checkConflict(input_a, input_b);
+  ConflictStatus result = validator.check_conflict(input_a, input_b);
 
   // output expectations
   ConflictType expected_conflict_type = ConflictType::PARTIAL_CONFLICT;
@@ -674,7 +674,7 @@ TEST_F(
     {TrafficLightElement::GREEN, TrafficLightElement::DOWN_RIGHT_ARROW},
     {TrafficLightElement::GREEN, TrafficLightElement::DOWN_RIGHT_ARROW}};
 
-  ConflictStatus result = validator.checkConflict(input_a, input_b);
+  ConflictStatus result = validator.check_conflict(input_a, input_b);
 
   // output expectations
   ConflictType expected_conflict_type = ConflictType::PARTIAL_CONFLICT;
@@ -696,7 +696,7 @@ TEST_F(SignalValidatorCheckConflict, EmptyInputs_1)
   StateKey input_a = {{TrafficLightElement::RED, TrafficLightElement::CIRCLE}};
   StateKey input_b = {};
 
-  ConflictStatus result = validator.checkConflict(input_a, input_b);
+  ConflictStatus result = validator.check_conflict(input_a, input_b);
 
   // output expectations
   ConflictType expected_conflict_type = ConflictType::NO_CONFLICT;
@@ -713,7 +713,7 @@ TEST_F(SignalValidatorCheckConflict, EmptyInputs_2)
   StateKey input_a = {};
   StateKey input_b = {{TrafficLightElement::RED, TrafficLightElement::CIRCLE}};
 
-  ConflictStatus result = validator.checkConflict(input_a, input_b);
+  ConflictStatus result = validator.check_conflict(input_a, input_b);
 
   // output expectations
   ConflictType expected_conflict_type = ConflictType::NO_CONFLICT;
@@ -729,7 +729,7 @@ TEST_F(SignalValidatorCheckConflict, EmptyInputs_3)
   StateKey input_a = {};
   StateKey input_b = {};
 
-  ConflictStatus result = validator.checkConflict(input_a, input_b);
+  ConflictStatus result = validator.check_conflict(input_a, input_b);
 
   // output expectations
   ConflictType expected_conflict_type = ConflictType::NO_CONFLICT;

--- a/perception/autoware_traffic_light_multi_camera_fusion/test/test_traffic_light_multi_camera_fusion_node.cpp
+++ b/perception/autoware_traffic_light_multi_camera_fusion/test/test_traffic_light_multi_camera_fusion_node.cpp
@@ -36,7 +36,7 @@
 #include <thread>
 #include <vector>
 
-using autoware::traffic_light::MultiCameraFusion;
+using autoware::traffic_light::MultiCameraFusionNode;
 using autoware_map_msgs::msg::LaneletMapBin;
 using autoware_perception_msgs::msg::TrafficLightGroupArray;
 using sensor_msgs::msg::CameraInfo;
@@ -109,7 +109,7 @@ protected:
       "signal_consistency_check.publish_partial_matched_signal",
       options.publish_partial_matched_signal);
 
-    node_ = std::make_shared<MultiCameraFusion>(node_options);
+    node_ = std::make_shared<MultiCameraFusionNode>(node_options);
     executor_->add_node(node_);
   }
 
@@ -221,7 +221,7 @@ protected:
     publish_signal(camera_index, stamp, frame_id, traffic_light_id, color, confidence);
   }
 
-  std::shared_ptr<MultiCameraFusion> node_;
+  std::shared_ptr<MultiCameraFusionNode> node_;
   std::shared_ptr<rclcpp::Node> test_node_;
   std::shared_ptr<rclcpp::executors::SingleThreadedExecutor> executor_;
 

--- a/perception/autoware_traffic_light_multi_camera_fusion/test/test_traffic_light_multi_camera_fusion_node.cpp
+++ b/perception/autoware_traffic_light_multi_camera_fusion/test/test_traffic_light_multi_camera_fusion_node.cpp
@@ -1,0 +1,375 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "../src/traffic_light_multi_camera_fusion_node.hpp"
+
+#include <autoware/lanelet2_utils/conversion.hpp>
+#include <autoware_lanelet2_extension/regulatory_elements/autoware_traffic_light.hpp>
+#include <rclcpp/rclcpp.hpp>
+
+#include <autoware_map_msgs/msg/lanelet_map_bin.hpp>
+#include <autoware_perception_msgs/msg/traffic_light_group_array.hpp>
+#include <sensor_msgs/msg/camera_info.hpp>
+#include <tier4_perception_msgs/msg/traffic_light_array.hpp>
+#include <tier4_perception_msgs/msg/traffic_light_roi_array.hpp>
+
+#include <gtest/gtest.h>
+#include <lanelet2_core/LaneletMap.h>
+#include <lanelet2_core/primitives/Lanelet.h>
+#include <lanelet2_core/primitives/LineString.h>
+#include <lanelet2_core/primitives/Point.h>
+
+#include <chrono>
+#include <memory>
+#include <string>
+#include <thread>
+#include <vector>
+
+using autoware::traffic_light::MultiCameraFusion;
+using autoware_map_msgs::msg::LaneletMapBin;
+using autoware_perception_msgs::msg::TrafficLightGroupArray;
+using sensor_msgs::msg::CameraInfo;
+using tier4_perception_msgs::msg::TrafficLight;
+using tier4_perception_msgs::msg::TrafficLightArray;
+using tier4_perception_msgs::msg::TrafficLightElement;
+using tier4_perception_msgs::msg::TrafficLightRoi;
+using tier4_perception_msgs::msg::TrafficLightRoiArray;
+
+// IDs assigned to map elements. The two traffic-light line strings (*_TRAFFIC_LIGHT_ID) are
+// bound to the same regulatory element (REGULATORY_ELEMENT_ID); the node groups them into a
+// single output.
+constexpr lanelet::Id LEFT_TRAFFIC_LIGHT_ID = 11;
+constexpr lanelet::Id RIGHT_TRAFFIC_LIGHT_ID = 12;
+constexpr lanelet::Id REGULATORY_ELEMENT_ID = 100;
+
+struct FusionNodeOptions
+{
+  std::vector<std::string> camera_namespaces{"camera0", "camera1"};
+  bool approximate_sync = true;
+  double message_lifespan = 1.0;
+  double prior_log_odds = 0.0;
+  bool consistency_check_enable = false;
+  bool publish_partial_matched_signal = false;
+};
+
+class MultiCameraFusionIntegrationTest : public ::testing::Test
+{
+protected:
+  void SetUp() override
+  {
+    rclcpp::init(0, nullptr);
+
+    test_node_ = std::make_shared<rclcpp::Node>("test_node");
+
+    executor_ = std::make_shared<rclcpp::executors::SingleThreadedExecutor>();
+    executor_->add_node(test_node_);
+
+    map_publisher_ = test_node_->create_publisher<LaneletMapBin>(
+      "/traffic_light_multi_camera_fusion/input/vector_map", rclcpp::QoS(1).transient_local());
+
+    const std::vector<std::string> camera_namespaces = {"camera0", "camera1"};
+    for (const auto & camera_namespace : camera_namespaces) {
+      camera_info_publishers_.push_back(test_node_->create_publisher<CameraInfo>(
+        "/" + camera_namespace + "/camera_info", rclcpp::SensorDataQoS()));
+      roi_publishers_.push_back(test_node_->create_publisher<TrafficLightRoiArray>(
+        "/" + camera_namespace + "/detection/rois", rclcpp::QoS(1)));
+      signal_publishers_.push_back(test_node_->create_publisher<TrafficLightArray>(
+        "/" + camera_namespace + "/classification/traffic_signals", rclcpp::QoS(1)));
+    }
+
+    output_subscription_ = test_node_->create_subscription<TrafficLightGroupArray>(
+      "/traffic_light_multi_camera_fusion/output/traffic_signals", rclcpp::QoS(1),
+      [this](const TrafficLightGroupArray::SharedPtr message) {
+        received_message_ = message;
+        message_received_ = true;
+      });
+  }
+
+  void initialize_fusion_node(const FusionNodeOptions & options)
+  {
+    rclcpp::NodeOptions node_options;
+    node_options.append_parameter_override("camera_namespaces", options.camera_namespaces);
+    node_options.append_parameter_override("approximate_sync", options.approximate_sync);
+    node_options.append_parameter_override("message_lifespan", options.message_lifespan);
+    node_options.append_parameter_override("prior_log_odds", options.prior_log_odds);
+    node_options.append_parameter_override(
+      "signal_consistency_check.enable", options.consistency_check_enable);
+    node_options.append_parameter_override(
+      "signal_consistency_check.publish_partial_matched_signal",
+      options.publish_partial_matched_signal);
+
+    node_ = std::make_shared<MultiCameraFusion>(node_options);
+    executor_->add_node(node_);
+  }
+
+  void TearDown() override
+  {
+    executor_.reset();
+    output_subscription_.reset();
+    camera_info_publishers_.clear();
+    roi_publishers_.clear();
+    signal_publishers_.clear();
+    map_publisher_.reset();
+    test_node_.reset();
+    node_.reset();
+    rclcpp::shutdown();
+  }
+
+  bool wait_for_message(std::chrono::milliseconds timeout = std::chrono::milliseconds(3000))
+  {
+    auto start = std::chrono::steady_clock::now();
+    message_received_ = false;
+    while (!message_received_) {
+      if (std::chrono::steady_clock::now() - start > timeout) {
+        return false;
+      }
+      executor_->spin_some();
+      std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+    return true;
+  }
+
+  void spin_for(std::chrono::milliseconds duration)
+  {
+    auto start = std::chrono::steady_clock::now();
+    while (std::chrono::steady_clock::now() - start < duration) {
+      executor_->spin_some();
+      std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+  }
+
+  void publish_map(const LaneletMapBin & map_bin)
+  {
+    map_publisher_->publish(map_bin);
+    spin_for(std::chrono::milliseconds(100));
+  }
+
+  void publish_camera_info(
+    size_t camera_index, const rclcpp::Time & stamp, const std::string & frame_id)
+  {
+    CameraInfo camera_info;
+    camera_info.header.stamp = stamp;
+    camera_info.header.frame_id = frame_id;
+    camera_info.width = 1920;
+    camera_info.height = 1080;
+
+    camera_info_publishers_[camera_index]->publish(camera_info);
+  }
+
+  void publish_roi(
+    size_t camera_index, const rclcpp::Time & stamp, const std::string & frame_id,
+    lanelet::Id traffic_light_id)
+  {
+    TrafficLightRoi roi;
+    roi.traffic_light_id = static_cast<TrafficLightRoi::_traffic_light_id_type>(traffic_light_id);
+    roi.traffic_light_type = 0;
+    // ROI placed well inside the image so the visibility score is maximal.
+    roi.roi.x_offset = 100;
+    roi.roi.y_offset = 100;
+    roi.roi.width = 50;
+    roi.roi.height = 50;
+
+    TrafficLightRoiArray roi_array;
+    roi_array.header.stamp = stamp;
+    roi_array.header.frame_id = frame_id;
+    roi_array.rois.push_back(roi);
+
+    roi_publishers_[camera_index]->publish(roi_array);
+  }
+
+  void publish_signal(
+    size_t camera_index, const rclcpp::Time & stamp, const std::string & frame_id,
+    lanelet::Id traffic_light_id, uint8_t color, float confidence)
+  {
+    TrafficLightElement element;
+    element.color = color;
+    element.shape = TrafficLightElement::CIRCLE;
+    element.status = TrafficLightElement::SOLID_ON;
+    element.confidence = confidence;
+
+    TrafficLight signal;
+    signal.traffic_light_id = static_cast<TrafficLight::_traffic_light_id_type>(traffic_light_id);
+    signal.elements.push_back(element);
+
+    TrafficLightArray signal_array;
+    signal_array.header.stamp = stamp;
+    signal_array.header.frame_id = frame_id;
+    signal_array.signals.push_back(signal);
+
+    signal_publishers_[camera_index]->publish(signal_array);
+  }
+
+  void publish_camera_detection(
+    size_t camera_index, lanelet::Id traffic_light_id, uint8_t color, float confidence)
+  {
+    const rclcpp::Time stamp(1, 0, RCL_ROS_TIME);
+    const std::string frame_id = "camera" + std::to_string(camera_index);
+
+    publish_camera_info(camera_index, stamp, frame_id);
+    publish_roi(camera_index, stamp, frame_id, traffic_light_id);
+    publish_signal(camera_index, stamp, frame_id, traffic_light_id, color, confidence);
+  }
+
+  std::shared_ptr<MultiCameraFusion> node_;
+  std::shared_ptr<rclcpp::Node> test_node_;
+  std::shared_ptr<rclcpp::executors::SingleThreadedExecutor> executor_;
+
+  rclcpp::Publisher<LaneletMapBin>::SharedPtr map_publisher_;
+  std::vector<rclcpp::Publisher<CameraInfo>::SharedPtr> camera_info_publishers_;
+  std::vector<rclcpp::Publisher<TrafficLightRoiArray>::SharedPtr> roi_publishers_;
+  std::vector<rclcpp::Publisher<TrafficLightArray>::SharedPtr> signal_publishers_;
+  rclcpp::Subscription<TrafficLightGroupArray>::SharedPtr output_subscription_;
+
+  TrafficLightGroupArray::SharedPtr received_message_;
+  bool message_received_ = false;
+};
+
+/// @brief Create a lanelet map with two traffic-light line strings sharing a single
+///        regulatory element.
+///
+///   y
+///   2 +-------------------+    <- road left bound
+///     |                   |
+///   0 +    [left_traffic_light] [right_traffic_light] (height=1, z=3.5..4.5, at x=20)
+///     |        AutowareTrafficLight reg-elem (id=100)
+///  -2 +-------------------+    <- road right bound
+///     0                  30   x
+///
+///   Both `left_traffic_light` (id=11) and `right_traffic_light` (id=12) are registered
+///   as `traffic_lights` on a single regulatory element (id=100), so the node maps both
+///   traffic_light_id → regulatory_element_id.
+LaneletMapBin create_map()
+{
+  using lanelet::AttributeName;
+  using lanelet::AttributeValueString;
+  using lanelet::Lanelet;
+  using lanelet::LineString3d;
+  using lanelet::Point3d;
+
+  Point3d road_left_start(1, 0.0, 2.0, 0.0);
+  Point3d road_left_end(2, 30.0, 2.0, 0.0);
+  Point3d road_right_start(3, 0.0, -2.0, 0.0);
+  Point3d road_right_end(4, 30.0, -2.0, 0.0);
+  LineString3d road_left(5, {road_left_start, road_left_end});
+  LineString3d road_right(6, {road_right_start, road_right_end});
+
+  auto road_lanelet = Lanelet(1000, road_left, road_right);
+  road_lanelet.attributes()[AttributeName::Subtype] = AttributeValueString::Road;
+
+  Point3d left_traffic_light_left_end(7, 19.5, 0.5, 3.5);
+  Point3d left_traffic_light_right_end(8, 19.5, -0.5, 3.5);
+  LineString3d left_traffic_light(
+    LEFT_TRAFFIC_LIGHT_ID, {left_traffic_light_left_end, left_traffic_light_right_end});
+  left_traffic_light.attributes()["subtype"] = "red_yellow_green";
+  left_traffic_light.attributes()["height"] = "1.0";
+
+  Point3d right_traffic_light_left_end(9, 20.5, 0.5, 3.5);
+  Point3d right_traffic_light_right_end(10, 20.5, -0.5, 3.5);
+  LineString3d right_traffic_light(
+    RIGHT_TRAFFIC_LIGHT_ID, {right_traffic_light_left_end, right_traffic_light_right_end});
+  right_traffic_light.attributes()["subtype"] = "red_yellow_green";
+  right_traffic_light.attributes()["height"] = "1.0";
+
+  auto traffic_light_regulatory_element = lanelet::autoware::AutowareTrafficLight::make(
+    REGULATORY_ELEMENT_ID, lanelet::AttributeMap(), {left_traffic_light, right_traffic_light});
+  road_lanelet.addRegulatoryElement(traffic_light_regulatory_element);
+
+  auto lanelet_map = std::make_shared<lanelet::LaneletMap>();
+  lanelet_map->add(road_lanelet);
+
+  auto map_bin = autoware::experimental::lanelet2_utils::to_autoware_map_msgs(lanelet_map);
+  map_bin.header.frame_id = "map";
+  return map_bin;
+}
+
+// Two cameras observe two distinct traffic lights that belong to the same regulatory element.
+// Per-camera fusion picks the only record per traffic-light id, and group fusion accumulates
+// evidence across the two ids and outputs a single GREEN group.
+TEST_F(MultiCameraFusionIntegrationTest, TwoCamerasOneRegulatoryElementOutputsGreenGroup)
+{
+  // Arrange
+  initialize_fusion_node(FusionNodeOptions{});
+  publish_map(create_map());
+
+  // Act
+  publish_camera_detection(0, LEFT_TRAFFIC_LIGHT_ID, TrafficLightElement::GREEN, 0.9f);
+  publish_camera_detection(1, RIGHT_TRAFFIC_LIGHT_ID, TrafficLightElement::GREEN, 0.9f);
+
+  // Assert
+  ASSERT_TRUE(wait_for_message());
+  ASSERT_EQ(received_message_->traffic_light_groups.size(), 1u);
+  const auto & group = received_message_->traffic_light_groups.front();
+  EXPECT_EQ(group.traffic_light_group_id, REGULATORY_ELEMENT_ID);
+  ASSERT_EQ(group.elements.size(), 1u);
+  EXPECT_EQ(
+    group.elements.front().color, autoware_perception_msgs::msg::TrafficLightElement::GREEN);
+  EXPECT_EQ(
+    group.elements.front().shape, autoware_perception_msgs::msg::TrafficLightElement::CIRCLE);
+}
+
+// Two cameras observe different traffic lights in the same regulatory element with
+// conflicting colors and different confidences. With consistency check disabled,
+// the node selects the color from the higher-confidence observation.
+TEST_F(MultiCameraFusionIntegrationTest, HigherConfidenceColorWinsAmongConflictingObservations)
+{
+  // Arrange
+  initialize_fusion_node(FusionNodeOptions{});
+  publish_map(create_map());
+
+  // Act
+  publish_camera_detection(0, LEFT_TRAFFIC_LIGHT_ID, TrafficLightElement::RED, 0.6f);
+  publish_camera_detection(1, RIGHT_TRAFFIC_LIGHT_ID, TrafficLightElement::GREEN, 0.9f);
+
+  // Assert
+  ASSERT_TRUE(wait_for_message());
+  ASSERT_EQ(received_message_->traffic_light_groups.size(), 1u);
+  const auto & group = received_message_->traffic_light_groups.front();
+  EXPECT_EQ(group.traffic_light_group_id, REGULATORY_ELEMENT_ID);
+  ASSERT_EQ(group.elements.size(), 1u);
+  EXPECT_EQ(
+    group.elements.front().color, autoware_perception_msgs::msg::TrafficLightElement::GREEN);
+}
+
+// Two cameras observe the same regulatory element with conflicting colors (RED vs GREEN).
+// With consistency check enabled and partial-match publishing disabled, the node detects
+// a CONFLICT between the two state keys and emits a fail-safe UNKNOWN group.
+TEST_F(MultiCameraFusionIntegrationTest, TwoCamerasConflictingColorsOutputsFailsafeUnknown)
+{
+  // Arrange
+  FusionNodeOptions options;
+  options.consistency_check_enable = true;
+  initialize_fusion_node(options);
+  publish_map(create_map());
+
+  // Act
+  publish_camera_detection(0, LEFT_TRAFFIC_LIGHT_ID, TrafficLightElement::RED, 0.9f);
+  publish_camera_detection(1, RIGHT_TRAFFIC_LIGHT_ID, TrafficLightElement::GREEN, 0.9f);
+
+  // Assert
+  ASSERT_TRUE(wait_for_message());
+  ASSERT_EQ(received_message_->traffic_light_groups.size(), 1u);
+  const auto & group = received_message_->traffic_light_groups.front();
+  EXPECT_EQ(group.traffic_light_group_id, REGULATORY_ELEMENT_ID);
+  ASSERT_EQ(group.elements.size(), 1u);
+  EXPECT_EQ(
+    group.elements.front().color, autoware_perception_msgs::msg::TrafficLightElement::UNKNOWN);
+  EXPECT_EQ(
+    group.elements.front().shape, autoware_perception_msgs::msg::TrafficLightElement::UNKNOWN);
+}
+
+int main(int argc, char ** argv)
+{
+  testing::InitGoogleTest(&argc, argv);
+  return RUN_ALL_TESTS();
+}

--- a/perception/autoware_traffic_light_multi_camera_fusion/test/test_utils.cpp
+++ b/perception/autoware_traffic_light_multi_camera_fusion/test/test_utils.cpp
@@ -20,7 +20,7 @@
 
 #include <unordered_map>
 
-TEST(is_unknown, normal)
+TEST(IsUnknown, Normal)
 {
   tier4_perception_msgs::msg::TrafficLight signal;
   tier4_perception_msgs::msg::TrafficLightElement element;
@@ -40,7 +40,7 @@ TEST(is_unknown, normal)
   EXPECT_FALSE(autoware::traffic_light::utils::is_unknown(signal));
 }
 
-TEST(at_or, normal)
+TEST(AtOr, Normal)
 {
   std::unordered_map<int, int> map;
   map[1] = 2;
@@ -54,7 +54,7 @@ namespace same_camera
 {
 
 // first condition
-TEST(compare_record, timestamp_check)
+TEST(CompareRecord, TimestampCheck)
 {
   // r1 is newer
   autoware::traffic_light::utils::FusionRecord r1;
@@ -158,7 +158,7 @@ TEST(compare_record, timestamp_check)
 }
 
 // second condition
-TEST(compare_record, unknown_check)
+TEST(CompareRecord, UnknownCheck)
 {
   // r1 is unknown
   autoware::traffic_light::utils::FusionRecord r1;
@@ -311,7 +311,7 @@ TEST(compare_record, unknown_check)
 }
 
 // third condition
-TEST(compare_record, visible_check)
+TEST(CompareRecord, VisibleCheck)
 {
   // r1 is better visible on top left
   autoware::traffic_light::utils::FusionRecord r1;
@@ -518,7 +518,7 @@ TEST(compare_record, visible_check)
 }
 
 // fourth condition
-TEST(compare_record, confidence_check)
+TEST(CompareRecord, ConfidenceCheck)
 {
   // r1 is higher confidence
   autoware::traffic_light::utils::FusionRecord r1;
@@ -629,7 +629,7 @@ namespace different_camera
 // first condition is nothing in different camera
 
 // second condition
-TEST(compare_record, unknown_check)
+TEST(CompareRecord, UnknownCheck)
 {
   // r1 is unknown
   autoware::traffic_light::utils::FusionRecord r1;
@@ -782,7 +782,7 @@ TEST(compare_record, unknown_check)
 }
 
 // third condition
-TEST(compare_record, visible_check)
+TEST(CompareRecord, VisibleCheck)
 {
   // r1 is better visible on top left
   autoware::traffic_light::utils::FusionRecord r1;
@@ -989,7 +989,7 @@ TEST(compare_record, visible_check)
 }
 
 // fourth condition
-TEST(compare_record, confidence_check)
+TEST(CompareRecord, ConfidenceCheck)
 {
   // r1 is higher confidence
   autoware::traffic_light::utils::FusionRecord r1;
@@ -1094,7 +1094,7 @@ TEST(compare_record, confidence_check)
 
 }  // namespace different_camera
 
-TEST(cal_visible_score, normal)
+TEST(CalVisibleScore, Normal)
 {
   // visible
   autoware::traffic_light::utils::FusionRecord r1;

--- a/perception/autoware_traffic_light_multi_camera_fusion/test/test_utils.cpp
+++ b/perception/autoware_traffic_light_multi_camera_fusion/test/test_utils.cpp
@@ -20,7 +20,7 @@
 
 #include <unordered_map>
 
-TEST(isUnknown, normal)
+TEST(is_unknown, normal)
 {
   tier4_perception_msgs::msg::TrafficLight signal;
   tier4_perception_msgs::msg::TrafficLightElement element;
@@ -29,7 +29,7 @@ TEST(isUnknown, normal)
     element.shape = tier4_perception_msgs::msg::TrafficLightElement::UNKNOWN;
     signal.elements.push_back(element);
   }
-  EXPECT_TRUE(autoware::traffic_light::utils::isUnknown(signal));
+  EXPECT_TRUE(autoware::traffic_light::utils::is_unknown(signal));
 
   {
     signal.elements.clear();
@@ -37,7 +37,7 @@ TEST(isUnknown, normal)
     element.shape = tier4_perception_msgs::msg::TrafficLightElement::CIRCLE;
     signal.elements.push_back(element);
   }
-  EXPECT_FALSE(autoware::traffic_light::utils::isUnknown(signal));
+  EXPECT_FALSE(autoware::traffic_light::utils::is_unknown(signal));
 }
 
 TEST(at_or, normal)
@@ -54,7 +54,7 @@ namespace same_camera
 {
 
 // first condition
-TEST(compareRecord, timestamp_check)
+TEST(compare_record, timestamp_check)
 {
   // r1 is newer
   autoware::traffic_light::utils::FusionRecord r1;
@@ -105,7 +105,7 @@ TEST(compareRecord, timestamp_check)
     element.confidence = 0.8;
     r2.signal.elements.push_back(element);
   }
-  EXPECT_EQ(autoware::traffic_light::utils::compareRecord(r1, r2), 1);
+  EXPECT_EQ(autoware::traffic_light::utils::compare_record(r1, r2), 1);
 
   // r2 is newer
   {
@@ -154,11 +154,11 @@ TEST(compareRecord, timestamp_check)
     element.confidence = 0.8;
     r2.signal.elements.push_back(element);
   }
-  EXPECT_EQ(autoware::traffic_light::utils::compareRecord(r1, r2), -1);
+  EXPECT_EQ(autoware::traffic_light::utils::compare_record(r1, r2), -1);
 }
 
 // second condition
-TEST(compareRecord, unknown_check)
+TEST(compare_record, unknown_check)
 {
   // r1 is unknown
   autoware::traffic_light::utils::FusionRecord r1;
@@ -209,7 +209,7 @@ TEST(compareRecord, unknown_check)
     element.confidence = 0.8;
     r2.signal.elements.push_back(element);
   }
-  EXPECT_EQ(autoware::traffic_light::utils::compareRecord(r1, r2), -1);
+  EXPECT_EQ(autoware::traffic_light::utils::compare_record(r1, r2), -1);
 
   // r2 is unknown
   {
@@ -258,7 +258,7 @@ TEST(compareRecord, unknown_check)
     element.confidence = 0.0;
     r2.signal.elements.push_back(element);
   }
-  EXPECT_EQ(autoware::traffic_light::utils::compareRecord(r1, r2), 1);
+  EXPECT_EQ(autoware::traffic_light::utils::compare_record(r1, r2), 1);
 
   // both of r1 and r2 is unknown
   {
@@ -307,11 +307,11 @@ TEST(compareRecord, unknown_check)
     element.confidence = 0.0;
     r2.signal.elements.push_back(element);
   }
-  EXPECT_EQ(autoware::traffic_light::utils::compareRecord(r1, r2), 0);
+  EXPECT_EQ(autoware::traffic_light::utils::compare_record(r1, r2), 0);
 }
 
 // third condition
-TEST(compareRecord, visible_check)
+TEST(compare_record, visible_check)
 {
   // r1 is better visible on top left
   autoware::traffic_light::utils::FusionRecord r1;
@@ -363,7 +363,7 @@ TEST(compareRecord, visible_check)
     element.confidence = 0.8;
     r2.signal.elements.push_back(element);
   }
-  EXPECT_EQ(autoware::traffic_light::utils::compareRecord(r1, r2), 1);
+  EXPECT_EQ(autoware::traffic_light::utils::compare_record(r1, r2), 1);
 
   // r1 is better visible on bottom left
   {
@@ -413,7 +413,7 @@ TEST(compareRecord, visible_check)
     element.confidence = 0.8;
     r2.signal.elements.push_back(element);
   }
-  EXPECT_EQ(autoware::traffic_light::utils::compareRecord(r1, r2), 1);
+  EXPECT_EQ(autoware::traffic_light::utils::compare_record(r1, r2), 1);
 
   // r2 is better visible on top left
   {
@@ -463,7 +463,7 @@ TEST(compareRecord, visible_check)
     element.confidence = 0.8;
     r2.signal.elements.push_back(element);
   }
-  EXPECT_EQ(autoware::traffic_light::utils::compareRecord(r1, r2), -1);
+  EXPECT_EQ(autoware::traffic_light::utils::compare_record(r1, r2), -1);
 
   // r2 is better visible on bottom left
   {
@@ -514,11 +514,11 @@ TEST(compareRecord, visible_check)
     element.confidence = 0.8;
     r2.signal.elements.push_back(element);
   }
-  EXPECT_EQ(autoware::traffic_light::utils::compareRecord(r1, r2), -1);
+  EXPECT_EQ(autoware::traffic_light::utils::compare_record(r1, r2), -1);
 }
 
 // fourth condition
-TEST(compareRecord, confidence_check)
+TEST(compare_record, confidence_check)
 {
   // r1 is higher confidence
   autoware::traffic_light::utils::FusionRecord r1;
@@ -569,7 +569,7 @@ TEST(compareRecord, confidence_check)
     element.confidence = 0.8;
     r2.signal.elements.push_back(element);
   }
-  EXPECT_EQ(autoware::traffic_light::utils::compareRecord(r1, r2), 1);
+  EXPECT_EQ(autoware::traffic_light::utils::compare_record(r1, r2), 1);
 
   // r2 is higher confidence
   {
@@ -618,7 +618,7 @@ TEST(compareRecord, confidence_check)
     element.confidence = 0.95;
     r2.signal.elements.push_back(element);
   }
-  EXPECT_EQ(autoware::traffic_light::utils::compareRecord(r1, r2), -1);
+  EXPECT_EQ(autoware::traffic_light::utils::compare_record(r1, r2), -1);
 }
 
 }  // namespace same_camera
@@ -629,7 +629,7 @@ namespace different_camera
 // first condition is nothing in different camera
 
 // second condition
-TEST(compareRecord, unknown_check)
+TEST(compare_record, unknown_check)
 {
   // r1 is unknown
   autoware::traffic_light::utils::FusionRecord r1;
@@ -680,7 +680,7 @@ TEST(compareRecord, unknown_check)
     element.confidence = 0.8;
     r2.signal.elements.push_back(element);
   }
-  EXPECT_EQ(autoware::traffic_light::utils::compareRecord(r1, r2), -1);
+  EXPECT_EQ(autoware::traffic_light::utils::compare_record(r1, r2), -1);
 
   // r2 is unknown
   {
@@ -729,7 +729,7 @@ TEST(compareRecord, unknown_check)
     element.confidence = 0.0;
     r2.signal.elements.push_back(element);
   }
-  EXPECT_EQ(autoware::traffic_light::utils::compareRecord(r1, r2), 1);
+  EXPECT_EQ(autoware::traffic_light::utils::compare_record(r1, r2), 1);
 
   // both of r1 and r2 is unknown
   {
@@ -778,11 +778,11 @@ TEST(compareRecord, unknown_check)
     element.confidence = 0.0;
     r2.signal.elements.push_back(element);
   }
-  EXPECT_EQ(autoware::traffic_light::utils::compareRecord(r1, r2), 0);
+  EXPECT_EQ(autoware::traffic_light::utils::compare_record(r1, r2), 0);
 }
 
 // third condition
-TEST(compareRecord, visible_check)
+TEST(compare_record, visible_check)
 {
   // r1 is better visible on top left
   autoware::traffic_light::utils::FusionRecord r1;
@@ -834,7 +834,7 @@ TEST(compareRecord, visible_check)
     element.confidence = 0.8;
     r2.signal.elements.push_back(element);
   }
-  EXPECT_EQ(autoware::traffic_light::utils::compareRecord(r1, r2), 1);
+  EXPECT_EQ(autoware::traffic_light::utils::compare_record(r1, r2), 1);
 
   // r1 is better visible on bottom left
   {
@@ -884,7 +884,7 @@ TEST(compareRecord, visible_check)
     element.confidence = 0.8;
     r2.signal.elements.push_back(element);
   }
-  EXPECT_EQ(autoware::traffic_light::utils::compareRecord(r1, r2), 1);
+  EXPECT_EQ(autoware::traffic_light::utils::compare_record(r1, r2), 1);
 
   // r2 is better visible on top left
   {
@@ -934,7 +934,7 @@ TEST(compareRecord, visible_check)
     element.confidence = 0.8;
     r2.signal.elements.push_back(element);
   }
-  EXPECT_EQ(autoware::traffic_light::utils::compareRecord(r1, r2), -1);
+  EXPECT_EQ(autoware::traffic_light::utils::compare_record(r1, r2), -1);
 
   // r2 is better visible on bottom left
   {
@@ -985,11 +985,11 @@ TEST(compareRecord, visible_check)
     element.confidence = 0.8;
     r2.signal.elements.push_back(element);
   }
-  EXPECT_EQ(autoware::traffic_light::utils::compareRecord(r1, r2), -1);
+  EXPECT_EQ(autoware::traffic_light::utils::compare_record(r1, r2), -1);
 }
 
 // fourth condition
-TEST(compareRecord, confidence_check)
+TEST(compare_record, confidence_check)
 {
   // r1 is higher confidence
   autoware::traffic_light::utils::FusionRecord r1;
@@ -1040,7 +1040,7 @@ TEST(compareRecord, confidence_check)
     element.confidence = 0.8;
     r2.signal.elements.push_back(element);
   }
-  EXPECT_EQ(autoware::traffic_light::utils::compareRecord(r1, r2), 1);
+  EXPECT_EQ(autoware::traffic_light::utils::compare_record(r1, r2), 1);
 
   // r2 is higher confidence
   {
@@ -1089,12 +1089,12 @@ TEST(compareRecord, confidence_check)
     element.confidence = 0.95;
     r2.signal.elements.push_back(element);
   }
-  EXPECT_EQ(autoware::traffic_light::utils::compareRecord(r1, r2), -1);
+  EXPECT_EQ(autoware::traffic_light::utils::compare_record(r1, r2), -1);
 }
 
 }  // namespace different_camera
 
-TEST(calVisibleScore, normal)
+TEST(cal_visible_score, normal)
 {
   // visible
   autoware::traffic_light::utils::FusionRecord r1;
@@ -1121,7 +1121,7 @@ TEST(calVisibleScore, normal)
     element.confidence = 0.9;
     r1.signal.elements.push_back(element);
   }
-  EXPECT_EQ(autoware::traffic_light::utils::calVisibleScore(r1), 1);
+  EXPECT_EQ(autoware::traffic_light::utils::cal_visible_score(r1), 1);
 
   // invisible by left top
   {
@@ -1148,7 +1148,7 @@ TEST(calVisibleScore, normal)
     element.confidence = 0.9;
     r1.signal.elements.push_back(element);
   }
-  EXPECT_EQ(autoware::traffic_light::utils::calVisibleScore(r1), 0);
+  EXPECT_EQ(autoware::traffic_light::utils::cal_visible_score(r1), 0);
 
   // invisible by right top
   {
@@ -1175,7 +1175,7 @@ TEST(calVisibleScore, normal)
     element.confidence = 0.9;
     r1.signal.elements.push_back(element);
   }
-  EXPECT_EQ(autoware::traffic_light::utils::calVisibleScore(r1), 0);
+  EXPECT_EQ(autoware::traffic_light::utils::cal_visible_score(r1), 0);
 
   // invisible by left bottom
   {
@@ -1202,7 +1202,7 @@ TEST(calVisibleScore, normal)
     element.confidence = 0.9;
     r1.signal.elements.push_back(element);
   }
-  EXPECT_EQ(autoware::traffic_light::utils::calVisibleScore(r1), 0);
+  EXPECT_EQ(autoware::traffic_light::utils::cal_visible_score(r1), 0);
 
   // invisible by right bottom
   {
@@ -1229,7 +1229,7 @@ TEST(calVisibleScore, normal)
     element.confidence = 0.9;
     r1.signal.elements.push_back(element);
   }
-  EXPECT_EQ(autoware::traffic_light::utils::calVisibleScore(r1), 0);
+  EXPECT_EQ(autoware::traffic_light::utils::cal_visible_score(r1), 0);
 }
 
 int main(int argc, char ** argv)

--- a/perception/autoware_traffic_light_multi_camera_fusion/test/test_utils.cpp
+++ b/perception/autoware_traffic_light_multi_camera_fusion/test/test_utils.cpp
@@ -14,1222 +14,268 @@
 
 #include "../src/traffic_light_multi_camera_fusion_process.hpp"
 
-#include <rclcpp/rclcpp.hpp>
+#include <rclcpp/time.hpp>
 
 #include <gtest/gtest.h>
 
+#include <string>
 #include <unordered_map>
 
-TEST(IsUnknown, Normal)
+namespace
 {
+namespace utils = autoware::traffic_light::utils;
+using TrafficLightElement = tier4_perception_msgs::msg::TrafficLightElement;
+
+// colors / shapes used by the tests
+constexpr uint8_t red = TrafficLightElement::RED;
+constexpr uint8_t green = TrafficLightElement::GREEN;
+constexpr uint8_t circle = TrafficLightElement::CIRCLE;
+// unknown is shared between the color and shape fields
+constexpr uint8_t unknown = TrafficLightElement::UNKNOWN;
+
+// image / roi geometry
+constexpr uint32_t image_width = 1440;
+constexpr uint32_t image_height = 1080;
+constexpr uint32_t roi_size = 100;
+constexpr uint32_t boundary_threshold = 5;
+// roi offset that keeps the traffic light fully inside the image (fully visible)
+constexpr uint32_t visible_offset = 100;
+// roi offsets that push the traffic light against each image boundary (truncated)
+constexpr uint32_t left_top_boundary_offset = boundary_threshold;
+constexpr uint32_t right_boundary_offset = image_width - (roi_size + boundary_threshold);
+constexpr uint32_t bottom_boundary_offset = image_height - (roi_size + boundary_threshold);
+
+constexpr int32_t default_stamp_sec = 100;
+
+tier4_perception_msgs::msg::TrafficLight make_signal(
+  uint8_t color, uint8_t shape, double confidence)
+{
+  TrafficLightElement element;
+  element.color = color;
+  element.shape = shape;
+  element.confidence = confidence;
+
   tier4_perception_msgs::msg::TrafficLight signal;
-  tier4_perception_msgs::msg::TrafficLightElement element;
-  {
-    element.color = tier4_perception_msgs::msg::TrafficLightElement::UNKNOWN;
-    element.shape = tier4_perception_msgs::msg::TrafficLightElement::UNKNOWN;
-    signal.elements.push_back(element);
-  }
-  EXPECT_TRUE(autoware::traffic_light::utils::is_unknown(signal));
-
-  {
-    signal.elements.clear();
-    element.color = tier4_perception_msgs::msg::TrafficLightElement::RED;
-    element.shape = tier4_perception_msgs::msg::TrafficLightElement::CIRCLE;
-    signal.elements.push_back(element);
-  }
-  EXPECT_FALSE(autoware::traffic_light::utils::is_unknown(signal));
+  signal.elements.push_back(element);
+  return signal;
 }
 
-TEST(AtOr, Normal)
+utils::FusionRecord make_record(
+  uint8_t color, uint8_t shape, double confidence, const std::string & frame_id = "camera0",
+  int32_t stamp_sec = default_stamp_sec, uint32_t roi_x_offset = visible_offset,
+  uint32_t roi_y_offset = visible_offset)
 {
-  std::unordered_map<int, int> map;
-  map[1] = 2;
-  map[3] = 4;
-  EXPECT_EQ(autoware::traffic_light::utils::at_or(map, 1, -1), 2);
-  EXPECT_EQ(autoware::traffic_light::utils::at_or(map, 2, -1), -1);
-  EXPECT_EQ(autoware::traffic_light::utils::at_or(map, 3, -1), 4);
+  std_msgs::msg::Header header;
+  header.stamp = rclcpp::Time(stamp_sec, 10);
+  header.frame_id = frame_id;
+
+  utils::FusionRecord record;
+  record.header = header;
+  record.cam_info.header = header;
+  record.cam_info.width = image_width;
+  record.cam_info.height = image_height;
+  record.roi.roi.x_offset = roi_x_offset;
+  record.roi.roi.y_offset = roi_y_offset;
+  record.roi.roi.width = roi_size;
+  record.roi.roi.height = roi_size;
+  record.signal = make_signal(color, shape, confidence);
+  return record;
 }
 
-namespace same_camera
+// only the roi position affects the visible score, so the signal content is fixed here
+utils::FusionRecord make_record_with_roi(
+  uint32_t roi_x_offset, uint32_t roi_y_offset, const std::string & frame_id = "camera0")
 {
-
-// first condition
-TEST(CompareRecord, TimestampCheck)
-{
-  // r1 is newer
-  autoware::traffic_light::utils::FusionRecord r1;
-  {
-    std_msgs::msg::Header header;
-    header.stamp = rclcpp::Time(200, 10);
-    header.frame_id = "camera0";
-    // header
-    r1.header = header;
-    // cam_info
-    r1.cam_info.header = header;
-    r1.cam_info.width = 1440;
-    r1.cam_info.height = 1080;
-    // roi
-    r1.roi.roi.x_offset = 100;
-    r1.roi.roi.y_offset = 100;
-    r1.roi.roi.width = 100;
-    r1.roi.roi.height = 100;
-    // signal
-    r1.signal.elements.clear();
-    tier4_perception_msgs::msg::TrafficLightElement element;
-    element.color = tier4_perception_msgs::msg::TrafficLightElement::RED;
-    element.shape = tier4_perception_msgs::msg::TrafficLightElement::CIRCLE;
-    element.confidence = 0.9;
-    r1.signal.elements.push_back(element);
-  }
-  autoware::traffic_light::utils::FusionRecord r2;
-  {
-    std_msgs::msg::Header header;
-    header.stamp = rclcpp::Time(100, 10);
-    header.frame_id = "camera0";
-    // header
-    r2.header = header;
-    // cam_info
-    r2.cam_info.header = header;
-    r2.cam_info.width = 1440;
-    r2.cam_info.height = 1080;
-    // roi
-    r2.roi.roi.x_offset = 100;
-    r2.roi.roi.y_offset = 100;
-    r2.roi.roi.width = 100;
-    r2.roi.roi.height = 100;
-    // signal
-    r2.signal.elements.clear();
-    tier4_perception_msgs::msg::TrafficLightElement element;
-    element.color = tier4_perception_msgs::msg::TrafficLightElement::GREEN;
-    element.shape = tier4_perception_msgs::msg::TrafficLightElement::CIRCLE;
-    element.confidence = 0.8;
-    r2.signal.elements.push_back(element);
-  }
-  EXPECT_EQ(autoware::traffic_light::utils::compare_record(r1, r2), 1);
-
-  // r2 is newer
-  {
-    std_msgs::msg::Header header;
-    header.stamp = rclcpp::Time(100, 10);
-    header.frame_id = "camera0";
-    // header
-    r1.header = header;
-    // cam_info
-    r1.cam_info.header = header;
-    r1.cam_info.width = 1440;
-    r1.cam_info.height = 1080;
-    // roi
-    r1.roi.roi.x_offset = 100;
-    r1.roi.roi.y_offset = 100;
-    r1.roi.roi.width = 100;
-    r1.roi.roi.height = 100;
-    // signal
-    r1.signal.elements.clear();
-    tier4_perception_msgs::msg::TrafficLightElement element;
-    element.color = tier4_perception_msgs::msg::TrafficLightElement::RED;
-    element.shape = tier4_perception_msgs::msg::TrafficLightElement::CIRCLE;
-    element.confidence = 0.9;
-    r1.signal.elements.push_back(element);
-  }
-  {
-    std_msgs::msg::Header header;
-    header.stamp = rclcpp::Time(200, 10);
-    header.frame_id = "camera0";
-    // header
-    r2.header = header;
-    // cam_info
-    r2.cam_info.header = header;
-    r2.cam_info.width = 1440;
-    r2.cam_info.height = 1080;
-    // roi
-    r2.roi.roi.x_offset = 100;
-    r2.roi.roi.y_offset = 100;
-    r2.roi.roi.width = 100;
-    r2.roi.roi.height = 100;
-    // signal
-    r2.signal.elements.clear();
-    tier4_perception_msgs::msg::TrafficLightElement element;
-    element.color = tier4_perception_msgs::msg::TrafficLightElement::GREEN;
-    element.shape = tier4_perception_msgs::msg::TrafficLightElement::CIRCLE;
-    element.confidence = 0.8;
-    r2.signal.elements.push_back(element);
-  }
-  EXPECT_EQ(autoware::traffic_light::utils::compare_record(r1, r2), -1);
+  return make_record(red, circle, 0.9, frame_id, default_stamp_sec, roi_x_offset, roi_y_offset);
 }
+}  // namespace
+
+TEST(IsSignalUnknown, ReturnsTrueForUnknownSignal)
+{
+  const auto signal = make_signal(unknown, unknown, 0.0);
+  EXPECT_TRUE(utils::is_signal_unknown(signal));
+}
+
+TEST(IsSignalUnknown, ReturnsFalseForColoredSignal)
+{
+  const auto signal = make_signal(red, circle, 0.9);
+  EXPECT_FALSE(utils::is_signal_unknown(signal));
+}
+
+TEST(AtOr, ReturnsMappedValueWhenKeyExists)
+{
+  const std::unordered_map<int, int> map = {{1, 2}, {3, 4}};
+  EXPECT_EQ(utils::at_or(map, 1, -1), 2);
+}
+
+TEST(AtOr, ReturnsDefaultValueWhenKeyMissing)
+{
+  const std::unordered_map<int, int> map = {{1, 2}, {3, 4}};
+  EXPECT_EQ(utils::at_or(map, 2, -1), -1);
+}
+
+// first condition: records from the same camera are ranked by timestamp
+TEST(HasHigherOrEqualPrioritySameCamera, NewerRecordWinsOverOlderRecord)
+{
+  const auto newer_record = make_record(red, circle, 0.9, "camera0", 200);
+  const auto older_record = make_record(green, circle, 0.8, "camera0", 100);
+  EXPECT_TRUE(utils::has_higher_or_equal_priority(newer_record, older_record));
+}
+
+TEST(HasHigherOrEqualPrioritySameCamera, OlderRecordLosesToNewerRecord)
+{
+  const auto older_record = make_record(red, circle, 0.9, "camera0", 100);
+  const auto newer_record = make_record(green, circle, 0.8, "camera0", 200);
+  EXPECT_FALSE(utils::has_higher_or_equal_priority(older_record, newer_record));
+}
+
+// second condition: an unknown signal loses to a recognized one
+TEST(HasHigherOrEqualPrioritySameCamera, UnknownRecordLosesToKnownRecord)
+{
+  const auto unknown_record = make_record(unknown, unknown, 0.0);
+  const auto known_record = make_record(green, circle, 0.8);
+  EXPECT_FALSE(utils::has_higher_or_equal_priority(unknown_record, known_record));
+}
+
+TEST(HasHigherOrEqualPrioritySameCamera, KnownRecordWinsOverUnknownRecord)
+{
+  const auto known_record = make_record(red, circle, 0.9);
+  const auto unknown_record = make_record(unknown, unknown, 0.0);
+  EXPECT_TRUE(utils::has_higher_or_equal_priority(known_record, unknown_record));
+}
+
+TEST(HasHigherOrEqualPrioritySameCamera, BothUnknownRecordsHaveEqualPriority)
+{
+  const auto unknown_record_1 = make_record(unknown, unknown, 0.0);
+  const auto unknown_record_2 = make_record(unknown, unknown, 0.0);
+  // equal priority: each record has a higher-or-equal priority than the other
+  EXPECT_TRUE(utils::has_higher_or_equal_priority(unknown_record_1, unknown_record_2));
+  EXPECT_TRUE(utils::has_higher_or_equal_priority(unknown_record_2, unknown_record_1));
+}
+
+// third condition: a fully visible signal wins over a truncated one
+TEST(HasHigherOrEqualPrioritySameCamera, VisibleRecordWinsOverTruncatedRecord)
+{
+  const auto visible_record = make_record_with_roi(visible_offset, visible_offset);
+  const auto truncated_record =
+    make_record_with_roi(left_top_boundary_offset, left_top_boundary_offset);
+  EXPECT_TRUE(utils::has_higher_or_equal_priority(visible_record, truncated_record));
+}
+
+TEST(HasHigherOrEqualPrioritySameCamera, TruncatedRecordLosesToVisibleRecord)
+{
+  const auto truncated_record =
+    make_record_with_roi(left_top_boundary_offset, left_top_boundary_offset);
+  const auto visible_record = make_record_with_roi(visible_offset, visible_offset);
+  EXPECT_FALSE(utils::has_higher_or_equal_priority(truncated_record, visible_record));
+}
+
+// fourth condition: a higher confidence signal wins
+TEST(HasHigherOrEqualPrioritySameCamera, HigherConfidenceRecordWins)
+{
+  const auto higher_confidence_record = make_record(red, circle, 0.9);
+  const auto lower_confidence_record = make_record(green, circle, 0.8);
+  EXPECT_TRUE(
+    utils::has_higher_or_equal_priority(higher_confidence_record, lower_confidence_record));
+}
+
+TEST(HasHigherOrEqualPrioritySameCamera, LowerConfidenceRecordLoses)
+{
+  const auto lower_confidence_record = make_record(red, circle, 0.9);
+  const auto higher_confidence_record = make_record(green, circle, 0.95);
+  EXPECT_FALSE(
+    utils::has_higher_or_equal_priority(lower_confidence_record, higher_confidence_record));
+}
+
+// the timestamp condition does not apply across different cameras, so the
+// remaining conditions are exercised with different frame_ids below
 
 // second condition
-TEST(CompareRecord, UnknownCheck)
+TEST(HasHigherOrEqualPriorityDifferentCamera, UnknownRecordLosesToKnownRecord)
 {
-  // r1 is unknown
-  autoware::traffic_light::utils::FusionRecord r1;
-  {
-    std_msgs::msg::Header header;
-    header.stamp = rclcpp::Time(100, 10);
-    header.frame_id = "camera0";
-    // header
-    r1.header = header;
-    // cam_info
-    r1.cam_info.header = header;
-    r1.cam_info.width = 1440;
-    r1.cam_info.height = 1080;
-    // roi
-    r1.roi.roi.x_offset = 100;
-    r1.roi.roi.y_offset = 100;
-    r1.roi.roi.width = 100;
-    r1.roi.roi.height = 100;
-    // signal
-    r1.signal.elements.clear();
-    tier4_perception_msgs::msg::TrafficLightElement element;
-    element.color = tier4_perception_msgs::msg::TrafficLightElement::UNKNOWN;
-    element.shape = tier4_perception_msgs::msg::TrafficLightElement::UNKNOWN;
-    element.confidence = 0.0;
-    r1.signal.elements.push_back(element);
-  }
-  autoware::traffic_light::utils::FusionRecord r2;
-  {
-    std_msgs::msg::Header header;
-    header.stamp = rclcpp::Time(100, 10);
-    header.frame_id = "camera0";
-    // header
-    r2.header = header;
-    // cam_info
-    r2.cam_info.header = header;
-    r2.cam_info.width = 1440;
-    r2.cam_info.height = 1080;
-    // roi
-    r2.roi.roi.x_offset = 100;
-    r2.roi.roi.y_offset = 100;
-    r2.roi.roi.width = 100;
-    r2.roi.roi.height = 100;
-    // signal
-    r2.signal.elements.clear();
-    tier4_perception_msgs::msg::TrafficLightElement element;
-    element.color = tier4_perception_msgs::msg::TrafficLightElement::GREEN;
-    element.shape = tier4_perception_msgs::msg::TrafficLightElement::CIRCLE;
-    element.confidence = 0.8;
-    r2.signal.elements.push_back(element);
-  }
-  EXPECT_EQ(autoware::traffic_light::utils::compare_record(r1, r2), -1);
+  const auto unknown_record = make_record(unknown, unknown, 0.0, "camera0");
+  const auto known_record = make_record(green, circle, 0.8, "camera1");
+  EXPECT_FALSE(utils::has_higher_or_equal_priority(unknown_record, known_record));
+}
 
-  // r2 is unknown
-  {
-    std_msgs::msg::Header header;
-    header.stamp = rclcpp::Time(100, 10);
-    header.frame_id = "camera0";
-    // header
-    r1.header = header;
-    // cam_info
-    r1.cam_info.header = header;
-    r1.cam_info.width = 1440;
-    r1.cam_info.height = 1080;
-    // roi
-    r1.roi.roi.x_offset = 100;
-    r1.roi.roi.y_offset = 100;
-    r1.roi.roi.width = 100;
-    r1.roi.roi.height = 100;
-    // signal
-    r1.signal.elements.clear();
-    tier4_perception_msgs::msg::TrafficLightElement element;
-    element.color = tier4_perception_msgs::msg::TrafficLightElement::RED;
-    element.shape = tier4_perception_msgs::msg::TrafficLightElement::CIRCLE;
-    element.confidence = 0.9;
-    r1.signal.elements.push_back(element);
-  }
-  {
-    std_msgs::msg::Header header;
-    header.stamp = rclcpp::Time(100, 10);
-    header.frame_id = "camera0";
-    // header
-    r2.header = header;
-    // cam_info
-    r2.cam_info.header = header;
-    r2.cam_info.width = 1440;
-    r2.cam_info.height = 1080;
-    // roi
-    r2.roi.roi.x_offset = 100;
-    r2.roi.roi.y_offset = 100;
-    r2.roi.roi.width = 100;
-    r2.roi.roi.height = 100;
-    // signal
-    r2.signal.elements.clear();
-    tier4_perception_msgs::msg::TrafficLightElement element;
-    element.color = tier4_perception_msgs::msg::TrafficLightElement::UNKNOWN;
-    element.shape = tier4_perception_msgs::msg::TrafficLightElement::UNKNOWN;
-    element.confidence = 0.0;
-    r2.signal.elements.push_back(element);
-  }
-  EXPECT_EQ(autoware::traffic_light::utils::compare_record(r1, r2), 1);
+TEST(HasHigherOrEqualPriorityDifferentCamera, KnownRecordWinsOverUnknownRecord)
+{
+  const auto known_record = make_record(red, circle, 0.9, "camera0");
+  const auto unknown_record = make_record(unknown, unknown, 0.0, "camera1");
+  EXPECT_TRUE(utils::has_higher_or_equal_priority(known_record, unknown_record));
+}
 
-  // both of r1 and r2 is unknown
-  {
-    std_msgs::msg::Header header;
-    header.stamp = rclcpp::Time(100, 10);
-    header.frame_id = "camera0";
-    // header
-    r1.header = header;
-    // cam_info
-    r1.cam_info.header = header;
-    r1.cam_info.width = 1440;
-    r1.cam_info.height = 1080;
-    // roi
-    r1.roi.roi.x_offset = 100;
-    r1.roi.roi.y_offset = 100;
-    r1.roi.roi.width = 100;
-    r1.roi.roi.height = 100;
-    // signal
-    r1.signal.elements.clear();
-    tier4_perception_msgs::msg::TrafficLightElement element;
-    element.color = tier4_perception_msgs::msg::TrafficLightElement::UNKNOWN;
-    element.shape = tier4_perception_msgs::msg::TrafficLightElement::UNKNOWN;
-    element.confidence = 0.0;
-    r1.signal.elements.push_back(element);
-  }
-  {
-    std_msgs::msg::Header header;
-    header.stamp = rclcpp::Time(100, 10);
-    header.frame_id = "camera0";
-    // header
-    r2.header = header;
-    // cam_info
-    r2.cam_info.header = header;
-    r2.cam_info.width = 1440;
-    r2.cam_info.height = 1080;
-    // roi
-    r2.roi.roi.x_offset = 100;
-    r2.roi.roi.y_offset = 100;
-    r2.roi.roi.width = 100;
-    r2.roi.roi.height = 100;
-    // signal
-    r2.signal.elements.clear();
-    tier4_perception_msgs::msg::TrafficLightElement element;
-    element.color = tier4_perception_msgs::msg::TrafficLightElement::UNKNOWN;
-    element.shape = tier4_perception_msgs::msg::TrafficLightElement::UNKNOWN;
-    element.confidence = 0.0;
-    r2.signal.elements.push_back(element);
-  }
-  EXPECT_EQ(autoware::traffic_light::utils::compare_record(r1, r2), 0);
+TEST(HasHigherOrEqualPriorityDifferentCamera, BothUnknownRecordsHaveEqualPriority)
+{
+  const auto unknown_record_1 = make_record(unknown, unknown, 0.0, "camera0");
+  const auto unknown_record_2 = make_record(unknown, unknown, 0.0, "camera1");
+  // equal priority: each record has a higher-or-equal priority than the other
+  EXPECT_TRUE(utils::has_higher_or_equal_priority(unknown_record_1, unknown_record_2));
+  EXPECT_TRUE(utils::has_higher_or_equal_priority(unknown_record_2, unknown_record_1));
 }
 
 // third condition
-TEST(CompareRecord, VisibleCheck)
+TEST(HasHigherOrEqualPriorityDifferentCamera, VisibleRecordWinsOverTruncatedRecord)
 {
-  // r1 is better visible on top left
-  autoware::traffic_light::utils::FusionRecord r1;
-  {
-    std_msgs::msg::Header header;
-    header.stamp = rclcpp::Time(100, 10);
-    header.frame_id = "camera0";
-    // header
-    r1.header = header;
-    // cam_info
-    r1.cam_info.header = header;
-    r1.cam_info.width = 1440;
-    r1.cam_info.height = 1080;
-    // roi
-    r1.roi.roi.x_offset = 100;
-    r1.roi.roi.y_offset = 100;
-    r1.roi.roi.width = 100;
-    r1.roi.roi.height = 100;
-    // signal
-    r1.signal.elements.clear();
-    tier4_perception_msgs::msg::TrafficLightElement element;
-    element.color = tier4_perception_msgs::msg::TrafficLightElement::RED;
-    element.shape = tier4_perception_msgs::msg::TrafficLightElement::CIRCLE;
-    element.confidence = 0.9;
-    r1.signal.elements.push_back(element);
-  }
-  autoware::traffic_light::utils::FusionRecord r2;
-  {
-    const uint32_t boundary_thres = 5;
-    std_msgs::msg::Header header;
-    header.stamp = rclcpp::Time(100, 10);
-    header.frame_id = "camera0";
-    // header
-    r2.header = header;
-    // cam_info
-    r2.cam_info.header = header;
-    r2.cam_info.width = 1440;
-    r2.cam_info.height = 1080;
-    // roi
-    r2.roi.roi.x_offset = boundary_thres;
-    r2.roi.roi.y_offset = boundary_thres;
-    r2.roi.roi.width = 100;
-    r2.roi.roi.height = 100;
-    // signal
-    r2.signal.elements.clear();
-    tier4_perception_msgs::msg::TrafficLightElement element;
-    element.color = tier4_perception_msgs::msg::TrafficLightElement::GREEN;
-    element.shape = tier4_perception_msgs::msg::TrafficLightElement::CIRCLE;
-    element.confidence = 0.8;
-    r2.signal.elements.push_back(element);
-  }
-  EXPECT_EQ(autoware::traffic_light::utils::compare_record(r1, r2), 1);
+  const auto visible_record = make_record_with_roi(visible_offset, visible_offset, "camera0");
+  const auto truncated_record =
+    make_record_with_roi(left_top_boundary_offset, left_top_boundary_offset, "camera1");
+  EXPECT_TRUE(utils::has_higher_or_equal_priority(visible_record, truncated_record));
+}
 
-  // r1 is better visible on bottom left
-  {
-    std_msgs::msg::Header header;
-    header.stamp = rclcpp::Time(100, 10);
-    header.frame_id = "camera0";
-    // header
-    r1.header = header;
-    // cam_info
-    r1.cam_info.header = header;
-    r1.cam_info.width = 1440;
-    r1.cam_info.height = 1080;
-    // roi
-    r1.roi.roi.x_offset = 100;
-    r1.roi.roi.y_offset = 100;
-    r1.roi.roi.width = 100;
-    r1.roi.roi.height = 100;
-    // signal
-    r1.signal.elements.clear();
-    tier4_perception_msgs::msg::TrafficLightElement element;
-    element.color = tier4_perception_msgs::msg::TrafficLightElement::RED;
-    element.shape = tier4_perception_msgs::msg::TrafficLightElement::CIRCLE;
-    element.confidence = 0.9;
-    r1.signal.elements.push_back(element);
-  }
-  {
-    const uint32_t boundary_thres = 5;
-    std_msgs::msg::Header header;
-    header.stamp = rclcpp::Time(100, 10);
-    header.frame_id = "camera0";
-    // header
-    r2.header = header;
-    // cam_info
-    r2.cam_info.header = header;
-    r2.cam_info.width = 1440;
-    r2.cam_info.height = 1080;
-    // roi
-    r2.roi.roi.x_offset = 1440 - (100 + boundary_thres);
-    r2.roi.roi.y_offset = 1080 - (100 + boundary_thres);
-    r2.roi.roi.width = 100;
-    r2.roi.roi.height = 100;
-    // signal
-    r2.signal.elements.clear();
-    tier4_perception_msgs::msg::TrafficLightElement element;
-    element.color = tier4_perception_msgs::msg::TrafficLightElement::GREEN;
-    element.shape = tier4_perception_msgs::msg::TrafficLightElement::CIRCLE;
-    element.confidence = 0.8;
-    r2.signal.elements.push_back(element);
-  }
-  EXPECT_EQ(autoware::traffic_light::utils::compare_record(r1, r2), 1);
-
-  // r2 is better visible on top left
-  {
-    const uint32_t boundary_thres = 5;
-    std_msgs::msg::Header header;
-    header.stamp = rclcpp::Time(100, 10);
-    header.frame_id = "camera0";
-    // header
-    r1.header = header;
-    // cam_info
-    r1.cam_info.header = header;
-    r1.cam_info.width = 1440;
-    r1.cam_info.height = 1080;
-    // roi
-    r1.roi.roi.x_offset = boundary_thres;
-    r1.roi.roi.y_offset = boundary_thres;
-    r1.roi.roi.width = 100;
-    r1.roi.roi.height = 100;
-    // signal
-    r1.signal.elements.clear();
-    tier4_perception_msgs::msg::TrafficLightElement element;
-    element.color = tier4_perception_msgs::msg::TrafficLightElement::RED;
-    element.shape = tier4_perception_msgs::msg::TrafficLightElement::CIRCLE;
-    element.confidence = 0.9;
-    r1.signal.elements.push_back(element);
-  }
-  {
-    std_msgs::msg::Header header;
-    header.stamp = rclcpp::Time(100, 10);
-    header.frame_id = "camera0";
-    // header
-    r2.header = header;
-    // cam_info
-    r2.cam_info.header = header;
-    r2.cam_info.width = 1440;
-    r2.cam_info.height = 1080;
-    // roi
-    r2.roi.roi.x_offset = 100;
-    r2.roi.roi.y_offset = 100;
-    r2.roi.roi.width = 100;
-    r2.roi.roi.height = 100;
-    // signal
-    r2.signal.elements.clear();
-    tier4_perception_msgs::msg::TrafficLightElement element;
-    element.color = tier4_perception_msgs::msg::TrafficLightElement::GREEN;
-    element.shape = tier4_perception_msgs::msg::TrafficLightElement::CIRCLE;
-    element.confidence = 0.8;
-    r2.signal.elements.push_back(element);
-  }
-  EXPECT_EQ(autoware::traffic_light::utils::compare_record(r1, r2), -1);
-
-  // r2 is better visible on bottom left
-  {
-    const uint32_t boundary_thres = 5;
-    std_msgs::msg::Header header;
-    header.stamp = rclcpp::Time(100, 10);
-    header.frame_id = "camera0";
-    // header
-    r1.header = header;
-    // cam_info
-    r1.cam_info.header = header;
-    r1.cam_info.width = 1440;
-    r1.cam_info.height = 1080;
-    // roi
-    r1.roi.roi.x_offset = 1440 - (100 + boundary_thres);
-    ;
-    r1.roi.roi.y_offset = 1080 - (100 + boundary_thres);
-    r1.roi.roi.width = 100;
-    r1.roi.roi.height = 100;
-    // signal
-    r1.signal.elements.clear();
-    tier4_perception_msgs::msg::TrafficLightElement element;
-    element.color = tier4_perception_msgs::msg::TrafficLightElement::RED;
-    element.shape = tier4_perception_msgs::msg::TrafficLightElement::CIRCLE;
-    element.confidence = 0.9;
-    r1.signal.elements.push_back(element);
-  }
-  {
-    std_msgs::msg::Header header;
-    header.stamp = rclcpp::Time(100, 10);
-    header.frame_id = "camera0";
-    // header
-    r2.header = header;
-    // cam_info
-    r2.cam_info.header = header;
-    r2.cam_info.width = 1440;
-    r2.cam_info.height = 1080;
-    // roi
-    r2.roi.roi.x_offset = 100;
-    r2.roi.roi.y_offset = 100;
-    r2.roi.roi.width = 100;
-    r2.roi.roi.height = 100;
-    // signal
-    r2.signal.elements.clear();
-    tier4_perception_msgs::msg::TrafficLightElement element;
-    element.color = tier4_perception_msgs::msg::TrafficLightElement::GREEN;
-    element.shape = tier4_perception_msgs::msg::TrafficLightElement::CIRCLE;
-    element.confidence = 0.8;
-    r2.signal.elements.push_back(element);
-  }
-  EXPECT_EQ(autoware::traffic_light::utils::compare_record(r1, r2), -1);
+TEST(HasHigherOrEqualPriorityDifferentCamera, TruncatedRecordLosesToVisibleRecord)
+{
+  const auto truncated_record =
+    make_record_with_roi(left_top_boundary_offset, left_top_boundary_offset, "camera0");
+  const auto visible_record = make_record_with_roi(visible_offset, visible_offset, "camera1");
+  EXPECT_FALSE(utils::has_higher_or_equal_priority(truncated_record, visible_record));
 }
 
 // fourth condition
-TEST(CompareRecord, ConfidenceCheck)
+TEST(HasHigherOrEqualPriorityDifferentCamera, HigherConfidenceRecordWins)
 {
-  // r1 is higher confidence
-  autoware::traffic_light::utils::FusionRecord r1;
-  {
-    std_msgs::msg::Header header;
-    header.stamp = rclcpp::Time(100, 10);
-    header.frame_id = "camera0";
-    // header
-    r1.header = header;
-    // cam_info
-    r1.cam_info.header = header;
-    r1.cam_info.width = 1440;
-    r1.cam_info.height = 1080;
-    // roi
-    r1.roi.roi.x_offset = 100;
-    r1.roi.roi.y_offset = 100;
-    r1.roi.roi.width = 100;
-    r1.roi.roi.height = 100;
-    // signal
-    r1.signal.elements.clear();
-    tier4_perception_msgs::msg::TrafficLightElement element;
-    element.color = tier4_perception_msgs::msg::TrafficLightElement::RED;
-    element.shape = tier4_perception_msgs::msg::TrafficLightElement::CIRCLE;
-    element.confidence = 0.9;
-    r1.signal.elements.push_back(element);
-  }
-  autoware::traffic_light::utils::FusionRecord r2;
-  {
-    std_msgs::msg::Header header;
-    header.stamp = rclcpp::Time(100, 10);
-    header.frame_id = "camera0";
-    // header
-    r2.header = header;
-    // cam_info
-    r2.cam_info.header = header;
-    r2.cam_info.width = 1440;
-    r2.cam_info.height = 1080;
-    // roi
-    r2.roi.roi.x_offset = 100;
-    r2.roi.roi.y_offset = 100;
-    r2.roi.roi.width = 100;
-    r2.roi.roi.height = 100;
-    // signal
-    r2.signal.elements.clear();
-    tier4_perception_msgs::msg::TrafficLightElement element;
-    element.color = tier4_perception_msgs::msg::TrafficLightElement::GREEN;
-    element.shape = tier4_perception_msgs::msg::TrafficLightElement::CIRCLE;
-    element.confidence = 0.8;
-    r2.signal.elements.push_back(element);
-  }
-  EXPECT_EQ(autoware::traffic_light::utils::compare_record(r1, r2), 1);
-
-  // r2 is higher confidence
-  {
-    std_msgs::msg::Header header;
-    header.stamp = rclcpp::Time(100, 10);
-    header.frame_id = "camera0";
-    // header
-    r1.header = header;
-    // cam_info
-    r1.cam_info.header = header;
-    r1.cam_info.width = 1440;
-    r1.cam_info.height = 1080;
-    // roi
-    r1.roi.roi.x_offset = 100;
-    r1.roi.roi.y_offset = 100;
-    r1.roi.roi.width = 100;
-    r1.roi.roi.height = 100;
-    // signal
-    r1.signal.elements.clear();
-    tier4_perception_msgs::msg::TrafficLightElement element;
-    element.color = tier4_perception_msgs::msg::TrafficLightElement::RED;
-    element.shape = tier4_perception_msgs::msg::TrafficLightElement::CIRCLE;
-    element.confidence = 0.9;
-    r1.signal.elements.push_back(element);
-  }
-  {
-    std_msgs::msg::Header header;
-    header.stamp = rclcpp::Time(100, 10);
-    header.frame_id = "camera0";
-    // header
-    r2.header = header;
-    // cam_info
-    r2.cam_info.header = header;
-    r2.cam_info.width = 1440;
-    r2.cam_info.height = 1080;
-    // roi
-    r2.roi.roi.x_offset = 100;
-    r2.roi.roi.y_offset = 100;
-    r2.roi.roi.width = 100;
-    r2.roi.roi.height = 100;
-    // signal
-    r2.signal.elements.clear();
-    tier4_perception_msgs::msg::TrafficLightElement element;
-    element.color = tier4_perception_msgs::msg::TrafficLightElement::GREEN;
-    element.shape = tier4_perception_msgs::msg::TrafficLightElement::CIRCLE;
-    element.confidence = 0.95;
-    r2.signal.elements.push_back(element);
-  }
-  EXPECT_EQ(autoware::traffic_light::utils::compare_record(r1, r2), -1);
+  const auto higher_confidence_record = make_record(red, circle, 0.9, "camera0");
+  const auto lower_confidence_record = make_record(green, circle, 0.8, "camera1");
+  EXPECT_TRUE(
+    utils::has_higher_or_equal_priority(higher_confidence_record, lower_confidence_record));
 }
 
-}  // namespace same_camera
-
-namespace different_camera
+TEST(HasHigherOrEqualPriorityDifferentCamera, LowerConfidenceRecordLoses)
 {
-
-// first condition is nothing in different camera
-
-// second condition
-TEST(CompareRecord, UnknownCheck)
-{
-  // r1 is unknown
-  autoware::traffic_light::utils::FusionRecord r1;
-  {
-    std_msgs::msg::Header header;
-    header.stamp = rclcpp::Time(100, 10);
-    header.frame_id = "camera0";
-    // header
-    r1.header = header;
-    // cam_info
-    r1.cam_info.header = header;
-    r1.cam_info.width = 1440;
-    r1.cam_info.height = 1080;
-    // roi
-    r1.roi.roi.x_offset = 100;
-    r1.roi.roi.y_offset = 100;
-    r1.roi.roi.width = 100;
-    r1.roi.roi.height = 100;
-    // signal
-    r1.signal.elements.clear();
-    tier4_perception_msgs::msg::TrafficLightElement element;
-    element.color = tier4_perception_msgs::msg::TrafficLightElement::UNKNOWN;
-    element.shape = tier4_perception_msgs::msg::TrafficLightElement::UNKNOWN;
-    element.confidence = 0.0;
-    r1.signal.elements.push_back(element);
-  }
-  autoware::traffic_light::utils::FusionRecord r2;
-  {
-    std_msgs::msg::Header header;
-    header.stamp = rclcpp::Time(100, 10);
-    header.frame_id = "camera1";
-    // header
-    r2.header = header;
-    // cam_info
-    r2.cam_info.header = header;
-    r2.cam_info.width = 1440;
-    r2.cam_info.height = 1080;
-    // roi
-    r2.roi.roi.x_offset = 100;
-    r2.roi.roi.y_offset = 100;
-    r2.roi.roi.width = 100;
-    r2.roi.roi.height = 100;
-    // signal
-    r2.signal.elements.clear();
-    tier4_perception_msgs::msg::TrafficLightElement element;
-    element.color = tier4_perception_msgs::msg::TrafficLightElement::GREEN;
-    element.shape = tier4_perception_msgs::msg::TrafficLightElement::CIRCLE;
-    element.confidence = 0.8;
-    r2.signal.elements.push_back(element);
-  }
-  EXPECT_EQ(autoware::traffic_light::utils::compare_record(r1, r2), -1);
-
-  // r2 is unknown
-  {
-    std_msgs::msg::Header header;
-    header.stamp = rclcpp::Time(100, 10);
-    header.frame_id = "camera0";
-    // header
-    r1.header = header;
-    // cam_info
-    r1.cam_info.header = header;
-    r1.cam_info.width = 1440;
-    r1.cam_info.height = 1080;
-    // roi
-    r1.roi.roi.x_offset = 100;
-    r1.roi.roi.y_offset = 100;
-    r1.roi.roi.width = 100;
-    r1.roi.roi.height = 100;
-    // signal
-    r1.signal.elements.clear();
-    tier4_perception_msgs::msg::TrafficLightElement element;
-    element.color = tier4_perception_msgs::msg::TrafficLightElement::RED;
-    element.shape = tier4_perception_msgs::msg::TrafficLightElement::CIRCLE;
-    element.confidence = 0.9;
-    r1.signal.elements.push_back(element);
-  }
-  {
-    std_msgs::msg::Header header;
-    header.stamp = rclcpp::Time(100, 10);
-    header.frame_id = "camera1";
-    // header
-    r2.header = header;
-    // cam_info
-    r2.cam_info.header = header;
-    r2.cam_info.width = 1440;
-    r2.cam_info.height = 1080;
-    // roi
-    r2.roi.roi.x_offset = 100;
-    r2.roi.roi.y_offset = 100;
-    r2.roi.roi.width = 100;
-    r2.roi.roi.height = 100;
-    // signal
-    r2.signal.elements.clear();
-    tier4_perception_msgs::msg::TrafficLightElement element;
-    element.color = tier4_perception_msgs::msg::TrafficLightElement::UNKNOWN;
-    element.shape = tier4_perception_msgs::msg::TrafficLightElement::UNKNOWN;
-    element.confidence = 0.0;
-    r2.signal.elements.push_back(element);
-  }
-  EXPECT_EQ(autoware::traffic_light::utils::compare_record(r1, r2), 1);
-
-  // both of r1 and r2 is unknown
-  {
-    std_msgs::msg::Header header;
-    header.stamp = rclcpp::Time(100, 10);
-    header.frame_id = "camera0";
-    // header
-    r1.header = header;
-    // cam_info
-    r1.cam_info.header = header;
-    r1.cam_info.width = 1440;
-    r1.cam_info.height = 1080;
-    // roi
-    r1.roi.roi.x_offset = 100;
-    r1.roi.roi.y_offset = 100;
-    r1.roi.roi.width = 100;
-    r1.roi.roi.height = 100;
-    // signal
-    r1.signal.elements.clear();
-    tier4_perception_msgs::msg::TrafficLightElement element;
-    element.color = tier4_perception_msgs::msg::TrafficLightElement::UNKNOWN;
-    element.shape = tier4_perception_msgs::msg::TrafficLightElement::UNKNOWN;
-    element.confidence = 0.0;
-    r1.signal.elements.push_back(element);
-  }
-  {
-    std_msgs::msg::Header header;
-    header.stamp = rclcpp::Time(100, 10);
-    header.frame_id = "camera1";
-    // header
-    r2.header = header;
-    // cam_info
-    r2.cam_info.header = header;
-    r2.cam_info.width = 1440;
-    r2.cam_info.height = 1080;
-    // roi
-    r2.roi.roi.x_offset = 100;
-    r2.roi.roi.y_offset = 100;
-    r2.roi.roi.width = 100;
-    r2.roi.roi.height = 100;
-    // signal
-    r2.signal.elements.clear();
-    tier4_perception_msgs::msg::TrafficLightElement element;
-    element.color = tier4_perception_msgs::msg::TrafficLightElement::UNKNOWN;
-    element.shape = tier4_perception_msgs::msg::TrafficLightElement::UNKNOWN;
-    element.confidence = 0.0;
-    r2.signal.elements.push_back(element);
-  }
-  EXPECT_EQ(autoware::traffic_light::utils::compare_record(r1, r2), 0);
+  const auto lower_confidence_record = make_record(red, circle, 0.9, "camera0");
+  const auto higher_confidence_record = make_record(green, circle, 0.95, "camera1");
+  EXPECT_FALSE(
+    utils::has_higher_or_equal_priority(lower_confidence_record, higher_confidence_record));
 }
 
-// third condition
-TEST(CompareRecord, VisibleCheck)
+TEST(IsFullyVisible, ReturnsTrueWhenRoiIsCentered)
 {
-  // r1 is better visible on top left
-  autoware::traffic_light::utils::FusionRecord r1;
-  {
-    std_msgs::msg::Header header;
-    header.stamp = rclcpp::Time(100, 10);
-    header.frame_id = "camera0";
-    // header
-    r1.header = header;
-    // cam_info
-    r1.cam_info.header = header;
-    r1.cam_info.width = 1440;
-    r1.cam_info.height = 1080;
-    // roi
-    r1.roi.roi.x_offset = 100;
-    r1.roi.roi.y_offset = 100;
-    r1.roi.roi.width = 100;
-    r1.roi.roi.height = 100;
-    // signal
-    r1.signal.elements.clear();
-    tier4_perception_msgs::msg::TrafficLightElement element;
-    element.color = tier4_perception_msgs::msg::TrafficLightElement::RED;
-    element.shape = tier4_perception_msgs::msg::TrafficLightElement::CIRCLE;
-    element.confidence = 0.9;
-    r1.signal.elements.push_back(element);
-  }
-  autoware::traffic_light::utils::FusionRecord r2;
-  {
-    const uint32_t boundary_thres = 5;
-    std_msgs::msg::Header header;
-    header.stamp = rclcpp::Time(100, 10);
-    header.frame_id = "camera1";
-    // header
-    r2.header = header;
-    // cam_info
-    r2.cam_info.header = header;
-    r2.cam_info.width = 1440;
-    r2.cam_info.height = 1080;
-    // roi
-    r2.roi.roi.x_offset = boundary_thres;
-    r2.roi.roi.y_offset = boundary_thres;
-    r2.roi.roi.width = 100;
-    r2.roi.roi.height = 100;
-    // signal
-    r2.signal.elements.clear();
-    tier4_perception_msgs::msg::TrafficLightElement element;
-    element.color = tier4_perception_msgs::msg::TrafficLightElement::GREEN;
-    element.shape = tier4_perception_msgs::msg::TrafficLightElement::CIRCLE;
-    element.confidence = 0.8;
-    r2.signal.elements.push_back(element);
-  }
-  EXPECT_EQ(autoware::traffic_light::utils::compare_record(r1, r2), 1);
-
-  // r1 is better visible on bottom left
-  {
-    std_msgs::msg::Header header;
-    header.stamp = rclcpp::Time(100, 10);
-    header.frame_id = "camera0";
-    // header
-    r1.header = header;
-    // cam_info
-    r1.cam_info.header = header;
-    r1.cam_info.width = 1440;
-    r1.cam_info.height = 1080;
-    // roi
-    r1.roi.roi.x_offset = 100;
-    r1.roi.roi.y_offset = 100;
-    r1.roi.roi.width = 100;
-    r1.roi.roi.height = 100;
-    // signal
-    r1.signal.elements.clear();
-    tier4_perception_msgs::msg::TrafficLightElement element;
-    element.color = tier4_perception_msgs::msg::TrafficLightElement::RED;
-    element.shape = tier4_perception_msgs::msg::TrafficLightElement::CIRCLE;
-    element.confidence = 0.9;
-    r1.signal.elements.push_back(element);
-  }
-  {
-    const uint32_t boundary_thres = 5;
-    std_msgs::msg::Header header;
-    header.stamp = rclcpp::Time(100, 10);
-    header.frame_id = "camera1";
-    // header
-    r2.header = header;
-    // cam_info
-    r2.cam_info.header = header;
-    r2.cam_info.width = 1440;
-    r2.cam_info.height = 1080;
-    // roi
-    r2.roi.roi.x_offset = 1440 - (100 + boundary_thres);
-    r2.roi.roi.y_offset = 1080 - (100 + boundary_thres);
-    r2.roi.roi.width = 100;
-    r2.roi.roi.height = 100;
-    // signal
-    r2.signal.elements.clear();
-    tier4_perception_msgs::msg::TrafficLightElement element;
-    element.color = tier4_perception_msgs::msg::TrafficLightElement::GREEN;
-    element.shape = tier4_perception_msgs::msg::TrafficLightElement::CIRCLE;
-    element.confidence = 0.8;
-    r2.signal.elements.push_back(element);
-  }
-  EXPECT_EQ(autoware::traffic_light::utils::compare_record(r1, r2), 1);
-
-  // r2 is better visible on top left
-  {
-    const uint32_t boundary_thres = 5;
-    std_msgs::msg::Header header;
-    header.stamp = rclcpp::Time(100, 10);
-    header.frame_id = "camera0";
-    // header
-    r1.header = header;
-    // cam_info
-    r1.cam_info.header = header;
-    r1.cam_info.width = 1440;
-    r1.cam_info.height = 1080;
-    // roi
-    r1.roi.roi.x_offset = boundary_thres;
-    r1.roi.roi.y_offset = boundary_thres;
-    r1.roi.roi.width = 100;
-    r1.roi.roi.height = 100;
-    // signal
-    r1.signal.elements.clear();
-    tier4_perception_msgs::msg::TrafficLightElement element;
-    element.color = tier4_perception_msgs::msg::TrafficLightElement::RED;
-    element.shape = tier4_perception_msgs::msg::TrafficLightElement::CIRCLE;
-    element.confidence = 0.9;
-    r1.signal.elements.push_back(element);
-  }
-  {
-    std_msgs::msg::Header header;
-    header.stamp = rclcpp::Time(100, 10);
-    header.frame_id = "camera1";
-    // header
-    r2.header = header;
-    // cam_info
-    r2.cam_info.header = header;
-    r2.cam_info.width = 1440;
-    r2.cam_info.height = 1080;
-    // roi
-    r2.roi.roi.x_offset = 100;
-    r2.roi.roi.y_offset = 100;
-    r2.roi.roi.width = 100;
-    r2.roi.roi.height = 100;
-    // signal
-    r2.signal.elements.clear();
-    tier4_perception_msgs::msg::TrafficLightElement element;
-    element.color = tier4_perception_msgs::msg::TrafficLightElement::GREEN;
-    element.shape = tier4_perception_msgs::msg::TrafficLightElement::CIRCLE;
-    element.confidence = 0.8;
-    r2.signal.elements.push_back(element);
-  }
-  EXPECT_EQ(autoware::traffic_light::utils::compare_record(r1, r2), -1);
-
-  // r2 is better visible on bottom left
-  {
-    const uint32_t boundary_thres = 5;
-    std_msgs::msg::Header header;
-    header.stamp = rclcpp::Time(100, 10);
-    header.frame_id = "camera0";
-    // header
-    r1.header = header;
-    // cam_info
-    r1.cam_info.header = header;
-    r1.cam_info.width = 1440;
-    r1.cam_info.height = 1080;
-    // roi
-    r1.roi.roi.x_offset = 1440 - (100 + boundary_thres);
-    ;
-    r1.roi.roi.y_offset = 1080 - (100 + boundary_thres);
-    r1.roi.roi.width = 100;
-    r1.roi.roi.height = 100;
-    // signal
-    r1.signal.elements.clear();
-    tier4_perception_msgs::msg::TrafficLightElement element;
-    element.color = tier4_perception_msgs::msg::TrafficLightElement::RED;
-    element.shape = tier4_perception_msgs::msg::TrafficLightElement::CIRCLE;
-    element.confidence = 0.9;
-    r1.signal.elements.push_back(element);
-  }
-  {
-    std_msgs::msg::Header header;
-    header.stamp = rclcpp::Time(100, 10);
-    header.frame_id = "camera1";
-    // header
-    r2.header = header;
-    // cam_info
-    r2.cam_info.header = header;
-    r2.cam_info.width = 1440;
-    r2.cam_info.height = 1080;
-    // roi
-    r2.roi.roi.x_offset = 100;
-    r2.roi.roi.y_offset = 100;
-    r2.roi.roi.width = 100;
-    r2.roi.roi.height = 100;
-    // signal
-    r2.signal.elements.clear();
-    tier4_perception_msgs::msg::TrafficLightElement element;
-    element.color = tier4_perception_msgs::msg::TrafficLightElement::GREEN;
-    element.shape = tier4_perception_msgs::msg::TrafficLightElement::CIRCLE;
-    element.confidence = 0.8;
-    r2.signal.elements.push_back(element);
-  }
-  EXPECT_EQ(autoware::traffic_light::utils::compare_record(r1, r2), -1);
+  const auto record = make_record_with_roi(visible_offset, visible_offset);
+  EXPECT_TRUE(utils::is_fully_visible(record));
 }
 
-// fourth condition
-TEST(CompareRecord, ConfidenceCheck)
+TEST(IsFullyVisible, ReturnsFalseWhenRoiNearLeftBoundary)
 {
-  // r1 is higher confidence
-  autoware::traffic_light::utils::FusionRecord r1;
-  {
-    std_msgs::msg::Header header;
-    header.stamp = rclcpp::Time(100, 10);
-    header.frame_id = "camera0";
-    // header
-    r1.header = header;
-    // cam_info
-    r1.cam_info.header = header;
-    r1.cam_info.width = 1440;
-    r1.cam_info.height = 1080;
-    // roi
-    r1.roi.roi.x_offset = 100;
-    r1.roi.roi.y_offset = 100;
-    r1.roi.roi.width = 100;
-    r1.roi.roi.height = 100;
-    // signal
-    r1.signal.elements.clear();
-    tier4_perception_msgs::msg::TrafficLightElement element;
-    element.color = tier4_perception_msgs::msg::TrafficLightElement::RED;
-    element.shape = tier4_perception_msgs::msg::TrafficLightElement::CIRCLE;
-    element.confidence = 0.9;
-    r1.signal.elements.push_back(element);
-  }
-  autoware::traffic_light::utils::FusionRecord r2;
-  {
-    std_msgs::msg::Header header;
-    header.stamp = rclcpp::Time(100, 10);
-    header.frame_id = "camera1";
-    // header
-    r2.header = header;
-    // cam_info
-    r2.cam_info.header = header;
-    r2.cam_info.width = 1440;
-    r2.cam_info.height = 1080;
-    // roi
-    r2.roi.roi.x_offset = 100;
-    r2.roi.roi.y_offset = 100;
-    r2.roi.roi.width = 100;
-    r2.roi.roi.height = 100;
-    // signal
-    r2.signal.elements.clear();
-    tier4_perception_msgs::msg::TrafficLightElement element;
-    element.color = tier4_perception_msgs::msg::TrafficLightElement::GREEN;
-    element.shape = tier4_perception_msgs::msg::TrafficLightElement::CIRCLE;
-    element.confidence = 0.8;
-    r2.signal.elements.push_back(element);
-  }
-  EXPECT_EQ(autoware::traffic_light::utils::compare_record(r1, r2), 1);
-
-  // r2 is higher confidence
-  {
-    std_msgs::msg::Header header;
-    header.stamp = rclcpp::Time(100, 10);
-    header.frame_id = "camera0";
-    // header
-    r1.header = header;
-    // cam_info
-    r1.cam_info.header = header;
-    r1.cam_info.width = 1440;
-    r1.cam_info.height = 1080;
-    // roi
-    r1.roi.roi.x_offset = 100;
-    r1.roi.roi.y_offset = 100;
-    r1.roi.roi.width = 100;
-    r1.roi.roi.height = 100;
-    // signal
-    r1.signal.elements.clear();
-    tier4_perception_msgs::msg::TrafficLightElement element;
-    element.color = tier4_perception_msgs::msg::TrafficLightElement::RED;
-    element.shape = tier4_perception_msgs::msg::TrafficLightElement::CIRCLE;
-    element.confidence = 0.9;
-    r1.signal.elements.push_back(element);
-  }
-  {
-    std_msgs::msg::Header header;
-    header.stamp = rclcpp::Time(100, 10);
-    header.frame_id = "camera1";
-    // header
-    r2.header = header;
-    // cam_info
-    r2.cam_info.header = header;
-    r2.cam_info.width = 1440;
-    r2.cam_info.height = 1080;
-    // roi
-    r2.roi.roi.x_offset = 100;
-    r2.roi.roi.y_offset = 100;
-    r2.roi.roi.width = 100;
-    r2.roi.roi.height = 100;
-    // signal
-    r2.signal.elements.clear();
-    tier4_perception_msgs::msg::TrafficLightElement element;
-    element.color = tier4_perception_msgs::msg::TrafficLightElement::GREEN;
-    element.shape = tier4_perception_msgs::msg::TrafficLightElement::CIRCLE;
-    element.confidence = 0.95;
-    r2.signal.elements.push_back(element);
-  }
-  EXPECT_EQ(autoware::traffic_light::utils::compare_record(r1, r2), -1);
+  const auto record = make_record_with_roi(left_top_boundary_offset, visible_offset);
+  EXPECT_FALSE(utils::is_fully_visible(record));
 }
 
-}  // namespace different_camera
-
-TEST(CalVisibleScore, Normal)
+TEST(IsFullyVisible, ReturnsFalseWhenRoiNearRightBoundary)
 {
-  // visible
-  autoware::traffic_light::utils::FusionRecord r1;
-  {
-    std_msgs::msg::Header header;
-    header.stamp = rclcpp::Time(100, 10);
-    header.frame_id = "camera0";
-    // header
-    r1.header = header;
-    // cam_info
-    r1.cam_info.header = header;
-    r1.cam_info.width = 1440;
-    r1.cam_info.height = 1080;
-    // roi
-    r1.roi.roi.x_offset = 100;
-    r1.roi.roi.y_offset = 100;
-    r1.roi.roi.width = 100;
-    r1.roi.roi.height = 100;
-    // signal
-    r1.signal.elements.clear();
-    tier4_perception_msgs::msg::TrafficLightElement element;
-    element.color = tier4_perception_msgs::msg::TrafficLightElement::RED;
-    element.shape = tier4_perception_msgs::msg::TrafficLightElement::CIRCLE;
-    element.confidence = 0.9;
-    r1.signal.elements.push_back(element);
-  }
-  EXPECT_EQ(autoware::traffic_light::utils::cal_visible_score(r1), 1);
+  const auto record = make_record_with_roi(right_boundary_offset, visible_offset);
+  EXPECT_FALSE(utils::is_fully_visible(record));
+}
 
-  // invisible by left top
-  {
-    const uint32_t boundary_thres = 5;
-    std_msgs::msg::Header header;
-    header.stamp = rclcpp::Time(100, 10);
-    header.frame_id = "camera0";
-    // header
-    r1.header = header;
-    // cam_info
-    r1.cam_info.header = header;
-    r1.cam_info.width = 1440;
-    r1.cam_info.height = 1080;
-    // roi
-    r1.roi.roi.x_offset = boundary_thres;
-    r1.roi.roi.y_offset = boundary_thres;
-    r1.roi.roi.width = 100;
-    r1.roi.roi.height = 100;
-    // signal
-    r1.signal.elements.clear();
-    tier4_perception_msgs::msg::TrafficLightElement element;
-    element.color = tier4_perception_msgs::msg::TrafficLightElement::RED;
-    element.shape = tier4_perception_msgs::msg::TrafficLightElement::CIRCLE;
-    element.confidence = 0.9;
-    r1.signal.elements.push_back(element);
-  }
-  EXPECT_EQ(autoware::traffic_light::utils::cal_visible_score(r1), 0);
+TEST(IsFullyVisible, ReturnsFalseWhenRoiNearTopBoundary)
+{
+  const auto record = make_record_with_roi(visible_offset, left_top_boundary_offset);
+  EXPECT_FALSE(utils::is_fully_visible(record));
+}
 
-  // invisible by right top
-  {
-    const uint32_t boundary_thres = 5;
-    std_msgs::msg::Header header;
-    header.stamp = rclcpp::Time(100, 10);
-    header.frame_id = "camera0";
-    // header
-    r1.header = header;
-    // cam_info
-    r1.cam_info.header = header;
-    r1.cam_info.width = 1440;
-    r1.cam_info.height = 1080;
-    // roi
-    r1.roi.roi.x_offset = 1080 - (100 + boundary_thres);
-    r1.roi.roi.y_offset = boundary_thres;
-    r1.roi.roi.width = 100;
-    r1.roi.roi.height = 100;
-    // signal
-    r1.signal.elements.clear();
-    tier4_perception_msgs::msg::TrafficLightElement element;
-    element.color = tier4_perception_msgs::msg::TrafficLightElement::RED;
-    element.shape = tier4_perception_msgs::msg::TrafficLightElement::CIRCLE;
-    element.confidence = 0.9;
-    r1.signal.elements.push_back(element);
-  }
-  EXPECT_EQ(autoware::traffic_light::utils::cal_visible_score(r1), 0);
-
-  // invisible by left bottom
-  {
-    const uint32_t boundary_thres = 5;
-    std_msgs::msg::Header header;
-    header.stamp = rclcpp::Time(100, 10);
-    header.frame_id = "camera0";
-    // header
-    r1.header = header;
-    // cam_info
-    r1.cam_info.header = header;
-    r1.cam_info.width = 1440;
-    r1.cam_info.height = 1080;
-    // roi
-    r1.roi.roi.x_offset = boundary_thres;
-    r1.roi.roi.y_offset = 1080 - (100 + boundary_thres);
-    r1.roi.roi.width = 100;
-    r1.roi.roi.height = 100;
-    // signal
-    r1.signal.elements.clear();
-    tier4_perception_msgs::msg::TrafficLightElement element;
-    element.color = tier4_perception_msgs::msg::TrafficLightElement::RED;
-    element.shape = tier4_perception_msgs::msg::TrafficLightElement::CIRCLE;
-    element.confidence = 0.9;
-    r1.signal.elements.push_back(element);
-  }
-  EXPECT_EQ(autoware::traffic_light::utils::cal_visible_score(r1), 0);
-
-  // invisible by right bottom
-  {
-    const uint32_t boundary_thres = 5;
-    std_msgs::msg::Header header;
-    header.stamp = rclcpp::Time(100, 10);
-    header.frame_id = "camera0";
-    // header
-    r1.header = header;
-    // cam_info
-    r1.cam_info.header = header;
-    r1.cam_info.width = 1440;
-    r1.cam_info.height = 1080;
-    // roi
-    r1.roi.roi.x_offset = 1440 - (100 + boundary_thres);
-    r1.roi.roi.y_offset = 1080 - (100 + boundary_thres);
-    r1.roi.roi.width = 100;
-    r1.roi.roi.height = 100;
-    // signal
-    r1.signal.elements.clear();
-    tier4_perception_msgs::msg::TrafficLightElement element;
-    element.color = tier4_perception_msgs::msg::TrafficLightElement::RED;
-    element.shape = tier4_perception_msgs::msg::TrafficLightElement::CIRCLE;
-    element.confidence = 0.9;
-    r1.signal.elements.push_back(element);
-  }
-  EXPECT_EQ(autoware::traffic_light::utils::cal_visible_score(r1), 0);
+TEST(IsFullyVisible, ReturnsFalseWhenRoiNearBottomBoundary)
+{
+  const auto record = make_record_with_roi(visible_offset, bottom_boundary_offset);
+  EXPECT_FALSE(utils::is_fully_visible(record));
 }
 
 int main(int argc, char ** argv)


### PR DESCRIPTION
## Description
`autoware_traffic_light_multi_camera_fusion` に publisher 側の `autoware_agnocast_wrapper` を適用するため、upstream の関連PRを merge 順で cherry-pick しました。

  目的は #12710, #12776（publisher への agnocast 適用）ですが、前提となるリファクタ・テスト追加PR群および CIE 向け agnocast_wrapper 適用PR(#12712)に依存しているため、依存PRをまとめて取り込んでいます。

  ## Cherry-picked PRs

  | # | Title |
  |---|-------|
  | #12581 | test(autoware_traffic_light_multi_camera_fusion): add integration test for node |
  | #12603 | refactor(autoware_traffic_light_multi_camera_fusion): rename functions to snake_case |
  | #12610 | refactor(traffic_light_multi_camera_fusion): extract core logic from node |
  | #12630 | test(autoware_traffic_light_multi_camera_fusion): add unit tests for core logic |
  | #12657 | refactor(traffic_light_multi_camera_fusion): improve readability and maintainability |
  | #12686 | refactor(traffic_light_multi_camera_fusion): improve readability |
  | #12712 | feat(traffic_light_multi_camera_fusion): apply autoware_agnocast_wrapper for CIE |
  | #12710 | feat(traffic_light_multi_camera_fusion): apply agnocast to publisher in `traffic_light_multi_camera_fusion` |
  | #12776 | fix(traffic_light_multi_camera_fusion): use CallbackIsolatedAgnocastExecutor |
  | #12777 | refactor(traffic_light_multi_camera_fusion): restore fuse() return-based output |

## Notes

  - src/ 以下は upstream #12710 と一致しています。
  - conflict: #12610 で design/TrafficLightMultiCameraFusion.node.yaml のみコンフリクトしましたが、このファイルは本レポジトリに存在しない upstream #12440由来のドキュメントのため、削除しました。

## agnocast適用全体像
https://tier4.atlassian.net/wiki/spaces/CRL/pages/5280465670/perception+nodes