### PR TITLE
feat(traffic_light_arbiter): cherry pick #12632, #12660, #12713, #12707

### DIFF
--- a/perception/autoware_traffic_light_arbiter/CMakeLists.txt
+++ b/perception/autoware_traffic_light_arbiter/CMakeLists.txt
@@ -6,6 +6,7 @@ autoware_package()
 
 ament_auto_add_library(${PROJECT_NAME} SHARED
   src/traffic_light_arbiter.cpp
+  src/traffic_light_arbiter_core.cpp
   src/signal_match_validator.cpp
 )
 

--- a/perception/autoware_traffic_light_arbiter/CMakeLists.txt
+++ b/perception/autoware_traffic_light_arbiter/CMakeLists.txt
@@ -13,11 +13,11 @@ ament_auto_add_library(${PROJECT_NAME} SHARED
 autoware_agnocast_wrapper_register_node(${PROJECT_NAME}
   PLUGIN "autoware::traffic_light::TrafficLightArbiter"
   EXECUTABLE traffic_light_arbiter_node
-  AGNOCAST_EXECUTOR CallbackIsolatedAgnocastExecutor
+  AGNOCAST_EXECUTOR AgnocastOnlyCallbackIsolatedExecutor
   ROS2_EXECUTOR SingleThreadedExecutor
 )
 
-if(BUILD_TESTING)
+if(BUILD_TESTING AND NOT "$ENV{ENABLE_AGNOCAST}" STREQUAL "1")
   ament_auto_add_gtest(${PROJECT_NAME}_test
     test/test_node.cpp
   )

--- a/perception/autoware_traffic_light_arbiter/CMakeLists.txt
+++ b/perception/autoware_traffic_light_arbiter/CMakeLists.txt
@@ -10,9 +10,11 @@ ament_auto_add_library(${PROJECT_NAME} SHARED
   src/signal_match_validator.cpp
 )
 
-rclcpp_components_register_node(${PROJECT_NAME}
+autoware_agnocast_wrapper_register_node(${PROJECT_NAME}
   PLUGIN "autoware::traffic_light::TrafficLightArbiter"
   EXECUTABLE traffic_light_arbiter_node
+  AGNOCAST_EXECUTOR CallbackIsolatedAgnocastExecutor
+  ROS2_EXECUTOR SingleThreadedExecutor
 )
 
 if(BUILD_TESTING)

--- a/perception/autoware_traffic_light_arbiter/CMakeLists.txt
+++ b/perception/autoware_traffic_light_arbiter/CMakeLists.txt
@@ -18,6 +18,9 @@ if(BUILD_TESTING)
   ament_auto_add_gtest(${PROJECT_NAME}_test
     test/test_node.cpp
   )
+  ament_auto_add_gtest(${PROJECT_NAME}_characteristic_test
+    test/test_traffic_arbiter_characteristic.cpp
+  )
 endif()
 
 ament_auto_package(INSTALL_TO_SHARE launch config)

--- a/perception/autoware_traffic_light_arbiter/include/autoware/traffic_light_arbiter/signal_match_validator.hpp
+++ b/perception/autoware_traffic_light_arbiter/include/autoware/traffic_light_arbiter/signal_match_validator.hpp
@@ -53,9 +53,16 @@ public:
   using TrafficLightConstPtr = lanelet::TrafficLightConstPtr;
 
   /**
-   * @brief Default constructor for SignalMatchValidator.
+   * @brief Construct a validator with the source-priority mode fixed at
+   *        construction. The mode is immutable for the validator's lifetime.
+   *
+   * @param source_priority CONFIDENCE (confidence-based selection),
+   *                        EXTERNAL (prioritize external), or
+   *                        PERCEPTION (prioritize perception).
    */
-  SignalMatchValidator() = default;
+  explicit SignalMatchValidator(SourcePriority source_priority) : source_priority_(source_priority)
+  {
+  }
 
   /**
    * @brief Validates and compares traffic signal data from perception and external sources.
@@ -69,34 +76,24 @@ public:
    * @param external_signals Traffic signal data from external source.
    * @return A validated TrafficSignalArray.
    */
-  TrafficSignalArray validateSignals(
+  TrafficSignalArray validate_signals(
     const TrafficSignalArray & perception_signals, const TrafficSignalArray & external_signals);
 
   /**
-   * @brief Sets the pedestrian signals to be considered during validation.
+   * @brief Sets the pedestrian signal IDs to be considered during validation.
    *
-   * This method allows the specification of pedestrian signals, which are then
-   * used to adjust the validation logic, acknowledging their unique characteristics
-   * in traffic signal datasets.
+   * Pedestrian-classified signals receive distinct reconciliation handling in
+   * validate_signals(). The caller supplies the set of regulatory-element IDs
+   * (typically derived from crosswalk lanelets); only the IDs are needed for
+   * the routing decision.
    *
-   * @param pedestrian_signals A vector of pedestrian signal pointers.
+   * @param ids Set of regulatory-element IDs classified as pedestrian signals.
    */
-  void setPedestrianSignals(const std::vector<TrafficLightConstPtr> & pedestrian_signals);
-
-  /**
-   * @brief Sets the source priority for signal selection.
-   *
-   * This method sets the priority mode for selecting between perception and external signals.
-   * Options are CONFIDENCE (use confidence-based selection), EXTERNAL (prioritize external),
-   * or PERCEPTION (prioritize perception signals).
-   *
-   * @param source_priority The priority mode for signal selection.
-   */
-  void setSourcePriority(const SourcePriority source_priority);
+  void set_pedestrian_traffic_light_ids(std::unordered_set<lanelet::Id> ids);
 
 private:
   SourcePriority source_priority_;
-  std::unordered_set<lanelet::Id> map_pedestrian_signal_regulatory_elements_set_;
+  std::unordered_set<lanelet::Id> pedestrian_traffic_light_ids_;
 
   /**
    * @brief Checks if a given signal ID corresponds to a pedestrian signal.
@@ -107,7 +104,7 @@ private:
    * @param signal_id The ID of the signal to check.
    * @return True if the signal is a pedestrian signal, false otherwise.
    */
-  bool isPedestrianSignal(const lanelet::Id & signal_id);
+  bool is_pedestrian_traffic_light(const lanelet::Id & signal_id);
 };
 
 }  // namespace autoware::traffic_light

--- a/perception/autoware_traffic_light_arbiter/include/autoware/traffic_light_arbiter/traffic_light_arbiter.hpp
+++ b/perception/autoware_traffic_light_arbiter/include/autoware/traffic_light_arbiter/traffic_light_arbiter.hpp
@@ -15,6 +15,7 @@
 #ifndef AUTOWARE__TRAFFIC_LIGHT_ARBITER__TRAFFIC_LIGHT_ARBITER_HPP_
 #define AUTOWARE__TRAFFIC_LIGHT_ARBITER__TRAFFIC_LIGHT_ARBITER_HPP_
 
+#include <autoware/agnocast_wrapper/node.hpp>
 #include <autoware/traffic_light_arbiter/traffic_light_arbiter_core.hpp>
 #include <rclcpp/rclcpp.hpp>
 
@@ -27,7 +28,7 @@
 namespace autoware::traffic_light
 {
 
-class TrafficLightArbiter : public rclcpp::Node
+class TrafficLightArbiter : public autoware::agnocast_wrapper::Node
 {
 public:
   explicit TrafficLightArbiter(const rclcpp::NodeOptions & options);
@@ -36,14 +37,14 @@ private:
   using LaneletMapBin = autoware_map_msgs::msg::LaneletMapBin;
   using TrafficSignalArray = autoware_perception_msgs::msg::TrafficLightGroupArray;
 
-  rclcpp::Subscription<LaneletMapBin>::SharedPtr map_sub_;
-  rclcpp::Subscription<TrafficSignalArray>::SharedPtr perception_tlr_sub_;
-  rclcpp::Subscription<TrafficSignalArray>::SharedPtr external_tlr_sub_;
-  rclcpp::Publisher<TrafficSignalArray>::SharedPtr pub_;
+  AUTOWARE_SUBSCRIPTION_PTR(LaneletMapBin) map_sub_;
+  AUTOWARE_SUBSCRIPTION_PTR(TrafficSignalArray) perception_tlr_sub_;
+  AUTOWARE_SUBSCRIPTION_PTR(TrafficSignalArray) external_tlr_sub_;
+  AUTOWARE_PUBLISHER_PTR(TrafficSignalArray) pub_;
 
-  void on_map(const LaneletMapBin::ConstSharedPtr msg);
-  void on_perception_msg(const TrafficSignalArray::ConstSharedPtr msg);
-  void on_external_msg(const TrafficSignalArray::ConstSharedPtr msg);
+  void on_map(const AUTOWARE_MESSAGE_CONST_SHARED_PTR(LaneletMapBin) & msg);
+  void on_perception_msg(const AUTOWARE_MESSAGE_CONST_SHARED_PTR(TrafficSignalArray) & msg);
+  void on_external_msg(const AUTOWARE_MESSAGE_CONST_SHARED_PTR(TrafficSignalArray) & msg);
   void arbitrate_and_publish(const builtin_interfaces::msg::Time & stamp);
 
   // Emits one DEBUG line per expired entry; called from the on_*_msg

--- a/perception/autoware_traffic_light_arbiter/include/autoware/traffic_light_arbiter/traffic_light_arbiter.hpp
+++ b/perception/autoware_traffic_light_arbiter/include/autoware/traffic_light_arbiter/traffic_light_arbiter.hpp
@@ -15,18 +15,14 @@
 #ifndef AUTOWARE__TRAFFIC_LIGHT_ARBITER__TRAFFIC_LIGHT_ARBITER_HPP_
 #define AUTOWARE__TRAFFIC_LIGHT_ARBITER__TRAFFIC_LIGHT_ARBITER_HPP_
 
-#include <autoware/traffic_light_arbiter/signal_match_validator.hpp>
+#include <autoware/traffic_light_arbiter/traffic_light_arbiter_core.hpp>
 #include <rclcpp/rclcpp.hpp>
 
 #include <autoware_map_msgs/msg/lanelet_map_bin.hpp>
 #include <autoware_perception_msgs/msg/traffic_light_group_array.hpp>
 
-#include <lanelet2_core/Forward.h>
-
 #include <memory>
-#include <unordered_map>
-#include <unordered_set>
-#include <utility>
+#include <vector>
 
 namespace autoware::traffic_light
 {
@@ -37,34 +33,25 @@ public:
   explicit TrafficLightArbiter(const rclcpp::NodeOptions & options);
 
 private:
-  using Element = autoware_perception_msgs::msg::TrafficLightElement;
-  using PredictedTrafficLightState = autoware_perception_msgs::msg::PredictedTrafficLightState;
   using LaneletMapBin = autoware_map_msgs::msg::LaneletMapBin;
   using TrafficSignalArray = autoware_perception_msgs::msg::TrafficLightGroupArray;
-  using TrafficSignal = autoware_perception_msgs::msg::TrafficLightGroup;
 
   rclcpp::Subscription<LaneletMapBin>::SharedPtr map_sub_;
   rclcpp::Subscription<TrafficSignalArray>::SharedPtr perception_tlr_sub_;
   rclcpp::Subscription<TrafficSignalArray>::SharedPtr external_tlr_sub_;
   rclcpp::Publisher<TrafficSignalArray>::SharedPtr pub_;
 
-  void onMap(const LaneletMapBin::ConstSharedPtr msg);
-  void onPerceptionMsg(const TrafficSignalArray::ConstSharedPtr msg);
-  void onExternalMsg(const TrafficSignalArray::ConstSharedPtr msg);
-  void arbitrateAndPublish(const builtin_interfaces::msg::Time & stamp);
-  void cleanupExpiredExternalSignals(const rclcpp::Time & current_time, double tolerance);
+  void on_map(const LaneletMapBin::ConstSharedPtr msg);
+  void on_perception_msg(const TrafficSignalArray::ConstSharedPtr msg);
+  void on_external_msg(const TrafficSignalArray::ConstSharedPtr msg);
+  void arbitrate_and_publish(const builtin_interfaces::msg::Time & stamp);
 
-  std::unique_ptr<std::unordered_set<lanelet::Id>> map_regulatory_elements_set_;
+  // Emits one DEBUG line per expired entry; called from the on_*_msg
+  // handlers with the result of the corresponding ingest_*().
+  void log_expired_external_signals(
+    const std::vector<TrafficLightArbiterCore::ExpiredExternalSignal> & expired);
 
-  double external_delay_tolerance_;
-  double external_time_tolerance_;
-  double perception_time_tolerance_;
-  SourcePriority source_priority_;
-  bool enable_signal_matching_;
-
-  TrafficSignalArray latest_perception_msg_;
-  std::unordered_map<lanelet::Id, std::pair<rclcpp::Time, TrafficSignal>> external_traffic_lights_;
-  std::unique_ptr<SignalMatchValidator> signal_match_validator_;
+  std::unique_ptr<TrafficLightArbiterCore> core_;
 };
 }  // namespace autoware::traffic_light
 

--- a/perception/autoware_traffic_light_arbiter/include/autoware/traffic_light_arbiter/traffic_light_arbiter_core.hpp
+++ b/perception/autoware_traffic_light_arbiter/include/autoware/traffic_light_arbiter/traffic_light_arbiter_core.hpp
@@ -1,0 +1,131 @@
+// Copyright 2026 The Autoware Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef AUTOWARE__TRAFFIC_LIGHT_ARBITER__TRAFFIC_LIGHT_ARBITER_CORE_HPP_
+#define AUTOWARE__TRAFFIC_LIGHT_ARBITER__TRAFFIC_LIGHT_ARBITER_CORE_HPP_
+
+#include <autoware/traffic_light_arbiter/signal_match_validator.hpp>
+#include <builtin_interfaces/msg/time.hpp>
+#include <rclcpp/time.hpp>
+
+#include <autoware_perception_msgs/msg/traffic_light_group_array.hpp>
+
+#include <lanelet2_core/Forward.h>
+
+#include <memory>
+#include <optional>
+#include <tuple>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+namespace autoware::traffic_light
+{
+
+class TrafficLightArbiterCore
+{
+public:
+  using Element = autoware_perception_msgs::msg::TrafficLightElement;
+  using PredictedTrafficLightState = autoware_perception_msgs::msg::PredictedTrafficLightState;
+  using TrafficSignalArray = autoware_perception_msgs::msg::TrafficLightGroupArray;
+  using TrafficSignal = autoware_perception_msgs::msg::TrafficLightGroup;
+  using TrafficLightConstPtr = lanelet::TrafficLightConstPtr;
+
+  TrafficLightArbiterCore(
+    SourcePriority source_priority, bool enable_signal_matching, double external_delay_tolerance,
+    double external_time_tolerance, double perception_time_tolerance);
+
+  // Load map-derived state from a parsed LaneletMap. Core extracts the
+  // regulatory-element IDs it needs (vehicle traffic lights and, when
+  // signal matching is enabled, pedestrian traffic lights) internally so
+  // callers don't have to know which subsets matter.
+  void set_map(const lanelet::LaneletMapConstPtr & map);
+
+  struct ExpiredExternalSignal
+  {
+    lanelet::Id id;
+    double age;
+  };
+
+  // Update perception buffer, then sweep external cache against msg.stamp
+  // using external_time_tolerance_. Returns expired entries for caller logging.
+  std::vector<ExpiredExternalSignal> ingest_perception(const TrafficSignalArray & msg);
+
+  // Outcome of an external-msg ingest. `accepted == false` means the msg's
+  // stamp differed from current_time by more than external_delay_tolerance_
+  // and was rejected without touching internal state. When accepted,
+  // `expired` carries any cache entries that the bundled sweep evicted.
+  struct ExternalIngestResult
+  {
+    bool accepted;
+    std::vector<ExpiredExternalSignal> expired;
+  };
+
+  // Admission-control + update + sweep for an external msg:
+  //   1. Reject (return {false, {}}) when the msg arrival is too far from
+  //      current_time, using external_delay_tolerance_.
+  //   2. Otherwise update external cache entries with msg.stamp, sweep
+  //      external cache against current_time using external_delay_tolerance_,
+  //      and return expired entries.
+  // Perception staleness is evaluated non-destructively inside arbitrate()
+  // using perception_time_tolerance_; ingest_external no longer touches
+  // latest_perception_msg_.
+  ExternalIngestResult ingest_external(
+    const TrafficSignalArray & msg, const rclcpp::Time & current_time);
+
+  // Result of one arbitration cycle. The arbiter intentionally does not stamp
+  // the output: stamp inheritance is an I/O concern owned by the Node (e.g.
+  // "publish carries the trigger msg's stamp"). The Node assigns
+  // `output->stamp` before publishing and compares its trigger stamp against
+  // `latest_input_time` for staleness logging.
+  //
+  // latest_input_time defaults to epoch on RCL_ROS_TIME so the Node can compare
+  // it against rclcpp::Time(msg->stamp) (also RCL_ROS_TIME) regardless of which
+  // arbitrate() branch was taken.
+  struct ArbitrationResult
+  {
+    std::optional<TrafficSignalArray> output;  // stamp left default; Node fills it in.
+    std::vector<lanelet::Id> off_map_signal_ids;
+    rclcpp::Time latest_input_time{0, 0, RCL_ROS_TIME};
+  };
+  ArbitrationResult arbitrate();
+
+private:
+  // True when |current_time - msg_stamp| exceeds external_delay_tolerance_.
+  // Used by ingest_external for admission control.
+  bool is_external_outdated(
+    const rclcpp::Time & current_time, const rclcpp::Time & msg_stamp) const;
+
+  // Sweeps external cache: removes every stored entry whose stamp deviates
+  // from `reference_time` beyond `tolerance`, returning the removed entries.
+  std::vector<ExpiredExternalSignal> sweep_expired_external_signals(
+    const rclcpp::Time & reference_time, double tolerance);
+
+  SourcePriority source_priority_;
+  bool enable_signal_matching_;
+  double external_delay_tolerance_;
+  double external_time_tolerance_;
+  double perception_time_tolerance_;
+
+  std::unique_ptr<std::unordered_set<lanelet::Id>> map_regulatory_elements_set_;
+  std::unique_ptr<SignalMatchValidator> signal_match_validator_;
+
+  TrafficSignalArray latest_perception_msg_;
+  std::unordered_map<lanelet::Id, std::pair<rclcpp::Time, TrafficSignal>> external_traffic_lights_;
+};
+
+}  // namespace autoware::traffic_light
+
+#endif  // AUTOWARE__TRAFFIC_LIGHT_ARBITER__TRAFFIC_LIGHT_ARBITER_CORE_HPP_

--- a/perception/autoware_traffic_light_arbiter/include/autoware/traffic_light_arbiter/traffic_light_arbiter_core.hpp
+++ b/perception/autoware_traffic_light_arbiter/include/autoware/traffic_light_arbiter/traffic_light_arbiter_core.hpp
@@ -24,7 +24,6 @@
 #include <lanelet2_core/Forward.h>
 
 #include <memory>
-#include <optional>
 #include <tuple>
 #include <unordered_map>
 #include <unordered_set>
@@ -85,10 +84,11 @@ public:
   ExternalIngestResult ingest_external(
     const TrafficSignalArray & msg, const rclcpp::Time & current_time);
 
-  // Result of one arbitration cycle. The arbiter intentionally does not stamp
+  // Result of one arbitration cycle. arbitrate() writes the arbitrated signals
+  // into the caller-provided `output`. The arbiter intentionally does not stamp
   // the output: stamp inheritance is an I/O concern owned by the Node (e.g.
   // "publish carries the trigger msg's stamp"). The Node assigns
-  // `output->stamp` before publishing and compares its trigger stamp against
+  // `output.stamp` before publishing and compares its trigger stamp against
   // `latest_input_time` for staleness logging.
   //
   // latest_input_time defaults to epoch on RCL_ROS_TIME so the Node can compare
@@ -96,11 +96,11 @@ public:
   // arbitrate() branch was taken.
   struct ArbitrationResult
   {
-    std::optional<TrafficSignalArray> output;  // stamp left default; Node fills it in.
+    bool has_output = false;  // false when no map yet (skip publish); true otherwise.
     std::vector<lanelet::Id> off_map_signal_ids;
     rclcpp::Time latest_input_time{0, 0, RCL_ROS_TIME};
   };
-  ArbitrationResult arbitrate();
+  ArbitrationResult arbitrate(TrafficSignalArray & output);
 
 private:
   // True when |current_time - msg_stamp| exceeds external_delay_tolerance_.

--- a/perception/autoware_traffic_light_arbiter/launch/traffic_light_arbiter.launch.xml
+++ b/perception/autoware_traffic_light_arbiter/launch/traffic_light_arbiter.launch.xml
@@ -1,10 +1,12 @@
 <launch>
+  <include file="$(find-pkg-share autoware_agnocast_wrapper)/launch/agnocast_env.launch.xml"/>
   <arg name="perception_traffic_signals" default="/internal/traffic_signals"/>
   <arg name="external_traffic_signals" default="/external/traffic_signals"/>
   <arg name="output_traffic_signals" default="/traffic_light_arbiter/traffic_signals"/>
   <arg name="param_path" default="$(find-pkg-share autoware_traffic_light_arbiter)/config/traffic_light_arbiter.param.yaml"/>
 
   <node pkg="autoware_traffic_light_arbiter" exec="traffic_light_arbiter_node" name="traffic_light_arbiter" output="screen">
+    <env name="LD_PRELOAD" value="$(var ld_preload_value)"/>
     <remap from="~/sub/vector_map" to="/map/vector_map"/>
     <remap from="~/sub/perception_traffic_signals" to="$(var perception_traffic_signals)"/>
     <remap from="~/sub/external_traffic_signals" to="$(var external_traffic_signals)"/>

--- a/perception/autoware_traffic_light_arbiter/package.xml
+++ b/perception/autoware_traffic_light_arbiter/package.xml
@@ -12,6 +12,7 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
+  <depend>autoware_agnocast_wrapper</depend>
   <depend>autoware_lanelet2_extension</depend>
   <depend>autoware_lanelet2_utils</depend>
   <depend>autoware_map_msgs</depend>

--- a/perception/autoware_traffic_light_arbiter/src/signal_match_validator.cpp
+++ b/perception/autoware_traffic_light_arbiter/src/signal_match_validator.cpp
@@ -18,6 +18,7 @@
 #include <map>
 #include <unordered_map>
 #include <unordered_set>
+#include <utility>
 #include <vector>
 
 namespace util
@@ -219,7 +220,7 @@ Time get_newer_stamp(const Time & stamp1, const Time & stamp2)
 namespace autoware::traffic_light
 {
 
-autoware_perception_msgs::msg::TrafficLightGroupArray SignalMatchValidator::validateSignals(
+autoware_perception_msgs::msg::TrafficLightGroupArray SignalMatchValidator::validate_signals(
   const TrafficSignalArray & perception_signals, const TrafficSignalArray & external_signals)
 {
   TrafficSignalArray validated_signals;
@@ -246,7 +247,7 @@ autoware_perception_msgs::msg::TrafficLightGroupArray SignalMatchValidator::vali
 
     // We don't validate the pedestrian signals
     // TODO(TomohitoAndo): Validate pedestrian signals
-    if (isPedestrianSignal(signal_id)) {
+    if (is_pedestrian_traffic_light(signal_id)) {
       validated_signals.traffic_light_groups.emplace_back(
         util::get_highest_confidence_signal(perception_result, external_result, source_priority_));
 
@@ -280,23 +281,14 @@ autoware_perception_msgs::msg::TrafficLightGroupArray SignalMatchValidator::vali
   return validated_signals;
 }
 
-void SignalMatchValidator::setPedestrianSignals(
-  const std::vector<TrafficLightConstPtr> & pedestrian_signals)
+void SignalMatchValidator::set_pedestrian_traffic_light_ids(std::unordered_set<lanelet::Id> ids)
 {
-  for (const auto & pedestrian_signal : pedestrian_signals) {
-    map_pedestrian_signal_regulatory_elements_set_.emplace(pedestrian_signal->id());
-  }
+  pedestrian_traffic_light_ids_ = std::move(ids);
 }
 
-void SignalMatchValidator::setSourcePriority(const SourcePriority source_priority)
+bool SignalMatchValidator::is_pedestrian_traffic_light(const lanelet::Id & signal_id)
 {
-  source_priority_ = source_priority;
-}
-
-bool SignalMatchValidator::isPedestrianSignal(const lanelet::Id & signal_id)
-{
-  return map_pedestrian_signal_regulatory_elements_set_.find(signal_id) !=
-         map_pedestrian_signal_regulatory_elements_set_.end();
+  return pedestrian_traffic_light_ids_.find(signal_id) != pedestrian_traffic_light_ids_.end();
 }
 
 }  // namespace autoware::traffic_light

--- a/perception/autoware_traffic_light_arbiter/src/traffic_light_arbiter.cpp
+++ b/perception/autoware_traffic_light_arbiter/src/traffic_light_arbiter.cpp
@@ -18,6 +18,7 @@
 
 #include <memory>
 #include <string>
+#include <utility>
 #include <vector>
 
 namespace autoware::traffic_light
@@ -67,18 +68,20 @@ TrafficLightArbiter::TrafficLightArbiter(const rclcpp::NodeOptions & options)
   pub_ = create_publisher<TrafficSignalArray>("~/pub/traffic_signals", rclcpp::QoS(1));
 }
 
-void TrafficLightArbiter::on_map(const LaneletMapBin::ConstSharedPtr msg)
+void TrafficLightArbiter::on_map(const AUTOWARE_MESSAGE_CONST_SHARED_PTR(LaneletMapBin) & msg)
 {
   core_->set_map(autoware::experimental::lanelet2_utils::from_autoware_map_msgs(*msg));
 }
 
-void TrafficLightArbiter::on_perception_msg(const TrafficSignalArray::ConstSharedPtr msg)
+void TrafficLightArbiter::on_perception_msg(
+  const AUTOWARE_MESSAGE_CONST_SHARED_PTR(TrafficSignalArray) & msg)
 {
   log_expired_external_signals(core_->ingest_perception(*msg));
   arbitrate_and_publish(msg->stamp);
 }
 
-void TrafficLightArbiter::on_external_msg(const TrafficSignalArray::ConstSharedPtr msg)
+void TrafficLightArbiter::on_external_msg(
+  const AUTOWARE_MESSAGE_CONST_SHARED_PTR(TrafficSignalArray) & msg)
 {
   const auto result = core_->ingest_external(*msg, this->now());
   if (!result.accepted) {
@@ -102,9 +105,10 @@ void TrafficLightArbiter::log_expired_external_signals(
 
 void TrafficLightArbiter::arbitrate_and_publish(const builtin_interfaces::msg::Time & stamp)
 {
-  auto result = core_->arbitrate();
+  auto output_signals_msg_ptr = ALLOCATE_OUTPUT_MESSAGE_UNIQUE(pub_);
+  auto result = core_->arbitrate(*output_signals_msg_ptr);
 
-  if (!result.output.has_value()) {
+  if (!result.has_output) {
     RCLCPP_WARN_THROTTLE(
       get_logger(), *get_clock(), 5000, "Received traffic signal messages before a map");
     return;
@@ -118,8 +122,8 @@ void TrafficLightArbiter::arbitrate_and_publish(const builtin_interfaces::msg::T
 
   // Stamp inheritance is the Node's I/O contract with downstream consumers:
   // the published output carries the trigger msg's stamp for time alignment.
-  result.output->stamp = stamp;
-  pub_->publish(*result.output);
+  output_signals_msg_ptr->stamp = stamp;
+  pub_->publish(std::move(output_signals_msg_ptr));
 
   if (rclcpp::Time(stamp) < result.latest_input_time) {
     RCLCPP_WARN_THROTTLE(

--- a/perception/autoware_traffic_light_arbiter/src/traffic_light_arbiter.cpp
+++ b/perception/autoware_traffic_light_arbiter/src/traffic_light_arbiter.cpp
@@ -14,301 +14,114 @@
 
 #include <autoware/lanelet2_utils/conversion.hpp>
 #include <autoware/traffic_light_arbiter/traffic_light_arbiter.hpp>
-#include <autoware_lanelet2_extension/utility/query.hpp>
 #include <rclcpp/time.hpp>
 
-#include <lanelet2_core/LaneletMap.h>
-#include <lanelet2_core/primitives/BasicRegulatoryElements.h>
-
-#include <algorithm>
-#include <map>
 #include <memory>
 #include <string>
-#include <tuple>
-#include <unordered_map>
-#include <utility>
 #include <vector>
-
-namespace lanelet
-{
-
-using TrafficLightConstPtr = std::shared_ptr<const TrafficLight>;
-
-std::vector<TrafficLightConstPtr> filter_traffic_signals(const LaneletMapConstPtr map)
-{
-  std::vector<TrafficLightConstPtr> signals;
-  for (const auto & element : map->regulatoryElementLayer) {
-    const auto signal = std::dynamic_pointer_cast<const TrafficLight>(element);
-    if (signal) {
-      signals.push_back(signal);
-    }
-  }
-
-  return signals;
-}
-
-std::vector<TrafficLightConstPtr> filter_pedestrian_signals(const LaneletMapConstPtr map)
-{
-  namespace query = lanelet::utils::query;
-
-  const auto all_lanelets = query::laneletLayer(map);
-  const auto crosswalks = query::crosswalkLanelets(all_lanelets);
-  std::vector<TrafficLightConstPtr> signals;
-
-  for (const auto & crosswalk : crosswalks) {
-    const auto traffic_light_reg_elems =
-      crosswalk.regulatoryElementsAs<const lanelet::TrafficLight>();
-    std::copy(
-      traffic_light_reg_elems.begin(), traffic_light_reg_elems.end(), std::back_inserter(signals));
-  }
-
-  return signals;
-}
-
-}  // namespace lanelet
 
 namespace autoware::traffic_light
 {
 TrafficLightArbiter::TrafficLightArbiter(const rclcpp::NodeOptions & options)
 : Node("traffic_light_arbiter", options)
 {
-  external_delay_tolerance_ = this->declare_parameter<double>("external_delay_tolerance");
-  external_time_tolerance_ = this->declare_parameter<double>("external_time_tolerance");
-  perception_time_tolerance_ = this->declare_parameter<double>("perception_time_tolerance");
+  const auto external_delay_tolerance = this->declare_parameter<double>("external_delay_tolerance");
+  const auto external_time_tolerance = this->declare_parameter<double>("external_time_tolerance");
+  const auto perception_time_tolerance =
+    this->declare_parameter<double>("perception_time_tolerance");
 
   // Parse source priority parameter
+  SourcePriority source_priority;
   const std::string priority_str = this->declare_parameter<std::string>("source_priority");
   if (priority_str == "external") {
-    source_priority_ = SourcePriority::EXTERNAL;
+    source_priority = SourcePriority::EXTERNAL;
   } else if (priority_str == "perception") {
-    source_priority_ = SourcePriority::PERCEPTION;
+    source_priority = SourcePriority::PERCEPTION;
   } else if (priority_str == "confidence") {
-    source_priority_ = SourcePriority::CONFIDENCE;
+    source_priority = SourcePriority::CONFIDENCE;
   } else {
     RCLCPP_WARN(
       get_logger(), "Unknown source_priority '%s', defaulting to 'confidence'",
       priority_str.c_str());
-    source_priority_ = SourcePriority::CONFIDENCE;
+    source_priority = SourcePriority::CONFIDENCE;
   }
 
-  enable_signal_matching_ = this->declare_parameter<bool>("enable_signal_matching");
+  const bool enable_signal_matching = this->declare_parameter<bool>("enable_signal_matching");
 
-  if (enable_signal_matching_) {
-    signal_match_validator_ = std::make_unique<SignalMatchValidator>();
-    signal_match_validator_->setSourcePriority(source_priority_);
-  }
+  core_ = std::make_unique<TrafficLightArbiterCore>(
+    source_priority, enable_signal_matching, external_delay_tolerance, external_time_tolerance,
+    perception_time_tolerance);
 
   map_sub_ = create_subscription<LaneletMapBin>(
     "~/sub/vector_map", rclcpp::QoS(1).transient_local(),
-    std::bind(&TrafficLightArbiter::onMap, this, std::placeholders::_1));
+    std::bind(&TrafficLightArbiter::on_map, this, std::placeholders::_1));
 
   perception_tlr_sub_ = create_subscription<TrafficSignalArray>(
     "~/sub/perception_traffic_signals", rclcpp::QoS(1),
-    std::bind(&TrafficLightArbiter::onPerceptionMsg, this, std::placeholders::_1));
+    std::bind(&TrafficLightArbiter::on_perception_msg, this, std::placeholders::_1));
 
   external_tlr_sub_ = create_subscription<TrafficSignalArray>(
     "~/sub/external_traffic_signals", rclcpp::QoS(1),
-    std::bind(&TrafficLightArbiter::onExternalMsg, this, std::placeholders::_1));
+    std::bind(&TrafficLightArbiter::on_external_msg, this, std::placeholders::_1));
 
   pub_ = create_publisher<TrafficSignalArray>("~/pub/traffic_signals", rclcpp::QoS(1));
 }
 
-void TrafficLightArbiter::onMap(const LaneletMapBin::ConstSharedPtr msg)
+void TrafficLightArbiter::on_map(const LaneletMapBin::ConstSharedPtr msg)
 {
-  const auto map = autoware::experimental::lanelet2_utils::from_autoware_map_msgs(*msg);
-
-  const auto signals = lanelet::filter_traffic_signals(map);
-  map_regulatory_elements_set_ = std::make_unique<std::unordered_set<lanelet::Id>>();
-
-  for (const auto & signal : signals) {
-    map_regulatory_elements_set_->emplace(signal->id());
-  }
-
-  if (enable_signal_matching_) {
-    // Filter only pedestrian signals to distinguish them in signal matching
-    const auto pedestrian_signals = lanelet::filter_pedestrian_signals(map);
-    signal_match_validator_->setPedestrianSignals(pedestrian_signals);
-  }
+  core_->set_map(autoware::experimental::lanelet2_utils::from_autoware_map_msgs(*msg));
 }
 
-void TrafficLightArbiter::onPerceptionMsg(const TrafficSignalArray::ConstSharedPtr msg)
+void TrafficLightArbiter::on_perception_msg(const TrafficSignalArray::ConstSharedPtr msg)
 {
-  latest_perception_msg_ = *msg;
-
-  // Clean up external signals that are too old relative to perception message
-  const auto msg_time = rclcpp::Time(msg->stamp);
-  cleanupExpiredExternalSignals(msg_time, external_time_tolerance_);
-
-  arbitrateAndPublish(msg->stamp);
+  log_expired_external_signals(core_->ingest_perception(*msg));
+  arbitrate_and_publish(msg->stamp);
 }
 
-void TrafficLightArbiter::onExternalMsg(const TrafficSignalArray::ConstSharedPtr msg)
+void TrafficLightArbiter::on_external_msg(const TrafficSignalArray::ConstSharedPtr msg)
 {
-  const auto current_time = this->now();
-  const auto msg_time = rclcpp::Time(msg->stamp);
-
-  if (std::abs((current_time - msg_time).seconds()) > external_delay_tolerance_) {
+  const auto result = core_->ingest_external(*msg, this->now());
+  if (!result.accepted) {
     RCLCPP_WARN_THROTTLE(
-      get_logger(), *get_clock(), 5000, "Received outdated V2X traffic signal messages");
+      get_logger(), *get_clock(), 5000, "Received outdated external traffic signal messages");
     return;
   }
-
-  // Update external traffic lights map with new information
-  for (const auto & signal : msg->traffic_light_groups) {
-    external_traffic_lights_[signal.traffic_light_group_id] =
-      std::make_pair(rclcpp::Time(msg->stamp), signal);
-  }
-
-  // Clean up expired signals
-  cleanupExpiredExternalSignals(current_time, external_delay_tolerance_);
-
-  // Clear perception data if too old relative to any external signal
-  if (
-    std::abs((msg_time - rclcpp::Time(latest_perception_msg_.stamp)).seconds()) >
-    perception_time_tolerance_) {
-    latest_perception_msg_.traffic_light_groups.clear();
-  }
-
-  arbitrateAndPublish(msg->stamp);
+  log_expired_external_signals(result.expired);
+  arbitrate_and_publish(msg->stamp);
 }
 
-void TrafficLightArbiter::cleanupExpiredExternalSignals(
-  const rclcpp::Time & current_time, double tolerance)
+void TrafficLightArbiter::log_expired_external_signals(
+  const std::vector<TrafficLightArbiterCore::ExpiredExternalSignal> & expired)
 {
-  auto it = external_traffic_lights_.begin();
-  while (it != external_traffic_lights_.end()) {
-    const auto & msg_stamp = it->second.first;
-    const auto age = (current_time - msg_stamp).seconds();
-    if (std::abs(age) > tolerance) {
-      RCLCPP_DEBUG(
-        get_logger(), "Removing expired external traffic light signal (ID: %lu, age: %.2f s)",
-        it->first, age);
-      it = external_traffic_lights_.erase(it);
-    } else {
-      ++it;
-    }
+  for (const auto & entry : expired) {
+    RCLCPP_DEBUG(
+      get_logger(), "Removing expired external traffic light signal (ID: %lu, age: %.2f s)",
+      entry.id, entry.age);
   }
 }
 
-void TrafficLightArbiter::arbitrateAndPublish(const builtin_interfaces::msg::Time & stamp)
+void TrafficLightArbiter::arbitrate_and_publish(const builtin_interfaces::msg::Time & stamp)
 {
-  using ElementAndPriority = std::pair<Element, bool>;
-  std::unordered_map<lanelet::Id, std::vector<ElementAndPriority>> regulatory_element_signals_map;
+  auto result = core_->arbitrate();
 
-  // Create external signals array from stored valid signals
-  TrafficSignalArray valid_external_signals;
-  for (const auto & [id, info] : external_traffic_lights_) {
-    valid_external_signals.traffic_light_groups.emplace_back(info.second);
-  }
-
-  auto append_predictions = [](auto & map, const auto & groups) {
-    for (const auto & group : groups) {
-      auto & predictions = map[group.traffic_light_group_id];
-      predictions.insert(predictions.end(), group.predictions.begin(), group.predictions.end());
-    }
-  };
-  std::unordered_map<lanelet::Id, std::vector<PredictedTrafficLightState>> predictions_map;
-  // add in order from perception msg
-  append_predictions(predictions_map, latest_perception_msg_.traffic_light_groups);
-  append_predictions(predictions_map, valid_external_signals.traffic_light_groups);
-
-  if (map_regulatory_elements_set_ == nullptr) {
+  if (!result.output.has_value()) {
     RCLCPP_WARN_THROTTLE(
       get_logger(), *get_clock(), 5000, "Received traffic signal messages before a map");
     return;
   }
 
-  TrafficSignalArray output_signals_msg;
-  output_signals_msg.stamp = stamp;
-
-  if (map_regulatory_elements_set_->empty()) {
-    pub_->publish(output_signals_msg);
-    return;
+  for (const auto & id : result.off_map_signal_ids) {
+    RCLCPP_WARN_THROTTLE(
+      get_logger(), *get_clock(), 5000,
+      "Received a traffic signal not present in the current map (%lu)", id);
   }
 
-  auto add_signal_function = [&](const auto & signal, bool priority) {
-    const auto id = signal.traffic_light_group_id;
-    if (!map_regulatory_elements_set_->count(id)) {
-      RCLCPP_WARN_THROTTLE(
-        get_logger(), *get_clock(), 5000,
-        "Received a traffic signal not present in the current map (%lu)", id);
-      return;
-    }
+  // Stamp inheritance is the Node's I/O contract with downstream consumers:
+  // the published output carries the trigger msg's stamp for time alignment.
+  result.output->stamp = stamp;
+  pub_->publish(*result.output);
 
-    auto & elements_and_priority = regulatory_element_signals_map[id];
-    for (const auto & element : signal.elements) {
-      elements_and_priority.emplace_back(element, priority);
-    }
-  };
-
-  if (enable_signal_matching_) {
-    const auto validated_signals =
-      signal_match_validator_->validateSignals(latest_perception_msg_, valid_external_signals);
-    for (const auto & signal : validated_signals.traffic_light_groups) {
-      add_signal_function(signal, false);
-    }
-  } else {
-    for (const auto & signal : latest_perception_msg_.traffic_light_groups) {
-      add_signal_function(signal, source_priority_ == SourcePriority::PERCEPTION);
-    }
-
-    for (const auto & signal : valid_external_signals.traffic_light_groups) {
-      add_signal_function(signal, source_priority_ == SourcePriority::EXTERNAL);
-    }
-  }
-
-  const auto get_highest_confidence_elements =
-    [](const std::vector<ElementAndPriority> & elements_and_priority_vector) {
-      using Key = Element::_shape_type;
-      std::map<Key, ElementAndPriority> highest_score_element_and_priority_map;
-      std::vector<Element> highest_score_elements_vector;
-
-      for (const auto & elements_and_priority : elements_and_priority_vector) {
-        const auto & element = elements_and_priority.first;
-        const auto & element_priority = elements_and_priority.second;
-        const auto key = element.shape;
-        auto [iter, success] =
-          highest_score_element_and_priority_map.try_emplace(key, elements_and_priority);
-        const auto & iter_element = iter->second.first;
-        const auto & iter_priority = iter->second.second;
-
-        if (
-          !success &&
-          (element_priority > iter_priority ||
-           (element_priority == iter_priority && element.confidence > iter_element.confidence))) {
-          iter->second = elements_and_priority;
-        }
-      }
-
-      for (const auto & [k, v] : highest_score_element_and_priority_map) {
-        highest_score_elements_vector.emplace_back(v.first);
-      }
-
-      return highest_score_elements_vector;
-    };
-
-  output_signals_msg.traffic_light_groups.reserve(regulatory_element_signals_map.size());
-
-  for (const auto & [regulatory_element_id, elements] : regulatory_element_signals_map) {
-    TrafficSignal signal_msg;
-    signal_msg.traffic_light_group_id = regulatory_element_id;
-    signal_msg.elements = get_highest_confidence_elements(elements);
-    signal_msg.predictions = predictions_map[regulatory_element_id];
-    output_signals_msg.traffic_light_groups.emplace_back(signal_msg);
-  }
-
-  pub_->publish(output_signals_msg);
-
-  // Calculate latest time from available sources
-  rclcpp::Time latest_time = rclcpp::Time(latest_perception_msg_.stamp);
-  for (const auto & [id, info] : external_traffic_lights_) {
-    const auto & external_time = info.first;
-    if (external_time > latest_time) {
-      latest_time = external_time;
-    }
-  }
-
-  if (rclcpp::Time(output_signals_msg.stamp) < latest_time) {
+  if (rclcpp::Time(stamp) < result.latest_input_time) {
     RCLCPP_WARN_THROTTLE(
       get_logger(), *get_clock(), 5000, "Published traffic signal messages are not latest");
   }

--- a/perception/autoware_traffic_light_arbiter/src/traffic_light_arbiter_core.cpp
+++ b/perception/autoware_traffic_light_arbiter/src/traffic_light_arbiter_core.cpp
@@ -1,0 +1,274 @@
+// Copyright 2026 The Autoware Contributors
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include <autoware/traffic_light_arbiter/traffic_light_arbiter_core.hpp>
+#include <autoware_lanelet2_extension/utility/query.hpp>
+
+#include <lanelet2_core/LaneletMap.h>
+#include <lanelet2_core/primitives/BasicRegulatoryElements.h>
+
+#include <algorithm>
+#include <map>
+#include <memory>
+#include <tuple>
+#include <unordered_map>
+#include <unordered_set>
+#include <utility>
+#include <vector>
+
+namespace autoware::traffic_light
+{
+
+namespace
+{
+
+std::unordered_set<lanelet::Id> extract_traffic_light_ids(const lanelet::LaneletMapConstPtr & map)
+{
+  std::unordered_set<lanelet::Id> traffic_light_ids;
+  for (const auto & element : map->regulatoryElementLayer) {
+    const auto traffic_light = std::dynamic_pointer_cast<const lanelet::TrafficLight>(element);
+    if (traffic_light) {
+      traffic_light_ids.emplace(traffic_light->id());
+    }
+  }
+  return traffic_light_ids;
+}
+
+std::unordered_set<lanelet::Id> extract_pedestrian_traffic_light_ids(
+  const lanelet::LaneletMapConstPtr & map)
+{
+  namespace query = lanelet::utils::query;
+
+  const auto all_lanelets = query::laneletLayer(map);
+  const auto crosswalks = query::crosswalkLanelets(all_lanelets);
+
+  std::unordered_set<lanelet::Id> pedestrian_traffic_light_ids;
+  for (const auto & crosswalk : crosswalks) {
+    const auto traffic_lights = crosswalk.regulatoryElementsAs<const lanelet::TrafficLight>();
+    for (const auto & traffic_light : traffic_lights) {
+      pedestrian_traffic_light_ids.emplace(traffic_light->id());
+    }
+  }
+  return pedestrian_traffic_light_ids;
+}
+
+}  // namespace
+
+TrafficLightArbiterCore::TrafficLightArbiterCore(
+  SourcePriority source_priority, bool enable_signal_matching, double external_delay_tolerance,
+  double external_time_tolerance, double perception_time_tolerance)
+: source_priority_(source_priority),
+  enable_signal_matching_(enable_signal_matching),
+  external_delay_tolerance_(external_delay_tolerance),
+  external_time_tolerance_(external_time_tolerance),
+  perception_time_tolerance_(perception_time_tolerance)
+{
+  if (enable_signal_matching_) {
+    signal_match_validator_ = std::make_unique<SignalMatchValidator>(source_priority_);
+  }
+}
+
+void TrafficLightArbiterCore::set_map(const lanelet::LaneletMapConstPtr & map)
+{
+  map_regulatory_elements_set_ =
+    std::make_unique<std::unordered_set<lanelet::Id>>(extract_traffic_light_ids(map));
+  if (enable_signal_matching_) {
+    signal_match_validator_->set_pedestrian_traffic_light_ids(
+      extract_pedestrian_traffic_light_ids(map));
+  }
+}
+
+bool TrafficLightArbiterCore::is_external_outdated(
+  const rclcpp::Time & current_time, const rclcpp::Time & msg_stamp) const
+{
+  return std::abs((current_time - msg_stamp).seconds()) > external_delay_tolerance_;
+}
+
+std::vector<TrafficLightArbiterCore::ExpiredExternalSignal>
+TrafficLightArbiterCore::sweep_expired_external_signals(
+  const rclcpp::Time & reference_time, double tolerance)
+{
+  std::vector<ExpiredExternalSignal> expired;
+  auto it = external_traffic_lights_.begin();
+  while (it != external_traffic_lights_.end()) {
+    const auto & msg_stamp = it->second.first;
+    const auto age = (reference_time - msg_stamp).seconds();
+    if (std::abs(age) > tolerance) {
+      expired.push_back({it->first, age});
+      it = external_traffic_lights_.erase(it);
+    } else {
+      ++it;
+    }
+  }
+  return expired;
+}
+
+std::vector<TrafficLightArbiterCore::ExpiredExternalSignal>
+TrafficLightArbiterCore::ingest_perception(const TrafficSignalArray & msg)
+{
+  latest_perception_msg_ = msg;
+  return sweep_expired_external_signals(rclcpp::Time(msg.stamp), external_time_tolerance_);
+}
+
+TrafficLightArbiterCore::ExternalIngestResult TrafficLightArbiterCore::ingest_external(
+  const TrafficSignalArray & msg, const rclcpp::Time & current_time)
+{
+  const auto msg_time = rclcpp::Time(msg.stamp);
+  if (is_external_outdated(current_time, msg_time)) {
+    return {false, {}};
+  }
+
+  // Update external traffic lights map with new information
+  for (const auto & signal : msg.traffic_light_groups) {
+    external_traffic_lights_[signal.traffic_light_group_id] = std::make_pair(msg_time, signal);
+  }
+
+  return {true, sweep_expired_external_signals(current_time, external_delay_tolerance_)};
+}
+
+TrafficLightArbiterCore::ArbitrationResult TrafficLightArbiterCore::arbitrate()
+{
+  ArbitrationResult result;
+
+  using ElementAndPriority = std::pair<Element, bool>;
+  std::unordered_map<lanelet::Id, std::vector<ElementAndPriority>> regulatory_element_signals_map;
+
+  // Create external signals array from stored valid signals, tracking the
+  // freshest external stamp for the perception-staleness check below.
+  TrafficSignalArray valid_external_signals;
+  rclcpp::Time max_external_stamp{0, 0, RCL_ROS_TIME};
+  bool has_externals = false;
+  for (const auto & [id, info] : external_traffic_lights_) {
+    valid_external_signals.traffic_light_groups.emplace_back(info.second);
+    if (!has_externals || info.first > max_external_stamp) {
+      max_external_stamp = info.first;
+      has_externals = true;
+    }
+  }
+
+  // Ignore perception for this cycle when it lags the freshest external by
+  // more than perception_time_tolerance_. Done as a non-destructive view so
+  // ingest_perception() remains the sole writer of latest_perception_msg_.
+  const auto perception_stamp = rclcpp::Time(latest_perception_msg_.stamp);
+  const bool perception_is_stale =
+    has_externals && (max_external_stamp - perception_stamp).seconds() > perception_time_tolerance_;
+  TrafficSignalArray empty_perception;
+  empty_perception.stamp = latest_perception_msg_.stamp;
+  const auto & effective_perception =
+    perception_is_stale ? empty_perception : latest_perception_msg_;
+
+  auto append_predictions = [](auto & map, const auto & groups) {
+    for (const auto & group : groups) {
+      auto & predictions = map[group.traffic_light_group_id];
+      predictions.insert(predictions.end(), group.predictions.begin(), group.predictions.end());
+    }
+  };
+  std::unordered_map<lanelet::Id, std::vector<PredictedTrafficLightState>> predictions_map;
+  // add in order from perception msg
+  append_predictions(predictions_map, effective_perception.traffic_light_groups);
+  append_predictions(predictions_map, valid_external_signals.traffic_light_groups);
+
+  if (map_regulatory_elements_set_ == nullptr) {
+    return result;
+  }
+
+  TrafficSignalArray output_signals_msg;
+  // stamp deliberately left default — the Node owns stamp inheritance.
+
+  if (map_regulatory_elements_set_->empty()) {
+    result.output = std::move(output_signals_msg);
+    return result;
+  }
+
+  auto add_signal_function = [&](const auto & signal, bool priority) {
+    const auto id = signal.traffic_light_group_id;
+    if (!map_regulatory_elements_set_->count(id)) {
+      result.off_map_signal_ids.push_back(id);
+      return;
+    }
+
+    auto & elements_and_priority = regulatory_element_signals_map[id];
+    for (const auto & element : signal.elements) {
+      elements_and_priority.emplace_back(element, priority);
+    }
+  };
+
+  if (enable_signal_matching_) {
+    const auto validated_signals =
+      signal_match_validator_->validate_signals(effective_perception, valid_external_signals);
+    for (const auto & signal : validated_signals.traffic_light_groups) {
+      add_signal_function(signal, false);
+    }
+  } else {
+    for (const auto & signal : effective_perception.traffic_light_groups) {
+      add_signal_function(signal, source_priority_ == SourcePriority::PERCEPTION);
+    }
+
+    for (const auto & signal : valid_external_signals.traffic_light_groups) {
+      add_signal_function(signal, source_priority_ == SourcePriority::EXTERNAL);
+    }
+  }
+
+  const auto get_highest_confidence_elements =
+    [](const std::vector<ElementAndPriority> & elements_and_priority_vector) {
+      using Key = Element::_shape_type;
+      std::map<Key, ElementAndPriority> highest_score_element_and_priority_map;
+      std::vector<Element> highest_score_elements_vector;
+
+      for (const auto & elements_and_priority : elements_and_priority_vector) {
+        const auto & element = elements_and_priority.first;
+        const auto & element_priority = elements_and_priority.second;
+        const auto key = element.shape;
+        auto [iter, success] =
+          highest_score_element_and_priority_map.try_emplace(key, elements_and_priority);
+        const auto & iter_element = iter->second.first;
+        const auto & iter_priority = iter->second.second;
+
+        if (
+          !success &&
+          (element_priority > iter_priority ||
+           (element_priority == iter_priority && element.confidence > iter_element.confidence))) {
+          iter->second = elements_and_priority;
+        }
+      }
+
+      for (const auto & [k, v] : highest_score_element_and_priority_map) {
+        highest_score_elements_vector.emplace_back(v.first);
+      }
+
+      return highest_score_elements_vector;
+    };
+
+  output_signals_msg.traffic_light_groups.reserve(regulatory_element_signals_map.size());
+
+  for (const auto & [regulatory_element_id, elements] : regulatory_element_signals_map) {
+    TrafficSignal signal_msg;
+    signal_msg.traffic_light_group_id = regulatory_element_id;
+    signal_msg.elements = get_highest_confidence_elements(elements);
+    signal_msg.predictions = predictions_map[regulatory_element_id];
+    output_signals_msg.traffic_light_groups.emplace_back(signal_msg);
+  }
+
+  // Latest input stamp across stored sources. The Node compares this against
+  // its trigger stamp to decide whether the published output is behind some
+  // input that has arrived but hasn't yet driven a publish cycle.
+  result.latest_input_time = (has_externals && max_external_stamp > perception_stamp)
+                               ? max_external_stamp
+                               : perception_stamp;
+
+  result.output = std::move(output_signals_msg);
+  return result;
+}
+
+}  // namespace autoware::traffic_light

--- a/perception/autoware_traffic_light_arbiter/src/traffic_light_arbiter_core.cpp
+++ b/perception/autoware_traffic_light_arbiter/src/traffic_light_arbiter_core.cpp
@@ -137,7 +137,8 @@ TrafficLightArbiterCore::ExternalIngestResult TrafficLightArbiterCore::ingest_ex
   return {true, sweep_expired_external_signals(current_time, external_delay_tolerance_)};
 }
 
-TrafficLightArbiterCore::ArbitrationResult TrafficLightArbiterCore::arbitrate()
+TrafficLightArbiterCore::ArbitrationResult TrafficLightArbiterCore::arbitrate(
+  TrafficSignalArray & output)
 {
   ArbitrationResult result;
 
@@ -183,11 +184,10 @@ TrafficLightArbiterCore::ArbitrationResult TrafficLightArbiterCore::arbitrate()
     return result;
   }
 
-  TrafficSignalArray output_signals_msg;
   // stamp deliberately left default — the Node owns stamp inheritance.
+  result.has_output = true;
 
   if (map_regulatory_elements_set_->empty()) {
-    result.output = std::move(output_signals_msg);
     return result;
   }
 
@@ -250,14 +250,14 @@ TrafficLightArbiterCore::ArbitrationResult TrafficLightArbiterCore::arbitrate()
       return highest_score_elements_vector;
     };
 
-  output_signals_msg.traffic_light_groups.reserve(regulatory_element_signals_map.size());
+  output.traffic_light_groups.reserve(regulatory_element_signals_map.size());
 
   for (const auto & [regulatory_element_id, elements] : regulatory_element_signals_map) {
     TrafficSignal signal_msg;
     signal_msg.traffic_light_group_id = regulatory_element_id;
     signal_msg.elements = get_highest_confidence_elements(elements);
     signal_msg.predictions = predictions_map[regulatory_element_id];
-    output_signals_msg.traffic_light_groups.emplace_back(signal_msg);
+    output.traffic_light_groups.emplace_back(signal_msg);
   }
 
   // Latest input stamp across stored sources. The Node compares this against
@@ -267,7 +267,6 @@ TrafficLightArbiterCore::ArbitrationResult TrafficLightArbiterCore::arbitrate()
                                ? max_external_stamp
                                : perception_stamp;
 
-  result.output = std::move(output_signals_msg);
   return result;
 }
 

--- a/perception/autoware_traffic_light_arbiter/test/test_traffic_arbiter_characteristic.cpp
+++ b/perception/autoware_traffic_light_arbiter/test/test_traffic_arbiter_characteristic.cpp
@@ -1,0 +1,1008 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/traffic_light_arbiter/traffic_light_arbiter.hpp"
+
+#include <autoware/lanelet2_utils/conversion.hpp>
+#include <rclcpp/executors/single_threaded_executor.hpp>
+#include <rclcpp/rclcpp.hpp>
+
+#include <autoware_map_msgs/msg/lanelet_map_bin.hpp>
+#include <autoware_perception_msgs/msg/traffic_light_group_array.hpp>
+
+#include <gtest/gtest.h>
+#include <lanelet2_core/Attribute.h>
+#include <lanelet2_core/LaneletMap.h>
+#include <lanelet2_core/primitives/BasicRegulatoryElements.h>
+#include <lanelet2_core/primitives/Lanelet.h>
+#include <lanelet2_core/primitives/LineString.h>
+#include <lanelet2_core/primitives/LineStringOrPolygon.h>
+#include <lanelet2_core/primitives/Point.h>
+
+#include <chrono>
+#include <memory>
+#include <optional>
+#include <string>
+#include <thread>
+#include <utility>
+#include <vector>
+
+namespace
+{
+
+using autoware::traffic_light::TrafficLightArbiter;
+using LaneletMapBin = autoware_map_msgs::msg::LaneletMapBin;
+using TrafficLightGroupArray = autoware_perception_msgs::msg::TrafficLightGroupArray;
+using TrafficLightGroup = autoware_perception_msgs::msg::TrafficLightGroup;
+using TrafficLightElement = autoware_perception_msgs::msg::TrafficLightElement;
+using PredictedTrafficLightState = autoware_perception_msgs::msg::PredictedTrafficLightState;
+using namespace lanelet;  // NOLINT(build/namespaces)
+using utils::getId;
+
+// --- Signal IDs --------------------------------------------------------
+
+// Traffic-light regulatory-element IDs that are installed on the test map.
+// Kept explicit (rather than auto-allocated) so that values appearing in
+// published TrafficLightGroupArray messages and warning logs stay readable.
+namespace map_ids
+{
+constexpr lanelet::Id vehicle_signal_a = 1001;
+constexpr lanelet::Id vehicle_signal_b = 1002;
+constexpr lanelet::Id pedestrian_signal = 2001;
+
+// Intentionally not installed on the map; used by tests as the "off-map id"
+// probe to exercise the WARN+skip branch in arbitrateAndPublish.
+constexpr lanelet::Id off_map_probe = 9999;
+}  // namespace map_ids
+
+// --- Map construction --------------------------------------------------
+
+Point3d make_point(lanelet::Id id, double x, double y, double z = 0.0)
+{
+  return Point3d(id, x, y, z);
+}
+
+Lanelet make_lanelet(double y_left, double y_right, const std::string & subtype)
+{
+  LineString3d left(getId(), {make_point(getId(), 0.0, y_left), make_point(getId(), 10.0, y_left)});
+  LineString3d right(
+    getId(), {make_point(getId(), 0.0, y_right), make_point(getId(), 10.0, y_right)});
+  Lanelet new_lanelet(getId(), left, right);
+  new_lanelet.attributes()[AttributeName::Subtype] = subtype;
+  new_lanelet.attributes()[AttributeName::Type] = AttributeValueString::Lanelet;
+  return new_lanelet;
+}
+
+LineString3d make_traffic_light_bulb()
+{
+  // The exact position does not affect arbiter logic; we pick the lanelet
+  // midpoint (x = 5.0 within the 0..10 span) at z = 5.0 above the ground.
+  constexpr double kBulbX = 5.0;
+  constexpr double kBulbZ = 5.0;
+  LineString3d bulb(
+    getId(), {make_point(getId(), kBulbX, 0.0, kBulbZ), make_point(getId(), kBulbX, 1.0, kBulbZ)});
+  bulb.attributes()[AttributeName::Type] = AttributeValueString::TrafficLight;
+  return bulb;
+}
+
+// Builds the minimal map required to drive every code path under test:
+// two road lanelets each carrying one Traffic Light, plus one crosswalk
+// lanelet carrying the pedestrian Traffic Light.
+//
+// Test map summary (top-down view).
+// Each lanelet spans x = 0..10 along the travel direction; +y is the left side.
+//
+//   left bound  right bound   Lanelet      Traffic Light id
+//   ----------  -----------   ----------   --------------------------
+//         8           5       crosswalk    2001 (pedestrian_signal)
+//         4           1       road2        1002 (vehicle_signal_b)
+//         0          -3       road1        1001 (vehicle_signal_a)
+//
+// Probe id intentionally absent from the map: 9999 (map_ids::off_map_probe)
+LaneletMapBin build_minimal_map_bin()
+{
+  Lanelet road1 = make_lanelet(0.0, -3.0, AttributeValueString::Road);
+  Lanelet road2 = make_lanelet(4.0, 1.0, AttributeValueString::Road);
+  Lanelet crosswalk = make_lanelet(8.0, 5.0, AttributeValueString::Crosswalk);
+
+  road1.addRegulatoryElement(
+    TrafficLight::make(
+      map_ids::vehicle_signal_a, {}, LineStringsOrPolygons3d{make_traffic_light_bulb()}));
+  road2.addRegulatoryElement(
+    TrafficLight::make(
+      map_ids::vehicle_signal_b, {}, LineStringsOrPolygons3d{make_traffic_light_bulb()}));
+  crosswalk.addRegulatoryElement(
+    TrafficLight::make(
+      map_ids::pedestrian_signal, {}, LineStringsOrPolygons3d{make_traffic_light_bulb()}));
+
+  const LaneletMapConstPtr map{utils::createMap(Lanelets{road1, road2, crosswalk}).release()};
+  auto bin = ::autoware::experimental::lanelet2_utils::to_autoware_map_msgs(map);
+  bin.header.frame_id = "base_link";
+  return bin;
+}
+
+// Variant of build_minimal_map_bin with a single road lanelet but no Traffic
+// Light regulatory elements. Used to drive the
+// "map_regulatory_elements_set_->empty()" branch in arbitrateAndPublish.
+LaneletMapBin build_empty_map_bin()
+{
+  Lanelet road = make_lanelet(0.0, -3.0, AttributeValueString::Road);
+  const LaneletMapConstPtr map{utils::createMap(Lanelets{road}).release()};
+  auto bin = ::autoware::experimental::lanelet2_utils::to_autoware_map_msgs(map);
+  bin.header.frame_id = "base_link";
+  return bin;
+}
+
+// --- Input message builders --------------------------------------------
+
+// Confidence defaults to 1.0f because most tests do not assert on it.
+TrafficLightElement make_traffic_light_element(
+  uint8_t color, uint8_t shape, float confidence = 1.0f)
+{
+  TrafficLightElement element;
+  element.color = color;
+  element.shape = shape;
+  element.status = TrafficLightElement::SOLID_ON;
+  element.confidence = confidence;
+  return element;
+}
+
+// Build a PredictedTrafficLightState with the given stamp. Color, shape,
+// and source default to placeholder values because most tests only assert
+// presence or count of predictions; tests that pin a specific source
+// (e.g., predictionsFromSingleSidePropagate) pass it explicitly.
+PredictedTrafficLightState make_traffic_light_prediction(
+  const builtin_interfaces::msg::Time & stamp, uint8_t color = TrafficLightElement::UNKNOWN,
+  uint8_t shape = TrafficLightElement::CIRCLE,
+  const std::string & source = PredictedTrafficLightState::INFORMATION_SOURCE_INTERNAL_ESTIMATION)
+{
+  // The arbiter passes predictions through without inspecting any field
+  // value, so the numbers below only need to form a syntactically complete
+  // PredictedTrafficLightState.
+  constexpr int32_t kPredictionOffsetSec = 10;
+  constexpr float kFullCertainty = 1.0f;
+
+  PredictedTrafficLightState prediction;
+  prediction.predicted_stamp = stamp;
+  prediction.predicted_stamp.sec += kPredictionOffsetSec;
+  prediction.simultaneous_elements.push_back(
+    make_traffic_light_element(color, shape, kFullCertainty));
+  prediction.reliability = kFullCertainty;
+  prediction.information_source = source;
+  return prediction;
+}
+
+TrafficLightGroup make_traffic_light_group(
+  lanelet::Id id, std::vector<TrafficLightElement> elements,
+  std::vector<PredictedTrafficLightState> predictions = {})
+{
+  TrafficLightGroup group;
+  group.traffic_light_group_id = id;
+  group.elements = std::move(elements);
+  group.predictions = std::move(predictions);
+  return group;
+}
+
+// Compose a TrafficLightGroupArray with one group in a single expression.
+TrafficLightGroupArray make_signal_array(
+  const rclcpp::Time & stamp, lanelet::Id id, std::vector<TrafficLightElement> elements,
+  std::vector<PredictedTrafficLightState> predictions = {})
+{
+  TrafficLightGroupArray msg;
+  msg.stamp = stamp;
+  msg.traffic_light_groups.push_back(
+    make_traffic_light_group(id, std::move(elements), std::move(predictions)));
+  return msg;
+}
+
+// Multi-group variant for tests that publish several ids in one message.
+TrafficLightGroupArray make_signal_array(
+  const rclcpp::Time & stamp, std::vector<TrafficLightGroup> groups)
+{
+  TrafficLightGroupArray msg;
+  msg.stamp = stamp;
+  msg.traffic_light_groups = std::move(groups);
+  return msg;
+}
+
+// --- Timestamp utility -------------------------------------------------
+
+builtin_interfaces::msg::Time offset_time(const rclcpp::Time & base, double seconds)
+{
+  return (base + rclcpp::Duration::from_seconds(seconds));
+}
+
+// --- Test fixture ------------------------------------------------------
+
+class ArbiterCharacteristic : public ::testing::Test
+{
+protected:
+  // --- Lifecycle ---------------------------------------------------------
+  static void SetUpTestSuite()
+  {
+    if (!rclcpp::ok()) {
+      rclcpp::init(0, nullptr);
+    }
+
+    // Reserve the highest signal id so utils::getId() never returns values
+    // that collide with map_ids::* or map_ids::off_map_probe. Calling registerId(9999)
+    // advances the global counter to >= 10000, which is safely above every
+    // fixed signal id we use. This is process-wide global state, so doing it
+    // once per suite is enough.
+    utils::registerId(map_ids::off_map_probe);
+
+    // map_bin_ is immutable across tests, so build it once for the suite.
+    map_bin_ = build_minimal_map_bin();
+  }
+  static void TearDownTestSuite()
+  {
+    if (rclcpp::ok()) {
+      rclcpp::shutdown();
+    }
+  }
+
+  void SetUp() override
+  {
+    test_node_ = std::make_shared<rclcpp::Node>("arbiter_characteristic_test");
+
+    map_pub_ =
+      test_node_->create_publisher<LaneletMapBin>(kMapTopic, rclcpp::QoS(1).transient_local());
+    perception_pub_ =
+      test_node_->create_publisher<TrafficLightGroupArray>(kPerceptionTopic, rclcpp::QoS(1));
+    external_pub_ =
+      test_node_->create_publisher<TrafficLightGroupArray>(kExternalTopic, rclcpp::QoS(1));
+
+    arbitrated_traffic_signal_sub_ = test_node_->create_subscription<TrafficLightGroupArray>(
+      kOutputTopic, rclcpp::QoS(1), [this](const TrafficLightGroupArray::ConstSharedPtr msg) {
+        latest_arbitrated_traffic_signal_ = *msg;
+        ++arbiter_publish_count_;
+      });
+  }
+
+  void TearDown() override
+  {
+    if (executor_) {
+      executor_->cancel();
+    }
+    executor_.reset();
+    arbiter_.reset();
+    arbitrated_traffic_signal_sub_.reset();
+    map_pub_.reset();
+    perception_pub_.reset();
+    external_pub_.reset();
+    test_node_.reset();
+  }
+
+  // --- Arrange helpers ---------------------------------------------------
+  void start_arbiter(bool enable_signal_matching, const std::string & source_priority)
+  {
+    rclcpp::NodeOptions options;
+    options.parameter_overrides({
+      rclcpp::Parameter("external_delay_tolerance", kDefaultExternalDelayTolerance),
+      rclcpp::Parameter("external_time_tolerance", kDefaultExternalTimeTolerance),
+      rclcpp::Parameter("perception_time_tolerance", kDefaultPerceptionTimeTolerance),
+      rclcpp::Parameter("source_priority", source_priority),
+      rclcpp::Parameter("enable_signal_matching", enable_signal_matching),
+    });
+    arbiter_ = std::make_shared<TrafficLightArbiter>(options);
+    executor_ = std::make_shared<rclcpp::executors::SingleThreadedExecutor>();
+    executor_->add_node(arbiter_);
+    executor_->add_node(test_node_);
+    spin_for();
+    t0_ = arbiter_->now();
+  }
+
+  void publish_map() { publish_map(*map_bin_); }
+
+  void publish_map(const LaneletMapBin & bin)
+  {
+    map_pub_->publish(bin);
+    spin_for();
+  }
+
+  // --- Act helpers -------------------------------------------------------
+  void publish_perception(const TrafficLightGroupArray & msg)
+  {
+    perception_pub_->publish(msg);
+    spin_for();
+  }
+  void publish_external(const TrafficLightGroupArray & msg)
+  {
+    external_pub_->publish(msg);
+    spin_for();
+  }
+
+  void spin_for(std::chrono::milliseconds duration = std::chrono::milliseconds(150))
+  {
+    const auto deadline = std::chrono::steady_clock::now() + duration;
+    while (std::chrono::steady_clock::now() < deadline) {
+      executor_->spin_some();
+      std::this_thread::sleep_for(std::chrono::milliseconds(5));
+    }
+  }
+
+  // --- Assert helpers ----------------------------------------------------
+  // Look up a TrafficLightGroup or TrafficLightElement in the latest
+  // arbitrated output. Returns nullptr when not present.
+  const TrafficLightGroup * find_traffic_light_group(lanelet::Id id) const
+  {
+    for (const auto & group : latest_arbitrated_traffic_signal_.traffic_light_groups) {
+      if (group.traffic_light_group_id == id) {
+        return &group;
+      }
+    }
+    return nullptr;
+  }
+  const TrafficLightElement * find_traffic_light_element(
+    const TrafficLightGroup & group, uint8_t shape) const
+  {
+    for (const auto & element : group.elements) {
+      if (element.shape == shape) {
+        return &element;
+      }
+    }
+    return nullptr;
+  }
+
+  // Return the first element's color/shape/confidence for the given id in
+  // the latest arbitrated output. When the id is absent or has no
+  // elements, return a sentinel value (UINT8_MAX / -1.0f) that is never
+  // valid, so EXPECT_EQ at the call site fails loudly.
+  uint8_t observed_color(lanelet::Id signal_id) const
+  {
+    const auto * group = find_traffic_light_group(signal_id);
+    return (group && !group->elements.empty()) ? group->elements[0].color : UINT8_MAX;
+  }
+  uint8_t observed_shape(lanelet::Id signal_id) const
+  {
+    const auto * group = find_traffic_light_group(signal_id);
+    return (group && !group->elements.empty()) ? group->elements[0].shape : UINT8_MAX;
+  }
+  float observed_confidence(lanelet::Id signal_id) const
+  {
+    const auto * group = find_traffic_light_group(signal_id);
+    return (group && !group->elements.empty()) ? group->elements[0].confidence : -1.0f;
+  }
+  std::size_t observed_prediction_count(lanelet::Id signal_id) const
+  {
+    const auto * group = find_traffic_light_group(signal_id);
+    return group ? group->predictions.size() : SIZE_MAX;
+  }
+
+  // Cardinality of the latest published TrafficLightGroupArray.
+  std::size_t observed_group_count() const
+  {
+    return latest_arbitrated_traffic_signal_.traffic_light_groups.size();
+  }
+
+  // Multi-element variants: pick the element with the matching shape.
+  std::size_t observed_element_count(lanelet::Id signal_id) const
+  {
+    const auto * group = find_traffic_light_group(signal_id);
+    return group ? group->elements.size() : SIZE_MAX;
+  }
+  uint8_t observed_color_of_shape(lanelet::Id signal_id, uint8_t shape) const
+  {
+    const auto * group = find_traffic_light_group(signal_id);
+    if (!group) {
+      return UINT8_MAX;
+    }
+    const auto * element = find_traffic_light_element(*group, shape);
+    return element ? element->color : UINT8_MAX;
+  }
+
+  // Wrapped in std::optional because LaneletMapBin (a generated ROS msg)
+  // has no usable default constructor that can be invoked at static storage
+  // duration; we initialise it during SetUpTestSuite().
+  inline static std::optional<LaneletMapBin> map_bin_;
+
+  rclcpp::Node::SharedPtr test_node_;
+  std::shared_ptr<TrafficLightArbiter> arbiter_;
+  std::shared_ptr<rclcpp::executors::SingleThreadedExecutor> executor_;
+
+  rclcpp::Publisher<LaneletMapBin>::SharedPtr map_pub_;
+  rclcpp::Publisher<TrafficLightGroupArray>::SharedPtr perception_pub_;
+  rclcpp::Publisher<TrafficLightGroupArray>::SharedPtr external_pub_;
+  rclcpp::Subscription<TrafficLightGroupArray>::SharedPtr arbitrated_traffic_signal_sub_;
+
+  TrafficLightGroupArray latest_arbitrated_traffic_signal_;
+  std::size_t arbiter_publish_count_ = 0;
+
+  // Reference timestamp captured once in start_arbiter(); tests use it
+  // (and offset_time(t0_, ...)) as a fixed clock.
+  rclcpp::Time t0_;
+
+private:
+  // Topic names used by the publishers/subscription owned by the fixture.
+  static constexpr const char * kMapTopic = "/traffic_light_arbiter/sub/vector_map";
+  static constexpr const char * kPerceptionTopic =
+    "/traffic_light_arbiter/sub/perception_traffic_signals";
+  static constexpr const char * kExternalTopic =
+    "/traffic_light_arbiter/sub/external_traffic_signals";
+  static constexpr const char * kOutputTopic = "/traffic_light_arbiter/pub/traffic_signals";
+
+protected:
+  // Tolerance used by EXPECT_NEAR when comparing confidence values.
+  static constexpr float kConfidenceEpsilon = 1e-5f;
+
+  // Default tolerance values declared on the arbiter (mirrors
+  // config/traffic_light_arbiter.param.yaml).
+  static constexpr double kDefaultExternalDelayTolerance = 5.0;
+  static constexpr double kDefaultExternalTimeTolerance = 5.0;
+  static constexpr double kDefaultPerceptionTimeTolerance = 1.0;
+};
+
+// ---------------------------------------------------------------------------
+// A. Signal Matching mode (enable_signal_matching=true)
+// ---------------------------------------------------------------------------
+
+// Matched: external and perception agree on color and shape. Perception
+// passes through verbatim, and predictions from both sides are merged.
+TEST_F(ArbiterCharacteristic, signalMatchingMatchedPassesThrough)
+{
+  // Arrange
+  start_arbiter(true, "confidence");  // signal matching mode, "confidence" priority
+  publish_map();
+
+  // Act
+  publish_external(make_signal_array(
+    t0_, map_ids::vehicle_signal_a,
+    {make_traffic_light_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)},
+    {make_traffic_light_prediction(t0_)}));
+  publish_perception(make_signal_array(
+    t0_, map_ids::vehicle_signal_a,
+    {make_traffic_light_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)},
+    {make_traffic_light_prediction(t0_)}));
+
+  // Assert
+  EXPECT_EQ(observed_color(map_ids::vehicle_signal_a), TrafficLightElement::RED);
+  EXPECT_EQ(observed_prediction_count(map_ids::vehicle_signal_a), 2u);
+}
+
+// Color mismatch: external GREEN/CIRCLE vs perception RED/CIRCLE.
+// Validator falls back to UNKNOWN over the shared shape.
+TEST_F(ArbiterCharacteristic, signalMatchingColorMismatchProducesUnknown)
+{
+  // Arrange
+  start_arbiter(true, "confidence");  // signal matching mode, "confidence" priority
+  publish_map();
+
+  // Act
+  publish_external(make_signal_array(
+    t0_, map_ids::vehicle_signal_b,
+    {make_traffic_light_element(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE)}));
+  publish_perception(make_signal_array(
+    t0_, map_ids::vehicle_signal_b,
+    {make_traffic_light_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)}));
+
+  // Assert
+  EXPECT_EQ(observed_color(map_ids::vehicle_signal_b), TrafficLightElement::UNKNOWN);
+  EXPECT_EQ(observed_shape(map_ids::vehicle_signal_b), TrafficLightElement::CIRCLE);
+}
+
+// Element-count mismatch: external has only CIRCLE while perception has
+// CIRCLE + RIGHT_ARROW. Validator produces UNKNOWN over the shape union.
+TEST_F(ArbiterCharacteristic, signalMatchingElementCountMismatchProducesUnknown)
+{
+  // Arrange
+  start_arbiter(true, "confidence");  // signal matching mode, "confidence" priority
+  publish_map();
+
+  // Act
+  publish_external(make_signal_array(
+    t0_, map_ids::vehicle_signal_b,
+    {make_traffic_light_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)}));
+  publish_perception(make_signal_array(
+    t0_, map_ids::vehicle_signal_b,
+    {make_traffic_light_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE),
+     make_traffic_light_element(TrafficLightElement::GREEN, TrafficLightElement::RIGHT_ARROW)}));
+
+  // Assert: shape union has both CIRCLE and RIGHT_ARROW, both as UNKNOWN.
+  EXPECT_EQ(observed_element_count(map_ids::vehicle_signal_b), 2u);
+  EXPECT_EQ(
+    observed_color_of_shape(map_ids::vehicle_signal_b, TrafficLightElement::CIRCLE),
+    TrafficLightElement::UNKNOWN);
+  EXPECT_EQ(
+    observed_color_of_shape(map_ids::vehicle_signal_b, TrafficLightElement::RIGHT_ARROW),
+    TrafficLightElement::UNKNOWN);
+}
+
+// Off-map id: an id not present in the vector map is silently dropped
+// (WARN log only) by add_signal_function before reaching the validator.
+// An on-map id is also included to confirm normal ids still pass through.
+TEST_F(ArbiterCharacteristic, signalMatchingOffMapIdDropped)
+{
+  // Arrange
+  start_arbiter(true, "confidence");  // signal matching mode, "confidence" priority
+  publish_map();
+
+  // Act
+  publish_external(make_signal_array(
+    t0_, {make_traffic_light_group(
+            map_ids::off_map_probe,
+            {make_traffic_light_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)}),
+          make_traffic_light_group(
+            map_ids::vehicle_signal_a,
+            {make_traffic_light_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)})}));
+  publish_perception(make_signal_array(
+    t0_, map_ids::vehicle_signal_a,
+    {make_traffic_light_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)}));
+
+  // Assert
+  EXPECT_EQ(find_traffic_light_group(map_ids::off_map_probe), nullptr);
+  EXPECT_NE(find_traffic_light_group(map_ids::vehicle_signal_a), nullptr);
+}
+
+// Pedestrian path bypasses element matching; with source_priority=external
+// the external value must win even though perception has higher confidence.
+TEST_F(ArbiterCharacteristic, signalMatchingPedestrianFallbackUsesSourcePriority)
+{
+  // Arrange
+  start_arbiter(true, "external");  // signal matching mode, "external" priority
+  publish_map();
+
+  // Act: confidence contrast (low external vs high perception) makes the
+  // priority override explicit: the lower-confidence external wins.
+  publish_external(make_signal_array(
+    t0_, map_ids::pedestrian_signal,
+    {make_traffic_light_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE, 0.1f)}));
+  publish_perception(make_signal_array(
+    t0_, map_ids::pedestrian_signal,
+    {make_traffic_light_element(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE, 0.9f)}));
+
+  // Assert: external priority wins despite its lower confidence.
+  EXPECT_EQ(observed_color(map_ids::pedestrian_signal), TrafficLightElement::RED);
+}
+
+// Symmetric counterpart of the external-priority pedestrian test: with
+// source_priority=perception, the perception value wins even at lower
+// confidence. Pins the PERCEPTION case of get_highest_confidence_signal
+// inside SignalMatchValidator's pedestrian branch.
+TEST_F(ArbiterCharacteristic, signalMatchingPedestrianPerceptionPriority)
+{
+  // Arrange
+  start_arbiter(true, "perception");  // signal matching mode, "perception" priority
+  publish_map();
+
+  // Act: confidence contrast (high external vs low perception) makes the
+  // priority override explicit: the lower-confidence perception still wins.
+  publish_external(make_signal_array(
+    t0_, map_ids::pedestrian_signal,
+    {make_traffic_light_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE, 0.99f)}));
+  publish_perception(make_signal_array(
+    t0_, map_ids::pedestrian_signal,
+    {make_traffic_light_element(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE, 0.10f)}));
+
+  // Assert: perception priority wins despite its lower confidence.
+  EXPECT_EQ(observed_color(map_ids::pedestrian_signal), TrafficLightElement::GREEN);
+}
+
+// Pedestrian + CONFIDENCE: get_highest_confidence_signal walks each shape and
+// picks the element with higher confidence. Bypasses the
+// color/shape-equivalence check that non-pedestrian ids must pass.
+TEST_F(ArbiterCharacteristic, signalMatchingPedestrianConfidenceMode)
+{
+  // Arrange
+  start_arbiter(true, "confidence");  // signal matching mode, "confidence" priority
+  publish_map();
+
+  // Act
+  publish_external(make_signal_array(
+    t0_, map_ids::pedestrian_signal,
+    {make_traffic_light_element(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE, 0.6f)}));
+  publish_perception(make_signal_array(
+    t0_, map_ids::pedestrian_signal,
+    {make_traffic_light_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE, 0.9f)}));
+
+  // Assert: CONFIDENCE picks the higher-confidence element (perception 0.9)
+  EXPECT_EQ(observed_color(map_ids::pedestrian_signal), TrafficLightElement::RED);
+  EXPECT_NEAR(observed_confidence(map_ids::pedestrian_signal), 0.9f, kConfidenceEpsilon);
+}
+
+// Pedestrian id with a single source: get_highest_confidence_signal early-
+// returns the present side and skips the source_priority switch entirely.
+// In contrast to non-pedestrian ids (which become UNKNOWN), the pedestrian's
+// color/shape passes through unchanged.
+TEST_F(ArbiterCharacteristic, signalMatchingPedestrianSingleSourcePasses)
+{
+  // Arrange: external_priority is set to demonstrate that absent-side handling
+  // happens BEFORE the priority switch is consulted.
+  start_arbiter(true, "external");  // signal matching mode, "external" priority
+  publish_map();
+
+  // Act (no external publish)
+  publish_perception(make_signal_array(
+    t0_, map_ids::pedestrian_signal,
+    {make_traffic_light_element(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE)}));
+
+  // Assert: perception passes through unchanged (no UNKNOWN translation)
+  EXPECT_EQ(observed_color(map_ids::pedestrian_signal), TrafficLightElement::GREEN);
+}
+
+// In Signal Matching mode, a non-pedestrian id that arrives on only one side
+// must be reported as UNKNOWN: the color/shape data is hidden, only the shape
+// mask of the present side survives. Both directions (perception-only and
+// external-only) exercise distinct branches in SignalMatchValidator.
+TEST_F(ArbiterCharacteristic, signalMatchingSingleSourceNonPedestrianYieldsUnknown)
+{
+  // Arrange
+  start_arbiter(true, "confidence");  // signal matching mode, "confidence" priority
+  publish_map();
+
+  // Act: each side carries a different id, so each id has only one source
+  // (vehicle_signal_a is perception-only, vehicle_signal_b is external-only).
+  publish_external(make_signal_array(
+    t0_, map_ids::vehicle_signal_b,
+    {make_traffic_light_element(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE)}));
+  publish_perception(make_signal_array(
+    t0_, map_ids::vehicle_signal_a,
+    {make_traffic_light_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)}));
+
+  // Assert
+  EXPECT_EQ(observed_color(map_ids::vehicle_signal_a), TrafficLightElement::UNKNOWN);
+  EXPECT_EQ(observed_shape(map_ids::vehicle_signal_a), TrafficLightElement::CIRCLE);
+  EXPECT_EQ(observed_color(map_ids::vehicle_signal_b), TrafficLightElement::UNKNOWN);
+  EXPECT_EQ(observed_shape(map_ids::vehicle_signal_b), TrafficLightElement::CIRCLE);
+}
+
+// Signal Matching does not consult the confidence field when checking
+// equivalence. Two elements with identical color/shape but very different
+// confidence values are treated as a match, and perception's value
+// (confidence included) propagates verbatim.
+TEST_F(ArbiterCharacteristic, signalMatchingIgnoresConfidenceInEquivalence)
+{
+  // Arrange
+  start_arbiter(true, "confidence");  // signal matching mode, "confidence" priority
+  publish_map();
+
+  // Act
+  publish_external(make_signal_array(
+    t0_, map_ids::vehicle_signal_a,
+    {make_traffic_light_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE, 0.10f)}));
+  publish_perception(make_signal_array(
+    t0_, map_ids::vehicle_signal_a,
+    {make_traffic_light_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE, 0.90f)}));
+
+  // Assert
+  EXPECT_EQ(observed_color(map_ids::vehicle_signal_a), TrafficLightElement::RED);
+  EXPECT_NEAR(observed_confidence(map_ids::vehicle_signal_a), 0.90f, kConfidenceEpsilon);
+}
+
+// ---------------------------------------------------------------------------
+// B. Priority-based mode (enable_signal_matching=false)
+// ---------------------------------------------------------------------------
+
+// Both sources contribute the same shape for the same id; under CONFIDENCE
+// the higher-confidence element wins (here, perception 0.9 over external 0.7).
+TEST_F(ArbiterCharacteristic, priorityBasedConfidencePicksHigherValue)
+{
+  // Arrange
+  start_arbiter(false, "confidence");  // priority-based mode, "confidence" priority
+  publish_map();
+
+  // Act
+  publish_external(make_signal_array(
+    t0_, map_ids::vehicle_signal_a,
+    {make_traffic_light_element(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE, 0.7f)}));
+  publish_perception(make_signal_array(
+    t0_, map_ids::vehicle_signal_a,
+    {make_traffic_light_element(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE, 0.9f)}));
+
+  // Assert
+  EXPECT_EQ(observed_color(map_ids::vehicle_signal_a), TrafficLightElement::GREEN);
+  EXPECT_NEAR(observed_confidence(map_ids::vehicle_signal_a), 0.9f, kConfidenceEpsilon);
+}
+
+// Only external contributes an id (perception silent). Both shapes survive
+// shape-wise selection and pass through unchanged.
+TEST_F(ArbiterCharacteristic, priorityBasedExternalOnlyPassesThrough)
+{
+  // Arrange
+  start_arbiter(false, "confidence");  // priority-based mode, "confidence" priority
+  publish_map();
+
+  // Act
+  publish_external(make_signal_array(
+    t0_, map_ids::vehicle_signal_b,
+    {make_traffic_light_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE, 0.5f),
+     make_traffic_light_element(
+       TrafficLightElement::GREEN, TrafficLightElement::RIGHT_ARROW, 0.3f)}));
+  // Send a separate id from perception so the arbiter publishes after both
+  // callbacks have settled (the test then inspects vehicle_signal_b output).
+  publish_perception(make_signal_array(
+    t0_, map_ids::vehicle_signal_a,
+    {make_traffic_light_element(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE, 0.9f)}));
+
+  // Assert: external-only passes through with both shapes and colors preserved.
+  EXPECT_EQ(observed_element_count(map_ids::vehicle_signal_b), 2u);
+  EXPECT_EQ(
+    observed_color_of_shape(map_ids::vehicle_signal_b, TrafficLightElement::CIRCLE),
+    TrafficLightElement::RED);
+  EXPECT_EQ(
+    observed_color_of_shape(map_ids::vehicle_signal_b, TrafficLightElement::RIGHT_ARROW),
+    TrafficLightElement::GREEN);
+}
+
+// Only perception contributes an id (external silent). The element flows
+// through unmodified.
+TEST_F(ArbiterCharacteristic, priorityBasedPerceptionOnlyPassesThrough)
+{
+  // Arrange
+  start_arbiter(false, "confidence");  // priority-based mode, "confidence" priority
+  publish_map();
+
+  // Act: external must publish something for the arbiter to settle; use a
+  // different id so vehicle_signal_b is perception-only.
+  publish_external(make_signal_array(
+    t0_, map_ids::vehicle_signal_a,
+    {make_traffic_light_element(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE, 0.7f)}));
+  publish_perception(make_signal_array(
+    t0_, map_ids::vehicle_signal_b,
+    {make_traffic_light_element(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE, 0.8f)}));
+
+  // Assert
+  EXPECT_EQ(observed_color(map_ids::vehicle_signal_b), TrafficLightElement::GREEN);
+  EXPECT_NEAR(observed_confidence(map_ids::vehicle_signal_b), 0.8f, kConfidenceEpsilon);
+}
+
+// An id not in the vector map is silently dropped (WARN log only) by
+// add_signal_function before reaching the per-shape selection.
+TEST_F(ArbiterCharacteristic, priorityBasedOffMapIdDropped)
+{
+  // Arrange
+  start_arbiter(false, "confidence");  // priority-based mode, "confidence" priority
+  publish_map();
+
+  // Act
+  publish_external(make_signal_array(
+    t0_, map_ids::off_map_probe,
+    {make_traffic_light_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE, 0.9f)}));
+  publish_perception(make_signal_array(
+    t0_, map_ids::vehicle_signal_a,
+    {make_traffic_light_element(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE, 0.9f)}));
+
+  // Assert
+  EXPECT_EQ(find_traffic_light_group(map_ids::off_map_probe), nullptr);
+  EXPECT_NE(find_traffic_light_group(map_ids::vehicle_signal_a), nullptr);
+}
+
+// ---------------------------------------------------------------------------
+// C. Focused specifications — boundary cases, time tolerances,
+//    input validation, priority overrides, predictions.
+// ---------------------------------------------------------------------------
+
+// Before the vector_map arrives, arbitrateAndPublish early-returns and no
+// TrafficLightGroupArray is emitted.
+TEST_F(ArbiterCharacteristic, perceptionBeforeMapProducesNoOutput)
+{
+  // Arrange (intentionally no publish_map())
+  start_arbiter(false, "confidence");  // priority-based mode, "confidence" priority
+
+  // Act
+  publish_perception(make_signal_array(
+    t0_, map_ids::vehicle_signal_a,
+    {make_traffic_light_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)}));
+
+  // Assert: arbitrateAndPublish should early-return when no map has been
+  // received. Content alone cannot prove this (a default-constructed
+  // message looks identical to no publish at all), so we read the counter.
+  EXPECT_EQ(arbiter_publish_count_, 0u);
+}
+
+// A non-null but signal-free map should yield an empty TrafficLightGroupArray
+// (stamp set, no groups). Exercises the
+// "map_regulatory_elements_set_->empty()" branch in arbitrateAndPublish.
+TEST_F(ArbiterCharacteristic, emptyMapProducesEmptyOutput)
+{
+  // Arrange: replace the default minimal map with a signal-free one.
+  start_arbiter(false, "confidence");  // priority-based mode, "confidence" priority
+  publish_map(build_empty_map_bin());
+
+  // Act
+  publish_perception(make_signal_array(
+    t0_, map_ids::vehicle_signal_a,
+    {make_traffic_light_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)}));
+
+  // Assert: arbiter publishes, but the output contains no groups. The
+  // counter read distinguishes "publish happened with zero groups" (the
+  // spec) from "no publish at all" (which would also leave groups empty).
+  ASSERT_GE(arbiter_publish_count_, 1u);
+  EXPECT_EQ(observed_group_count(), 0u);
+}
+
+// An unknown source_priority string must fall back to CONFIDENCE. Verified
+// by feeding a CONFIDENCE scenario and confirming the higher-confidence
+// perception wins.
+TEST_F(ArbiterCharacteristic, unknownSourcePriorityFallsBackToConfidence)
+{
+  // Arrange: pass a value not in {"external", "perception", "confidence"}.
+  start_arbiter(false, "invalid_value");  // priority-based mode, "invalid_value" priority
+  publish_map();
+
+  // Act
+  publish_external(make_signal_array(
+    t0_, map_ids::vehicle_signal_a,
+    {make_traffic_light_element(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE, 0.7f)}));
+  publish_perception(make_signal_array(
+    t0_, map_ids::vehicle_signal_a,
+    {make_traffic_light_element(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE, 0.9f)}));
+
+  // Assert: CONFIDENCE behavior - the higher-confidence perception wins.
+  EXPECT_EQ(observed_color(map_ids::vehicle_signal_a), TrafficLightElement::GREEN);
+  EXPECT_NEAR(observed_confidence(map_ids::vehicle_signal_a), 0.9f, kConfidenceEpsilon);
+}
+
+// With source_priority=perception, the perception value wins even when its
+// confidence is much lower than external's. Pins the PERCEPTION priority
+// branch in arbitrateAndPublish.
+TEST_F(ArbiterCharacteristic, priorityFlagOverridesHigherConfidence)
+{
+  // Arrange
+  start_arbiter(false, "perception");  // priority-based mode, "perception" priority
+  publish_map();
+
+  // Act: confidence contrast (high external vs low perception) makes the
+  // priority override explicit: the lower-confidence perception still wins.
+  publish_external(make_signal_array(
+    t0_, map_ids::vehicle_signal_a,
+    {make_traffic_light_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE, 0.99f)}));
+  publish_perception(make_signal_array(
+    t0_, map_ids::vehicle_signal_a,
+    {make_traffic_light_element(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE, 0.10f)}));
+
+  // Assert: perception priority wins despite its lower confidence.
+  EXPECT_EQ(observed_color(map_ids::vehicle_signal_a), TrafficLightElement::GREEN);
+}
+
+// Symmetric counterpart of priorityFlagOverridesHigherConfidence: with
+// source_priority=external, the external value wins over a higher-confidence
+// perception value.
+TEST_F(ArbiterCharacteristic, priorityFlagFromExternalOverridesHigherConfidence)
+{
+  // Arrange
+  start_arbiter(false, "external");  // priority-based mode, "external" priority
+  publish_map();
+
+  // Act: confidence contrast (low external vs high perception) makes the
+  // priority override explicit: the lower-confidence external still wins.
+  publish_external(make_signal_array(
+    t0_, map_ids::vehicle_signal_a,
+    {make_traffic_light_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE, 0.10f)}));
+  publish_perception(make_signal_array(
+    t0_, map_ids::vehicle_signal_a,
+    {make_traffic_light_element(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE, 0.99f)}));
+
+  // Assert: external priority wins despite its lower confidence.
+  EXPECT_EQ(observed_color(map_ids::vehicle_signal_a), TrafficLightElement::RED);
+}
+
+// Successive external publishes that carry different ids accumulate in the
+// arbiter's external_traffic_lights_ map; both end up in the final output
+// with their published values preserved.
+TEST_F(ArbiterCharacteristic, multipleExternalSourcesAccumulate)
+{
+  // Arrange
+  start_arbiter(false, "confidence");  // priority-based mode, "confidence" priority
+  publish_map();
+
+  // Act: publish two external signals carrying different ids.
+  publish_external(make_signal_array(
+    t0_, map_ids::vehicle_signal_a,
+    {make_traffic_light_element(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE)}));
+  publish_external(make_signal_array(
+    t0_, map_ids::vehicle_signal_b,
+    {make_traffic_light_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)}));
+
+  // Assert: both ids accumulated, each id retains its published color.
+  EXPECT_EQ(observed_group_count(), 2u);
+  EXPECT_EQ(observed_color(map_ids::vehicle_signal_a), TrafficLightElement::GREEN);
+  EXPECT_EQ(observed_color(map_ids::vehicle_signal_b), TrafficLightElement::RED);
+}
+
+// An external message whose stamp is older than external_delay_tolerance
+// is dropped before reaching arbitrateAndPublish, so the last published
+// content stays as the earlier perception value.
+TEST_F(ArbiterCharacteristic, externalDelayToleranceDropsStaleMessage)
+{
+  // Arrange: seed a perception value (RED). If the stale external below were
+  // ever accepted, the output would change to GREEN — the content check at
+  // the bottom is what pins "stale dropped".
+  start_arbiter(false, "confidence");  // priority-based mode, "confidence" priority
+  publish_map();
+  publish_perception(make_signal_array(
+    t0_, map_ids::vehicle_signal_a,
+    {make_traffic_light_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)}));
+
+  // Act: stamp is past external_delay_tolerance in the past.
+  publish_external(make_signal_array(
+    offset_time(t0_, -(kDefaultExternalDelayTolerance + 1.0)), map_ids::vehicle_signal_a,
+    {make_traffic_light_element(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE)}));
+
+  // Assert: the stale GREEN never propagates; the published color stays RED.
+  EXPECT_EQ(observed_color(map_ids::vehicle_signal_a), TrafficLightElement::RED);
+}
+
+// When perception arrives past external_time_tolerance after a stored
+// external entry, cleanupExpiredExternalSignals purges that entry so the
+// upcoming publish reflects only perception.
+TEST_F(ArbiterCharacteristic, externalTimeToleranceCleanupOnPerception)
+{
+  // Arrange: seed an external entry that should be purged by the perception
+  // arrival's cleanupExpiredExternalSignals (perception is past
+  // external_time_tolerance newer than the stored external).
+  start_arbiter(false, "confidence");  // priority-based mode, "confidence" priority
+  publish_map();
+  publish_external(make_signal_array(
+    t0_, map_ids::vehicle_signal_a,
+    {make_traffic_light_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)}));
+
+  // Act
+  publish_perception(make_signal_array(
+    offset_time(t0_, kDefaultExternalTimeTolerance + 1.0), map_ids::vehicle_signal_a,
+    {make_traffic_light_element(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE)}));
+
+  // Assert
+  EXPECT_EQ(observed_color(map_ids::vehicle_signal_a), TrafficLightElement::GREEN);
+}
+
+// onExternalMsg compares its own stamp to latest_perception_msg_.stamp; if
+// the gap exceeds perception_time_tolerance it clears the stored perception
+// groups so the upcoming publish reflects only external.
+TEST_F(ArbiterCharacteristic, perceptionTimeToleranceClearsLatestPerception)
+{
+  // Arrange
+  start_arbiter(false, "confidence");  // priority-based mode, "confidence" priority
+  publish_map();
+
+  // Seed a perception value at t0_.
+  publish_perception(make_signal_array(
+    t0_, map_ids::vehicle_signal_a,
+    {make_traffic_light_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)}));
+
+  // Act: external arrives past perception_time_tolerance after perception
+  // (so latest perception is cleared) but within external_delay_tolerance
+  // so external itself is accepted.
+  publish_external(make_signal_array(
+    offset_time(t0_, kDefaultPerceptionTimeTolerance + 1.0), map_ids::vehicle_signal_a,
+    {make_traffic_light_element(TrafficLightElement::GREEN, TrafficLightElement::CIRCLE)}));
+
+  // Assert: stale perception was wiped, output reflects only external.
+  EXPECT_EQ(observed_color(map_ids::vehicle_signal_a), TrafficLightElement::GREEN);
+}
+
+// Predictions sent on only one side propagate to the arbitrated output
+// with their information_source preserved.
+TEST_F(ArbiterCharacteristic, predictionsFromSingleSidePropagate)
+{
+  // Arrange
+  start_arbiter(false, "confidence");  // priority-based mode, "confidence" priority
+  publish_map();
+
+  // Act
+  publish_perception(make_signal_array(
+    t0_, map_ids::vehicle_signal_a,
+    {make_traffic_light_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)},
+    {make_traffic_light_prediction(
+      t0_, TrafficLightElement::GREEN, TrafficLightElement::CIRCLE,
+      PredictedTrafficLightState::INFORMATION_SOURCE_INTERNAL_ESTIMATION)}));
+
+  // Assert
+  ASSERT_EQ(observed_prediction_count(map_ids::vehicle_signal_a), 1u);
+  const auto * group = find_traffic_light_group(map_ids::vehicle_signal_a);
+  EXPECT_EQ(
+    group->predictions[0].information_source,
+    PredictedTrafficLightState::INFORMATION_SOURCE_INTERNAL_ESTIMATION);
+}
+
+}  // namespace

