### PR TITLE
refactor(trajectory_validator): rename trajectory feasibility filter

### DIFF
--- a/planning/autoware_trajectory_validator/CMakeLists.txt
+++ b/planning/autoware_trajectory_validator/CMakeLists.txt
@@ -34,7 +34,7 @@ target_compile_options(${trajectory_validator_lib_target} PUBLIC
 
 ament_auto_add_library(autoware_trajectory_validator_plugins SHARED
   src/filters/safety/uncrossable_boundary_departure.cpp
-  src/filters/safety/vehicle_constraint_filter.cpp
+  src/filters/safety/trajectory_feasibility_filter.cpp
     src/filters/safety/collision_check_filter/collision_check_filter.cpp
   src/filters/safety/collision_check_filter/reporter.cpp
   src/filters/safety/collision_check_filter/assessment.cpp
@@ -81,10 +81,10 @@ if(BUILD_TESTING)
   # ==========================================
   # 1. Plugin Unit Tests
   # ==========================================
-  ament_add_gtest(test_vehicle_constraint_filter
-    test/plugins/test_vehicle_constraint_filter.cpp
+  ament_add_gtest(test_trajectory_feasibility_filter
+    test/plugins/test_trajectory_feasibility_filter.cpp
   )
-  target_link_libraries(test_vehicle_constraint_filter
+  target_link_libraries(test_trajectory_feasibility_filter
     autoware_trajectory_validator_plugins
   )
 

--- a/planning/autoware_trajectory_validator/config/trajectory_validator.param.yaml
+++ b/planning/autoware_trajectory_validator/config/trajectory_validator.param.yaml
@@ -6,7 +6,7 @@
     shadow_mode_filter_names:
       [
         "safety::UncrossableBoundaryDepartureFilter",
-        "safety::VehicleConstraintFilter",
+        "safety::TrajectoryFeasibilityFilter",
         "traffic_rule::TrafficLightFilter",
       ]
 
@@ -87,7 +87,7 @@
         error_threshold:
           ego_acceleration: -4.0
 
-    vehicle_constraint:
+    trajectory_feasibility:
       max_speed: 16.7 # m/s
       max_acceleration: 5.0 # m/s^2
       max_deceleration: 5.0 # m/s^2 (positive but represents deceleration)

--- a/planning/autoware_trajectory_validator/config/trajectory_validator_diagnostic.param.yaml
+++ b/planning/autoware_trajectory_validator/config/trajectory_validator_diagnostic.param.yaml
@@ -2,5 +2,5 @@
   ros__parameters:
     configured_actions:
       - uncrossable_boundary_departure_filter:moderate:trajectory_validator_uncrossable_boundary_departure_danger
-      - vehicle_constraint_filter:comfortable:vehicle_constraint_filter_high_caution
+      - trajectory_feasibility_filter:comfortable:trajectory_feasibility_filter_high_caution
     no_candidates_diag_status_name: trajectory_validator_no_candidate_trajectory

--- a/planning/autoware_trajectory_validator/include/autoware/trajectory_validator/filters/safety/trajectory_feasibility_filter.hpp
+++ b/planning/autoware_trajectory_validator/include/autoware/trajectory_validator/filters/safety/trajectory_feasibility_filter.hpp
@@ -12,8 +12,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef AUTOWARE__TRAJECTORY_VALIDATOR__FILTERS__SAFETY__VEHICLE_CONSTRAINT_FILTER_HPP_
-#define AUTOWARE__TRAJECTORY_VALIDATOR__FILTERS__SAFETY__VEHICLE_CONSTRAINT_FILTER_HPP_
+#ifndef AUTOWARE__TRAJECTORY_VALIDATOR__FILTERS__SAFETY__TRAJECTORY_FEASIBILITY_FILTER_HPP_
+#define AUTOWARE__TRAJECTORY_VALIDATOR__FILTERS__SAFETY__TRAJECTORY_FEASIBILITY_FILTER_HPP_
 
 #include "autoware/trajectory_validator/validator_interface.hpp"
 
@@ -25,13 +25,13 @@
 namespace autoware::trajectory_validator::plugin::safety
 {
 /**
- * @brief VehicleConstraintFilter class - checks if the trajectory respects vehicle constraints
- * (e.g., max speed, max acceleration/deceleration).
+ * @brief TrajectoryFeasibilityFilter class - checks if the trajectory respects vehicle
+ * feasibility constraints (e.g., max speed, max acceleration/deceleration).
  */
-class VehicleConstraintFilter final : public plugin::ValidatorInterface
+class TrajectoryFeasibilityFilter final : public plugin::ValidatorInterface
 {
 public:
-  VehicleConstraintFilter();
+  TrajectoryFeasibilityFilter();
 
   result_t is_feasible(
     const CandidateTrajectory & candidate_trajectory, const FilterContext & context) final;
@@ -45,17 +45,17 @@ private:
   MetricReport check_steering_angle(const TrajectoryPoints & traj_points) const;
   MetricReport check_steering_rate(const TrajectoryPoints & traj_points) const;
 
-  using Checker = MetricReport (VehicleConstraintFilter::*)(const TrajectoryPoints &) const;
+  using Checker = MetricReport (TrajectoryFeasibilityFilter::*)(const TrajectoryPoints &) const;
 
   inline static const std::array<Checker, 5> checkers_ = {{
-    &VehicleConstraintFilter::check_speed,
-    &VehicleConstraintFilter::check_acceleration,
-    &VehicleConstraintFilter::check_deceleration,
-    &VehicleConstraintFilter::check_steering_angle,
-    &VehicleConstraintFilter::check_steering_rate,
+    &TrajectoryFeasibilityFilter::check_speed,
+    &TrajectoryFeasibilityFilter::check_acceleration,
+    &TrajectoryFeasibilityFilter::check_deceleration,
+    &TrajectoryFeasibilityFilter::check_steering_angle,
+    &TrajectoryFeasibilityFilter::check_steering_rate,
   }};  //!< Array of checker functions
 
-  validator::Params::VehicleConstraint params_;  //!< Parameters for this filter
+  validator::Params::TrajectoryFeasibility params_;  //!< Parameters for this filter
 };
 
 // --- Helper functions for constraint checks ---
@@ -113,4 +113,4 @@ std::pair<double, bool> is_steering_angle_ok(
 std::pair<double, bool> is_steering_rate_ok(
   const TrajectoryPoints & traj_points, const VehicleInfo & vehicle_info, double max_steering_rate);
 }  // namespace autoware::trajectory_validator::plugin::safety
-#endif  // AUTOWARE__TRAJECTORY_VALIDATOR__FILTERS__SAFETY__VEHICLE_CONSTRAINT_FILTER_HPP_
+#endif  // AUTOWARE__TRAJECTORY_VALIDATOR__FILTERS__SAFETY__TRAJECTORY_FEASIBILITY_FILTER_HPP_

--- a/planning/autoware_trajectory_validator/param/parameter_struct.yaml
+++ b/planning/autoware_trajectory_validator/param/parameter_struct.yaml
@@ -11,7 +11,7 @@ validator:
     description: List of filter names that run in which results are logged but do not affect trajectory feasibility.
     read_only: false
 
-  vehicle_constraint:
+  trajectory_feasibility:
     max_speed:
       type: double
       default_value: 16.7

--- a/planning/autoware_trajectory_validator/plugins.xml
+++ b/planning/autoware_trajectory_validator/plugins.xml
@@ -6,10 +6,11 @@
       Filters trajectories that cross uncrossable boundaries
     </description>
   </class>
-  <class type="safety::VehicleConstraintFilter"
+  <class type="safety::TrajectoryFeasibilityFilter"
     base_class_type="autoware::trajectory_validator::plugin::ValidatorInterface">
     <description>
-      Filters trajectories that violate vehicle constraints such as maximum speed, acceleration, and steering angle
+      Filters trajectories that violate vehicle feasibility constraints such as maximum speed,
+      acceleration, and steering angle
     </description>
   </class>
   <class type="safety::CollisionCheckFilter"

--- a/planning/autoware_trajectory_validator/schema/trajectory_validator.schema.json
+++ b/planning/autoware_trajectory_validator/schema/trajectory_validator.schema.json
@@ -289,7 +289,7 @@
           "required": [],
           "additionalProperties": false
         },
-        "vehicle_constraint": {
+        "trajectory_feasibility": {
           "type": "object",
           "properties": {
             "max_speed": {

--- a/planning/autoware_trajectory_validator/src/filters/safety/trajectory_feasibility_filter.cpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/trajectory_feasibility_filter.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "autoware/trajectory_validator/filters/safety/vehicle_constraint_filter.hpp"
+#include "autoware/trajectory_validator/filters/safety/trajectory_feasibility_filter.hpp"
 
 #include <autoware_utils_geometry/geometry.hpp>
 #include <builtin_interfaces/msg/duration.hpp>
@@ -105,16 +105,17 @@ std::vector<std::optional<double>> to_steering_angles(
 }
 }  // namespace
 
-VehicleConstraintFilter::VehicleConstraintFilter() : ValidatorInterface("vehicle_constraint_filter")
+TrajectoryFeasibilityFilter::TrajectoryFeasibilityFilter()
+: ValidatorInterface("trajectory_feasibility_filter")
 {
 }
 
-void VehicleConstraintFilter::update_parameters(const validator::Params & params)
+void TrajectoryFeasibilityFilter::update_parameters(const validator::Params & params)
 {
-  params_ = params.vehicle_constraint;
+  params_ = params.trajectory_feasibility;
 }
 
-VehicleConstraintFilter::result_t VehicleConstraintFilter::is_feasible(
+TrajectoryFeasibilityFilter::result_t TrajectoryFeasibilityFilter::is_feasible(
   const CandidateTrajectory & candidate_trajectory, const FilterContext &)
 {
   const auto & traj_points = candidate_trajectory.points;
@@ -135,7 +136,7 @@ VehicleConstraintFilter::result_t VehicleConstraintFilter::is_feasible(
   return ValidationResult{is_feasible, std::move(metrics)};
 }
 
-MetricReport VehicleConstraintFilter::check_speed(const TrajectoryPoints & traj_points) const
+MetricReport TrajectoryFeasibilityFilter::check_speed(const TrajectoryPoints & traj_points) const
 {
   const auto [max_observed, is_ok] = is_speed_ok(traj_points, params_.max_speed);
 
@@ -149,7 +150,8 @@ MetricReport VehicleConstraintFilter::check_speed(const TrajectoryPoints & traj_
     .risk(risk_level);
 }
 
-MetricReport VehicleConstraintFilter::check_acceleration(const TrajectoryPoints & traj_points) const
+MetricReport TrajectoryFeasibilityFilter::check_acceleration(
+  const TrajectoryPoints & traj_points) const
 {
   const auto [max_observed, is_ok] = is_acceleration_ok(traj_points, params_.max_acceleration);
 
@@ -163,7 +165,8 @@ MetricReport VehicleConstraintFilter::check_acceleration(const TrajectoryPoints 
     .risk(risk_level);
 }
 
-MetricReport VehicleConstraintFilter::check_deceleration(const TrajectoryPoints & traj_points) const
+MetricReport TrajectoryFeasibilityFilter::check_deceleration(
+  const TrajectoryPoints & traj_points) const
 {
   const auto [max_observed, is_ok] = is_deceleration_ok(traj_points, params_.max_deceleration);
 
@@ -177,7 +180,7 @@ MetricReport VehicleConstraintFilter::check_deceleration(const TrajectoryPoints 
     .risk(risk_level);
 }
 
-MetricReport VehicleConstraintFilter::check_steering_angle(
+MetricReport TrajectoryFeasibilityFilter::check_steering_angle(
   const TrajectoryPoints & traj_points) const
 {
   const auto [max_observed, is_ok] =
@@ -193,7 +196,7 @@ MetricReport VehicleConstraintFilter::check_steering_angle(
     .risk(risk_level);
 }
 
-MetricReport VehicleConstraintFilter::check_steering_rate(
+MetricReport TrajectoryFeasibilityFilter::check_steering_rate(
   const TrajectoryPoints & traj_points) const
 {
   const auto [max_observed, is_ok] =
@@ -302,4 +305,4 @@ std::pair<double, bool> is_steering_rate_ok(
 namespace safety = autoware::trajectory_validator::plugin::safety;
 
 PLUGINLIB_EXPORT_CLASS(
-  safety::VehicleConstraintFilter, autoware::trajectory_validator::plugin::ValidatorInterface)
+  safety::TrajectoryFeasibilityFilter, autoware::trajectory_validator::plugin::ValidatorInterface)

--- a/planning/autoware_trajectory_validator/test/plugins/test_trajectory_feasibility_filter.cpp
+++ b/planning/autoware_trajectory_validator/test/plugins/test_trajectory_feasibility_filter.cpp
@@ -12,7 +12,7 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#include "autoware/trajectory_validator/filters/safety/vehicle_constraint_filter.hpp"
+#include "autoware/trajectory_validator/filters/safety/trajectory_feasibility_filter.hpp"
 
 #include <gtest/gtest.h>
 
@@ -39,7 +39,7 @@ autoware_planning_msgs::msg::TrajectoryPoint create_trajectory_point(
 
 namespace autoware::trajectory_validator::plugin::safety::testing
 {
-TEST(VehicleConstraintFilterTest, FeasibleWhenAllConstraintsSatisfied)
+TEST(TrajectoryFeasibilityFilterTest, FeasibleWhenAllConstraintsSatisfied)
 {
   // Create a simple trajectory that satisfies all constraints
   TrajectoryPoints traj_points = {
@@ -50,13 +50,13 @@ TEST(VehicleConstraintFilterTest, FeasibleWhenAllConstraintsSatisfied)
   VehicleInfo vehicle_info;
   vehicle_info.wheel_base_m = 2.5;  // Example wheelbase
 
-  VehicleConstraintFilter filter;
+  TrajectoryFeasibilityFilter filter;
   validator::Params params;
-  params.vehicle_constraint.max_speed = 10.0;
-  params.vehicle_constraint.max_acceleration = 2.0;
-  params.vehicle_constraint.max_deceleration = 2.0;
-  params.vehicle_constraint.max_steering_angle = 0.5;
-  params.vehicle_constraint.max_steering_rate = 0.1;
+  params.trajectory_feasibility.max_speed = 10.0;
+  params.trajectory_feasibility.max_acceleration = 2.0;
+  params.trajectory_feasibility.max_deceleration = 2.0;
+  params.trajectory_feasibility.max_steering_angle = 0.5;
+  params.trajectory_feasibility.max_steering_rate = 0.1;
   filter.update_parameters(params);
   filter.set_vehicle_info(vehicle_info);
 
@@ -69,7 +69,7 @@ TEST(VehicleConstraintFilterTest, FeasibleWhenAllConstraintsSatisfied)
   EXPECT_TRUE(result.value().is_feasible);
 }
 
-TEST(VehicleConstraintFilterTest, InfeasibleWhenSpeedExceedsMax)
+TEST(TrajectoryFeasibilityFilterTest, InfeasibleWhenSpeedExceedsMax)
 {
   // Create a trajectory that exceeds max speed
   TrajectoryPoints traj_points = {
@@ -80,10 +80,10 @@ TEST(VehicleConstraintFilterTest, InfeasibleWhenSpeedExceedsMax)
   VehicleInfo vehicle_info;
   vehicle_info.wheel_base_m = 2.5;  // Example wheelbase
 
-  VehicleConstraintFilter filter;
+  TrajectoryFeasibilityFilter filter;
 
   validator::Params params;
-  params.vehicle_constraint.max_speed = 10.0;
+  params.trajectory_feasibility.max_speed = 10.0;
   filter.update_parameters(params);
   filter.set_vehicle_info(vehicle_info);
 
@@ -96,7 +96,7 @@ TEST(VehicleConstraintFilterTest, InfeasibleWhenSpeedExceedsMax)
   EXPECT_FALSE(result.value().is_feasible);
 }
 
-TEST(VehicleConstraintFilterTest, InfeasibleWhenAccelerationExceedsMax)
+TEST(TrajectoryFeasibilityFilterTest, InfeasibleWhenAccelerationExceedsMax)
 {
   // Create a trajectory that exceeds max acceleration
   TrajectoryPoints traj_points = {
@@ -108,9 +108,9 @@ TEST(VehicleConstraintFilterTest, InfeasibleWhenAccelerationExceedsMax)
   VehicleInfo vehicle_info;
   vehicle_info.wheel_base_m = 2.5;  // Example wheelbase
 
-  VehicleConstraintFilter filter;
+  TrajectoryFeasibilityFilter filter;
   validator::Params params;
-  params.vehicle_constraint.max_acceleration = 2.0;
+  params.trajectory_feasibility.max_acceleration = 2.0;
   filter.update_parameters(params);
   filter.set_vehicle_info(vehicle_info);
 
@@ -123,7 +123,7 @@ TEST(VehicleConstraintFilterTest, InfeasibleWhenAccelerationExceedsMax)
   EXPECT_FALSE(result.value().is_feasible);
 }
 
-TEST(VehicleConstraintFilterTest, InfeasibleWhenDecelerationExceedsMax)
+TEST(TrajectoryFeasibilityFilterTest, InfeasibleWhenDecelerationExceedsMax)
 {
   // Create a trajectory that exceeds max deceleration
   TrajectoryPoints traj_points = {
@@ -135,10 +135,10 @@ TEST(VehicleConstraintFilterTest, InfeasibleWhenDecelerationExceedsMax)
   VehicleInfo vehicle_info;
   vehicle_info.wheel_base_m = 2.5;  // Example wheelbase
 
-  VehicleConstraintFilter filter;
+  TrajectoryFeasibilityFilter filter;
 
   validator::Params params;
-  params.vehicle_constraint.max_deceleration = 2.0;
+  params.trajectory_feasibility.max_deceleration = 2.0;
   filter.update_parameters(params);
   filter.set_vehicle_info(vehicle_info);
 
@@ -151,7 +151,7 @@ TEST(VehicleConstraintFilterTest, InfeasibleWhenDecelerationExceedsMax)
   EXPECT_FALSE(result.value().is_feasible);
 }
 
-TEST(VehicleConstraintFilterTest, InfeasibleWhenSteeringAngleExceedsMax)
+TEST(TrajectoryFeasibilityFilterTest, InfeasibleWhenSteeringAngleExceedsMax)
 {
   // Create a trajectory that exceeds max steering angle after smoothing
   TrajectoryPoints traj_points = {
@@ -166,10 +166,10 @@ TEST(VehicleConstraintFilterTest, InfeasibleWhenSteeringAngleExceedsMax)
   VehicleInfo vehicle_info;
   vehicle_info.wheel_base_m = 2.5;  // Example wheelbase
 
-  VehicleConstraintFilter filter;
+  TrajectoryFeasibilityFilter filter;
 
   validator::Params params;
-  params.vehicle_constraint.max_steering_angle = 0.5;
+  params.trajectory_feasibility.max_steering_angle = 0.5;
   filter.update_parameters(params);
   filter.set_vehicle_info(vehicle_info);
 
@@ -182,7 +182,7 @@ TEST(VehicleConstraintFilterTest, InfeasibleWhenSteeringAngleExceedsMax)
   EXPECT_FALSE(result.value().is_feasible);
 }
 
-TEST(VehicleConstraintFilterTest, InfeasibleWhenSteeringRateExceedsMax)
+TEST(TrajectoryFeasibilityFilterTest, InfeasibleWhenSteeringRateExceedsMax)
 {
   // Create a trajectory that exceeds max steering rate after smoothing
   TrajectoryPoints traj_points = {
@@ -199,10 +199,10 @@ TEST(VehicleConstraintFilterTest, InfeasibleWhenSteeringRateExceedsMax)
   VehicleInfo vehicle_info;
   vehicle_info.wheel_base_m = 2.5;  // Example wheelbase
 
-  VehicleConstraintFilter filter;
+  TrajectoryFeasibilityFilter filter;
 
   validator::Params params;
-  params.vehicle_constraint.max_steering_rate = 0.1;
+  params.trajectory_feasibility.max_steering_rate = 0.1;
   filter.update_parameters(params);
   filter.set_vehicle_info(vehicle_info);
 

--- a/planning/autoware_trajectory_validator/trajectory_validator.param.yaml
+++ b/planning/autoware_trajectory_validator/trajectory_validator.param.yaml
@@ -3,17 +3,17 @@
     filter_names:
       [
         "autoware::trajectory_validator::plugin::OutOfLaneFilter",
-        "autoware::trajectory_validator::plugin::VehicleConstraintFilter",
+        "autoware::trajectory_validator::plugin::TrajectoryFeasibilityFilter",
       ]
     # available filters:
     #  "autoware::trajectory_validator::plugin::OutOfLaneFilter"
-    #  "autoware::trajectory_validator::plugin::VehicleConstraintFilter"
+    #  "autoware::trajectory_validator::plugin::TrajectoryFeasibilityFilter"
 
     out_of_lane:
       time: 2.0
       min_value: 0.0
 
-    vehicle_constraint:
+    trajectory_feasibility:
       max_speed: 16.7 # m/s
       max_acceleration: 5.0 # m/s^2
       max_deceleration: 5.0 # m/s^2 (positive but represents deceleration)


### PR DESCRIPTION
## What

[TIER IV INTERNAL TICKET](https://tier4.atlassian.net/browse/PDDP-258)

Launcher update: https://github.com/tier4/autoware_launch.x2/pull/2480

This pull request renames the "VehicleConstraintFilter" to "TrajectoryFeasibilityFilter" throughout the `autoware_trajectory_validator` package to better reflect its purpose—validating the feasibility of trajectories based on vehicle constraints. All related code, configuration, documentation, and tests have been updated accordingly. No functional changes were made; this is a refactor for clarity and consistency.

**Rename Options:**
- TrajectoryKinematicsFilter
- VehicleKinematicsFilter