### PR TITLE
feat(object_merger): cherry-pick #12704 and #12782 to apply agnocast

### DIFF
--- a/perception/autoware_object_merger/CMakeLists.txt
+++ b/perception/autoware_object_merger/CMakeLists.txt
@@ -48,9 +48,11 @@ if(BUILD_TESTING)
   find_package(ament_lint_auto REQUIRED)
   ament_lint_auto_find_test_dependencies()
 
-  ament_auto_add_gtest(object_fusion_merger_node_tests
-    test/test_object_fusion_merger_node.cpp
-  )
+  if(NOT "$ENV{ENABLE_AGNOCAST}" STREQUAL "1")
+    ament_auto_add_gtest(object_fusion_merger_node_tests
+      test/test_object_fusion_merger_node.cpp
+    )
+  endif()
 endif()
 
 ament_auto_package(INSTALL_TO_SHARE

--- a/perception/autoware_object_merger/CMakeLists.txt
+++ b/perception/autoware_object_merger/CMakeLists.txt
@@ -34,14 +34,14 @@ autoware_agnocast_wrapper_register_node(${PROJECT_NAME}
   PLUGIN "autoware::object_merger::ObjectAssociationMergerNode"
   EXECUTABLE object_association_merger_node
   ROS2_EXECUTOR SingleThreadedExecutor
-  AGNOCAST_EXECUTOR CallbackIsolatedAgnocastExecutor
+  AGNOCAST_EXECUTOR AgnocastOnlyCallbackIsolatedExecutor
 )
 
 autoware_agnocast_wrapper_register_node(${PROJECT_NAME}
   PLUGIN "autoware::object_merger::ObjectFusionMergerNode"
   EXECUTABLE object_fusion_merger_node
   ROS2_EXECUTOR SingleThreadedExecutor
-  AGNOCAST_EXECUTOR CallbackIsolatedAgnocastExecutor
+  AGNOCAST_EXECUTOR AgnocastOnlyCallbackIsolatedExecutor
 )
 
 if(BUILD_TESTING)

--- a/perception/autoware_object_merger/include/autoware/object_merger/object_association_merger_node.hpp
+++ b/perception/autoware_object_merger/include/autoware/object_merger/object_association_merger_node.hpp
@@ -16,11 +16,14 @@
 #define AUTOWARE__OBJECT_MERGER__OBJECT_ASSOCIATION_MERGER_NODE_HPP_
 
 #include "autoware/object_merger/association/data_association.hpp"
-#include "autoware_utils/ros/debug_publisher.hpp"
-#include "autoware_utils/ros/published_time_publisher.hpp"
 #include "autoware_utils/system/stop_watch.hpp"
 
-#include <autoware_utils/ros/diagnostics_interface.hpp>
+#include <autoware/agnocast_wrapper/message_filters.hpp>
+#include <autoware/agnocast_wrapper/node.hpp>
+#include <autoware/agnocast_wrapper/tf2.hpp>
+#include <autoware_utils_debug/debug_publisher.hpp>
+#include <autoware_utils_debug/published_time_publisher.hpp>
+#include <autoware_utils_diagnostics/diagnostics_interface.hpp>
 #include <rclcpp/rclcpp.hpp>
 #include <tf2/LinearMath/Transform.hpp>
 #include <tf2/convert.hpp>
@@ -28,12 +31,6 @@
 
 #include "autoware_perception_msgs/msg/detected_objects.hpp"
 #include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
-
-#include <message_filters/subscriber.h>
-#include <message_filters/sync_policies/approximate_time.h>
-#include <message_filters/synchronizer.h>
-#include <tf2_ros/buffer.h>
-#include <tf2_ros/transform_listener.h>
 
 #include <map>
 #include <memory>
@@ -43,7 +40,7 @@
 
 namespace autoware::object_merger
 {
-class ObjectAssociationMergerNode : public rclcpp::Node
+class ObjectAssociationMergerNode : public autoware::agnocast_wrapper::Node
 {
   using Label = autoware_perception_msgs::msg::ObjectClassification;
 
@@ -53,20 +50,26 @@ public:
 
 private:
   void objectsCallback(
-    const autoware_perception_msgs::msg::DetectedObjects::ConstSharedPtr & input_objects0_msg,
-    const autoware_perception_msgs::msg::DetectedObjects::ConstSharedPtr & input_objects1_msg);
+    const AUTOWARE_MESSAGE_CONST_SHARED_PTR(autoware_perception_msgs::msg::DetectedObjects) &
+      input_objects0_msg,
+    const AUTOWARE_MESSAGE_CONST_SHARED_PTR(autoware_perception_msgs::msg::DetectedObjects) &
+      input_objects1_msg);
 
   void diagCallback();
 
-  tf2_ros::Buffer tf_buffer_;
-  tf2_ros::TransformListener tf_listener_;
-  rclcpp::Publisher<autoware_perception_msgs::msg::DetectedObjects>::SharedPtr merged_object_pub_;
-  message_filters::Subscriber<autoware_perception_msgs::msg::DetectedObjects> object0_sub_{};
-  message_filters::Subscriber<autoware_perception_msgs::msg::DetectedObjects> object1_sub_{};
+  autoware::agnocast_wrapper::Buffer tf_buffer_;
+  autoware::agnocast_wrapper::TransformListener tf_listener_;
+  AUTOWARE_PUBLISHER_PTR(autoware_perception_msgs::msg::DetectedObjects) merged_object_pub_;
+  autoware::agnocast_wrapper::message_filters::Subscriber<
+    autoware_perception_msgs::msg::DetectedObjects>
+    object0_sub_{};
+  autoware::agnocast_wrapper::message_filters::Subscriber<
+    autoware_perception_msgs::msg::DetectedObjects>
+    object1_sub_{};
 
-  using SyncPolicy = message_filters::sync_policies::ApproximateTime<
+  using SyncPolicy = autoware::agnocast_wrapper::message_filters::sync_policies::ApproximateTime<
     autoware_perception_msgs::msg::DetectedObjects, autoware_perception_msgs::msg::DetectedObjects>;
-  using Sync = message_filters::Synchronizer<SyncPolicy>;
+  using Sync = autoware::agnocast_wrapper::message_filters::Synchronizer<SyncPolicy>;
   typename std::shared_ptr<Sync> sync_ptr_;
 
   int sync_queue_size_;
@@ -78,8 +81,10 @@ private:
   double initialization_timeout_sec_;
   std::optional<rclcpp::Time> last_sync_time_;
   std::optional<double> message_interval_;
-  rclcpp::TimerBase::SharedPtr timeout_timer_;
-  std::unique_ptr<autoware_utils::DiagnosticsInterface> diagnostics_interface_ptr_;
+  AUTOWARE_TIMER_PTR timeout_timer_;
+  std::unique_ptr<
+    autoware_utils_diagnostics::BasicDiagnosticsInterface<autoware::agnocast_wrapper::Node>>
+    diagnostics_interface_ptr_;
 
   PriorityMode priority_mode_;
   std::vector<int64_t> class_based_priority_matrix_;
@@ -96,10 +101,13 @@ private:
   } overlapped_judge_param_;
 
   // debug publisher
-  std::unique_ptr<autoware_utils::DebugPublisher> processing_time_publisher_;
+  std::unique_ptr<autoware_utils_debug::BasicDebugPublisher<autoware::agnocast_wrapper::Node>>
+    processing_time_publisher_;
   std::unique_ptr<autoware_utils::StopWatch<std::chrono::milliseconds>> stop_watch_ptr_;
 
-  std::unique_ptr<autoware_utils::PublishedTimePublisher> published_time_publisher_;
+  std::unique_ptr<
+    autoware_utils_debug::BasicPublishedTimePublisher<autoware::agnocast_wrapper::Node>>
+    published_time_publisher_;
 };
 }  // namespace autoware::object_merger
 

