### PR TITLE
feat(perception): cherry pick upstream PR of applying agnocast to simple_object_merger/object_sorter/lanelet_filter

### DIFF
--- a/perception/autoware_detected_object_validation/CMakeLists.txt
+++ b/perception/autoware_detected_object_validation/CMakeLists.txt
@@ -75,14 +75,14 @@ autoware_agnocast_wrapper_register_node(object_lanelet_filter
   PLUGIN "autoware::detected_object_validation::lanelet_filter::DetectedObjectLaneletFilterNode"
   EXECUTABLE object_lanelet_filter_node
   ROS2_EXECUTOR SingleThreadedExecutor
-  AGNOCAST_EXECUTOR CallbackIsolatedAgnocastExecutor
+  AGNOCAST_EXECUTOR AgnocastOnlyCallbackIsolatedExecutor
 )
 
 autoware_agnocast_wrapper_register_node(object_lanelet_filter
   PLUGIN "autoware::detected_object_validation::lanelet_filter::TrackedObjectLaneletFilterNode"
   EXECUTABLE tracked_object_lanelet_filter_node
   ROS2_EXECUTOR SingleThreadedExecutor
-  AGNOCAST_EXECUTOR CallbackIsolatedAgnocastExecutor
+  AGNOCAST_EXECUTOR AgnocastOnlyCallbackIsolatedExecutor
 )
 
 rclcpp_components_register_node(object_position_filter
@@ -95,7 +95,7 @@ rclcpp_components_register_node(occupancy_grid_based_validator
   EXECUTABLE occupancy_grid_based_validator_node
 )
 
-if(BUILD_TESTING)
+if(BUILD_TESTING AND (NOT "$ENV{ENABLE_AGNOCAST}" STREQUAL "1"))
   ament_auto_add_gtest(detection_object_validation_tests
     test/test_utils.cpp
     test/object_position_filter/test_object_position_filter.cpp

--- a/perception/autoware_detected_object_validation/launch/object_lanelet_filter.launch.xml
+++ b/perception/autoware_detected_object_validation/launch/object_lanelet_filter.launch.xml
@@ -5,10 +5,13 @@
   <arg name="output/object" default="out_objects"/>
   <arg name="filtering_range_param" default="$(find-pkg-share autoware_detected_object_validation)/config/object_lanelet_filter.param.yaml"/>
 
+  <include file="$(find-pkg-share autoware_agnocast_wrapper)/launch/agnocast_env.launch.xml"/>
+
   <node pkg="autoware_detected_object_validation" exec="object_lanelet_filter_node" name="object_lanelet_filter" output="screen">
     <remap from="input/vector_map" to="$(var vector_map_topic)"/>
     <remap from="input/object" to="$(var input/object)"/>
     <remap from="output/object" to="$(var output/object)"/>
     <param from="$(var filtering_range_param)"/>
+    <env name="LD_PRELOAD" value="$(var ld_preload_value)"/>
   </node>
 </launch>

--- a/perception/autoware_detected_object_validation/launch/tracked_object_lanelet_filter.launch.xml
+++ b/perception/autoware_detected_object_validation/launch/tracked_object_lanelet_filter.launch.xml
@@ -5,10 +5,13 @@
   <arg name="output/object" default="out_objects"/>
   <arg name="filtering_range_param" default="$(find-pkg-share autoware_detected_object_validation)/config/tracked_object_lanelet_filter.param.yaml"/>
 
+  <include file="$(find-pkg-share autoware_agnocast_wrapper)/launch/agnocast_env.launch.xml"/>
+
   <node pkg="autoware_detected_object_validation" exec="tracked_object_lanelet_filter_node" name="tracked_object_lanelet_filter" output="screen">
     <remap from="input/vector_map" to="$(var vector_map_topic)"/>
     <remap from="input/object" to="$(var input/object)"/>
     <remap from="output/object" to="$(var output/object)"/>
     <param from="$(var filtering_range_param)"/>
+    <env name="LD_PRELOAD" value="$(var ld_preload_value)"/>
   </node>
 </launch>

--- a/perception/autoware_detected_object_validation/src/lanelet_filter/lanelet_filter_base.cpp
+++ b/perception/autoware_detected_object_validation/src/lanelet_filter/lanelet_filter_base.cpp
@@ -54,10 +54,10 @@ using TriangleMesh = std::vector<std::array<Eigen::Vector3d, 3>>;
 template <typename ObjsMsgType, typename ObjMsgType>
 ObjectLaneletFilterBase<ObjsMsgType, ObjMsgType>::ObjectLaneletFilterBase(
   const std::string & node_name, const rclcpp::NodeOptions & node_options)
-: Node(node_name, node_options), tf_buffer_(this->get_clock()), tf_listener_(tf_buffer_)
+: autoware::agnocast_wrapper::Node(node_name, node_options),
+  tf_buffer_(this->get_clock()),
+  tf_listener_(tf_buffer_, *this)
 {
-  using std::placeholders::_1;
-
   // Set parameters
   filter_target_.UNKNOWN = declare_parameter<bool>("filter_target_label.UNKNOWN");
   filter_target_.CAR = declare_parameter<bool>("filter_target_label.CAR");
@@ -101,14 +101,20 @@ ObjectLaneletFilterBase<ObjsMsgType, ObjMsgType>::ObjectLaneletFilterBase(
   // Set publisher/subscriber
   map_sub_ = this->create_subscription<autoware_map_msgs::msg::LaneletMapBin>(
     "input/vector_map", rclcpp::QoS{1}.transient_local(),
-    std::bind(&ObjectLaneletFilterBase::mapCallback, this, _1));
+    [this](const AUTOWARE_MESSAGE_CONST_SHARED_PTR(autoware_map_msgs::msg::LaneletMapBin) & msg) {
+      mapCallback(msg);
+    });
   object_sub_ = this->create_subscription<ObjsMsgType>(
-    "input/object", rclcpp::QoS{1}, std::bind(&ObjectLaneletFilterBase::objectCallback, this, _1));
+    "input/object", rclcpp::QoS{1},
+    [this](const AUTOWARE_MESSAGE_CONST_SHARED_PTR(ObjsMsgType) & msg) { objectCallback(msg); });
   object_pub_ = this->create_publisher<ObjsMsgType>("output/object", rclcpp::QoS{1});
 
   debug_publisher_ =
-    std::make_unique<autoware_utils::DebugPublisher>(this, "object_lanelet_filter");
-  published_time_publisher_ = std::make_unique<autoware_utils::PublishedTimePublisher>(this);
+    std::make_unique<autoware_utils::BasicDebugPublisher<autoware::agnocast_wrapper::Node>>(
+      this, "object_lanelet_filter");
+  published_time_publisher_ =
+    std::make_unique<autoware_utils::BasicPublishedTimePublisher<autoware::agnocast_wrapper::Node>>(
+      this);
   stop_watch_ptr_ = std::make_unique<autoware_utils::StopWatch<std::chrono::milliseconds>>();
   if (filter_settings_.debug) {
     viz_pub_ = this->create_publisher<visualization_msgs::msg::MarkerArray>(
@@ -319,7 +325,7 @@ bool isPointAboveLaneletMesh(
 
 template <typename ObjsMsgType, typename ObjMsgType>
 void ObjectLaneletFilterBase<ObjsMsgType, ObjMsgType>::mapCallback(
-  const autoware_map_msgs::msg::LaneletMapBin::ConstSharedPtr map_msg)
+  const AUTOWARE_MESSAGE_CONST_SHARED_PTR(autoware_map_msgs::msg::LaneletMapBin) & map_msg)
 {
   lanelet_frame_id_ = map_msg->header.frame_id;
   lanelet_map_ptr_ = autoware::experimental::lanelet2_utils::remove_const(
@@ -328,15 +334,15 @@ void ObjectLaneletFilterBase<ObjsMsgType, ObjMsgType>::mapCallback(
 
 template <typename ObjsMsgType, typename ObjMsgType>
 void ObjectLaneletFilterBase<ObjsMsgType, ObjMsgType>::objectCallback(
-  const typename ObjsMsgType::ConstSharedPtr input_msg)
+  const AUTOWARE_MESSAGE_CONST_SHARED_PTR(ObjsMsgType) & input_msg)
 {
   stop_watch_ptr_->tic("processing_time");
 
   // Guard
   if (object_pub_->get_subscription_count() < 1) return;
 
-  ObjsMsgType output_object_msg;
-  output_object_msg.header = input_msg->header;
+  auto output_object_msg = ALLOCATE_OUTPUT_MESSAGE_UNIQUE(object_pub_);
+  output_object_msg->header = input_msg->header;
 
   if (!lanelet_map_ptr_) {
     RCLCPP_ERROR_THROTTLE(get_logger(), *get_clock(), 3000, "No vector map received.");
@@ -370,18 +376,18 @@ void ObjectLaneletFilterBase<ObjsMsgType, ObjMsgType>::objectCallback(
     for (size_t index = 0; index < transformed_objects.objects.size(); ++index) {
       const auto & transformed_object = transformed_objects.objects.at(index);
       const auto & input_object = input_msg->objects.at(index);
-      filterObject(transformed_object, input_object, local_rtree, output_object_msg);
+      filterObject(transformed_object, input_object, local_rtree, *output_object_msg);
     }
   }
 
-  object_pub_->publish(output_object_msg);
-  published_time_publisher_->publish_if_subscribed(object_pub_, output_object_msg.header.stamp);
+  const auto output_stamp = output_object_msg->header.stamp;
+  object_pub_->publish(std::move(output_object_msg));
+  published_time_publisher_->publish_if_subscribed(object_pub_, output_stamp);
 
   // Publish debug info
   const double pipeline_latency =
     std::chrono::duration<double, std::milli>(
-      std::chrono::nanoseconds(
-        (this->get_clock()->now() - output_object_msg.header.stamp).nanoseconds()))
+      std::chrono::nanoseconds((this->get_clock()->now() - output_stamp).nanoseconds()))
       .count();
   debug_publisher_->publish<autoware_internal_debug_msgs::msg::Float64Stamped>(
     "debug/pipeline_latency_ms", pipeline_latency);

--- a/perception/autoware_detected_object_validation/src/lanelet_filter/lanelet_filter_base.hpp
+++ b/perception/autoware_detected_object_validation/src/lanelet_filter/lanelet_filter_base.hpp
@@ -15,6 +15,8 @@
 #ifndef LANELET_FILTER__LANELET_FILTER_BASE_HPP_
 #define LANELET_FILTER__LANELET_FILTER_BASE_HPP_
 
+#include "autoware/agnocast_wrapper/node.hpp"
+#include "autoware/agnocast_wrapper/tf2.hpp"
 #include "autoware/detected_object_validation/utils/utils.hpp"
 #include "autoware_lanelet2_extension/utility/utilities.hpp"
 #include "autoware_utils/geometry/geometry.hpp"
@@ -62,32 +64,34 @@ using BoxAndLanelet = std::pair<Box, PolygonAndLanelet>;
 using RtreeAlgo = bgi::rstar<16>;
 
 template <typename ObjsMsgType, typename ObjMsgType>
-class ObjectLaneletFilterBase : public rclcpp::Node
+class ObjectLaneletFilterBase : public autoware::agnocast_wrapper::Node
 {
 public:
   explicit ObjectLaneletFilterBase(
     const std::string & node_name, const rclcpp::NodeOptions & node_options);
 
 private:
-  void objectCallback(const typename ObjsMsgType::ConstSharedPtr);
-  void mapCallback(const autoware_map_msgs::msg::LaneletMapBin::ConstSharedPtr);
+  void objectCallback(const AUTOWARE_MESSAGE_CONST_SHARED_PTR(ObjsMsgType) & input_msg);
+  void mapCallback(
+    const AUTOWARE_MESSAGE_CONST_SHARED_PTR(autoware_map_msgs::msg::LaneletMapBin) & map_msg);
 
   void publishDebugMarkers(
     rclcpp::Time stamp, const LinearRing2d & hull, const std::vector<BoxAndLanelet> & lanelets);
 
-  typename rclcpp::Publisher<ObjsMsgType>::SharedPtr object_pub_;
-  rclcpp::Publisher<visualization_msgs::msg::MarkerArray>::SharedPtr viz_pub_;
-  rclcpp::Subscription<autoware_map_msgs::msg::LaneletMapBin>::SharedPtr map_sub_;
-  typename rclcpp::Subscription<ObjsMsgType>::SharedPtr object_sub_;
+  AUTOWARE_PUBLISHER_PTR(ObjsMsgType) object_pub_;
+  AUTOWARE_PUBLISHER_PTR(visualization_msgs::msg::MarkerArray) viz_pub_;
+  AUTOWARE_SUBSCRIPTION_PTR(autoware_map_msgs::msg::LaneletMapBin) map_sub_;
+  AUTOWARE_SUBSCRIPTION_PTR(ObjsMsgType) object_sub_;
 
-  std::unique_ptr<autoware_utils::DebugPublisher> debug_publisher_{nullptr};
+  std::unique_ptr<autoware_utils::BasicDebugPublisher<autoware::agnocast_wrapper::Node>>
+    debug_publisher_{nullptr};
   std::unique_ptr<autoware_utils::StopWatch<std::chrono::milliseconds>> stop_watch_ptr_;
 
   lanelet::LaneletMapPtr lanelet_map_ptr_;
   std::string lanelet_frame_id_;
 
-  tf2_ros::Buffer tf_buffer_;
-  tf2_ros::TransformListener tf_listener_;
+  autoware::agnocast_wrapper::Buffer tf_buffer_;
+  autoware::agnocast_wrapper::TransformListener tf_listener_;
 
   utils::FilterTargetLabel filter_target_;
   double ego_base_height_ = 0.0;
@@ -126,7 +130,8 @@ private:
   geometry_msgs::msg::Polygon setFootprint(const ObjMsgType &);
 
   lanelet::BasicPolygon2d getPolygon(const lanelet::ConstLanelet & lanelet);
-  std::unique_ptr<autoware_utils::PublishedTimePublisher> published_time_publisher_;
+  std::unique_ptr<autoware_utils::BasicPublishedTimePublisher<autoware::agnocast_wrapper::Node>>
+    published_time_publisher_;
 };
 
 }  // namespace lanelet_filter

--- a/perception/autoware_object_sorter/CMakeLists.txt
+++ b/perception/autoware_object_sorter/CMakeLists.txt
@@ -16,14 +16,14 @@ autoware_agnocast_wrapper_register_node(${PROJECT_NAME}
   PLUGIN "autoware::object_sorter::DetectedObjectSorterNode"
   EXECUTABLE detected_object_sorter_node
   ROS2_EXECUTOR SingleThreadedExecutor
-  AGNOCAST_EXECUTOR CallbackIsolatedAgnocastExecutor
+  AGNOCAST_EXECUTOR AgnocastOnlyCallbackIsolatedExecutor
 )
 
 autoware_agnocast_wrapper_register_node(${PROJECT_NAME}
   PLUGIN "autoware::object_sorter::TrackedObjectSorterNode"
   EXECUTABLE tracked_object_sorter_node
   ROS2_EXECUTOR SingleThreadedExecutor
-  AGNOCAST_EXECUTOR CallbackIsolatedAgnocastExecutor
+  AGNOCAST_EXECUTOR AgnocastOnlyCallbackIsolatedExecutor
 )
 
 # Tests

--- a/perception/autoware_object_sorter/launch/detected_object_sorter.launch.xml
+++ b/perception/autoware_object_sorter/launch/detected_object_sorter.launch.xml
@@ -1,4 +1,5 @@
 <launch>
+  <include file="$(find-pkg-share autoware_agnocast_wrapper)/launch/agnocast_env.launch.xml"/>
   <!-- Input -->
   <arg name="input/objects" default="~/input/objects"/>
   <!-- Output -->
@@ -8,6 +9,7 @@
 
   <!-- Node -->
   <node pkg="autoware_object_sorter" exec="detected_object_sorter_node" name="detected_object_sorter" output="screen">
+    <env name="LD_PRELOAD" value="$(var ld_preload_value)"/>
     <remap from="~/input/objects" to="$(var input/objects)"/>
     <remap from="~/output/objects" to="$(var output/objects)"/>
     <param from="$(var param_path)"/>

--- a/perception/autoware_object_sorter/launch/tracked_object_sorter.launch.xml
+++ b/perception/autoware_object_sorter/launch/tracked_object_sorter.launch.xml
@@ -1,4 +1,5 @@
 <launch>
+  <include file="$(find-pkg-share autoware_agnocast_wrapper)/launch/agnocast_env.launch.xml"/>
   <!-- Input -->
   <arg name="input/objects" default="~/input/objects"/>
   <!-- Output -->
@@ -8,6 +9,7 @@
 
   <!-- Node -->
   <node pkg="autoware_object_sorter" exec="tracked_object_sorter_node" name="tracked_object_sorter" output="screen">
+    <env name="LD_PRELOAD" value="$(var ld_preload_value)"/>
     <remap from="~/input/objects" to="$(var input/objects)"/>
     <remap from="~/output/objects" to="$(var output/objects)"/>
     <param from="$(var param_path)"/>

--- a/perception/autoware_object_sorter/src/object_sorter_base.cpp
+++ b/perception/autoware_object_sorter/src/object_sorter_base.cpp
@@ -21,6 +21,7 @@
 
 #include <memory>
 #include <string>
+#include <utility>
 #include <vector>
 
 namespace autoware::object_sorter
@@ -30,7 +31,7 @@ using autoware_perception_msgs::msg::DetectedObjects;
 template <typename ObjsMsgType>
 ObjectSorterBase<ObjsMsgType>::ObjectSorterBase(
   const std::string & node_name, const rclcpp::NodeOptions & node_options)
-: Node(node_name, node_options), tf_buffer_(this->get_clock()), tf_listener_(tf_buffer_)
+: Node(node_name, node_options), tf_buffer_(this->get_clock()), tf_listener_(tf_buffer_, *this)
 {
   // Node Parameter
   range_calc_frame_id_ = declare_parameter<std::string>("range_calc_frame_id");
@@ -107,15 +108,18 @@ void ObjectSorterBase<ObjsMsgType>::setupSortTarget(bool use_distance_thresholdi
 
 template <typename ObjsMsgType>
 void ObjectSorterBase<ObjsMsgType>::objectCallback(
-  const typename ObjsMsgType::ConstSharedPtr input_msg)
+  const AUTOWARE_MESSAGE_CONST_SHARED_PTR(ObjsMsgType) & input_msg)
 {
   // Guard
-  if (pub_output_objects_->get_subscription_count() < 1) {
+  if (
+    pub_output_objects_->get_subscription_count() +
+      pub_output_objects_->get_intra_process_subscription_count() <
+    1) {
     return;
   }
 
-  ObjsMsgType output_objects;
-  output_objects.header = input_msg->header;
+  auto output_objects = ALLOCATE_OUTPUT_MESSAGE_UNIQUE(pub_output_objects_);
+  output_objects->header = input_msg->header;
 
   geometry_msgs::msg::TransformStamped tf_input_frame_to_target_frame;
   // Even when it failed to get the transform, we still can do the velocity check
@@ -159,11 +163,11 @@ void ObjectSorterBase<ObjsMsgType>::objectCallback(
       }
     }
 
-    output_objects.objects.push_back(object);
+    output_objects->objects.push_back(object);
   }
 
   // Publish
-  pub_output_objects_->publish(output_objects);
+  pub_output_objects_->publish(std::move(output_objects));
 }
 
 // Explicit instantiation

--- a/perception/autoware_object_sorter/src/object_sorter_base.hpp
+++ b/perception/autoware_object_sorter/src/object_sorter_base.hpp
@@ -17,12 +17,12 @@
 
 #include "rclcpp/rclcpp.hpp"
 
+#include <autoware/agnocast_wrapper/autoware_agnocast_wrapper.hpp>
+#include <autoware/agnocast_wrapper/node.hpp>
+#include <autoware/agnocast_wrapper/tf2.hpp>
 #include <autoware_utils_geometry/geometry.hpp>
 
 #include <autoware_perception_msgs/msg/detected_objects.hpp>
-
-#include <tf2_ros/buffer.h>
-#include <tf2_ros/transform_listener.h>
 
 #include <string>
 #include <unordered_map>
@@ -33,7 +33,7 @@ namespace autoware::object_sorter
 using Label = autoware_perception_msgs::msg::ObjectClassification;
 
 template <typename ObjsMsgType>
-class ObjectSorterBase : public rclcpp::Node
+class ObjectSorterBase : public autoware::agnocast_wrapper::Node
 {
 public:
   explicit ObjectSorterBase(
@@ -60,18 +60,18 @@ public:
 
 private:
   void setupSortTarget(bool use_distance_thresholding);
-  void objectCallback(const typename ObjsMsgType::ConstSharedPtr input_msg);
+  void objectCallback(const AUTOWARE_MESSAGE_CONST_SHARED_PTR(ObjsMsgType) & input_msg);
   void splitByVelocity(const ObjsMsgType & input_object);
   void splitByRange(const ObjsMsgType & input_object);
 
   // Subscriber
-  typename rclcpp::Subscription<ObjsMsgType>::SharedPtr sub_objects_{};
+  AUTOWARE_SUBSCRIPTION_PTR(ObjsMsgType) sub_objects_ {};
 
   // Publisher
-  typename rclcpp::Publisher<ObjsMsgType>::SharedPtr pub_output_objects_{};
+  AUTOWARE_PUBLISHER_PTR(ObjsMsgType) pub_output_objects_ {};
 
-  tf2_ros::Buffer tf_buffer_;
-  tf2_ros::TransformListener tf_listener_;
+  autoware::agnocast_wrapper::Buffer tf_buffer_;
+  autoware::agnocast_wrapper::TransformListener tf_listener_;
 
   // Parameter
   std::string range_calc_frame_id_;

--- a/perception/autoware_simple_object_merger/CMakeLists.txt
+++ b/perception/autoware_simple_object_merger/CMakeLists.txt
@@ -20,14 +20,14 @@ autoware_agnocast_wrapper_register_node(${PROJECT_NAME}
   PLUGIN "autoware::simple_object_merger::SimpleDetectedObjectMergerNode"
   EXECUTABLE simple_object_merger_node
   ROS2_EXECUTOR SingleThreadedExecutor
-  AGNOCAST_EXECUTOR CallbackIsolatedAgnocastExecutor
+  AGNOCAST_EXECUTOR AgnocastOnlyCallbackIsolatedExecutor
 )
 
 autoware_agnocast_wrapper_register_node(${PROJECT_NAME}
   PLUGIN "autoware::simple_object_merger::SimpleTrackedObjectMergerNode"
   EXECUTABLE simple_tracked_object_merger_node
   ROS2_EXECUTOR SingleThreadedExecutor
-  AGNOCAST_EXECUTOR CallbackIsolatedAgnocastExecutor
+  AGNOCAST_EXECUTOR AgnocastOnlyCallbackIsolatedExecutor
 )
 
 # Tests
@@ -36,9 +36,11 @@ if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   ament_lint_auto_find_test_dependencies()
 
-  ament_auto_add_gtest(simple_object_merger_node_tests
-    test/test_node.cpp
-  )
+  if(NOT "$ENV{ENABLE_AGNOCAST}" STREQUAL "1")
+    ament_auto_add_gtest(simple_object_merger_node_tests
+      test/test_node.cpp
+    )
+  endif()
 endif()
 
 # Package

--- a/perception/autoware_simple_object_merger/include/autoware/simple_object_merger/simple_detected_object_merger_node.hpp
+++ b/perception/autoware_simple_object_merger/include/autoware/simple_object_merger/simple_detected_object_merger_node.hpp
@@ -16,7 +16,6 @@
 #define AUTOWARE__SIMPLE_OBJECT_MERGER__SIMPLE_DETECTED_OBJECT_MERGER_NODE_HPP_
 
 #include "autoware/simple_object_merger/simple_object_merger_base.hpp"
-#include "autoware_utils/ros/transform_listener.hpp"
 #include "rclcpp/rclcpp.hpp"
 
 #include "autoware_perception_msgs/msg/detected_objects.hpp"
@@ -33,8 +32,8 @@ public:
 
 private:
   void approximateMerger(
-    const DetectedObjects::ConstSharedPtr & object_msg0,
-    const DetectedObjects::ConstSharedPtr & object_msg1) override;
+    const AUTOWARE_MESSAGE_CONST_SHARED_PTR(DetectedObjects) & object_msg0,
+    const AUTOWARE_MESSAGE_CONST_SHARED_PTR(DetectedObjects) & object_msg1) override;
 
   void onTimer() override;
 };

--- a/perception/autoware_simple_object_merger/include/autoware/simple_object_merger/simple_object_merger_base.hpp
+++ b/perception/autoware_simple_object_merger/include/autoware/simple_object_merger/simple_object_merger_base.hpp
@@ -15,12 +15,13 @@
 #ifndef AUTOWARE__SIMPLE_OBJECT_MERGER__SIMPLE_OBJECT_MERGER_BASE_HPP_
 #define AUTOWARE__SIMPLE_OBJECT_MERGER__SIMPLE_OBJECT_MERGER_BASE_HPP_
 
-#include "autoware_utils/ros/transform_listener.hpp"
-#include "rclcpp/rclcpp.hpp"
+#include <autoware/agnocast_wrapper/message_filters.hpp>
+#include <autoware/agnocast_wrapper/node.hpp>
+#include <autoware/agnocast_wrapper/tf2.hpp>
+#include <autoware_utils/ros/transform_listener.hpp>
+#include <rclcpp/rclcpp.hpp>
 
-#include <message_filters/subscriber.h>
-#include <message_filters/sync_policies/approximate_time.h>
-#include <message_filters/synchronizer.h>
+#include <geometry_msgs/msg/transform_stamped.hpp>
 
 #include <chrono>
 #include <memory>
@@ -31,7 +32,7 @@ namespace autoware::simple_object_merger
 {
 
 template <class ObjsMsgType>
-class SimpleObjectMergerBase : public rclcpp::Node
+class SimpleObjectMergerBase : public autoware::agnocast_wrapper::Node
 {
 public:
   explicit SimpleObjectMergerBase(
@@ -47,42 +48,46 @@ public:
 
 private:
   // Subscriber
-  typename rclcpp::Subscription<ObjsMsgType>::SharedPtr sub_objects_{};
-  std::vector<typename rclcpp::Subscription<ObjsMsgType>::SharedPtr> sub_objects_array{};
+  AUTOWARE_SUBSCRIPTION_PTR(ObjsMsgType) sub_objects_ {};
+  std::vector<AUTOWARE_SUBSCRIPTION_PTR(ObjsMsgType)> sub_objects_array{};
 
   // Subscriber by message_filter
-  typename message_filters::Subscriber<ObjsMsgType> input0_{};
-  typename message_filters::Subscriber<ObjsMsgType> input1_{};
-  using SyncPolicy = message_filters::sync_policies::ApproximateTime<ObjsMsgType, ObjsMsgType>;
-  using Sync = message_filters::Synchronizer<SyncPolicy>;
+  autoware::agnocast_wrapper::message_filters::Subscriber<ObjsMsgType> input0_{};
+  autoware::agnocast_wrapper::message_filters::Subscriber<ObjsMsgType> input1_{};
+  using SyncPolicy = autoware::agnocast_wrapper::message_filters::sync_policies::ApproximateTime<
+    ObjsMsgType, ObjsMsgType>;
+  using Sync = autoware::agnocast_wrapper::message_filters::Synchronizer<SyncPolicy>;
   typename std::shared_ptr<Sync> sync_ptr_;
 
   // Timer
-  rclcpp::TimerBase::SharedPtr timer_{};
+  AUTOWARE_TIMER_PTR timer_{};
 
   // Parameter Server
-  OnSetParametersCallbackHandle::SharedPtr set_param_res_;
+  rclcpp::node_interfaces::OnSetParametersCallbackHandle::SharedPtr set_param_res_;
 
   // Process callbacks
   virtual void approximateMerger(
-    const typename ObjsMsgType::ConstSharedPtr & object_msg0,
-    const typename ObjsMsgType::ConstSharedPtr & object_msg1);
+    const AUTOWARE_MESSAGE_CONST_SHARED_PTR(ObjsMsgType) & object_msg0,
+    const AUTOWARE_MESSAGE_CONST_SHARED_PTR(ObjsMsgType) & object_msg1);
 
   virtual void onTimer();
 
-  void onData(const typename ObjsMsgType::ConstSharedPtr msg, size_t array_number);
+  void onData(const AUTOWARE_MESSAGE_CONST_SHARED_PTR(ObjsMsgType) & msg, size_t array_number);
 
   rcl_interfaces::msg::SetParametersResult onSetParam(
     const std::vector<rclcpp::Parameter> & params);
 
 protected:
   // Publisher
-  typename rclcpp::Publisher<ObjsMsgType>::SharedPtr pub_objects_{};
+  AUTOWARE_PUBLISHER_PTR(ObjsMsgType) pub_objects_ {};
 
-  std::shared_ptr<autoware_utils::TransformListener> transform_listener_;
+  using TfListener = autoware_utils::TransformListenerT<
+    autoware::agnocast_wrapper::Node, autoware::agnocast_wrapper::Buffer,
+    autoware::agnocast_wrapper::TransformListener>;
+  std::shared_ptr<TfListener> transform_listener_;
 
   // Data Buffer
-  std::vector<typename ObjsMsgType::ConstSharedPtr> objects_data_{};
+  std::vector<AUTOWARE_MESSAGE_CONST_SHARED_PTR(ObjsMsgType)> objects_data_{};
 
   // Core
   size_t input_topic_size_;
@@ -95,7 +100,7 @@ protected:
     double throttle_interval_sec);
 
   typename ObjsMsgType::SharedPtr getTransformedObjects(
-    typename ObjsMsgType::ConstSharedPtr objects, const std::string & target_frame_id,
+    AUTOWARE_MESSAGE_CONST_SHARED_PTR(ObjsMsgType) objects, const std::string & target_frame_id,
     geometry_msgs::msg::TransformStamped::ConstSharedPtr transform);
 };
 

--- a/perception/autoware_simple_object_merger/include/autoware/simple_object_merger/simple_tracked_object_merger_node.hpp
+++ b/perception/autoware_simple_object_merger/include/autoware/simple_object_merger/simple_tracked_object_merger_node.hpp
@@ -16,7 +16,6 @@
 #define AUTOWARE__SIMPLE_OBJECT_MERGER__SIMPLE_TRACKED_OBJECT_MERGER_NODE_HPP_
 
 #include "autoware/simple_object_merger/simple_object_merger_base.hpp"
-#include "autoware_utils/ros/transform_listener.hpp"
 #include "rclcpp/rclcpp.hpp"
 
 #include "autoware_perception_msgs/msg/tracked_objects.hpp"
@@ -49,8 +48,8 @@ private:
   std::unordered_map<std::string, UUIDMapping> uuid_mapper_;
 
   void approximateMerger(
-    const TrackedObjects::ConstSharedPtr & object_msg0,
-    const TrackedObjects::ConstSharedPtr & object_msg1) override;
+    const AUTOWARE_MESSAGE_CONST_SHARED_PTR(TrackedObjects) & object_msg0,
+    const AUTOWARE_MESSAGE_CONST_SHARED_PTR(TrackedObjects) & object_msg1) override;
   void onTimer() override;
 
   void mapUUID(TrackedObject & object, const int & node_id);

--- a/perception/autoware_simple_object_merger/launch/simple_object_merger.launch.xml
+++ b/perception/autoware_simple_object_merger/launch/simple_object_merger.launch.xml
@@ -1,9 +1,11 @@
 <launch>
+  <include file="$(find-pkg-share autoware_agnocast_wrapper)/launch/agnocast_env.launch.xml"/>
   <arg name="input_topics" default="['/input1', '/input2']"/>
   <arg name="output/objects" default="~/output/objects"/>
   <arg name="param_path" default="$(find-pkg-share autoware_simple_object_merger)/config/simple_object_merger.param.yaml"/>
 
   <node pkg="autoware_simple_object_merger" exec="simple_object_merger_node" name="simple_object_merger" output="screen">
+    <env name="LD_PRELOAD" value="$(var ld_preload_value)"/>
     <param name="input_topics" value="$(var input_topics)"/>
     <remap from="~/output/objects" to="$(var output/objects)"/>
     <param from="$(var param_path)"/>

--- a/perception/autoware_simple_object_merger/launch/simple_tracked_object_merger.launch.xml
+++ b/perception/autoware_simple_object_merger/launch/simple_tracked_object_merger.launch.xml
@@ -1,8 +1,10 @@
 <launch>
+  <include file="$(find-pkg-share autoware_agnocast_wrapper)/launch/agnocast_env.launch.xml"/>
   <arg name="output/objects" default="~/output/objects"/>
   <arg name="param_path" default="$(find-pkg-share autoware_simple_object_merger)/config/simple_tracked_object_merger.param.yaml"/>
 
   <node pkg="autoware_simple_object_merger" exec="simple_tracked_object_merger_node" name="simple_tracked_object_merger" output="screen">
+    <env name="LD_PRELOAD" value="$(var ld_preload_value)"/>
     <remap from="~/output/objects" to="$(var output/objects)"/>
     <param from="$(var param_path)"/>
   </node>

--- a/perception/autoware_simple_object_merger/src/simple_detected_object_merger_node.cpp
+++ b/perception/autoware_simple_object_merger/src/simple_detected_object_merger_node.cpp
@@ -18,6 +18,7 @@
 
 #include <memory>
 #include <string>
+#include <utility>
 #include <vector>
 
 namespace autoware::simple_object_merger
@@ -35,8 +36,8 @@ SimpleDetectedObjectMergerNode::SimpleDetectedObjectMergerNode(
 }
 
 void SimpleDetectedObjectMergerNode::approximateMerger(
-  const DetectedObjects::ConstSharedPtr & object_msg0,
-  const DetectedObjects::ConstSharedPtr & object_msg1)
+  const AUTOWARE_MESSAGE_CONST_SHARED_PTR(DetectedObjects) & object_msg0,
+  const AUTOWARE_MESSAGE_CONST_SHARED_PTR(DetectedObjects) & object_msg1)
 {
   DetectedObjects::SharedPtr transformed_objects0;
   if (node_param_.new_frame_id == object_msg0->header.frame_id) {
@@ -64,7 +65,8 @@ void SimpleDetectedObjectMergerNode::approximateMerger(
     transformed_objects1 = getTransformedObjects(object_msg1, node_param_.new_frame_id, transform1);
   }
 
-  DetectedObjects output_objects;
+  auto output = ALLOCATE_OUTPUT_MESSAGE_UNIQUE(pub_objects_);
+  auto & output_objects = *output;
   output_objects.header = object_msg0->header;
   output_objects.header.frame_id = node_param_.new_frame_id;
   output_objects.objects.reserve(
@@ -74,7 +76,7 @@ void SimpleDetectedObjectMergerNode::approximateMerger(
     output_objects.objects.end(), std::begin(transformed_objects1->objects),
     std::end(transformed_objects1->objects));
 
-  pub_objects_->publish(output_objects);
+  pub_objects_->publish(std::move(output));
 }
 
 void SimpleDetectedObjectMergerNode::onTimer()
@@ -92,12 +94,13 @@ void SimpleDetectedObjectMergerNode::onTimer()
     }
   }
 
-  DetectedObjects output_objects;
+  auto output = ALLOCATE_OUTPUT_MESSAGE_UNIQUE(pub_objects_);
+  auto & output_objects = *output;
   output_objects.header.frame_id = node_param_.new_frame_id;
 
   if (!has_valid_input) {
     output_objects.header.stamp = this->now();
-    pub_objects_->publish(output_objects);
+    pub_objects_->publish(std::move(output));
     return;
   }
 
@@ -142,7 +145,7 @@ void SimpleDetectedObjectMergerNode::onTimer()
     }
   }
 
-  pub_objects_->publish(output_objects);
+  pub_objects_->publish(std::move(output));
 }
 
 }  // namespace autoware::simple_object_merger

