### PR TITLE
feat(decorative_tracker_merger): cherry-pick #12425 and #12709

### DIFF
--- a/perception/autoware_bevfusion/include/autoware/bevfusion/bevfusion_node.hpp
+++ b/perception/autoware_bevfusion/include/autoware/bevfusion/bevfusion_node.hpp
@@ -22,11 +22,10 @@
 #include "autoware/bevfusion/visibility_control.hpp"
 
 #include <Eigen/Core>
-#include <autoware/universe_utils/system/stop_watch.hpp>
-#include <autoware_utils/ros/debug_publisher.hpp>
-#include <autoware_utils/ros/diagnostics_interface.hpp>
-#include <autoware_utils/ros/published_time_publisher.hpp>
-#include <autoware_utils/system/stop_watch.hpp>
+#include <autoware_utils_debug/debug_publisher.hpp>
+#include <autoware_utils_debug/published_time_publisher.hpp>
+#include <autoware_utils_diagnostics/diagnostics_interface.hpp>
+#include <autoware_utils_system/stop_watch.hpp>
 #include <cuda_blackboard/cuda_adaptation.hpp>
 #include <cuda_blackboard/cuda_blackboard_subscriber.hpp>
 #include <cuda_blackboard/cuda_pointcloud2.hpp>
@@ -130,12 +129,13 @@ private:
   NonMaximumSuppression iou_bev_nms_;
 
   std::unique_ptr<BEVFusionTRT> detector_ptr_{nullptr};
-  std::unique_ptr<autoware_utils::DiagnosticsInterface> diagnostics_detector_trt_;
+  std::unique_ptr<autoware_utils_diagnostics::DiagnosticsInterface> diagnostics_detector_trt_;
 
   // debugger
-  std::unique_ptr<autoware_utils::StopWatch<std::chrono::milliseconds>> stop_watch_ptr_{nullptr};
-  std::unique_ptr<autoware_utils::DebugPublisher> debug_publisher_ptr_{nullptr};
-  std::unique_ptr<autoware_utils::PublishedTimePublisher> published_time_pub_{nullptr};
+  std::unique_ptr<autoware_utils_system::StopWatch<std::chrono::milliseconds>> stop_watch_ptr_{
+    nullptr};
+  std::unique_ptr<autoware_utils_debug::DebugPublisher> debug_publisher_ptr_{nullptr};
+  std::unique_ptr<autoware_utils_debug::PublishedTimePublisher> published_time_pub_{nullptr};
 };
 }  // namespace autoware::bevfusion
 

--- a/perception/autoware_bevfusion/include/autoware/bevfusion/bevfusion_trt.hpp
+++ b/perception/autoware_bevfusion/include/autoware/bevfusion/bevfusion_trt.hpp
@@ -25,7 +25,7 @@
 #include <autoware/cuda_utils/cuda_check_error.hpp>
 #include <autoware/cuda_utils/cuda_unique_ptr.hpp>
 #include <autoware/tensorrt_common/tensorrt_common.hpp>
-#include <autoware/universe_utils/system/stop_watch.hpp>
+#include <autoware_utils_system/stop_watch.hpp>
 #include <cuda_blackboard/cuda_pointcloud2.hpp>
 
 #include <sensor_msgs/msg/camera_info.hpp>
@@ -135,7 +135,7 @@ protected:
   std::unique_ptr<autoware::tensorrt_common::TrtCommon> network_trt_ptr_{nullptr};
   std::unique_ptr<autoware::tensorrt_common::TrtCommon> image_backbone_trt_ptr_{nullptr};
   std::unique_ptr<VoxelGenerator> vg_ptr_{nullptr};
