### PR TITLE
feat: add a initial duration for error duration accumulation

### DIFF
--- a/evaluator/autoware_planning_evaluator/config/planning_evaluator.param.yaml
+++ b/evaluator/autoware_planning_evaluator/config/planning_evaluator.param.yaml
@@ -1,6 +1,7 @@
 /**:
   ros__parameters:
     ego_frame: base_link # reference frame of ego
+    initial_span_duration_s: 0.1 # [s] default duration on the first frame of a span accumulation (error_duration, keep_duration)
 
     metrics_for_publish:
       - curvature

--- a/evaluator/autoware_planning_evaluator/include/autoware/planning_evaluator/metric_accumulators/planning_factor_accumulator.hpp
+++ b/evaluator/autoware_planning_evaluator/include/autoware/planning_evaluator/metric_accumulators/planning_factor_accumulator.hpp
@@ -55,7 +55,9 @@ public:
     double time_count_threshold_s = 60.0;  // [s] time threshold to count a stop as a new one
     double dist_count_threshold_m = 5.0;   // [m] distance threshold to count a stop as a new one
     double abnormal_deceleration_threshold_mps2 =
-      2.0;       // [m/s^2] deceleration threshold for a stop to be considered as abnormal
+      2.0;  // [m/s^2] deceleration threshold for a stop to be considered as abnormal
+    double initial_span_duration_s =
+      0.1;      // [s] default duration on the first frame of a stop decision span
   } parameters;  // struct Parameters
 
   PlanningFactorAccumulator() = default;
@@ -136,6 +138,7 @@ private:
         // set new stop decision
         last_decision_time = cur_time;
         clear_current_stop_decision();
+        stop_decision_keep_time = parameters.initial_span_duration_s;
 
       } else {
         // keep the last stop decision

--- a/evaluator/autoware_planning_evaluator/include/autoware/planning_evaluator/metric_accumulators/planning_factor_accumulator.hpp
+++ b/evaluator/autoware_planning_evaluator/include/autoware/planning_evaluator/metric_accumulators/planning_factor_accumulator.hpp
@@ -57,7 +57,7 @@ public:
     double abnormal_deceleration_threshold_mps2 =
       2.0;  // [m/s^2] deceleration threshold for a stop to be considered as abnormal
     double initial_span_duration_s =
-      0.1;      // [s] default duration on the first frame of a stop decision span
+      0.1;       // [s] default duration on the first frame of a stop decision span
   } parameters;  // struct Parameters
 
   PlanningFactorAccumulator() = default;

--- a/evaluator/autoware_planning_evaluator/include/autoware/planning_evaluator/metric_accumulators/trajectory_validation_accumulator.hpp
+++ b/evaluator/autoware_planning_evaluator/include/autoware/planning_evaluator/metric_accumulators/trajectory_validation_accumulator.hpp
@@ -61,6 +61,8 @@ public:
   struct Parameters
   {
     bool count_warn_as_error = false;
+    double initial_span_duration_s =
+      0.1;  // [s] default duration on the first frame of an error span
   } parameters;
 
   TrajectoryValidationAccumulator() = default;
@@ -102,7 +104,7 @@ private:
     std::optional<double> last_update_time_s_;
 
     /// `current_time_s` is ValidationReport.trajectory_stamp for this step; dt is derived inside.
-    void update(bool is_error, double current_time_s);
+    void update(bool is_error, double current_time_s, double initial_span_duration_s);
     /// Move ongoing error duration into the accumulator (e.g. before final JSON export).
     void flushOpenErrorForJson();
   };

--- a/evaluator/autoware_planning_evaluator/schema/autoware_planning_evaluator.schema.json
+++ b/evaluator/autoware_planning_evaluator/schema/autoware_planning_evaluator.schema.json
@@ -11,6 +11,11 @@
           "type": "string",
           "default": "base_link"
         },
+        "initial_span_duration_s": {
+          "description": "default duration [s] on the first frame of a span accumulation (error_duration, keep_duration)",
+          "type": "number",
+          "default": 0.1
+        },
         "metrics_for_publish": {
           "description": "metrics to collect and publish",
           "type": "array",

--- a/evaluator/autoware_planning_evaluator/src/metric_accumulators/trajectory_validation_accumulator.cpp
+++ b/evaluator/autoware_planning_evaluator/src/metric_accumulators/trajectory_validation_accumulator.cpp
@@ -47,7 +47,7 @@ bool isMetricScopeUnderGenerator(const std::string & scope, const std::string & 
 }  // namespace
 
 void TrajectoryValidationAccumulator::ErrorSpanStats::update(
-  const bool is_error, const double current_time_s)
+  const bool is_error, const double current_time_s, const double initial_span_duration_s)
 {
   double dt = 0.0;
   if (last_update_time_s_.has_value()) {
@@ -62,7 +62,7 @@ void TrajectoryValidationAccumulator::ErrorSpanStats::update(
     if (!in_error_) {
       in_error_ = true;
       error_count++;
-      current_error_duration_s = 0.0;
+      current_error_duration_s = initial_span_duration_s;
     } else {
       current_error_duration_s += dt;
     }
@@ -99,8 +99,9 @@ void TrajectoryValidationAccumulator::update(const ValidationReportArray & msg)
       static_cast<double>(stamp.sec) + static_cast<double>(stamp.nanosec) * 1e-9;
 
     const bool warn_as_err = parameters.count_warn_as_error;
+    const double initial_span_duration_s = parameters.initial_span_duration_s;
     const bool traj_err = levelIndicatesError(report.level, warn_as_err);
-    stats_by_scope_[gen].update(traj_err, report_time_s);
+    stats_by_scope_[gen].update(traj_err, report_time_s, initial_span_duration_s);
 
     // Rows in this report (last row wins if the same scope appears more than once).
     std::unordered_map<std::string, bool> present_error_by_scope;
@@ -113,7 +114,7 @@ void TrajectoryValidationAccumulator::update(const ValidationReportArray & msg)
     }
 
     for (const auto & [scope, m_err] : present_error_by_scope) {
-      stats_by_scope_[scope].update(m_err, report_time_s);
+      stats_by_scope_[scope].update(m_err, report_time_s, initial_span_duration_s);
     }
 
     for (const auto & entry : stats_by_scope_) {
@@ -124,7 +125,7 @@ void TrajectoryValidationAccumulator::update(const ValidationReportArray & msg)
       if (present_error_by_scope.count(scope) != 0) {
         continue;
       }
-      stats_by_scope_[scope].update(false, report_time_s);
+      stats_by_scope_[scope].update(false, report_time_s, initial_span_duration_s);
     }
   }
 }

--- a/evaluator/autoware_planning_evaluator/src/planning_evaluator_node.cpp
+++ b/evaluator/autoware_planning_evaluator/src/planning_evaluator_node.cpp
@@ -90,6 +90,12 @@ PlanningEvaluatorNode::PlanningEvaluatorNode(const rclcpp::NodeOptions & node_op
   metrics_accumulator_.planning_factor_accumulator.parameters.abnormal_deceleration_threshold_mps2 =
     declare_parameter<double>("stop_decision.abnormal_deceleration_threshold_mps2");
 
+  const auto initial_span_duration_s = declare_parameter<double>("initial_span_duration_s");
+  metrics_accumulator_.planning_factor_accumulator.parameters.initial_span_duration_s =
+    initial_span_duration_s;
+  metrics_accumulator_.trajectory_validation_accumulator.parameters.initial_span_duration_s =
+    initial_span_duration_s;
+
   metrics_accumulator_.steer_accumulator.parameters.window_duration_s =
     declare_parameter<double>("steer_change_count.window_duration_s");
   metrics_accumulator_.steer_accumulator.parameters.steer_rate_margin =

--- a/evaluator/autoware_planning_evaluator/test/test_planning_evaluator_node.cpp
+++ b/evaluator/autoware_planning_evaluator/test/test_planning_evaluator_node.cpp
@@ -781,7 +781,7 @@ TEST_F(EvalTest, TestStopDecisionDuration)
     rclcpp::spin_some(dummy_node);
     rclcpp::sleep_for(std::chrono::milliseconds(100));
   }
-  EXPECT_NEAR(metric_value_, 0.0, 0.1);
+  EXPECT_NEAR(metric_value_, 0.1, 0.1);
 
   metric_updated_ = false;
   publishStopPlanningFactor(100.0, 100.0, 0.0, 500);
@@ -842,7 +842,7 @@ TEST_F(EvalTest, TestAbnormalStopDecisionDuration)
     rclcpp::spin_some(dummy_node);
     rclcpp::sleep_for(std::chrono::milliseconds(100));
   }
-  EXPECT_NEAR(metric_value_, 0.0, 0.1);
+  EXPECT_NEAR(metric_value_, 0.1, 0.1);
 
   metric_updated_ = false;
   publishStopPlanningFactor(5.0, 5.0, 0.0, 1000);


### PR DESCRIPTION
# Summary

When a filter_error occurs 1 frame, the `error_duration` accumulates `0[s]` in the previous implementation. 

This PR makes the first error frame, accumulating a default `initial_span_duration_s=0.1 [s]`. So it can be treated as failed during DLR tests.

# How to Test
Psim
Evaluator:
- [DevOps](https://evaluation.tier4.jp/evaluation/reports/0f65348d-420e-556b-af7a-ce57c6763db4?project_id=x2_dev)
- [ReferenceDriving](https://evaluation.tier4.jp/evaluation/reports/76e3b402-56a4-5066-9cb0-20a7dd14df88?project_id=x2_dev)