--- a/perception/autoware_simple_object_merger/src/simple_object_merger_base.cpp
+++ b/perception/autoware_simple_object_merger/src/simple_object_merger_base.cpp
@@ -78,7 +78,7 @@ SimpleObjectMergerBase<ObjsMsgType>::SimpleObjectMergerBase(
   }
 
   // Subscriber
-  transform_listener_ = std::make_shared<autoware_utils::TransformListener>(this);
+  transform_listener_ = std::make_shared<TfListener>(this);
   if (input_topic_size_ == 2) {
     // Trigger the process and publish by message_filter
     input0_.subscribe(
@@ -97,7 +97,7 @@ SimpleObjectMergerBase<ObjsMsgType>::SimpleObjectMergerBase(
 
     // subscriber
     for (size_t i = 0; i < input_topic_size_; i++) {
-      std::function<void(const typename ObjsMsgType::ConstSharedPtr msg)> func =
+      std::function<void(const AUTOWARE_MESSAGE_CONST_SHARED_PTR(ObjsMsgType) & msg)> func =
         std::bind(&SimpleObjectMergerBase::onData, this, std::placeholders::_1, i);
       sub_objects_array.at(i) = create_subscription<ObjsMsgType>(
         node_param_.topic_names.at(i), rclcpp::QoS{1}.best_effort(), func);
@@ -105,7 +105,7 @@ SimpleObjectMergerBase<ObjsMsgType>::SimpleObjectMergerBase(
 
     // process callback
     const auto update_period_ns = rclcpp::Rate(node_param_.update_rate_hz).period();
-    timer_ = rclcpp::create_timer(
+    timer_ = autoware::agnocast_wrapper::create_timer(
       this, get_clock(), update_period_ns, std::bind(&SimpleObjectMergerBase::onTimer, this));
   }
 
@@ -115,7 +115,7 @@ SimpleObjectMergerBase<ObjsMsgType>::SimpleObjectMergerBase(
 
 template <class ObjsMsgType>
 typename ObjsMsgType::SharedPtr SimpleObjectMergerBase<ObjsMsgType>::getTransformedObjects(
-  typename ObjsMsgType::ConstSharedPtr objects, const std::string & target_frame_id,
+  AUTOWARE_MESSAGE_CONST_SHARED_PTR(ObjsMsgType) objects, const std::string & target_frame_id,
   geometry_msgs::msg::TransformStamped::ConstSharedPtr transform)
 {
   typename ObjsMsgType::SharedPtr output_objects = std::make_shared<ObjsMsgType>(*objects);
@@ -139,15 +139,15 @@ typename ObjsMsgType::SharedPtr SimpleObjectMergerBase<ObjsMsgType>::getTransfor
 
 template <class ObjsMsgType>
 void SimpleObjectMergerBase<ObjsMsgType>::approximateMerger(
-  [[maybe_unused]] const typename ObjsMsgType::ConstSharedPtr & object_msg0,
-  [[maybe_unused]] const typename ObjsMsgType::ConstSharedPtr & object_msg1)
+  [[maybe_unused]] const AUTOWARE_MESSAGE_CONST_SHARED_PTR(ObjsMsgType) & object_msg0,
+  [[maybe_unused]] const AUTOWARE_MESSAGE_CONST_SHARED_PTR(ObjsMsgType) & object_msg1)
 {
   // This must be overridden
 }
 
 template <class ObjsMsgType>
 void SimpleObjectMergerBase<ObjsMsgType>::onData(
-  typename ObjsMsgType::ConstSharedPtr msg, const size_t array_number)
+  const AUTOWARE_MESSAGE_CONST_SHARED_PTR(ObjsMsgType) & msg, const size_t array_number)
 {
   objects_data_.at(array_number) = msg;
 }

--- a/perception/autoware_simple_object_merger/src/simple_tracked_object_merger_node.cpp
+++ b/perception/autoware_simple_object_merger/src/simple_tracked_object_merger_node.cpp
@@ -26,6 +26,7 @@
 #include <stdexcept>
 #include <string>
 #include <unordered_map>
+#include <utility>
 #include <vector>
 
 namespace autoware::simple_object_merger
@@ -91,8 +92,8 @@ SimpleTrackedObjectMergerNode::SimpleTrackedObjectMergerNode(
 }
 
 void SimpleTrackedObjectMergerNode::approximateMerger(
-  const TrackedObjects::ConstSharedPtr & object_msg0,
-  const TrackedObjects::ConstSharedPtr & object_msg1)
+  const AUTOWARE_MESSAGE_CONST_SHARED_PTR(TrackedObjects) & object_msg0,
+  const AUTOWARE_MESSAGE_CONST_SHARED_PTR(TrackedObjects) & object_msg1)
 {
   TrackedObjects::SharedPtr transformed_objects0;
   if (node_param_.new_frame_id == object_msg0->header.frame_id) {
@@ -120,7 +121,8 @@ void SimpleTrackedObjectMergerNode::approximateMerger(
     transformed_objects1 = getTransformedObjects(object_msg1, node_param_.new_frame_id, transform1);
   }
 
-  TrackedObjects output_objects;
+  auto output = ALLOCATE_OUTPUT_MESSAGE_UNIQUE(pub_objects_);
+  auto & output_objects = *output;
   output_objects.header = object_msg0->header;
   output_objects.header.frame_id = node_param_.new_frame_id;
   output_objects.objects.reserve(
@@ -136,7 +138,7 @@ void SimpleTrackedObjectMergerNode::approximateMerger(
     output_objects.objects.push_back(object);
   }
 
-  pub_objects_->publish(output_objects);
+  pub_objects_->publish(std::move(output));
   cleanupUUIDMap();
 }
 
@@ -155,12 +157,13 @@ void SimpleTrackedObjectMergerNode::onTimer()
     }
   }
 
-  TrackedObjects output_objects;
+  auto output = ALLOCATE_OUTPUT_MESSAGE_UNIQUE(pub_objects_);
+  auto & output_objects = *output;
   output_objects.header.frame_id = node_param_.new_frame_id;
 
   if (!has_valid_input) {
     output_objects.header.stamp = this->now();
-    pub_objects_->publish(output_objects);
+    pub_objects_->publish(std::move(output));
     cleanupUUIDMap();
     return;
   }
@@ -207,7 +210,7 @@ void SimpleTrackedObjectMergerNode::onTimer()
     }
   }
 
-  pub_objects_->publish(output_objects);
+  pub_objects_->publish(std::move(output));
   cleanupUUIDMap();
 }
 


### PR DESCRIPTION
  ## Description
  upstream の **各 perception パッケージへの `agnocast_wrapper::Node` 適用** を `feat/v0.64/e2e` に取り込みます。対象は `lanelet_filter`（detected_object_validation）/ `object_sorter` / `simple_object_merger` の 3 パッケージで、いずれも独立した agnocast 適用 PR です。

  ### Cherry-pick したコミット

  | | 元 PR | 内容 |
  |---|---|---|
  | 1 | [#12663](https://github.com/autowarefoundation/autoware_universe/pull/12663) | `feat(lanelet_filter): apply agnocast_wrapper::Node` |
  | 2 | [#12705](https://github.com/autowarefoundation/autoware_universe/pull/12705) | `feat(object_sorter): apply agnocast_wrapper::Node to object_sorter` |
  | 3 | [#12706](https://github.com/autowarefoundation/autoware_universe/pull/12706) | `feat(simple_object_merger): apply agnocast_wrapper::Node to simple_object_merger` |

  ## 補足
  - 3 PR はそれぞれ別パッケージ（`autoware_detected_object_validation` / `autoware_object_sorter` / `autoware_simple_object_merger`）への適用で、相互の依存関係はありません。元 PR の単位をそのまま 1 コミットずつ取り込んでいます。
  - コンフリクト: なし

## agnocast適用全体像
https://tier4.atlassian.net/wiki/spaces/CRL/pages/5280465670/perception+nodes