--- a/perception/autoware_object_merger/include/autoware/object_merger/object_fusion_merger_node.hpp
+++ b/perception/autoware_object_merger/include/autoware/object_merger/object_fusion_merger_node.hpp
@@ -56,6 +56,12 @@ private:
     DetectedObjects, DetectedObjects>;
   using Sync = autoware::agnocast_wrapper::message_filters::Synchronizer<SyncPolicy>;
 
+  struct FusionResult
+  {
+    DetectedObjects fused_objects;
+    DetectedObjects other_objects;
+  };
+
   /**
    * @brief Transform synchronized inputs, perform fusion, and publish both outputs.
    *
@@ -71,12 +77,10 @@ private:
    *
    * @param main_objects_msg Main detected objects transformed into the base frame.
    * @param sub_objects_msg Sub detected objects transformed into the base frame.
-   * @param fused_objects Output message populated with the main-based fused objects.
-   * @param other_objects Output message populated with the unmatched sub objects.
+   * @return Fusion result containing the main-based output and unmatched sub objects.
    */
-  void fuse_objects(
-    const DetectedObjects & main_objects_msg, const DetectedObjects & sub_objects_msg,
-    DetectedObjects & fused_objects, DetectedObjects & other_objects);
+  FusionResult fuse_objects(
+    const DetectedObjects & main_objects_msg, const DetectedObjects & sub_objects_msg);
 
   autoware::agnocast_wrapper::Buffer tf_buffer_;
   autoware::agnocast_wrapper::TransformListener tf_listener_;