-  std::unique_ptr<autoware::universe_utils::StopWatch<std::chrono::milliseconds>> stop_watch_ptr_{
+  std::unique_ptr<autoware_utils_system::StopWatch<std::chrono::milliseconds>> stop_watch_ptr_{
     nullptr};
   std::unique_ptr<PreprocessCuda> pre_ptr_{nullptr};
   std::unique_ptr<PostprocessCuda> post_ptr_{nullptr};

--- a/perception/autoware_bevfusion/lib/bevfusion_trt.cpp
+++ b/perception/autoware_bevfusion/lib/bevfusion_trt.cpp
@@ -22,7 +22,7 @@
 
 #include <autoware/cuda_utils/cuda_utils.hpp>
 #include <autoware/point_types/memory.hpp>
-#include <autoware/universe_utils/math/constants.hpp>
+#include <autoware_utils_math/constants.hpp>
 
 #include <algorithm>
 #include <cstddef>
@@ -51,8 +51,7 @@ BEVFusionTRT::BEVFusionTRT(
   }
   vg_ptr_ = std::make_unique<VoxelGenerator>(densification_param, config_, stream_);
 
-  stop_watch_ptr_ =
-    std::make_unique<autoware::universe_utils::StopWatch<std::chrono::milliseconds>>();
+  stop_watch_ptr_ = std::make_unique<autoware_utils_system::StopWatch<std::chrono::milliseconds>>();
   stop_watch_ptr_->tic("processing/inner");
 
   initPtr();

--- a/perception/autoware_bevfusion/lib/postprocess/non_maximum_suppression.cpp
+++ b/perception/autoware_bevfusion/lib/postprocess/non_maximum_suppression.cpp
@@ -16,7 +16,7 @@
 
 #include <autoware/object_recognition_utils/geometry.hpp>
 #include <autoware/object_recognition_utils/object_recognition_utils.hpp>
-#include <autoware/universe_utils/geometry/geometry.hpp>
+#include <autoware_utils_geometry/geometry.hpp>
 
 #include <cstddef>
 #include <cstdint>
@@ -48,7 +48,7 @@ bool NonMaximumSuppression::isTargetPairObject(
     return false;
   }
 
-  const auto sqr_dist_2d = autoware::universe_utils::calcSquaredDistance2d(
+  const auto sqr_dist_2d = autoware_utils_geometry::calc_squared_distance2d(
     autoware::object_recognition_utils::getPose(object1),
     autoware::object_recognition_utils::getPose(object2));
   return sqr_dist_2d <= search_distance_2d_sq_;

--- a/perception/autoware_bevfusion/lib/ros_utils.cpp
+++ b/perception/autoware_bevfusion/lib/ros_utils.cpp
@@ -15,8 +15,8 @@
 #include "autoware/bevfusion/ros_utils.hpp"
 
 #include <autoware/object_recognition_utils/object_recognition_utils.hpp>
-#include <autoware/universe_utils/geometry/geometry.hpp>
-#include <autoware/universe_utils/math/constants.hpp>
+#include <autoware_utils_geometry/geometry.hpp>
+#include <autoware_utils_math/constants.hpp>
 
 #include <cstddef>
 #include <string>
@@ -52,12 +52,12 @@ void box3DToDetectedObject(
 
   // pose and shape
   obj.kinematics.pose_with_covariance.pose.position =
-    autoware::universe_utils::createPoint(box3d.x, box3d.y, box3d.z);
+    autoware_utils_geometry::create_point(box3d.x, box3d.y, box3d.z);
   obj.kinematics.pose_with_covariance.pose.orientation =
-    autoware::universe_utils::createQuaternionFromYaw(box3d.yaw);
+    autoware_utils_geometry::create_quaternion_from_yaw(box3d.yaw);
   obj.shape.type = autoware_perception_msgs::msg::Shape::BOUNDING_BOX;
   obj.shape.dimensions =
-    autoware::universe_utils::createTranslation(box3d.length, box3d.width, box3d.height);
+    autoware_utils_geometry::create_translation(box3d.length, box3d.width, box3d.height);
 }
 
 std::uint8_t getSemanticType(const std::string & class_name)

--- a/perception/autoware_bevfusion/package.xml
+++ b/perception/autoware_bevfusion/package.xml
@@ -20,7 +20,11 @@
   <depend>autoware_perception_msgs</depend>
   <depend>autoware_point_types</depend>
   <depend>autoware_tensorrt_common</depend>
-  <depend>autoware_universe_utils</depend>
+  <depend>autoware_utils_debug</depend>
+  <depend>autoware_utils_diagnostics</depend>
+  <depend>autoware_utils_geometry</depend>
+  <depend>autoware_utils_math</depend>
+  <depend>autoware_utils_system</depend>
   <depend>cuda_blackboard</depend>
   <depend>launch_ros</depend>
   <depend>pcl_ros</depend>

--- a/perception/autoware_bevfusion/src/bevfusion_node.cpp
+++ b/perception/autoware_bevfusion/src/bevfusion_node.cpp
@@ -145,7 +145,7 @@ BEVFusionNode::BEVFusionNode(const rclcpp::NodeOptions & options)
   // clang-format on
   detector_ptr_ = std::make_unique<BEVFusionTRT>(trt_bevfusion_config, densification_param, config);
   diagnostics_detector_trt_ =
-    std::make_unique<autoware_utils::DiagnosticsInterface>(this, "bevfusion_trt");
+    std::make_unique<autoware_utils_diagnostics::DiagnosticsInterface>(this, "bevfusion_trt");
 
   cloud_sub_ =
     std::make_unique<cuda_blackboard::CudaBlackboardSubscriber<cuda_blackboard::CudaPointCloud2>>(
@@ -157,11 +157,11 @@ BEVFusionNode::BEVFusionNode(const rclcpp::NodeOptions & options)
 
   initializeSensorFusionSubscribers(config.num_cameras_);
 
-  published_time_pub_ = std::make_unique<autoware_utils::PublishedTimePublisher>(this);
+  published_time_pub_ = std::make_unique<autoware_utils_debug::PublishedTimePublisher>(this);
 
   {
-    using autoware_utils::DebugPublisher;
-    using autoware_utils::StopWatch;
+    using autoware_utils_debug::DebugPublisher;
+    using autoware_utils_system::StopWatch;
     stop_watch_ptr_ = std::make_unique<StopWatch<std::chrono::milliseconds>>();
     debug_publisher_ptr_ = std::make_unique<DebugPublisher>(this, this->get_name());
     stop_watch_ptr_->tic("cyclic");

--- a/perception/autoware_image_object_locator/package.xml
+++ b/perception/autoware_image_object_locator/package.xml
@@ -17,8 +17,9 @@
   <buildtool_depend>autoware_cmake</buildtool_depend>
   <depend>autoware_object_recognition_utils</depend>
   <depend>autoware_perception_msgs</depend>
-  <depend>autoware_universe_utils</depend>
+  <depend>autoware_utils_geometry</depend>
   <depend>autoware_utils_math</depend>
+  <depend>autoware_utils_tf</depend>
   <depend>libopencv-dev</depend>
   <depend>rclcpp_components</depend>
   <depend>sensor_msgs</depend>

--- a/perception/autoware_image_object_locator/src/bbox_object_locator_node.cpp
+++ b/perception/autoware_image_object_locator/src/bbox_object_locator_node.cpp
@@ -14,7 +14,7 @@
 
 #include "bbox_object_locator_node.hpp"
 
-#include <autoware/universe_utils/geometry/geometry.hpp>
+#include <autoware_utils_geometry/msg/covariance.hpp>
 #include <autoware_utils_math/unit_conversion.hpp>
 #include <rclcpp/qos.hpp>
 #include <tf2_eigen/tf2_eigen.hpp>
@@ -32,7 +32,7 @@
 
 namespace autoware::image_object_locator
 {
-using autoware::universe_utils::xyzrpy_covariance_index::XYZRPY_COV_IDX;
+using autoware_utils_geometry::xyzrpy_covariance_index::XYZRPY_COV_IDX;
 using autoware_utils_math::deg2rad;
 
 void transformToRT(const geometry_msgs::msg::TransformStamped & tf, cv::Matx33d & R, cv::Vec3d & t)
@@ -580,7 +580,7 @@ void BboxObjectLocatorNode::roiCallback(
 
   // get transform from camera frame to target frame
   try {
-    transform_ = transform_listener_->getTransform(
+    transform_ = transform_listener_->get_transform(
       target_frame_, msg->header.frame_id, msg->header.stamp, rclcpp::Duration::from_seconds(0.01));
   } catch (const tf2::TransformException & ex) {
     RCLCPP_ERROR(get_logger(), "Failed to get transform: %s", ex.what());

--- a/perception/autoware_image_object_locator/src/bbox_object_locator_node.hpp
+++ b/perception/autoware_image_object_locator/src/bbox_object_locator_node.hpp
@@ -15,7 +15,7 @@
 #ifndef BBOX_OBJECT_LOCATOR_NODE_HPP_
 #define BBOX_OBJECT_LOCATOR_NODE_HPP_
 
-#include <autoware/universe_utils/ros/transform_listener.hpp>
+#include <autoware_utils_tf/transform_listener.hpp>
 #include <opencv2/opencv.hpp>
 #include <rclcpp/rclcpp.hpp>
 
@@ -41,9 +41,9 @@
 
 namespace autoware::image_object_locator
 {
-using autoware::universe_utils::TransformListener;
 using autoware_perception_msgs::msg::DetectedObject;
 using autoware_perception_msgs::msg::DetectedObjects;
+using autoware_utils_tf::TransformListener;
 using sensor_msgs::msg::CameraInfo;
 using tier4_perception_msgs::msg::DetectedObjectsWithFeature;
 using Label = autoware_perception_msgs::msg::ObjectClassification;

--- a/perception/autoware_tracking_object_merger/CMakeLists.txt
+++ b/perception/autoware_tracking_object_merger/CMakeLists.txt
@@ -37,7 +37,7 @@ autoware_agnocast_wrapper_register_node(${PROJECT_NAME}
   PLUGIN "autoware::tracking_object_merger::DecorativeTrackerMergerNode"
   EXECUTABLE decorative_tracker_merger_node
   ROS2_EXECUTOR SingleThreadedExecutor
-  AGNOCAST_EXECUTOR CallbackIsolatedAgnocastExecutor
+  AGNOCAST_EXECUTOR AgnocastOnlyCallbackIsolatedExecutor
 )
 
 ament_auto_package(INSTALL_TO_SHARE

--- a/perception/autoware_tracking_object_merger/include/autoware/tracking_object_merger/decorative_tracker_merger_node.hpp
+++ b/perception/autoware_tracking_object_merger/include/autoware/tracking_object_merger/decorative_tracker_merger_node.hpp
@@ -18,11 +18,11 @@
 #include "autoware/tracking_object_merger/association/data_association.hpp"
 #include "autoware/tracking_object_merger/utils/tracker_state.hpp"
 #include "autoware/tracking_object_merger/utils/utils.hpp"
-#include "autoware/universe_utils/ros/diagnostics_interface.hpp"
-#include "autoware_utils/ros/debug_publisher.hpp"
-#include "autoware_utils/ros/published_time_publisher.hpp"
-#include "autoware_utils/system/stop_watch.hpp"
+#include "autoware_utils_diagnostics/diagnostics_interface.hpp"
 
+#include <autoware_utils_debug/debug_publisher.hpp>
+#include <autoware_utils_debug/published_time_publisher.hpp>
+#include <autoware_utils_system/stop_watch.hpp>
 #include <rclcpp/rclcpp.hpp>
 
 #include "autoware_perception_msgs/msg/tracked_objects.hpp"
@@ -83,8 +83,8 @@ private:
   // debug object publisher
   rclcpp::Publisher<autoware_perception_msgs::msg::TrackedObjects>::SharedPtr debug_object_pub_;
   bool publish_interpolated_sub_objects_;
-  std::unique_ptr<autoware_utils::StopWatch<std::chrono::milliseconds>> stop_watch_ptr_;
-  std::unique_ptr<autoware_utils::DebugPublisher> processing_time_publisher_;
+  std::unique_ptr<autoware_utils_system::StopWatch<std::chrono::milliseconds>> stop_watch_ptr_;
+  std::unique_ptr<autoware_utils_debug::DebugPublisher> processing_time_publisher_;
 
   /* handle objects */
   std::unordered_map<MEASUREMENT_STATE, std::function<void(TrackedObject &, const TrackedObject &)>>
@@ -103,7 +103,7 @@ private:
   // tracker default settings
   TrackerStateParameter tracker_state_parameter_;
 
-  std::unique_ptr<autoware_utils::PublishedTimePublisher> published_time_publisher_;
+  std::unique_ptr<autoware_utils_debug::PublishedTimePublisher> published_time_publisher_;
 
   // merge policy (currently not used)
   struct
@@ -128,7 +128,7 @@ private:
   } logging_;
 
   // diagnostics
-  std::unique_ptr<autoware::universe_utils::DiagnosticsInterface> diagnostics_interface_ptr_;
+  std::unique_ptr<autoware_utils_diagnostics::DiagnosticsInterface> diagnostics_interface_ptr_;
   double delay_main_objects_tolerance_;
   double duration_empty_main_objects_tolerance_;
   double delay_sub_objects_tolerance_;

--- a/perception/autoware_tracking_object_merger/include/autoware/tracking_object_merger/decorative_tracker_merger_node.hpp
+++ b/perception/autoware_tracking_object_merger/include/autoware/tracking_object_merger/decorative_tracker_merger_node.hpp
@@ -20,6 +20,8 @@
 #include "autoware/tracking_object_merger/utils/utils.hpp"
 #include "autoware_utils_diagnostics/diagnostics_interface.hpp"
 
+#include <autoware/agnocast_wrapper/node.hpp>
+#include <autoware/agnocast_wrapper/tf2.hpp>
 #include <autoware_utils_debug/debug_publisher.hpp>
 #include <autoware_utils_debug/published_time_publisher.hpp>
 #include <autoware_utils_system/stop_watch.hpp>
@@ -28,9 +30,6 @@
 #include "autoware_perception_msgs/msg/tracked_objects.hpp"
 #include <std_msgs/msg/header.hpp>
 #include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
-
-#include <tf2_ros/buffer.h>
-#include <tf2_ros/transform_listener.h>
 
 #include <map>
 #include <memory>
@@ -42,7 +41,7 @@
 namespace autoware::tracking_object_merger
 {
 
-class DecorativeTrackerMergerNode : public rclcpp::Node
+class DecorativeTrackerMergerNode : public autoware::agnocast_wrapper::Node
 {
 public:
   explicit DecorativeTrackerMergerNode(const rclcpp::NodeOptions & node_options);
@@ -54,9 +53,10 @@ private:
     std::unordered_map<std::string, std::unique_ptr<DataAssociation>> & data_association_map);
 
   void mainObjectsCallback(
-    const autoware_perception_msgs::msg::TrackedObjects::ConstSharedPtr & main_objects);
+    const AUTOWARE_MESSAGE_CONST_SHARED_PTR(autoware_perception_msgs::msg::TrackedObjects) &
+    main_objects);
   void subObjectsCallback(
-    const autoware_perception_msgs::msg::TrackedObjects::ConstSharedPtr & msg);
+    const AUTOWARE_MESSAGE_CONST_SHARED_PTR(autoware_perception_msgs::msg::TrackedObjects) & msg);
 
   bool decorativeMerger(
     const MEASUREMENT_STATE input_sensor,
@@ -75,16 +75,17 @@ private:
   void updateDiagnostics();
 
 private:
-  tf2_ros::Buffer tf_buffer_;
-  tf2_ros::TransformListener tf_listener_;
-  rclcpp::Publisher<autoware_perception_msgs::msg::TrackedObjects>::SharedPtr merged_object_pub_;
-  rclcpp::Subscription<autoware_perception_msgs::msg::TrackedObjects>::SharedPtr sub_main_objects_;
-  rclcpp::Subscription<autoware_perception_msgs::msg::TrackedObjects>::SharedPtr sub_sub_objects_;
+  autoware::agnocast_wrapper::Buffer tf_buffer_;
+  autoware::agnocast_wrapper::TransformListener tf_listener_;
+  AUTOWARE_PUBLISHER_PTR(autoware_perception_msgs::msg::TrackedObjects) merged_object_pub_;
+  AUTOWARE_SUBSCRIPTION_PTR(autoware_perception_msgs::msg::TrackedObjects) sub_main_objects_;
+  AUTOWARE_SUBSCRIPTION_PTR(autoware_perception_msgs::msg::TrackedObjects) sub_sub_objects_;
   // debug object publisher
-  rclcpp::Publisher<autoware_perception_msgs::msg::TrackedObjects>::SharedPtr debug_object_pub_;
+  AUTOWARE_PUBLISHER_PTR(autoware_perception_msgs::msg::TrackedObjects) debug_object_pub_;
   bool publish_interpolated_sub_objects_;
   std::unique_ptr<autoware_utils_system::StopWatch<std::chrono::milliseconds>> stop_watch_ptr_;
-  std::unique_ptr<autoware_utils_debug::DebugPublisher> processing_time_publisher_;
+  std::unique_ptr<autoware_utils_debug::BasicDebugPublisher<autoware::agnocast_wrapper::Node>>
+    processing_time_publisher_;
 
   /* handle objects */
   std::unordered_map<MEASUREMENT_STATE, std::function<void(TrackedObject &, const TrackedObject &)>>
@@ -103,7 +104,9 @@ private:
   // tracker default settings
   TrackerStateParameter tracker_state_parameter_;
 
-  std::unique_ptr<autoware_utils_debug::PublishedTimePublisher> published_time_publisher_;
+  std::unique_ptr<
+    autoware_utils_debug::BasicPublishedTimePublisher<autoware::agnocast_wrapper::Node>>
+    published_time_publisher_;
 
   // merge policy (currently not used)
   struct
@@ -128,7 +131,9 @@ private:
   } logging_;
 
   // diagnostics
-  std::unique_ptr<autoware_utils_diagnostics::DiagnosticsInterface> diagnostics_interface_ptr_;
+  std::unique_ptr<
+    autoware_utils_diagnostics::BasicDiagnosticsInterface<autoware::agnocast_wrapper::Node>>
+    diagnostics_interface_ptr_;
   double delay_main_objects_tolerance_;
   double duration_empty_main_objects_tolerance_;
   double delay_sub_objects_tolerance_;

--- a/perception/autoware_tracking_object_merger/include/autoware/tracking_object_merger/utils/utils.hpp
+++ b/perception/autoware_tracking_object_merger/include/autoware/tracking_object_merger/utils/utils.hpp
@@ -17,8 +17,7 @@
 #ifndef AUTOWARE__TRACKING_OBJECT_MERGER__UTILS__UTILS_HPP_
 #define AUTOWARE__TRACKING_OBJECT_MERGER__UTILS__UTILS_HPP_
 
-#include "autoware_utils/geometry/geometry.hpp"
-
+#include <autoware_utils_geometry/geometry.hpp>
 #include <rclcpp/rclcpp.hpp>
 #include <tf2/LinearMath/Quaternion.hpp>
 #include <tf2/LinearMath/Transform.hpp>

--- a/perception/autoware_tracking_object_merger/launch/decorative_tracker_merger.launch.xml
+++ b/perception/autoware_tracking_object_merger/launch/decorative_tracker_merger.launch.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0"?>
 <launch>
+  <include file="$(find-pkg-share autoware_agnocast_wrapper)/launch/agnocast_env.launch.xml"/>
   <arg name="node_name" default="$(anon decorative_tracker_merger)"/>
   <arg name="input/main_object" default="main_object"/>
   <arg name="input/sub_object" default="sub_object"/>
@@ -9,6 +10,7 @@
   <arg name="node_param_file_path" default="$(find-pkg-share autoware_tracking_object_merger)/config/decorative_tracker_merger.param.yaml"/>
 
   <node pkg="autoware_tracking_object_merger" exec="decorative_tracker_merger_node" name="$(var node_name)" output="screen">
+    <env name="LD_PRELOAD" value="$(var ld_preload_value)"/>
     <remap from="input/main_object" to="$(var input/main_object)"/>
     <remap from="input/sub_object" to="$(var input/sub_object)"/>
     <remap from="output/object" to="$(var output)"/>

--- a/perception/autoware_tracking_object_merger/package.xml
+++ b/perception/autoware_tracking_object_merger/package.xml
@@ -17,7 +17,11 @@
   <depend>autoware_agnocast_wrapper</depend>
   <depend>autoware_object_recognition_utils</depend>
   <depend>autoware_perception_msgs</depend>
-  <depend>autoware_universe_utils</depend>
+  <depend>autoware_utils_debug</depend>
+  <depend>autoware_utils_diagnostics</depend>
+  <depend>autoware_utils_geometry</depend>
+  <depend>autoware_utils_math</depend>
+  <depend>autoware_utils_system</depend>
   <depend>eigen</depend>
   <depend>mussp</depend>
   <depend>rclcpp</depend>

--- a/perception/autoware_tracking_object_merger/src/association/data_association.cpp
+++ b/perception/autoware_tracking_object_merger/src/association/data_association.cpp
@@ -17,7 +17,9 @@
 #include "autoware/object_recognition_utils/object_recognition_utils.hpp"
 #include "autoware/tracking_object_merger/association/solver/gnn_solver.hpp"
 #include "autoware/tracking_object_merger/utils/utils.hpp"
-#include "autoware_utils/geometry/geometry.hpp"
+
+#include <autoware_utils_geometry/geometry.hpp>
+#include <autoware_utils_math/normalization.hpp>
 
 #include <algorithm>
 #include <fstream>
@@ -31,8 +33,8 @@ double getFormedYawAngle(
   const geometry_msgs::msg::Quaternion & quat0, const geometry_msgs::msg::Quaternion & quat1,
   const bool distinguish_front_or_back = true)
 {
-  const double yaw0 = autoware_utils::normalize_radian(tf2::getYaw(quat0));
-  const double yaw1 = autoware_utils::normalize_radian(tf2::getYaw(quat1));
+  const double yaw0 = autoware_utils_math::normalize_radian(tf2::getYaw(quat0));
+  const double yaw1 = autoware_utils_math::normalize_radian(tf2::getYaw(quat1));
   const double angle_range = distinguish_front_or_back ? M_PI : M_PI_2;
   const double angle_step = distinguish_front_or_back ? 2.0 * M_PI : M_PI;
   // Fixed yaw0 to be in the range of +-90 or 180 degrees of yaw1
@@ -189,7 +191,7 @@ double DataAssociation::calcScoreBetweenObjects(
   double score = 0.0;
   if (can_assign_matrix_(object1_label, object0_label)) {
     const double max_dist = max_dist_matrix_(object1_label, object0_label);
-    const double dist = autoware_utils::calc_distance2d(
+    const double dist = autoware_utils_geometry::calc_distance2d(
       object0.kinematics.pose_with_covariance.pose.position,
       object1.kinematics.pose_with_covariance.pose.position);
 

--- a/perception/autoware_tracking_object_merger/src/decorative_tracker_merger_node.cpp
+++ b/perception/autoware_tracking_object_merger/src/decorative_tracker_merger_node.cpp
@@ -159,14 +159,14 @@ DecorativeTrackerMergerNode::DecorativeTrackerMergerNode(const rclcpp::NodeOptio
 
   // debug publisher
   processing_time_publisher_ =
-    std::make_unique<autoware_utils::DebugPublisher>(this, "decorative_object_merger_node");
-  stop_watch_ptr_ = std::make_unique<autoware_utils::StopWatch<std::chrono::milliseconds>>();
+    std::make_unique<autoware_utils_debug::DebugPublisher>(this, "decorative_object_merger_node");
+  stop_watch_ptr_ = std::make_unique<autoware_utils_system::StopWatch<std::chrono::milliseconds>>();
   stop_watch_ptr_->tic("cyclic_time");
   stop_watch_ptr_->tic("processing_time");
-  published_time_publisher_ = std::make_unique<autoware_utils::PublishedTimePublisher>(this);
+  published_time_publisher_ = std::make_unique<autoware_utils_debug::PublishedTimePublisher>(this);
 
   // diagnostics
-  diagnostics_interface_ptr_ = std::make_unique<autoware::universe_utils::DiagnosticsInterface>(
+  diagnostics_interface_ptr_ = std::make_unique<autoware_utils_diagnostics::DiagnosticsInterface>(
     this, "decorative_object_merger_node");
   stop_watch_ptr_->tic("delay_main_objects");
   stop_watch_ptr_->tic("duration_empty_main_objects");

--- a/perception/autoware_tracking_object_merger/src/decorative_tracker_merger_node.cpp
+++ b/perception/autoware_tracking_object_merger/src/decorative_tracker_merger_node.cpp
@@ -29,6 +29,7 @@
 #include <memory>
 #include <string>
 #include <unordered_map>
+#include <utility>
 #include <vector>
 
 using Label = autoware_perception_msgs::msg::ObjectClassification;
@@ -87,9 +88,9 @@ Eigen::MatrixXd calcScoreMatrixForAssociation(
 }
 
 DecorativeTrackerMergerNode::DecorativeTrackerMergerNode(const rclcpp::NodeOptions & node_options)
-: rclcpp::Node("decorative_object_merger_node", node_options),
+: Node("decorative_object_merger_node", node_options),
   tf_buffer_(get_clock()),
-  tf_listener_(tf_buffer_)
+  tf_listener_(tf_buffer_, *this)
 {
   // Subscriber
   sub_main_objects_ = create_subscription<TrackedObjects>(
@@ -159,14 +160,17 @@ DecorativeTrackerMergerNode::DecorativeTrackerMergerNode(const rclcpp::NodeOptio
 
   // debug publisher
   processing_time_publisher_ =
-    std::make_unique<autoware_utils_debug::DebugPublisher>(this, "decorative_object_merger_node");
+    std::make_unique<autoware_utils_debug::BasicDebugPublisher<autoware::agnocast_wrapper::Node>>(
+      this, "decorative_object_merger_node");
   stop_watch_ptr_ = std::make_unique<autoware_utils_system::StopWatch<std::chrono::milliseconds>>();
   stop_watch_ptr_->tic("cyclic_time");
   stop_watch_ptr_->tic("processing_time");
-  published_time_publisher_ = std::make_unique<autoware_utils_debug::PublishedTimePublisher>(this);
+  published_time_publisher_ = std::make_unique<
+    autoware_utils_debug::BasicPublishedTimePublisher<autoware::agnocast_wrapper::Node>>(this);
 
   // diagnostics
-  diagnostics_interface_ptr_ = std::make_unique<autoware_utils_diagnostics::DiagnosticsInterface>(
+  diagnostics_interface_ptr_ = std::make_unique<
+    autoware_utils_diagnostics::BasicDiagnosticsInterface<autoware::agnocast_wrapper::Node>>(
     this, "decorative_object_merger_node");
   stop_watch_ptr_->tic("delay_main_objects");
   stop_watch_ptr_->tic("duration_empty_main_objects");
@@ -201,7 +205,7 @@ void DecorativeTrackerMergerNode::set3dDataAssociation(
  *       else, merge main objects and sub objects
  */
 void DecorativeTrackerMergerNode::mainObjectsCallback(
-  const TrackedObjects::ConstSharedPtr & main_objects)
+  const AUTOWARE_MESSAGE_CONST_SHARED_PTR(TrackedObjects) & main_objects)
 {
   stop_watch_ptr_->toc("processing_time", true);
   stop_watch_ptr_->toc("delay_main_objects", true);
@@ -245,10 +249,11 @@ void DecorativeTrackerMergerNode::mainObjectsCallback(
       closest_time_sub_objects, closest_time_sub_objects_later, transformed_main_objects->header);
     if (interpolated_sub_objects.has_value()) {
       // Merge sub objects
-      const auto interp_sub_objs = interpolated_sub_objects.value();
-      debug_object_pub_->publish(interp_sub_objs);
-      this->decorativeMerger(
-        sub_sensor_type_, std::make_shared<TrackedObjects>(interpolated_sub_objects.value()));
+      const auto & interp_sub_objs = interpolated_sub_objects.value();
+      auto debug_msg = ALLOCATE_OUTPUT_MESSAGE_UNIQUE(debug_object_pub_);
+      *debug_msg = interp_sub_objs;
+      debug_object_pub_->publish(std::move(debug_msg));
+      this->decorativeMerger(sub_sensor_type_, std::make_shared<TrackedObjects>(interp_sub_objs));
     } else {
       RCLCPP_DEBUG(this->get_logger(), "interpolated_sub_objects is null");
     }
@@ -256,19 +261,20 @@ void DecorativeTrackerMergerNode::mainObjectsCallback(
 
   // try to merge main object
   this->decorativeMerger(main_sensor_type_, transformed_main_objects);
-  const auto & tracked_objects = getTrackedObjects(transformed_main_objects->header);
-  merged_object_pub_->publish(tracked_objects);
+  auto output = ALLOCATE_OUTPUT_MESSAGE_UNIQUE(merged_object_pub_);
+  *output = getTrackedObjects(transformed_main_objects->header);
+  const auto output_stamp = output->header.stamp;
+  merged_object_pub_->publish(std::move(output));
 
   // update diagnostics
   updateDiagnostics();
 
-  published_time_publisher_->publish_if_subscribed(
-    merged_object_pub_, tracked_objects.header.stamp);
+  published_time_publisher_->publish_if_subscribed(merged_object_pub_, output_stamp);
   processing_time_publisher_->publish<autoware_internal_debug_msgs::msg::Float64Stamped>(
     "debug/cyclic_time_ms", stop_watch_ptr_->toc("cyclic_time", true));
   processing_time_publisher_->publish<autoware_internal_debug_msgs::msg::Float64Stamped>(
     "debug/processing_time_ms", stop_watch_ptr_->toc("processing_time", true));
-  diagnostics_interface_ptr_->publish(tracked_objects.header.stamp);
+  diagnostics_interface_ptr_->publish(output_stamp);
 }
 
 /**
@@ -277,7 +283,8 @@ void DecorativeTrackerMergerNode::mainObjectsCallback(
  * @param msg
  * @note push back sub objects to buffer and remove old sub objects
  */
-void DecorativeTrackerMergerNode::subObjectsCallback(const TrackedObjects::ConstSharedPtr & msg)
+void DecorativeTrackerMergerNode::subObjectsCallback(
+  const AUTOWARE_MESSAGE_CONST_SHARED_PTR(TrackedObjects) & msg)
 {
   stop_watch_ptr_->toc("delay_sub_objects", true);
   diagnostics_interface_ptr_->clear();

--- a/perception/autoware_tracking_object_merger/src/utils/utils.cpp
+++ b/perception/autoware_tracking_object_merger/src/utils/utils.cpp
@@ -14,6 +14,8 @@
 
 #include "autoware/tracking_object_merger/utils/utils.hpp"
 
+#include <autoware_utils_math/normalization.hpp>
+
 #include "autoware_perception_msgs/msg/shape.hpp"
 #include "autoware_perception_msgs/msg/tracked_object.hpp"
 #include "autoware_perception_msgs/msg/tracked_objects.hpp"
@@ -281,7 +283,7 @@ bool objectsHaveSameMotionDirections(const TrackedObject & main_obj, const Track
   // diff of motion yaw angle
   const auto motion_yaw_diff = std::fabs(main_motion_yaw - sub_motion_yaw);
   const auto normalized_motion_yaw_diff =
-    autoware_utils::normalize_radian(motion_yaw_diff);  // -pi ~ pi
+    autoware_utils_math::normalize_radian(motion_yaw_diff);  // -pi ~ pi
   // evaluate if motion yaw angle is same
   constexpr double yaw_threshold = M_PI / 4.0;  // 45 deg
   if (std::abs(normalized_motion_yaw_diff) < yaw_threshold) {


### PR DESCRIPTION
## Description 
upstream の **decorative_tracker_merger への `agnocast_wrapper::Node` 適用 (#12709)** を `feat/v0.64/e2e` に取り込みます。依存 PR として #12425 も併せて cherry-pick しています。

### Cherry-pick したコミット

  | | 元 PR | 内容 |
  |---|---|---|
  | 1（依存） | [#12425](https://github.com/autowarefoundation/autoware_universe/pull/12425) | `feat(perception): replace autoware_universe_utils with specific autoware_utils sub-packages` |
  | 2（目的） | [#12709](https://github.com/autowarefoundation/autoware_universe/pull/12709) | `feat(decorative_tracker_merger): apply agnocast_wrapper::Node` |

  ## 補足
  - 依存 PR #12425 は 1 コミットで **3 パッケージ**（`autoware_tracking_object_merger` / `autoware_bevfusion` / `autoware_image_object_locator`）の include パス・型をサブパッケージ API へ移行します。#12709 が必要とするのは `autoware_tracking_object_merger` 分のみですが、upstream の PR 単位を保つため #12425 を丸ごと取り込んでいます。
  - コンフリクト: なし

## agnocast適用全体像 
https://tier4.atlassian.net/wiki/spaces/CRL/pages/5280465670/perception+nodes