### PR TITLE
feat: actively reset nearest time to zero if we receive new trajectory

### DIFF
--- a/control/autoware_mpc_lateral_controller/src/mpc.cpp
+++ b/control/autoware_mpc_lateral_controller/src/mpc.cpp
@@ -288,8 +288,11 @@ void MPC::setReferenceTrajectory(
   const Trajectory & trajectory_msg, const TrajectoryFilteringParam & param,
   const Odometry & current_kinematics)
 {
+  bool trajectory_stamp_changed = false;
   if (m_use_temporal_trajectory) {
     const rclcpp::Time current_stamp(trajectory_msg.header.stamp);
+    trajectory_stamp_changed =
+      m_prev_trajectory_stamp.has_value() && current_stamp != *m_prev_trajectory_stamp;
     m_prev_trajectory_stamp = current_stamp;
   } else {
     m_prev_trajectory_stamp.reset();
@@ -311,6 +314,21 @@ void MPC::setReferenceTrajectory(
   MPCTrajectory mpc_traj_resampled;
   if (m_use_temporal_trajectory) {
     mpc_traj_resampled = mpc_traj_raw;
+    if (trajectory_stamp_changed && mpc_traj_resampled.size() >= 2) {
+      Pose spatial_nearest_pose;
+      size_t spatial_nearest_idx = 0;
+      double spatial_nearest_time = 0.0;
+      if (MPCUtils::calcNearestPoseInterp(
+            mpc_traj_resampled, current_kinematics.pose.pose, &spatial_nearest_pose,
+            &spatial_nearest_idx, &spatial_nearest_time, ego_nearest_dist_threshold,
+            ego_nearest_yaw_threshold)) {
+        // Planner trajectories restart time_from_start near t=0 on each update. Reuse the previous
+        // phase time and getData()'s narrow temporal window cannot observe ego near t~0.
+        m_prev_nearest_time = spatial_nearest_time;
+      } else {
+        m_prev_nearest_time.reset();
+      }
+    }
   } else {
     const auto [success_resample, resampled] = MPCUtils::resampleMPCTrajectoryByDistance(
       mpc_traj_raw, param.traj_resample_dist, nearest_seg_idx, ego_offset_to_segment);
@@ -429,7 +447,6 @@ std::pair<ResultWithReason, MPCData> MPC::getData(
       traj, current_pose, &observed_pose, &observed_index, &observed_time,
       ego_nearest_dist_threshold, ego_nearest_yaw_threshold, true, predicted_time - backward_window,
       predicted_time + forward_window);
-
     double fused_time = predicted_time;
     if (observed) {
       data.temporal_observed_time = observed_time;
@@ -589,6 +606,7 @@ std::pair<ResultWithReason, MPCTrajectory> MPC::resampleMPCTrajectoryByTime(
   for (double i = 0; i < static_cast<double>(m_param.prediction_horizon); ++i) {
     mpc_time_v.push_back(ts + i * prediction_dt);
   }
+
   if (!MPCUtils::linearInterpMPCTrajectory(input.relative_time, input, mpc_time_v, output)) {
     return {ResultWithReason{false, "mpc resample error"}, {}};
   }


### PR DESCRIPTION
## Summary

Fixes a bug in **temporal trajectory mode** where the MPC resampled reference (`~/debug/resampled_reference_trajectory`) could jump **several meters ahead of ego** immediately after a planner trajectory update. The lateral controller then tracked a reference that did not start near the vehicle — unsafe and confusing in simulation/rosbag replay.

## Symptom

After `setReferenceTrajectory` receives a message with a **new `header.stamp`**:

- `spatial_nearest` on the new plan: ego at `t ≈ 0.1 s`, distance ≈ 0 m
- MPC phase tracker still used `m_prev_nearest_time ≈ 3 s` from the previous plan
- Resampled reference first point **2–7 m** ahead of ego
- `longitudinal_err` large negative (ego behind assumed reference point)

Healthy cycles (no replan) showed `dist_to_nearest < 0.05 m` and aligned resampled reference.

## Root cause

Temporal MPC aligns ego to the plan using **phase tracking** in `MPC::getData()`:

1. `predicted_time = clamp(m_prev_nearest_time + ctrl_period, …)`
2. Search spatial nearest pose only inside a **narrow time window** around `predicted_time` (~±0.03–0.4 s)
3. Fuse with observation → `fused_time` → shift all reference times by `-fused_time` (ego at `t=0`)
4. Resample from `mpc_start_time = input_delay`

On each new planner trajectory, `time_from_start` restarts near **0 s**, but **`m_prev_nearest_time` was never reset** when `header.stamp` changed.

| State after replan | Value |
|--------------------|--------|
| Ego on new plan (spatial) | `t ≈ 0.1 s` |
| `m_prev_nearest_time` (stale) | `t ≈ 3.0 s` |
| `getData()` search window | `[2.9, 3.3] s` only |
| Points at `t ≈ 0.1 s` | **Excluded from search** |

Phase correction is capped (~±0.2 s per cycle) and cannot recover a **3 s** gap while the window stays near 3 s. The wrong `fused_time` propagates into time-shift and resample — not a bug in `linearInterpMPCTrajectory` itself.

```mermaid
flowchart LR
  A["New planner traj t≈0..8s"] --> B["m_prev_nearest_time still ≈3s"]
  B --> C["getData window ≈3s"]
  C --> D["fused_time ≈3s"]
  D --> E["Resampled ref ~3s ahead spatially"]
```

## Fix

In `MPC::setReferenceTrajectory()`, when `header.stamp` changes in temporal mode:

1. Compute **spatial** nearest time on the incoming trajectory (no time window — same as spatial mode nearest).
2. Set `m_prev_nearest_time = spatial_nearest_time`.

Next `getData()` cycle uses `predicted_time ≈ spatial_nearest + ctrl_period`, the temporal window includes the true ego match, and resampled reference stays on the vehicle.

**File:** `src/mpc.cpp` — `setReferenceTrajectory()`

```cpp
if (trajectory_stamp_changed && mpc_traj_resampled.size() >= 2) {
  // calcNearestPoseInterp(..., use_time_window=false)
  m_prev_nearest_time = spatial_nearest_time;
}
```

## What this does *not* change

- Resample grid still starts at `input_delay` (~0.18 s) — intentional delay compensation
- Far-end horizon still limited by logical planner end (`back() - 100 s` padding)
- Spatial trajectory mode unchanged
- No extra runtime logging in production path
- **When repeated old trajectories receives, the nearest time index can naturally grow and we drive along the single old trajectories as a MRM action**

## How to verify

### Rosbag / planning simulator

1. Enable `publish_debug_trajectories: true`
2. Visualize `/control/trajectory_follower/lateral/debug/resampled_reference_trajectory`
3. Trigger planner replans (new trajectory stamps every ~100 ms)

**Before fix:** after replan, resampled polyline starts meters ahead of ego.

**After fix:** first resampled points stay near ego (`< 0.5 m` typically).