--- a/perception/autoware_object_merger/include/autoware/object_merger/object_fusion_merger_node.hpp
+++ b/perception/autoware_object_merger/include/autoware/object_merger/object_fusion_merger_node.hpp
@@ -15,21 +15,17 @@
 #ifndef AUTOWARE__OBJECT_MERGER__OBJECT_FUSION_MERGER_NODE_HPP_
 #define AUTOWARE__OBJECT_MERGER__OBJECT_FUSION_MERGER_NODE_HPP_
 
-#include "autoware_utils/ros/debug_publisher.hpp"
-#include "autoware_utils/ros/published_time_publisher.hpp"
 #include "autoware_utils/system/stop_watch.hpp"
 
-#include <autoware_utils/ros/diagnostics_interface.hpp>
+#include <autoware/agnocast_wrapper/message_filters.hpp>
+#include <autoware/agnocast_wrapper/node.hpp>
+#include <autoware/agnocast_wrapper/tf2.hpp>
+#include <autoware_utils_debug/debug_publisher.hpp>
+#include <autoware_utils_debug/published_time_publisher.hpp>
 #include <rclcpp/rclcpp.hpp>
 
 #include "autoware_perception_msgs/msg/detected_object.hpp"
 #include "autoware_perception_msgs/msg/detected_objects.hpp"
-
-#include <message_filters/subscriber.h>
-#include <message_filters/sync_policies/approximate_time.h>
-#include <message_filters/synchronizer.h>
-#include <tf2_ros/buffer.h>
-#include <tf2_ros/transform_listener.h>
 
 #include <chrono>
 #include <memory>
@@ -43,7 +39,7 @@ namespace autoware::object_merger
  * @brief Merge two detected-object streams by expanding each main object with uniquely overlapped
  * sub objects.
  */
-class ObjectFusionMergerNode : public rclcpp::Node
+class ObjectFusionMergerNode : public autoware::agnocast_wrapper::Node
 {
 public:
   /**
@@ -56,15 +52,9 @@ public:
 private:
   using DetectedObject = autoware_perception_msgs::msg::DetectedObject;
   using DetectedObjects = autoware_perception_msgs::msg::DetectedObjects;
-  using SyncPolicy =
-    message_filters::sync_policies::ApproximateTime<DetectedObjects, DetectedObjects>;
-  using Sync = message_filters::Synchronizer<SyncPolicy>;
-
-  struct FusionResult
-  {
-    DetectedObjects fused_objects;
-    DetectedObjects other_objects;
-  };
+  using SyncPolicy = autoware::agnocast_wrapper::message_filters::sync_policies::ApproximateTime<
+    DetectedObjects, DetectedObjects>;
+  using Sync = autoware::agnocast_wrapper::message_filters::Synchronizer<SyncPolicy>;
 
   /**
    * @brief Transform synchronized inputs, perform fusion, and publish both outputs.
@@ -73,32 +63,37 @@ private:
    * @param sub_objects_msg Sub detected objects input.
    */
   void callback(
-    const DetectedObjects::ConstSharedPtr & main_objects_msg,
-    const DetectedObjects::ConstSharedPtr & sub_objects_msg);
+    const AUTOWARE_MESSAGE_CONST_SHARED_PTR(DetectedObjects) & main_objects_msg,
+    const AUTOWARE_MESSAGE_CONST_SHARED_PTR(DetectedObjects) & sub_objects_msg);
 
   /**
    * @brief Group sub objects by unique overlap and produce fused and unmatched outputs.
    *
    * @param main_objects_msg Main detected objects transformed into the base frame.
    * @param sub_objects_msg Sub detected objects transformed into the base frame.
-   * @return Fusion result containing the main-based output and unmatched sub objects.
+   * @param fused_objects Output message populated with the main-based fused objects.
+   * @param other_objects Output message populated with the unmatched sub objects.
    */
