### PR TITLE
feat(pid_longitudinal_controller): add optional velocity look-ahead feedback

### DIFF
--- a/control/autoware_pid_longitudinal_controller/config/autoware_pid_longitudinal_controller.param.yaml
+++ b/control/autoware_pid_longitudinal_controller/config/autoware_pid_longitudinal_controller.param.yaml
@@ -35,6 +35,9 @@
     time_threshold_before_pid_integration: 2.0
     ff_scale_min: 0.5
     ff_scale_max: 2.0
+    enable_velocity_lookahead_feedback: true
+    velocity_lookahead_time: 1.0
+    velocity_lookahead_blend_weight: 0.5
     enable_brake_keeping_before_stop: false
     brake_keeping_acc: -0.2
 

--- a/control/autoware_pid_longitudinal_controller/include/autoware/pid_longitudinal_controller/pid_longitudinal_controller.hpp
+++ b/control/autoware_pid_longitudinal_controller/include/autoware/pid_longitudinal_controller/pid_longitudinal_controller.hpp
@@ -182,6 +182,9 @@ private:
   double m_time_threshold_before_pid_integrate;
   double m_ff_scale_min{0.5};
   double m_ff_scale_max{2.0};
+  bool m_enable_velocity_lookahead_feedback{true};
+  double m_velocity_lookahead_time{1.0};
+  double m_velocity_lookahead_blend_weight{0.5};
   bool m_enable_brake_keeping_before_stop;
   double m_brake_keeping_acc;
 

--- a/control/autoware_pid_longitudinal_controller/schema/autoware_pid_longitudinal_controller.schema.json
+++ b/control/autoware_pid_longitudinal_controller/schema/autoware_pid_longitudinal_controller.schema.json
@@ -156,6 +156,21 @@
           "description": "maximum clamp value for feedforward scaling",
           "default": "2.0"
         },
