### PR TITLE
chore: consolidate branch conventions for main and awf-latest branches

### DIFF
--- a/.github/workflows/check-pr-target-branch.yaml
+++ b/.github/workflows/check-pr-target-branch.yaml
@@ -1,0 +1,42 @@
+name: check-pr-target-branch
+
+on:
+  pull_request_target:
+    types:
+      - opened
+      - edited
+      - synchronize
+      - reopened
+
+jobs:
+  check-target-branch:
+    runs-on: ubuntu-latest
+    permissions:
+      pull-requests: write
+    steps:
+      - name: Check target branch
+        id: check-branch
+        run: |
+          TARGET_BRANCH="${{ github.event.pull_request.base.ref }}"
+          echo "Target branch is: $TARGET_BRANCH"
+
+          if [ "$TARGET_BRANCH" = "awf-latest" ]; then
+            echo "is_awf_latest=true" >> $GITHUB_OUTPUT
+            echo "ERROR: Pull requests targeting the awf-latest branch are not allowed."
+            exit 1
+          else
+            echo "is_awf_latest=false" >> $GITHUB_OUTPUT
+            echo "Target branch is acceptable."
+          fi
+
+      - name: Comment on PR
+        if: failure() && steps.check-branch.outputs.is_awf_latest == 'true'
+        uses: marocchino/sticky-pull-request-comment@v2
+        with:
+          message: |
+            ⚠️ **WARNING: Invalid Target Branch** ⚠️
+
+            This pull request is targeting the `awf-latest` branch, which is not allowed.
+
+            The `awf-latest` branch is a mirror of https://github.com/autowarefoundation/autoware_universe and is not intended for direct contributions.
+            Please push your changes to Autoware Foundation main branch, or appropriate release branch for hotfixes.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,8 @@
 ## TIEV IV universe
 
-This universe branch is dedicated solely to holding workflow files. In general, this repository is intended only for release branches. The main development branch for the universe is `autowarefoundation/main`.
+This repository is a fork of [autowarefoundation/autoware_universe](https://github.com/autowarefoundation/autoware_universe).
+
+- `main` branch: only holds CI workflow files. The source codes are unused for development. **Do not create PRs against this branch** unless you are working for CI.
+- `awf-latest` branch: a mirror from Autoware Foundation. **Do not create any PRs against this branch.**
+  - If you need an immediate mirror refresh, run [TIER IV internal workflow](https://github.com/tier4/auto-evaluator/actions/workflows/sync-awf-latest.yaml).
+- release branches: hotfix branches for TIER IV product release purposes.


### PR DESCRIPTION
## Description

Consolidate TIER IV branch conventions as a fork, different from AWF autoware_universe:

* `main` branch: only holds CI workflow files.

* `awf-latest` branch: should be a mirror of AWF main.

Added guide in README how to enforce the trigger from the [private workflow](https://github.com/tier4/auto-evaluator/blob/921dc3a107436a286c10c73a1d8dc9b176525a12/.github/workflows/sync-awf-latest.yaml#L40).

Added target branch check to warn direct PR against `awf-latest`. `check-pr-target-branch` should be a required check for PRs.

## Related Links

https://github.com/tier4/autoware_core/pull/111