-  FusionResult fuse_objects(
-    const DetectedObjects & main_objects_msg, const DetectedObjects & sub_objects_msg);
+  void fuse_objects(
+    const DetectedObjects & main_objects_msg, const DetectedObjects & sub_objects_msg,
+    DetectedObjects & fused_objects, DetectedObjects & other_objects);
 
-  tf2_ros::Buffer tf_buffer_;
-  tf2_ros::TransformListener tf_listener_;
-  rclcpp::Publisher<DetectedObjects>::SharedPtr fused_objects_pub_;
-  rclcpp::Publisher<DetectedObjects>::SharedPtr other_objects_pub_;
-  message_filters::Subscriber<DetectedObjects> main_object_sub_{};
-  message_filters::Subscriber<DetectedObjects> sub_object_sub_{};
+  autoware::agnocast_wrapper::Buffer tf_buffer_;
+  autoware::agnocast_wrapper::TransformListener tf_listener_;
+  AUTOWARE_PUBLISHER_PTR(DetectedObjects) fused_objects_pub_;
+  AUTOWARE_PUBLISHER_PTR(DetectedObjects) other_objects_pub_;
+  autoware::agnocast_wrapper::message_filters::Subscriber<DetectedObjects> main_object_sub_{};
+  autoware::agnocast_wrapper::message_filters::Subscriber<DetectedObjects> sub_object_sub_{};
   std::shared_ptr<Sync> sync_ptr_;
 
   std::string base_link_frame_id_;
 
-  std::unique_ptr<autoware_utils::DebugPublisher> processing_time_publisher_;
+  std::unique_ptr<autoware_utils_debug::BasicDebugPublisher<autoware::agnocast_wrapper::Node>>
+    processing_time_publisher_;
   std::unique_ptr<autoware_utils::StopWatch<std::chrono::milliseconds>> stop_watch_ptr_;
-  std::unique_ptr<autoware_utils::PublishedTimePublisher> published_time_publisher_;
+  std::unique_ptr<
+    autoware_utils_debug::BasicPublishedTimePublisher<autoware::agnocast_wrapper::Node>>
+    published_time_publisher_;
 };
 }  // namespace autoware::object_merger
 

--- a/perception/autoware_object_merger/launch/object_association_merger.launch.xml
+++ b/perception/autoware_object_merger/launch/object_association_merger.launch.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0"?>
 <launch>
+  <include file="$(find-pkg-share autoware_agnocast_wrapper)/launch/agnocast_env.launch.xml"/>
   <arg name="node_name" default="$(anon object_association_merger)"/>
   <arg name="input/object0" default="object0"/>
   <arg name="input/object1" default="object1"/>
@@ -10,6 +11,7 @@
   <arg name="object_association_merger_param_path" default="$(find-pkg-share autoware_object_merger)/config/object_association_merger.param.yaml"/>
 
   <node pkg="autoware_object_merger" exec="object_association_merger_node" name="$(var node_name)" output="screen">
+    <env name="LD_PRELOAD" value="$(var ld_preload_value)"/>
     <remap from="input/object0" to="$(var input/object0)"/>
     <remap from="input/object1" to="$(var input/object1)"/>
     <remap from="output/object" to="$(var output/object)"/>

--- a/perception/autoware_object_merger/launch/object_fusion_merger.launch.xml
+++ b/perception/autoware_object_merger/launch/object_fusion_merger.launch.xml
@@ -1,4 +1,5 @@
 <launch>
