### PR TITLE
feat(perception): cherry pick upstream PR of applying agnocast to label_based_euclidean_cluster/radar_objects_adapter

### DIFF
--- a/perception/autoware_euclidean_cluster/launch/label_based_euclidean_cluster.launch.py
+++ b/perception/autoware_euclidean_cluster/launch/label_based_euclidean_cluster.launch.py
@@ -14,10 +14,13 @@
 
 import launch
 from launch.actions import DeclareLaunchArgument
+from launch.actions import IncludeLaunchDescription
 from launch.actions import OpaqueFunction
 from launch.conditions import IfCondition
 from launch.conditions import UnlessCondition
+from launch.launch_description_sources import PythonLaunchDescriptionSource
 from launch.substitutions import LaunchConfiguration
+from launch.substitutions import PathJoinSubstitution
 from launch_ros.actions import ComposableNodeContainer
 from launch_ros.actions import LoadComposableNodes
 from launch_ros.descriptions import ComposableNode
@@ -49,11 +52,14 @@ def launch_setup(context, *args, **kwargs):
     container = ComposableNodeContainer(
         name="label_based_euclidean_cluster_container",
         namespace=ns,
-        package="rclcpp_components",
-        executable="component_container",
+        package=LaunchConfiguration("container_package"),
+        executable=LaunchConfiguration("container_executable"),
         composable_node_descriptions=[],
         output="screen",
         condition=UnlessCondition(LaunchConfiguration("use_pointcloud_container")),
+        additional_env={
+            "LD_PRELOAD": LaunchConfiguration("ld_preload_value"),
+        },
     )
 
     target_container = (
@@ -74,8 +80,22 @@ def generate_launch_description():
     def add_launch_arg(name: str, default_value=None):
         return DeclareLaunchArgument(name, default_value=default_value)
 
+    # Resolve LD_PRELOAD / container package / container executable based on ENABLE_AGNOCAST.
+    agnocast_env = IncludeLaunchDescription(
+        PythonLaunchDescriptionSource(
+            PathJoinSubstitution(
+                [
+                    FindPackageShare("autoware_agnocast_wrapper"),
+                    "launch",
+                    "agnocast_env.launch.py",
+                ]
+            )
+        ),
+    )
+
     return launch.LaunchDescription(
         [
+            agnocast_env,
             add_launch_arg("input_pointcloud", "/perception/ptv3/segmented/pointcloud"),
             add_launch_arg("output_objects", "objects"),
             add_launch_arg("use_pointcloud_container", "false"),

--- a/perception/autoware_euclidean_cluster/src/label_based_euclidean_cluster_node.cpp
+++ b/perception/autoware_euclidean_cluster/src/label_based_euclidean_cluster_node.cpp
@@ -371,7 +371,7 @@ LabelBasedEuclideanClusterNode::LabelBasedEuclideanClusterNode(const rclcpp::Nod
   pointcloud_sub_ = this->create_subscription<sensor_msgs::msg::PointCloud2>(
     "input", rclcpp::SensorDataQoS().keep_last(1),
     std::bind(&LabelBasedEuclideanClusterNode::on_pointcloud, this, _1));
-  objects_pub_ = this->create_publisher<DetectedObjects>("output", rclcpp::QoS{1});
+  objects_pub_ = AUTOWARE_CREATE_PUBLISHER2(DetectedObjects, "output", rclcpp::QoS{1});
 
   stop_watch_ptr_ = std::make_unique<autoware_utils::StopWatch<std::chrono::milliseconds>>();
   debug_publisher_ = std::make_unique<autoware_utils::DebugPublisher>(this, "~/debug");
@@ -422,8 +422,8 @@ void LabelBasedEuclideanClusterNode::on_pointcloud(
   // 1. Split points by label and filter by probability
   auto split_points = split_pointcloud(*input_msg, class_id_to_object_label_, min_probability_);
 
-  DetectedObjects output_msg;
-  output_msg.header = input_msg->header;
+  auto output_msg = ALLOCATE_OUTPUT_MESSAGE_UNIQUE(objects_pub_);
+  output_msg->header = input_msg->header;
 
   for (const auto & [label, semantic_points] : split_points) {
     pcl::PointCloud<pcl::PointXYZ>::Ptr label_cloud(new pcl::PointCloud<pcl::PointXYZ>);
@@ -441,12 +441,12 @@ void LabelBasedEuclideanClusterNode::on_pointcloud(
         continue;
       }
 
-      output_msg.objects.push_back(create_detected_object(
+      output_msg->objects.push_back(create_detected_object(
         cluster, label, label_probability, shape_policy_, *shape_estimator_));
     }
   }
 
-  objects_pub_->publish(output_msg);
+  objects_pub_->publish(std::move(output_msg));
 
   if (debug_publisher_) {
     const double cyclic_time_ms = stop_watch_ptr_->toc("cyclic_time", true);

--- a/perception/autoware_euclidean_cluster/src/label_based_euclidean_cluster_node.hpp
+++ b/perception/autoware_euclidean_cluster/src/label_based_euclidean_cluster_node.hpp
@@ -17,6 +17,7 @@
 #include "autoware/euclidean_cluster/euclidean_cluster_interface.hpp"
 #include "autoware/euclidean_cluster/voxel_grid_based_euclidean_cluster.hpp"
 
+#include <autoware/agnocast_wrapper/autoware_agnocast_wrapper.hpp>
 #include <autoware/shape_estimation/shape_estimator.hpp>
 #include <autoware_utils/ros/debug_publisher.hpp>
 #include <autoware_utils/system/stop_watch.hpp>
@@ -60,7 +61,7 @@ private:
     const std::vector<std::pair<std::string, std::string>> & class_mappings);
 
   rclcpp::Subscription<sensor_msgs::msg::PointCloud2>::SharedPtr pointcloud_sub_;
-  rclcpp::Publisher<autoware_perception_msgs::msg::DetectedObjects>::SharedPtr objects_pub_;
+  AUTOWARE_PUBLISHER_PTR(autoware_perception_msgs::msg::DetectedObjects) objects_pub_;
 
   std::shared_ptr<EuclideanClusterInterface> cluster_;
   std::unique_ptr<autoware::shape_estimation::ShapeEstimator> shape_estimator_;

--- a/sensing/autoware_radar_objects_adapter/launch/radar_objects_adapter.launch.xml
+++ b/sensing/autoware_radar_objects_adapter/launch/radar_objects_adapter.launch.xml
@@ -1,4 +1,5 @@
 <launch>
+  <include file="$(find-pkg-share autoware_agnocast_wrapper)/launch/agnocast_env.launch.xml"/>
   <arg name="input_radar_objects" default="/radar_objects"/>
   <arg name="input_radar_info" default="/radar_info"/>
   <arg name="output_detections" default="/detections"/>
@@ -7,6 +8,7 @@
   <arg name="param_path" default="$(find-pkg-share autoware_radar_objects_adapter)/config/radar_objects_adapter.param.yaml"/>
 
   <node pkg="autoware_radar_objects_adapter" exec="radar_objects_adapter_node" name="radar_objects_adapter" output="screen">
+    <env name="LD_PRELOAD" value="$(var ld_preload_value)"/>
     <remap from="~/input/objects" to="$(var input_radar_objects)"/>
     <remap from="~/input/radar_info" to="$(var input_radar_info)"/>
     <remap from="~/output/detections" to="$(var output_detections)"/>

--- a/sensing/autoware_radar_objects_adapter/src/radar_objects_adapter.cpp
+++ b/sensing/autoware_radar_objects_adapter/src/radar_objects_adapter.cpp
@@ -56,11 +56,13 @@ RadarObjectsAdapter::RadarObjectsAdapter(const rclcpp::NodeOptions & options)
     "~/input/radar_info", rclcpp::SensorDataQoS(),
     std::bind(&RadarObjectsAdapter::radar_info_callback, this, std::placeholders::_1));
 
-  detections_pub_ = create_publisher<autoware_perception_msgs::msg::DetectedObjects>(
-    "~/output/detections", rclcpp::QoS(10).reliable().transient_local());
+  detections_pub_ = AUTOWARE_CREATE_PUBLISHER2(
+    autoware_perception_msgs::msg::DetectedObjects, "~/output/detections",
+    rclcpp::QoS(10).reliable().transient_local());
 
-  tracks_pub_ = create_publisher<autoware_perception_msgs::msg::TrackedObjects>(
-    "~/output/tracks", rclcpp::QoS(10).reliable().transient_local());
+  tracks_pub_ = AUTOWARE_CREATE_PUBLISHER2(
+    autoware_perception_msgs::msg::TrackedObjects, "~/output/tracks",
+    rclcpp::QoS(10).reliable().transient_local());
 
   default_position_z_ = this->declare_parameter<float>("default_position_z");
   default_velocity_z_ = this->declare_parameter<float>("default_velocity_z");
@@ -290,7 +292,7 @@ void RadarObjectsAdapter::populate_classifications(
 void RadarObjectsAdapter::parse_as_detections(
   const autoware_sensing_msgs::msg::RadarObjects & input_msg)
 {
-  auto output_msg_ptr = std::make_unique<autoware_perception_msgs::msg::DetectedObjects>();
+  auto output_msg_ptr = ALLOCATE_OUTPUT_MESSAGE_UNIQUE(detections_pub_);
   auto & output_msg = *output_msg_ptr;
 
   output_msg.header = input_msg.header;
@@ -322,7 +324,7 @@ void RadarObjectsAdapter::parse_as_detections(
 void RadarObjectsAdapter::parse_as_tracks(
   const autoware_sensing_msgs::msg::RadarObjects & input_msg)
 {
-  auto output_msg_ptr = std::make_unique<autoware_perception_msgs::msg::TrackedObjects>();
+  auto output_msg_ptr = ALLOCATE_OUTPUT_MESSAGE_UNIQUE(tracks_pub_);
   auto & output_msg = *output_msg_ptr;
 
   output_msg.header = input_msg.header;

--- a/sensing/autoware_radar_objects_adapter/src/radar_objects_adapter.hpp
+++ b/sensing/autoware_radar_objects_adapter/src/radar_objects_adapter.hpp
@@ -15,6 +15,7 @@
 #ifndef RADAR_OBJECTS_ADAPTER_HPP_
 #define RADAR_OBJECTS_ADAPTER_HPP_
 
+#include <autoware/agnocast_wrapper/autoware_agnocast_wrapper.hpp>
 #include <rclcpp/rclcpp.hpp>
 
 #include <autoware_perception_msgs/msg/detected_objects.hpp>
@@ -66,8 +67,8 @@ private:
 
   rclcpp::Subscription<autoware_sensing_msgs::msg::RadarObjects>::SharedPtr radar_objects_sub_;
   rclcpp::Subscription<autoware_sensing_msgs::msg::RadarInfo>::SharedPtr radar_info_sub_;
-  rclcpp::Publisher<autoware_perception_msgs::msg::DetectedObjects>::SharedPtr detections_pub_;
-  rclcpp::Publisher<autoware_perception_msgs::msg::TrackedObjects>::SharedPtr tracks_pub_;
+  AUTOWARE_PUBLISHER_PTR(autoware_perception_msgs::msg::DetectedObjects) detections_pub_;
+  AUTOWARE_PUBLISHER_PTR(autoware_perception_msgs::msg::TrackedObjects) tracks_pub_;
 
   std::unordered_map<std::string, autoware_sensing_msgs::msg::RadarFieldInfo> field_info_map_;
 


### PR DESCRIPTION
  ## Description
 upstream の **publisher への agnocast 適用** を `feat/v0.64/e2e` に取り込みます。対象は `label_based_euclidean_cluster`（euclidean_cluster）/ `radar_objects_adapter` の 2 パッケージで、いずれも独立した agnocast 適用 PR です。

  ### Cherry-pick したコミット

  | | 元 PR | 内容 |
  |---|---|---|
  | 1 | [#12720](https://github.com/autowarefoundation/autoware_universe/pull/12720) | `feat(label_based_euclidean_cluster): apply agnocast to publisher for label_based_euclidean_cluster` |
  | 2 | [#12756](https://github.com/autowarefoundation/autoware_universe/pull/12756) | `feat(radar_objects_adapter): apply agnocast for publisher of radar_objects_adapter` |

  ## 補足
  - 2 PR はそれぞれ別パッケージ（`autoware_euclidean_cluster` / `autoware_radar_objects_adapter`）への適用で、相互の依存関係はありません。元 PR の単位をそのまま 1 コミットずつ取り込んでいます。
  - コンフリクト: なし

## agnocast適用全体像
https://tier4.atlassian.net/wiki/spaces/CRL/pages/5280465670/perception+nodes