+        "enable_velocity_lookahead_feedback": {
+          "type": "boolean",
+          "description": "flag to use look-ahead velocity feedback blending instead of PID+feedforward",
+          "default": "true"
+        },
+        "velocity_lookahead_time": {
+          "type": "number",
+          "description": "look-ahead horizon for velocity feedback [s]",
+          "default": "1.0"
+        },
+        "velocity_lookahead_blend_weight": {
+          "type": "number",
+          "description": "blend weight for look-ahead velocity feedback (0.0-1.0, larger prioritizes velocity connection)",
+          "default": "0.5"
+        },
         "enable_brake_keeping_before_stop": {
           "type": "boolean",
           "description": "flag to keep a certain acceleration during DRIVE state before the ego stops. See [Brake keeping]",
@@ -341,6 +356,9 @@
         "enable_integration_at_low_speed",
         "current_vel_threshold_pid_integration",
         "time_threshold_before_pid_integration",
+        "enable_velocity_lookahead_feedback",
+        "velocity_lookahead_time",
+        "velocity_lookahead_blend_weight",
         "enable_brake_keeping_before_stop",
         "brake_keeping_acc",
         "smooth_stop_max_strong_acc",

--- a/control/autoware_pid_longitudinal_controller/src/pid_longitudinal_controller.cpp
+++ b/control/autoware_pid_longitudinal_controller/src/pid_longitudinal_controller.cpp
@@ -1277,14 +1277,14 @@ double PidLongitudinalController::applyVelocityFeedback(const ControlData & cont
     const double error_vel_filtered = m_lpf_vel_error->filter(diff_vel);
 
     const double a_connect = error_vel_filtered / dt_target;
-    
 
     double target_acc = target_motion.acc;
 
     // Detect stopped points, on the trajectory they have acceleration 0 based on the speed diff,
     // but we still need deacceleration to enter stop.
-    if ( abs(target_motion.vel) < m_state_transition_params.stopped_state_entry_vel &&
-              target_motion.acc < m_state_transition_params.stopped_state_entry_acc ) {
+    if (
+      abs(target_motion.vel) < m_state_transition_params.stopped_state_entry_vel &&
+      target_motion.acc < m_state_transition_params.stopped_state_entry_acc) {
       target_acc = m_stopped_state_params.acc;
     }
 

--- a/control/autoware_pid_longitudinal_controller/src/pid_longitudinal_controller.cpp
+++ b/control/autoware_pid_longitudinal_controller/src/pid_longitudinal_controller.cpp
@@ -129,6 +129,12 @@ PidLongitudinalController::PidLongitudinalController(
     m_ff_scale_min = node.declare_parameter<double>("ff_scale_min");
     m_ff_scale_max = node.declare_parameter<double>("ff_scale_max");
 
+    m_enable_velocity_lookahead_feedback =
+      node.declare_parameter<bool>("enable_velocity_lookahead_feedback");
+    m_velocity_lookahead_time = node.declare_parameter<double>("velocity_lookahead_time");  // [s]
+    m_velocity_lookahead_blend_weight =
+      node.declare_parameter<double>("velocity_lookahead_blend_weight");  // [-]
+
     m_enable_brake_keeping_before_stop =
       node.declare_parameter<bool>("enable_brake_keeping_before_stop");         // [-]
     m_brake_keeping_acc = node.declare_parameter<double>("brake_keeping_acc");  // [m/s^2]
@@ -346,6 +352,8 @@ rcl_interfaces::msg::SetParametersResult PidLongitudinalController::paramCallbac
     update_param("time_threshold_before_pid_integration", m_time_threshold_before_pid_integrate);
     update_param("ff_scale_min", m_ff_scale_min);
     update_param("ff_scale_max", m_ff_scale_max);
+    update_param("velocity_lookahead_time", m_velocity_lookahead_time);
+    update_param("velocity_lookahead_blend_weight", m_velocity_lookahead_blend_weight);
   }
 
   // stopping state
@@ -1230,7 +1238,50 @@ double PidLongitudinalController::applyVelocityFeedback(const ControlData & cont
   const double vel_sign = (control_data.shift == Shift::Forward)
                             ? 1.0
                             : (control_data.shift == Shift::Reverse ? -1.0 : 0.0);
+
   const double current_vel = control_data.current_motion.vel;
+
+  if (m_enable_velocity_lookahead_feedback) {
+    const double dt_target = m_velocity_lookahead_time;
+    const double w = m_velocity_lookahead_blend_weight;
+
+    const double current_vel_abs = std::max(std::abs(current_vel), 0.1);
+    const double lookahead_distance = current_vel_abs * dt_target;
+
+    size_t future_idx = control_data.target_idx;
+    double accumulated_dist = 0.0;
+
+    for (size_t i = control_data.target_idx; i + 1 < control_data.interpolated_traj.points.size();
+         ++i) {
+      const auto & p0 = control_data.interpolated_traj.points.at(i).pose.position;
+      const auto & p1 = control_data.interpolated_traj.points.at(i + 1).pose.position;
+
+      const double dx = p1.x - p0.x;
+      const double dy = p1.y - p0.y;
+      const double dz = p1.z - p0.z;
+      const double ds = std::sqrt(dx * dx + dy * dy + dz * dz);
+
+      accumulated_dist += ds;
+      future_idx = i + 1;
+
+      if (accumulated_dist >= lookahead_distance) {
+        break;
+      }
+    }
+
+    const auto target_motion = Motion{
+      control_data.interpolated_traj.points.at(future_idx).longitudinal_velocity_mps,
+      control_data.interpolated_traj.points.at(future_idx).acceleration_mps2};
+
+    const double diff_vel = (target_motion.vel - current_vel) * vel_sign;
+    const double error_vel_filtered = m_lpf_vel_error->filter(diff_vel);
+
+    const double a_connect = error_vel_filtered / dt_target;
+    const double target_acc = target_motion.acc;
+
+    return w * a_connect + (1.0 - w) * target_acc;
+  }
+
   const auto target_motion = Motion{
     control_data.interpolated_traj.points.at(control_data.target_idx).longitudinal_velocity_mps,
     control_data.interpolated_traj.points.at(control_data.target_idx).acceleration_mps2};

--- a/control/autoware_pid_longitudinal_controller/src/pid_longitudinal_controller.cpp
+++ b/control/autoware_pid_longitudinal_controller/src/pid_longitudinal_controller.cpp
@@ -1277,9 +1277,19 @@ double PidLongitudinalController::applyVelocityFeedback(const ControlData & cont
     const double error_vel_filtered = m_lpf_vel_error->filter(diff_vel);
 
     const double a_connect = error_vel_filtered / dt_target;
-    const double target_acc = target_motion.acc;
+    
 
-    return w * a_connect + (1.0 - w) * target_acc;
+    double target_acc = target_motion.acc;
+
+    // Detect stopped points, on the trajectory they have acceleration 0 based on the speed diff,
+    // but we still need deacceleration to enter stop.
+    if ( abs(target_motion.vel) < m_state_transition_params.stopped_state_entry_vel &&
+              target_motion.acc < m_state_transition_params.stopped_state_entry_acc ) {
+      target_acc = m_stopped_state_params.acc;
+    }
+
+    const double feedback_acc = w * a_connect + (1.0 - w) * target_acc;
+    return feedback_acc;
   }
 
   const auto target_motion = Motion{


### PR DESCRIPTION
## Description

Add an optional velocity feedback mode to `autoware_pid_longitudinal_controller` that improves trajectory velocity tracking for time-based / neural-net planner outputs, while preserving the original PID + feedforward behavior behind a parameter toggle.

### Background

The original `applyVelocityFeedback()` uses PID on velocity error plus scaled trajectory acceleration feedforward at `target_idx`. For planners that emit dense temporal trajectories, tracking only the immediate target point can lag behind the intended velocity profile.

The new **look-ahead** mode walks forward along the interpolated trajectory from `target_idx` by `|v| × velocity_lookahead_time`, then blends:
- a connection acceleration derived from filtered velocity error, and
- the acceleration at the look-ahead point.

When disabled, the controller falls back to the existing PID + FF path unchanged (including integration gating and debug outputs).

### Stopping-case handling (commit 2)

Planner trajectories often mark stop points with near-zero velocity and `acceleration_mps2 ≈ 0` (derived from velocity differences). In look-ahead mode, blindly using that feedforward acceleration prevents the vehicle from decelerating into a stop.

The follow-up change detects when the look-ahead point is effectively a stop point:
- `|target_vel| < stopped_state_entry_vel` (default `0.01` m/s), and
- `target_acc < stopped_state_entry_acc` (default `0.1` m/s²),

and overrides the feedforward term with `stopped_acc` (default `-3.4` m/s²) — the same deceleration used in the STOPPED state — before blending with `a_connect`. No new parameters were added; existing state-transition and stopped-state thresholds are reused.

### New parameters

| Parameter | Type | Default | Description |
|-----------|------|---------|-------------|
| `enable_velocity_lookahead_feedback` | bool | `true` | Enable look-ahead blending; `false` restores original PID+FF |
| `velocity_lookahead_time` | double | `1.0` [s] | Look-ahead horizon |
| `velocity_lookahead_blend_weight` | double | `0.5` | Blend weight (0–1; larger prioritizes velocity connection) |

`velocity_lookahead_time` and `velocity_lookahead_blend_weight` are hot-reloadable via `paramCallback`. The enable flag is read at startup (consistent with other `enable_*` flags in this package).

## Related links

- Companion launcher PR: https://github.com/tier4/autoware_launch.x2/pull/2471

## How was this PR tested?

- [x] `colcon build --packages-select autoware_pid_longitudinal_controller` — passed
- [x] Planning simulator validation (manual): compare look-ahead vs PID mode via `enable_velocity_lookahead_feedback`
- [x] Planning simulator validation (manual): verify deceleration into stop points with look-ahead enabled

## Notes for reviewers

- Look-ahead path intentionally does **not** clamp acceleration inside `applyVelocityFeedback()`; downstream limits in `calcCtrlCmd()` remain unchanged for both modes.
- PID gains (`kp`, `ki`, `kd`, `ff_scale_*`) are only used when look-ahead is disabled.
- Stop-point override only applies inside the look-ahead branch; the original PID+FF path is unchanged.

## Interface changes

### ROS Parameter Changes

#### Additions

| Change type | Parameter Name | Type | Default Value | Description |
|:------------|:---------------|:-----|:--------------|:------------|
| Added | `enable_velocity_lookahead_feedback` | `bool` | `true` | Toggle look-ahead vs original PID+FF velocity feedback |
| Added | `velocity_lookahead_time` | `double` | `1.0` | Look-ahead horizon [s] |
| Added | `velocity_lookahead_blend_weight` | `double` | `0.5` | Blend weight for look-ahead feedback (0–1) |

## Effects on system behavior

When `enable_velocity_lookahead_feedback` is `true` (default), longitudinal acceleration commands in DRIVE state use the look-ahead blend instead of PID+FF. Set to `false` to restore prior Autoware behavior.

With look-ahead enabled, approaching trajectory stop points now applies `stopped_acc` feedforward when the look-ahead target is classified as stopped, improving deceleration into full stops without relying on the state machine to transition to STOPPED first.