--- a/perception/autoware_traffic_light_arbiter/test/test_traffic_arbiter_characteristic.cpp
+++ b/perception/autoware_traffic_light_arbiter/test/test_traffic_arbiter_characteristic.cpp
@@ -62,7 +62,7 @@ constexpr lanelet::Id vehicle_signal_b = 1002;
 constexpr lanelet::Id pedestrian_signal = 2001;
 
 // Intentionally not installed on the map; used by tests as the "off-map id"
-// probe to exercise the WARN+skip branch in arbitrateAndPublish.
+// probe to exercise the WARN+skip branch in arbitrate_and_publish.
 constexpr lanelet::Id off_map_probe = 9999;
 }  // namespace map_ids
 
@@ -134,7 +134,7 @@ LaneletMapBin build_minimal_map_bin()
 
 // Variant of build_minimal_map_bin with a single road lanelet but no Traffic
 // Light regulatory elements. Used to drive the
-// "map_regulatory_elements_set_->empty()" branch in arbitrateAndPublish.
+// "map_regulatory_elements_set_->empty()" branch in arbitrate_and_publish.
 LaneletMapBin build_empty_map_bin()
 {
   Lanelet road = make_lanelet(0.0, -3.0, AttributeValueString::Road);
@@ -782,7 +782,7 @@ TEST_F(ArbiterCharacteristic, priorityBasedOffMapIdDropped)
 //    input validation, priority overrides, predictions.
 // ---------------------------------------------------------------------------
 
-// Before the vector_map arrives, arbitrateAndPublish early-returns and no
+// Before the vector_map arrives, arbitrate_and_publish early-returns and no
 // TrafficLightGroupArray is emitted.
 TEST_F(ArbiterCharacteristic, perceptionBeforeMapProducesNoOutput)
 {
@@ -794,7 +794,7 @@ TEST_F(ArbiterCharacteristic, perceptionBeforeMapProducesNoOutput)
     t0_, map_ids::vehicle_signal_a,
     {make_traffic_light_element(TrafficLightElement::RED, TrafficLightElement::CIRCLE)}));
 