+  <include file="$(find-pkg-share autoware_agnocast_wrapper)/launch/agnocast_env.launch.xml"/>
   <arg name="node_name" default="object_fusion_merger"/>
   <arg name="object_fusion_merger_param_path" default="$(find-pkg-share autoware_object_merger)/config/object_fusion_merger.param.yaml"/>
   <arg name="input/main_objects" default="input/main_objects"/>
@@ -7,6 +8,7 @@
   <arg name="output/other_objects" default="output/other_objects"/>
 
   <node pkg="autoware_object_merger" exec="object_fusion_merger_node" name="$(var node_name)" output="screen">
+    <env name="LD_PRELOAD" value="$(var ld_preload_value)"/>
     <param from="$(var object_fusion_merger_param_path)"/>
     <remap from="input/main_objects" to="$(var input/main_objects)"/>
     <remap from="input/sub_objects" to="$(var input/sub_objects)"/>

--- a/perception/autoware_object_merger/package.xml
+++ b/perception/autoware_object_merger/package.xml
@@ -19,6 +19,8 @@
   <depend>autoware_perception_msgs</depend>
   <depend>autoware_test_utils</depend>
   <depend>autoware_utils</depend>
+  <depend>autoware_utils_debug</depend>
+  <depend>autoware_utils_diagnostics</depend>
   <depend>eigen</depend>
   <depend>geometry_msgs</depend>
   <depend>mussp</depend>

