### PR TITLE
refactor(image_transport_decompressor): replace anonymous node name with static name using camera_id (cherry-pick #3040)

### DIFF
--- a/sensing/autoware_image_transport_decompressor/launch/image_transport_decompressor.launch.xml
+++ b/sensing/autoware_image_transport_decompressor/launch/image_transport_decompressor.launch.xml
@@ -1,9 +1,10 @@
 <launch>
+  <arg name="camera_id" default=""/>
   <arg name="input_topic_name" default="/input/compressed_image"/>
   <arg name="output_topic_name" default="/output/raw_image"/>
   <arg name="param_file" default="$(find-pkg-share autoware_image_transport_decompressor)/config/image_transport_decompressor.param.yaml"/>
 
-  <node pkg="autoware_image_transport_decompressor" exec="image_transport_decompressor_node" name="$(anon image_transport_decompressor_node)">
+  <node pkg="autoware_image_transport_decompressor" exec="image_transport_decompressor_node" name="image_transport_decompressor$(var camera_id)">
     <remap from="~/input/compressed_image" to="$(var input_topic_name)"/>
     <remap from="~/output/raw_image" to="$(var output_topic_name)"/>
     <param from="$(var param_file)" allow_substs="true"/>


### PR DESCRIPTION
## Description

Cherry-pick of #3040 into `feat/v0.64/e2e`.

Apply `autoware_agnocast_wrapper` (CallbackIsolatedAgnocastExecutor / CIE) preconditions to `image_transport_decompressor`.

In order to adopt CIE, all running node names must be statically defined and predictable. Previously, `image_transport_decompressor.launch.xml` used a hardcoded `$(anon ...)` tag, which resulted in randomly generated node names at runtime. This change removes the anonymous naming and enforces a static node name based on `camera_id`.

### What was changed

`image_transport_decompressor.launch.xml`:
- Added an `<arg name="camera_id" default=""/>`.
- Removed `name="$(anon image_transport_decompressor_node)"` from the `<node>` definition.
- Changed the attribute to `name="image_transport_decompressor$(var camera_id)"`, utilizing the argument passed from the parent launch file.

This aligns with the design pattern already used in other files within the project (e.g. `image_diagnostics.launch.xml`, which uses `camera_id` as a suffix), allowing unique, static node names without modifying the parent Python launch files. It is a non-breaking internal cleanup to stabilize node naming for CIE compatibility; the underlying node functionality remains identical.

## Related links

**Parent Issue:**

- Original PR: https://github.com/tier4/autoware_universe/pull/3040

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

## Effects on system behavior

None.