-  // Assert: arbitrateAndPublish should early-return when no map has been
+  // Assert: arbitrate_and_publish should early-return when no map has been
   // received. Content alone cannot prove this (a default-constructed
   // message looks identical to no publish at all), so we read the counter.
   EXPECT_EQ(arbiter_publish_count_, 0u);
@@ -802,7 +802,7 @@ TEST_F(ArbiterCharacteristic, perceptionBeforeMapProducesNoOutput)
 
 // A non-null but signal-free map should yield an empty TrafficLightGroupArray
 // (stamp set, no groups). Exercises the
-// "map_regulatory_elements_set_->empty()" branch in arbitrateAndPublish.
+// "map_regulatory_elements_set_->empty()" branch in arbitrate_and_publish.
 TEST_F(ArbiterCharacteristic, emptyMapProducesEmptyOutput)
 {
   // Arrange: replace the default minimal map with a signal-free one.
@@ -845,7 +845,7 @@ TEST_F(ArbiterCharacteristic, unknownSourcePriorityFallsBackToConfidence)
 
 // With source_priority=perception, the perception value wins even when its
 // confidence is much lower than external's. Pins the PERCEPTION priority
-// branch in arbitrateAndPublish.
+// branch in arbitrate_and_publish.
 TEST_F(ArbiterCharacteristic, priorityFlagOverridesHigherConfidence)
 {
   // Arrange
@@ -911,7 +911,7 @@ TEST_F(ArbiterCharacteristic, multipleExternalSourcesAccumulate)
 }
 
 // An external message whose stamp is older than external_delay_tolerance
-// is dropped before reaching arbitrateAndPublish, so the last published
+// is dropped before reaching arbitrate_and_publish, so the last published
 // content stays as the earlier perception value.
 TEST_F(ArbiterCharacteristic, externalDelayToleranceDropsStaleMessage)
 {
@@ -934,12 +934,12 @@ TEST_F(ArbiterCharacteristic, externalDelayToleranceDropsStaleMessage)
 }
 
 // When perception arrives past external_time_tolerance after a stored
-// external entry, cleanupExpiredExternalSignals purges that entry so the
+// external entry, cleanup_expired_external_signals purges that entry so the
 // upcoming publish reflects only perception.
 TEST_F(ArbiterCharacteristic, externalTimeToleranceCleanupOnPerception)
 {
   // Arrange: seed an external entry that should be purged by the perception
-  // arrival's cleanupExpiredExternalSignals (perception is past
+  // arrival's cleanup_expired_external_signals (perception is past
   // external_time_tolerance newer than the stored external).
   start_arbiter(false, "confidence");  // priority-based mode, "confidence" priority
   publish_map();
@@ -956,7 +956,7 @@ TEST_F(ArbiterCharacteristic, externalTimeToleranceCleanupOnPerception)
   EXPECT_EQ(observed_color(map_ids::vehicle_signal_a), TrafficLightElement::GREEN);
 }
 
-// onExternalMsg compares its own stamp to latest_perception_msg_.stamp; if
+// on_external_msg compares its own stamp to latest_perception_msg_.stamp; if
 // the gap exceeds perception_time_tolerance it clears the stored perception
 // groups so the upcoming publish reflects only external.
 TEST_F(ArbiterCharacteristic, perceptionTimeToleranceClearsLatestPerception)


### PR DESCRIPTION
  ## Description

  upstream の **traffic_light_arbiter への `agnocast_wrapper::Node` 適用 ([#12707](https://github.com/autowarefoundation/autoware_universe/pull/12707))** を `feat/v0.64/e2e` に取り込みます。#12707 が前提とするリファクタ・テスト・CallbackIsolatedExecutor適用の各 PR も依存として併せて cherry-pick しています。

  ### Cherry-pick したコミット

  | | 元 PR | 内容 |
  |---|---|---|
  | 1（依存） | [#12632](https://github.com/autowarefoundation/autoware_universe/pull/12632) | `test(autoware_traffic_light_arbiter): add characterization test suite` |
  | 2（依存） | [#12660](https://github.com/autowarefoundation/autoware_universe/pull/12660) | `refactor(autoware_traffic_light_arbiter): extract TrafficLightArbiterCore from Node` |
  | 3（依存） | [#12713](https://github.com/autowarefoundation/autoware_universe/pull/12713) | `feat(traffic_light_arbiter): apply autoware_agnocast_wrapper for CIE` |
  | 4（目的） | [#12707](https://github.com/autowarefoundation/autoware_universe/pull/12707) | `feat(traffic_light_arbiter): apply agnocast_wrapper::Node` |

  ## 補足
  - #12632: characterization テスト追加
  - #12660: `TrafficLightArbiterCore` を Node から分離するリファクタ（#12707 が編集する `traffic_light_arbiter_core.{hpp,cpp}` を生成）
  - #12713: CIE インフラ（`CMakeLists.txt` を `autoware_agnocast_wrapper_register_node` 化、`package.xml` に `<depend>autoware_agnocast_wrapper</depend>` 追加）
  - **コンフリクト: なし**（#12632 → #12660 → #12713 → #12707 の順でcleanに適用）。

#agnocast適用全体像
https://tier4.atlassian.net/wiki/spaces/CRL/pages/5280465670/perception+node