--- a/perception/autoware_object_merger/src/object_association_merger_node.cpp
+++ b/perception/autoware_object_merger/src/object_association_merger_node.cpp
@@ -91,9 +91,9 @@ std::map<int, double> convertListToClassMap(const std::vector<double> & distance
 namespace autoware::object_merger
 {
 ObjectAssociationMergerNode::ObjectAssociationMergerNode(const rclcpp::NodeOptions & node_options)
-: rclcpp::Node("object_association_merger_node", node_options),
+: Node("object_association_merger_node", node_options),
   tf_buffer_(get_clock()),
-  tf_listener_(tf_buffer_),
+  tf_listener_(tf_buffer_, *this),
   object0_sub_(this, "input/object0", rclcpp::QoS{1}.get_rmw_qos_profile()),
   object1_sub_(this, "input/object1", rclcpp::QoS{1}.get_rmw_qos_profile())
 {
@@ -143,26 +143,31 @@ ObjectAssociationMergerNode::ObjectAssociationMergerNode(const rclcpp::NodeOptio
 
   // Debug publisher
   processing_time_publisher_ =
-    std::make_unique<autoware_utils::DebugPublisher>(this, "object_association_merger");
+    std::make_unique<autoware_utils_debug::BasicDebugPublisher<autoware::agnocast_wrapper::Node>>(
+      this, "object_association_merger");
   stop_watch_ptr_ = std::make_unique<autoware_utils::StopWatch<std::chrono::milliseconds>>();
   stop_watch_ptr_->tic("cyclic_time");
   stop_watch_ptr_->tic("processing_time");
-  published_time_publisher_ = std::make_unique<autoware_utils::PublishedTimePublisher>(this);
+  published_time_publisher_ = std::make_unique<
+    autoware_utils_debug::BasicPublishedTimePublisher<autoware::agnocast_wrapper::Node>>(this);
   // Timeout process initialization
   message_timeout_sec_ = this->declare_parameter<double>("message_timeout_sec");
   initialization_timeout_sec_ = this->declare_parameter<double>("initialization_timeout_sec");
   last_sync_time_ = std::nullopt;
   message_interval_ = std::nullopt;
-  timeout_timer_ = rclcpp::create_timer(
-    this, get_clock(), std::chrono::duration<double>(message_timeout_sec_ / 2),
+  timeout_timer_ = autoware::agnocast_wrapper::create_timer(
+    this, get_clock(), rclcpp::Duration::from_seconds(message_timeout_sec_ / 2),
     std::bind(&ObjectAssociationMergerNode::diagCallback, this));
-  diagnostics_interface_ptr_ =
-    std::make_unique<autoware_utils::DiagnosticsInterface>(this, "object_association_merger");
+  diagnostics_interface_ptr_ = std::make_unique<
+    autoware_utils_diagnostics::BasicDiagnosticsInterface<autoware::agnocast_wrapper::Node>>(
+    this, "object_association_merger");
 }
 
 void ObjectAssociationMergerNode::objectsCallback(
-  const autoware_perception_msgs::msg::DetectedObjects::ConstSharedPtr & input_objects0_msg,
-  const autoware_perception_msgs::msg::DetectedObjects::ConstSharedPtr & input_objects1_msg)
+  const AUTOWARE_MESSAGE_CONST_SHARED_PTR(autoware_perception_msgs::msg::DetectedObjects) &
+    input_objects0_msg,
+  const AUTOWARE_MESSAGE_CONST_SHARED_PTR(autoware_perception_msgs::msg::DetectedObjects) &
+    input_objects1_msg)
 {
   // Guard
   if (merged_object_pub_->get_subscription_count() < 1) {
@@ -181,7 +186,8 @@ void ObjectAssociationMergerNode::objectsCallback(
   }
 
   // build output msg
-  autoware_perception_msgs::msg::DetectedObjects output_msg;
+  auto output = ALLOCATE_OUTPUT_MESSAGE_UNIQUE(merged_object_pub_);
+  auto & output_msg = *output;
   output_msg.header = input_objects0_msg->header;
   output_msg.header.frame_id = base_link_frame_id_;
 
@@ -292,8 +298,9 @@ void ObjectAssociationMergerNode::objectsCallback(
   last_sync_time_ = now;
 
   // publish output msg
-  merged_object_pub_->publish(output_msg);
-  published_time_publisher_->publish_if_subscribed(merged_object_pub_, output_msg.header.stamp);
+  const auto output_stamp = output_msg.header.stamp;
+  merged_object_pub_->publish(std::move(output));
+  published_time_publisher_->publish_if_subscribed(merged_object_pub_, output_stamp);
   // publish processing time
   processing_time_publisher_->publish<autoware_internal_debug_msgs::msg::Float64Stamped>(
     "debug/cyclic_time_ms", stop_watch_ptr_->toc("cyclic_time", true));

--- a/perception/autoware_object_merger/src/object_fusion_merger_node.cpp
+++ b/perception/autoware_object_merger/src/object_fusion_merger_node.cpp
@@ -276,18 +276,18 @@ void ObjectFusionMergerNode::callback(
     return;
   }
 
+  const auto result = fuse_objects(transformed_main_objects, transformed_sub_objects);
+
   auto fused_output = ALLOCATE_OUTPUT_MESSAGE_UNIQUE(fused_objects_pub_);
   auto other_output = ALLOCATE_OUTPUT_MESSAGE_UNIQUE(other_objects_pub_);
-  auto result = fuse_objects(transformed_main_objects, transformed_sub_objects);
-  *fused_output = std::move(result.fused_objects);
-  *other_output = std::move(result.other_objects);
-
-  const auto fused_stamp = fused_output->header.stamp;
+  *fused_output = result.fused_objects;
+  *other_output = result.other_objects;
   fused_objects_pub_->publish(std::move(fused_output));
   other_objects_pub_->publish(std::move(other_output));
 
   // Publish debug info
-  published_time_publisher_->publish_if_subscribed(fused_objects_pub_, fused_stamp);
+  published_time_publisher_->publish_if_subscribed(
+    fused_objects_pub_, result.fused_objects.header.stamp);
   processing_time_publisher_->publish<autoware_internal_debug_msgs::msg::Float64Stamped>(
     "debug/cyclic_time_ms", stop_watch_ptr_->toc("cyclic_time", true));
   processing_time_publisher_->publish<autoware_internal_debug_msgs::msg::Float64Stamped>(
@@ -299,7 +299,7 @@ void ObjectFusionMergerNode::callback(
  *
  * @param main_objects_msg Main detected objects already transformed into the base frame.
  * @param sub_objects_msg Sub detected objects already transformed into the base frame.
- * @return Fusion result containing the main-based output and unmatched sub objects.
+ * @return Fused main-based objects and unmatched sub objects for separate publication.
  */
 ObjectFusionMergerNode::FusionResult ObjectFusionMergerNode::fuse_objects(
   const DetectedObjects & main_objects_msg, const DetectedObjects & sub_objects_msg)
@@ -349,8 +349,10 @@ ObjectFusionMergerNode::FusionResult ObjectFusionMergerNode::fuse_objects(
                         .frame_id(base_link_frame_id_);
 
   return FusionResult{
-    autoware_perception_msgs::build<DetectedObjects>().header(header).objects(matched_objects),
-    autoware_perception_msgs::build<DetectedObjects>().header(header).objects(other_objects)};
+    autoware_perception_msgs::build<DetectedObjects>().header(header).objects(
+      std::move(matched_objects)),
+    autoware_perception_msgs::build<DetectedObjects>().header(header).objects(
+      std::move(other_objects))};
 }
 
 }  // namespace autoware::object_merger

--- a/perception/autoware_object_merger/src/object_fusion_merger_node.cpp
+++ b/perception/autoware_object_merger/src/object_fusion_merger_node.cpp
@@ -215,9 +215,9 @@ namespace autoware::object_merger
  * @param node_options ROS node options used for component construction.
  */
 ObjectFusionMergerNode::ObjectFusionMergerNode(const rclcpp::NodeOptions & node_options)
-: rclcpp::Node("object_fusion_merger_node", node_options),
+: Node("object_fusion_merger_node", node_options),
   tf_buffer_(get_clock()),
-  tf_listener_(tf_buffer_),
+  tf_listener_(tf_buffer_, *this),
   main_object_sub_(this, "input/main_objects", rclcpp::QoS{1}.get_rmw_qos_profile()),
   sub_object_sub_(this, "input/sub_objects", rclcpp::QoS{1}.get_rmw_qos_profile())
 {
@@ -235,11 +235,14 @@ ObjectFusionMergerNode::ObjectFusionMergerNode(const rclcpp::NodeOptions & node_
   fused_objects_pub_ = create_publisher<DetectedObjects>("output/objects", rclcpp::QoS{1});
   other_objects_pub_ = create_publisher<DetectedObjects>("output/other_objects", rclcpp::QoS{1});
 
-  processing_time_publisher_ = std::make_unique<autoware_utils::DebugPublisher>(this, get_name());
+  processing_time_publisher_ =
+    std::make_unique<autoware_utils_debug::BasicDebugPublisher<autoware::agnocast_wrapper::Node>>(
+      this, get_name());
   stop_watch_ptr_ = std::make_unique<autoware_utils::StopWatch<std::chrono::milliseconds>>();
   stop_watch_ptr_->tic("cyclic_time");
   stop_watch_ptr_->tic("processing_time");
-  published_time_publisher_ = std::make_unique<autoware_utils::PublishedTimePublisher>(this);
+  published_time_publisher_ = std::make_unique<
+    autoware_utils_debug::BasicPublishedTimePublisher<autoware::agnocast_wrapper::Node>>(this);
 }
 
 /**
@@ -249,8 +252,8 @@ ObjectFusionMergerNode::ObjectFusionMergerNode(const rclcpp::NodeOptions & node_
  * @param sub_objects_msg Sub detected objects input message.
  */
 void ObjectFusionMergerNode::callback(
-  const DetectedObjects::ConstSharedPtr & main_objects_msg,
-  const DetectedObjects::ConstSharedPtr & sub_objects_msg)
+  const AUTOWARE_MESSAGE_CONST_SHARED_PTR(DetectedObjects) & main_objects_msg,
+  const AUTOWARE_MESSAGE_CONST_SHARED_PTR(DetectedObjects) & sub_objects_msg)
 {
   stop_watch_ptr_->toc("processing_time", true);
 
@@ -273,13 +276,18 @@ void ObjectFusionMergerNode::callback(
     return;
   }
 
-  const auto result = fuse_objects(transformed_main_objects, transformed_sub_objects);
-  fused_objects_pub_->publish(result.fused_objects);
-  other_objects_pub_->publish(result.other_objects);
+  auto fused_output = ALLOCATE_OUTPUT_MESSAGE_UNIQUE(fused_objects_pub_);
+  auto other_output = ALLOCATE_OUTPUT_MESSAGE_UNIQUE(other_objects_pub_);
+  auto result = fuse_objects(transformed_main_objects, transformed_sub_objects);
+  *fused_output = std::move(result.fused_objects);
+  *other_output = std::move(result.other_objects);
+
+  const auto fused_stamp = fused_output->header.stamp;
+  fused_objects_pub_->publish(std::move(fused_output));
+  other_objects_pub_->publish(std::move(other_output));
 
   // Publish debug info
-  published_time_publisher_->publish_if_subscribed(
-    fused_objects_pub_, result.fused_objects.header.stamp);
+  published_time_publisher_->publish_if_subscribed(fused_objects_pub_, fused_stamp);
   processing_time_publisher_->publish<autoware_internal_debug_msgs::msg::Float64Stamped>(
     "debug/cyclic_time_ms", stop_watch_ptr_->toc("cyclic_time", true));
   processing_time_publisher_->publish<autoware_internal_debug_msgs::msg::Float64Stamped>(
@@ -287,11 +295,11 @@ void ObjectFusionMergerNode::callback(
 }
 
 /**
- * @brief Group sub objects by unique overlap and build fused and unmatched outputs.
+ * @brief Group sub objects by unique overlap and produce fused and unmatched outputs.
  *
  * @param main_objects_msg Main detected objects already transformed into the base frame.
  * @param sub_objects_msg Sub detected objects already transformed into the base frame.
- * @return Fused main-based objects and unmatched sub objects for separate publication.
+ * @return Fusion result containing the main-based output and unmatched sub objects.
  */
 ObjectFusionMergerNode::FusionResult ObjectFusionMergerNode::fuse_objects(
   const DetectedObjects & main_objects_msg, const DetectedObjects & sub_objects_msg)


### PR DESCRIPTION
## Description
 upstream の **object_merger への `agnocast_wrapper::Node` 適用 (#12704)** を `feat/v0.64/e2e` に取り込みます。`autoware_object_merger` の `object_fusion_merger` は e2e 側が独自の perception pipeline（**#3008 "apply new perception pipeline"**）を採用しており、upstream とは `fuse_objects()` の実装系統が分岐しています。
 
### Cherry-pick したコミット
  | | 元 PR | 内容 |
  |---|---|---|
  | 1（目的） | [#12704](https://github.com/autowarefoundation/autoware_universe/pull/12704) | `feat(object_merger): apply agnocast_wrapper::Node to object_merger` |
  | 2（追従） | [#12782](https://github.com/autowarefoundation/autoware_universe/pull/12782) | `refactor(object_merger): fix to improve readability beside copy`（#12704 の `fuse_objects` 入出力変更を撤回し `FusionResult` 返しに戻す。agnocast publisher 採用は維持） |
  | 3（追従） | [#12773](https://github.com/autowarefoundation/autoware_universe/pull/12773) | `fix(autoware_object_merger): disable test when agnocast enabled`（agnocast 有効時にビルドされるテストを無効化） |

  ## 補足
  - **コンフリクト箇所**: `perception/autoware_object_merger/src/object_fusion_merger_node.cpp` の `fuse_objects()` のみ。原因は agnocast ではなく、融合ロジックが e2e(#3008) と upstream(#12682) で乖離しているため。agnocast 化されたノード本体・callback・hpp はクリーンに自動マージされます。
  - **解決方針**: 本ブランチの（#3008）のノードロジック（`enclose_union_with_main_shape` ベース・`FusionResult` 返し・変数名）はそのまま保存し、agnocast の変更のみ取り込みました。
  - **#12782 を併せて取り込んだ理由**: 本ブランチでの変更を最小限に抑えるため、upstreamでagnocast適用時に関数Signatureの変更＋ゼロコピーを導入していたものをrevertし、関数Signature無変更+1コピーにしました。これによって、このPRでの差分が最小化されます。DetectedObjectsの1コピーはagnocastの適用効果をわずかに下げますが、readabilityとのトレードオフを鑑みても許容できるものです。
  - **#12773 を併せて取り込んだ理由**: agnocast 有効時には `CMakeLists.txt` のテストビルドが成立しないため、upstream で対応済みのテスト無効化を取り込みました。これにより agnocast ビルドが通るようになります。

## Tests
odaiba-rinkai mapによるrosbagでLSIM動作確認済み。

## agnocast適用全体像
https://tier4.atlassian.net/wiki/spaces/CRL/pages/5280465670/perception+nodes