### PR TITLE
feat(trajectory_modifier): improve obstacle stop crossing object assessment

### DIFF
--- a/planning/autoware_minimum_rule_based_planner/plugins/obstacle_stop.cpp
+++ b/planning/autoware_minimum_rule_based_planner/plugins/obstacle_stop.cpp
@@ -156,7 +156,7 @@ std::optional<CollisionPoint> ObstacleStop::check_predicted_objects(
 
   object_filter_->filter_objects(predicted_objects);
   object_filter_->filter_by_target_area(
-    predicted_objects, traj_points, debug_data_.trajectory_shape.polygon,
+    predicted_objects, traj_points, vehicle_info_, debug_data_.trajectory_shape.polygon,
     debug_data_.target_polygons);
 
   autoware_perception_msgs::msg::PredictedObject colliding_object;

--- a/planning/autoware_trajectory_modifier/README.md
+++ b/planning/autoware_trajectory_modifier/README.md
@@ -38,8 +38,18 @@ Both conditions are individually enabled or disabled via parameters, allowing fi
 The Obstacle Stop plugin serves as a deterministic safety shield operating independently of the generative model to:
 
 - **Enforce Longitudinal Safety**: Monitors the gap to dynamic and static obstacles to ensure a safe distance is maintained under all kinematic conditions.
-- **Ensure Definitive Stopping**: Guarantees zero-velocity set-points for stationary objects (e.g., traffic lights, stopped vehicles) to prevent "creeping" or oscillating behavior near obstacles.
-- **Provide Predictable Deceleration**: Standardizes the vehicle’s stopping profile to ensure consistent, comfortable, and physically guaranteed deceleration regardless of the AI's intended path.
+- **Ensure Definitive Stopping For Obstacles**: Guarantees zero-velocity set-points for stationary objects (e.g., traffic lights, stopped vehicles) to prevent "creeping" or oscillating behavior near obstacles.
+
+#### Traffic Light Stop
+
+The Traffic Light Stop plugin serves as a deterministic safety shield operating independently of the generative model to:
+
+- **Enforce Traffic Rules Compliance**: Monitors DP trajectory behavior near RED/AMBER traffic lights to ensure ego does not violate traffic rules.
+- **Ensure Definitive Stopping For Mandatory Stops**: Guarantees zero-velocity set-points for RED/AMBER lights to prevent violating mandatory stops or overshooting road stop lines.
+
+#### Velocity Modifier
+
+The Velocity Modifier plugins is responsible for ensuring the velocity profile is smooth and feasible, and adjusts the velocity profile if an anomaly is detected while respecting deceleration and jerk constraints.
 
 ## Dependencies
 

--- a/planning/autoware_trajectory_modifier/config/trajectory_modifier.param.yaml
+++ b/planning/autoware_trajectory_modifier/config/trajectory_modifier.param.yaml
@@ -32,12 +32,12 @@
       enable_stop_for_objects: true
       enable_stop_for_pointcloud: false
       stop_margin: 6.0 # [m]
-      lateral_margin: 0.0     # lateral margin on top of ego width from trajectory to consider for obstacle stop [m]
+      lateral_margin: 0.2     # lateral margin on top of ego width from trajectory to consider for obstacle stop [m]
       duplicate_check_threshold: 0.5 # threshold to check if the stop point is already in the trajectory [m]
 
       obstacle_tracking:
         on_time_buffer: 0.5
-        off_time_buffer: 1.0
+        off_time_buffer: 0.7
         object_distance_th: 1.0 # [m]
         object_yaw_th: 0.1745 # [rad] (10 degrees)
         pcd_distance_th: 1.0 # [m]
@@ -45,10 +45,10 @@
 
       objects:
         object_types: ["car", "truck", "bus", "trailer", "motorcycle", "bicycle", "pedestrian"] # object types to consider for obstacle stop
-        max_velocity_th: 5.0      # maximum velocity threshold for target object [m/s]
-        stopped_velocity_th: 0.4 # [m/s]
+        max_velocity_th: 3.0      # maximum velocity threshold for target object [m/s]
+        stopped_velocity_th: 0.3 # [m/s]
         max_lateral_velocity_th: 1.0 # [m/s] max lateral velocity (w.r.t ego traj) to consider for obstacle stop
-        safety_buffer: 0.0 # [m] safety buffer to expand object shape
+        safety_buffer: 0.1 # [m] safety buffer to expand object shape
 
       pointcloud:
         height_buffer: 0.5  # height buffer to add above ego height [m]
@@ -71,19 +71,19 @@
           truck: 1.5
           bus: 1.5
           trailer: 1.5
-          motorcycle: 3.0
-          bicycle: 5.0
+          motorcycle: 2.0
+          bicycle: 3.0
           pedestrian: 5.0
-        ego_decel: 2.0 # [m/s^2]
-        reaction_time: 0.4 # [s]
-        safety_margin: 2.5 # [m]
+        ego_decel: 2.5 # [m/s^2]
+        reaction_time: 0.2 # [s]
+        safety_margin: 2.0 # [m]
         lookahead_horizon: 1.5 # [s]
 
     # Traffic Light Stop Plugin Parameters
     traffic_light_stop:
       stop_margin: 0.75 # [m]
       stop_for_red_light: true
-      stop_for_amber_light: true
+      stop_for_amber_light: false
       treat_amber_light_as_red: false
       overshoot_tolerance: 0.0 # [m]
       th_stable_duration_red: 0.2 # [s]

--- a/planning/autoware_trajectory_modifier/include/autoware/trajectory_modifier/trajectory_modifier_utils/obstacle_stop_utils.hpp
+++ b/planning/autoware_trajectory_modifier/include/autoware/trajectory_modifier/trajectory_modifier_utils/obstacle_stop_utils.hpp
@@ -286,6 +286,7 @@ struct ObjectFilter
    */
   void filter_by_target_area(
     PredictedObjects & objects, const TrajectoryPoints & trajectory_points,
+    const autoware::vehicle_info_utils::VehicleInfo & vehicle_info,
     const MultiPolygon2d & target_area, MultiPolygon2d & target_polygons);
 
   /**

--- a/planning/autoware_trajectory_modifier/include/autoware/trajectory_modifier/trajectory_modifier_utils/obstacle_stop_utils.hpp
+++ b/planning/autoware_trajectory_modifier/include/autoware/trajectory_modifier/trajectory_modifier_utils/obstacle_stop_utils.hpp
@@ -91,14 +91,16 @@ struct CollisionPoint
   double arc_length;
   rclcpp::Time start_time;
   bool is_active{false};
+  bool is_dynamic{false};
 
   /**
    * @brief Construct a collision sample from a point and its arc length along the reference path.
    * @param point Collision position in map frame.
    * @param arc_length Signed arc length from the start of the trajectory to the collision point.
+   * @param is_dynamic Whether this collision is dynamic.
    */
-  CollisionPoint(const geometry_msgs::msg::Point & point, const double arc_length)
-  : point(point), arc_length(arc_length)
+  CollisionPoint(const geometry_msgs::msg::Point & point, const double arc_length, const bool is_dynamic = false)
+  : point(point), arc_length(arc_length), is_dynamic(is_dynamic)
   {
   }
 
@@ -113,7 +115,8 @@ struct CollisionPoint
   : point(collision_point.point),
     arc_length(collision_point.arc_length),
     start_time(start_time),
-    is_active(active)
+    is_active(active),
+    is_dynamic(collision_point.is_dynamic)
   {
   }
 };

--- a/planning/autoware_trajectory_modifier/include/autoware/trajectory_modifier/trajectory_modifier_utils/obstacle_stop_utils.hpp
+++ b/planning/autoware_trajectory_modifier/include/autoware/trajectory_modifier/trajectory_modifier_utils/obstacle_stop_utils.hpp
@@ -99,7 +99,8 @@ struct CollisionPoint
    * @param arc_length Signed arc length from the start of the trajectory to the collision point.
    * @param is_dynamic Whether this collision is dynamic.
    */
-  CollisionPoint(const geometry_msgs::msg::Point & point, const double arc_length, const bool is_dynamic = false)
+  CollisionPoint(
+    const geometry_msgs::msg::Point & point, const double arc_length, const bool is_dynamic = false)
   : point(point), arc_length(arc_length), is_dynamic(is_dynamic)
   {
   }

--- a/planning/autoware_trajectory_modifier/src/trajectory_modifier_plugins/obstacle_stop.cpp
+++ b/planning/autoware_trajectory_modifier/src/trajectory_modifier_plugins/obstacle_stop.cpp
@@ -434,7 +434,8 @@ void ObstacleStop::publish_debug_string(bool is_safe) const
   if (nearest_collision_point_) {
     ss << "\t\t" << "DISTANCE TO COLLISION: " << nearest_collision_point_->arc_length << " m"
        << "\n";
-    ss << "\t\t" << "OBSTACLE TYPE: " << (nearest_collision_point_->is_dynamic ? "DYNAMIC" : "STATIC")
+    ss << "\t\t"
+       << "OBSTACLE TYPE: " << (nearest_collision_point_->is_dynamic ? "DYNAMIC" : "STATIC")
        << "\n";
   }
 

--- a/planning/autoware_trajectory_modifier/src/trajectory_modifier_plugins/obstacle_stop.cpp
+++ b/planning/autoware_trajectory_modifier/src/trajectory_modifier_plugins/obstacle_stop.cpp
@@ -321,7 +321,8 @@ std::optional<CollisionPoint> ObstacleStop::check_predicted_objects(
     debug_data_.filtered_objects, active_objects, get_clock()->now());
 
   object_filter_->filter_by_target_area(
-    active_objects, traj_points, debug_data_.trajectory_shape.polygon, debug_data_.target_polygons);
+    active_objects, traj_points, context_->vehicle_info, debug_data_.trajectory_shape.polygon,
+    debug_data_.target_polygons);
 
   autoware_perception_msgs::msg::PredictedObject colliding_object;
   auto collision_point = get_nearest_object_collision(

--- a/planning/autoware_trajectory_modifier/src/trajectory_modifier_plugins/obstacle_stop.cpp
+++ b/planning/autoware_trajectory_modifier/src/trajectory_modifier_plugins/obstacle_stop.cpp
@@ -434,6 +434,8 @@ void ObstacleStop::publish_debug_string(bool is_safe) const
   if (nearest_collision_point_) {
     ss << "\t\t" << "DISTANCE TO COLLISION: " << nearest_collision_point_->arc_length << " m"
        << "\n";
+    ss << "\t\t" << "OBSTACLE TYPE: " << (nearest_collision_point_->is_dynamic ? "DYNAMIC" : "STATIC")
+       << "\n";
   }
 
   StringStamped string_stamp;

--- a/planning/autoware_trajectory_modifier/src/trajectory_modifier_utils/obstacle_stop_utils.cpp
+++ b/planning/autoware_trajectory_modifier/src/trajectory_modifier_utils/obstacle_stop_utils.cpp
@@ -505,7 +505,7 @@ void ObjectFilter::filter_by_target_area(
   const MultiPolygon2d & target_area, MultiPolygon2d & target_polygons)
 {
   const auto ego_front_offset = vehicle_info.max_longitudinal_offset_m;
-  constexpr double time_buffer = 1.0;
+  constexpr double time_buffer = 0.5;
   auto time_to_obj_current_pos =
     [&](const auto & object_pose, const size_t nearest_seg_idx) -> double {
     const auto t_to_nearest_seg =

--- a/planning/autoware_trajectory_modifier/src/trajectory_modifier_utils/obstacle_stop_utils.cpp
+++ b/planning/autoware_trajectory_modifier/src/trajectory_modifier_utils/obstacle_stop_utils.cpp
@@ -474,8 +474,10 @@ void PointCloudFilter::filter_pointcloud_by_object(
 
 void ObjectFilter::filter_by_target_area(
   PredictedObjects & objects, const TrajectoryPoints & trajectory_points,
+  const autoware::vehicle_info_utils::VehicleInfo & vehicle_info,
   const MultiPolygon2d & target_area, MultiPolygon2d & target_polygons)
 {
+  const auto ego_front_offset = vehicle_info.max_longitudinal_offset_m;
   constexpr double time_buffer = 1.0;
   auto time_to_obj_current_pos =
     [&](const auto & object_pose, const size_t nearest_seg_idx) -> double {
@@ -485,8 +487,10 @@ void ObjectFilter::filter_by_target_area(
     const auto lon_offset_dist =
       motion_utils::calcSignedArcLength(trajectory_points, nearest_seg_idx, object_pose.position);
     const auto nearest_seg_vel = trajectory_points.at(nearest_seg_idx).longitudinal_velocity_mps;
-    const auto t_to_obj = t_to_nearest_seg + lon_offset_dist / nearest_seg_vel;
-    return t_to_obj - time_buffer;
+    const auto ego_front_time_offset = ego_front_offset / nearest_seg_vel;
+    const auto t_to_obj =
+      t_to_nearest_seg + (lon_offset_dist / nearest_seg_vel) - ego_front_time_offset - time_buffer;
+    return std::max(0.0, t_to_obj);
   };
 
   auto get_object_polygon = [&](const auto & pose, const auto & shape) {

--- a/planning/autoware_trajectory_modifier/src/trajectory_modifier_utils/obstacle_stop_utils.cpp
+++ b/planning/autoware_trajectory_modifier/src/trajectory_modifier_utils/obstacle_stop_utils.cpp
@@ -19,6 +19,7 @@
 #include <autoware/motion_utils/trajectory/trajectory.hpp>
 #include <autoware_utils/geometry/boost_polygon_utils.hpp>
 #include <autoware_utils/transform/transforms.hpp>
+#include <autoware_utils_geometry/geometry.hpp>
 #include <range/v3/view.hpp>
 
 #include <boost/geometry.hpp>
@@ -265,17 +266,40 @@ std::optional<CollisionPoint> get_nearest_object_collision(
   return CollisionPoint(nearest_collision_point, min_arc_length);
 }
 
+geometry_msgs::msg::Pose extrapolate_object_pose_from_kinematics(
+  const PredictedObject & object, const double t)
+{
+  const auto & initial_pose = object.kinematics.initial_pose_with_covariance.pose;
+  if (t <= 0.0) return initial_pose;
+
+  const auto obj_vel = object.kinematics.initial_twist_with_covariance.twist.linear.x;
+  const auto obj_accel = object.kinematics.initial_acceleration_with_covariance.accel.linear.x;
+  const auto dist = obj_vel * t + 0.5 * obj_accel * t * t;
+  return autoware_utils::calc_offset_pose(initial_pose, dist, 0, 0);
+}
+
 geometry_msgs::msg::Pose get_predicted_obj_pose_at_time(
   const PredictedObject & object, const double t)
 {
-  if (object.kinematics.predicted_paths.empty())
-    return object.kinematics.initial_pose_with_covariance.pose;
+  if (object.kinematics.predicted_paths.empty()) {
+    return extrapolate_object_pose_from_kinematics(object, t);
+  }
+
   const auto & pred_path = object.kinematics.predicted_paths.front();
-  if (pred_path.path.empty()) return object.kinematics.initial_pose_with_covariance.pose;
+  if (pred_path.path.size() < 2) {
+    return extrapolate_object_pose_from_kinematics(object, t);
+  }
+
   const auto dt = std::max(rclcpp::Duration(pred_path.time_step).seconds(), 1e-3);
-  size_t pred_pose_index = (t + 1e-6) / dt;
-  pred_pose_index = std::min(pred_pose_index, pred_path.path.size() - 1);
-  return pred_path.path.at(pred_pose_index);
+  const double max_time = dt * static_cast<double>(pred_path.path.size() - 1);
+  const double clamped_t = std::clamp(t, 0.0, max_time);
+
+  const auto index = static_cast<size_t>(std::floor(clamped_t / dt));
+  const size_t next_index = std::min(index + 1, pred_path.path.size() - 1);
+  const double ratio = (clamped_t - static_cast<double>(index) * dt) / dt;
+
+  return autoware_utils_geometry::calc_interpolated_pose(
+    pred_path.path.at(index), pred_path.path.at(next_index), ratio, false);
 }
 
 ObjectState get_object_state_at_time(
@@ -372,7 +396,8 @@ std::optional<CollisionPoint> get_nearest_object_collision(
       curr_arc_length += autoware_utils::calc_distance2d(last_p, traj_p.pose.position);
       const auto target_ego_vel = traj_p.longitudinal_velocity_mps;
       const auto obj_state = get_object_state_at_time(trajectory_points, object, t);
-      const auto [safe, dynamic] = is_safe(object, obj_state.arc_length, obj_state.lon_vel, curr_arc_length, target_ego_vel);
+      const auto [safe, dynamic] =
+        is_safe(object, obj_state.arc_length, obj_state.lon_vel, curr_arc_length, target_ego_vel);
       if (safe) continue;
       found_collision = true;
       if (obj_state.arc_length < min_obj_arc_length) {
@@ -485,7 +510,6 @@ void ObjectFilter::filter_by_target_area(
     [&](const auto & object_pose, const size_t nearest_seg_idx) -> double {
     const auto t_to_nearest_seg =
       rclcpp::Duration(trajectory_points.at(nearest_seg_idx).time_from_start).seconds();
-    if (nearest_seg_idx < trajectory_points.size() - 2) return t_to_nearest_seg - time_buffer;
     const auto lon_offset_dist =
       motion_utils::calcSignedArcLength(trajectory_points, nearest_seg_idx, object_pose.position);
     const auto nearest_seg_vel = trajectory_points.at(nearest_seg_idx).longitudinal_velocity_mps;
@@ -515,7 +539,6 @@ void ObjectFilter::filter_by_target_area(
     const auto obj_lon_vel = std::abs(obj_vel_vector.dot(traj_dir));
     const auto obj_lat_vel = std::abs(obj_vel_vector.dot(traj_lat_dir));
     if (obj_lat_vel < max_lateral_velocity_th_ && obj_lat_vel < obj_lon_vel) return false;
-    if (object.kinematics.predicted_paths.empty()) return true;
     const auto t_to_obj_current_pos = time_to_obj_current_pos(object_pose, nearest_seg);
     const auto obj_pred_pose = get_predicted_obj_pose_at_time(object, t_to_obj_current_pos);
     const auto obj_pred_polygon = get_object_polygon(obj_pred_pose, object.shape);

--- a/planning/autoware_trajectory_modifier/src/trajectory_modifier_utils/obstacle_stop_utils.cpp
+++ b/planning/autoware_trajectory_modifier/src/trajectory_modifier_utils/obstacle_stop_utils.cpp
@@ -345,22 +345,23 @@ std::optional<CollisionPoint> get_nearest_object_collision(
 
   auto is_safe = [&](
                    const auto & object, const double obj_arc_length, const double obj_lon_vel,
-                   const double ego_arc_length, const double ego_vel) -> bool {
-    if (object.classification.empty()) return false;
+                   const double ego_arc_length, const double ego_vel) -> std::pair<bool, bool> {
+    if (object.classification.empty()) return {false, false};
     const auto obj_type = classification_to_object_type.at(object.classification.front().label);
-    if (!object_decel_map.count(obj_type)) return false;
+    if (!object_decel_map.count(obj_type)) return {false, false};
     const auto obj_decel = object_decel_map.at(obj_type);
-    if (obj_lon_vel < stopped_vel_th) return false;
+    if (obj_lon_vel < stopped_vel_th) return {false, false};
     const auto safe_dist =
       get_safe_distance(ego_vel, obj_lon_vel, ego_decel, obj_decel, reaction_time, safety_margin);
     const auto ego_front_arc_length = ego_arc_length + ego_front_offset;
     const auto relative_arc_length = std::max(0.0, obj_arc_length - ego_front_arc_length);
-    return relative_arc_length - safe_dist > 1e-3;
+    return {relative_arc_length - safe_dist > 1e-3, true};
   };
 
   auto min_obj_arc_length = std::numeric_limits<double>::max();
   geometry_msgs::msg::Point nearest_collision_point;
   bool found_collision = false;
+  bool is_dynamic_collision = false;
   auto curr_arc_length = 0.0;
 
   for (const auto & object : target_objects.objects) {
@@ -371,13 +372,14 @@ std::optional<CollisionPoint> get_nearest_object_collision(
       curr_arc_length += autoware_utils::calc_distance2d(last_p, traj_p.pose.position);
       const auto target_ego_vel = traj_p.longitudinal_velocity_mps;
       const auto obj_state = get_object_state_at_time(trajectory_points, object, t);
-      if (is_safe(object, obj_state.arc_length, obj_state.lon_vel, curr_arc_length, target_ego_vel))
-        continue;
+      const auto [safe, dynamic] = is_safe(object, obj_state.arc_length, obj_state.lon_vel, curr_arc_length, target_ego_vel);
+      if (safe) continue;
       found_collision = true;
       if (obj_state.arc_length < min_obj_arc_length) {
         min_obj_arc_length = obj_state.arc_length;
         colliding_object = object;
         nearest_collision_point = obj_state.nearest_point;
+        is_dynamic_collision = dynamic;
       }
       last_p = traj_p.pose.position;
       break;
@@ -385,7 +387,7 @@ std::optional<CollisionPoint> get_nearest_object_collision(
   }
 
   if (!found_collision) return std::nullopt;
-  return CollisionPoint(nearest_collision_point, min_obj_arc_length);
+  return CollisionPoint(nearest_collision_point, min_obj_arc_length, is_dynamic_collision);
 }
 
 void PointCloudFilter::filter_pointcloud(

--- a/planning/autoware_trajectory_modifier/tests/test_obstacle_stop_integration.cpp
+++ b/planning/autoware_trajectory_modifier/tests/test_obstacle_stop_integration.cpp
@@ -344,7 +344,7 @@ TEST_F(ObstacleStopIntegrationTest, TrajectoryModifiedWhenObjectBlocksPath)
 TEST_F(ObstacleStopIntegrationTest, StopPointInsertedBeforeObject)
 {
   // Arrange
-  constexpr double object_x = 20.0;
+  constexpr double object_x = 25.0;
   auto trajectory = create_straight_trajectory(30.0, 8.0);
   const auto car_blocking_path = make_blocking_car(object_x, 0.0);
   const auto input =
@@ -368,7 +368,68 @@ TEST_F(ObstacleStopIntegrationTest, StopPointInsertedBeforeObject)
   EXPECT_NEAR(object_x - trajectory.back().pose.position.x, expected_stop_margin, 0.1);
 }
 
+TEST_F(ObstacleStopIntegrationTest, StopPointInsertedBeforeObject_ReachMaxDecel)
+{
+  // Arrange
+  constexpr double object_x = 20.0;
+  auto trajectory = create_straight_trajectory(30.0, 8.0);
+  const auto car_blocking_path = make_blocking_car(object_x, 0.0);
+  const auto input =
+    create_input_data(make_odometry(0.0, 0.0, 8.0), make_acceleration(0.0), car_blocking_path);
+
+  // Act: obstacle tracker requires `on_time_buffer` of continuous observation
+  //      before becoming active
+  plugin_->modify_trajectory(trajectory, input);
+  std::this_thread::sleep_for(std::chrono::milliseconds(50));
+  const bool modified = plugin_->modify_trajectory(trajectory, input);
+
+  // Assert
+  ASSERT_TRUE(modified);
+  EXPECT_FLOAT_EQ(trajectory.back().longitudinal_velocity_mps, 0.0F);
+  EXPECT_LT(trajectory.back().pose.position.x, object_x);
+
+  const auto expected_stop_margin = 6.96;  // Computed based on max_decel limit and jerk limit
+  EXPECT_NEAR(object_x - trajectory.back().pose.position.x, expected_stop_margin, 0.1);
+}
+
 TEST_F(ObstacleStopIntegrationTest, StopPointInsertedForBlockingPointcloudCluster)
+{
+  // Arrange
+  constexpr double cluster_center_x = 25.0;
+  auto trajectory = create_straight_trajectory(30.0, 8.0);
+  const auto pointcloud_blocking_path =
+    make_blocking_pointcloud_cluster(cluster_center_x, 0.0, 0.7);
+  const auto input = create_input_data(
+    make_odometry(0.0, 0.0, 8.0), make_acceleration(0.0), nullptr, pointcloud_blocking_path);
+
+  // Act: obstacle tracker requires `on_time_buffer` of continuous observation
+  //      before becoming active
+  plugin_->modify_trajectory(trajectory, input);
+  std::this_thread::sleep_for(std::chrono::milliseconds(50));
+  const bool modified = plugin_->modify_trajectory(trajectory, input);
+
+  // Assert
+  ASSERT_TRUE(modified);
+  EXPECT_FLOAT_EQ(trajectory.back().longitudinal_velocity_mps, 0.0F);
+  EXPECT_LT(trajectory.back().pose.position.x, cluster_center_x);
+
+  const auto min_pcd_x = [&pointcloud_blocking_path]() {
+    sensor_msgs::PointCloud2ConstIterator<float> iter_x(*pointcloud_blocking_path, "x");
+    auto min_x = std::numeric_limits<float>::max();
+    for (; iter_x != iter_x.end(); ++iter_x) {
+      if (*iter_x < min_x) {
+        min_x = *iter_x;
+      }
+    }
+    return min_x;
+  }();
+
+  const auto ego_front_offset = context_->vehicle_info.max_longitudinal_offset_m;
+  const auto expected_stop_margin = params_.obstacle_stop.stop_margin + ego_front_offset;
+  EXPECT_NEAR(min_pcd_x - trajectory.back().pose.position.x, expected_stop_margin, 0.1);
+}
+
+TEST_F(ObstacleStopIntegrationTest, StopPointInsertedForBlockingPointcloudCluster_ReachMaxDecel)
 {
   // Arrange
   constexpr double cluster_center_x = 15.0;
@@ -400,7 +461,6 @@ TEST_F(ObstacleStopIntegrationTest, StopPointInsertedForBlockingPointcloudCluste
     return min_x;
   }();
 
-  const auto ego_front_offset = context_->vehicle_info.max_longitudinal_offset_m;
-  const auto expected_stop_margin = params_.obstacle_stop.stop_margin + ego_front_offset;
+  const auto expected_stop_margin = 2.01;  // Computed based on max_decel limit and jerk limit
   EXPECT_NEAR(min_pcd_x - trajectory.back().pose.position.x, expected_stop_margin, 0.1);
 }


### PR DESCRIPTION
This PR applies the following changes to obstacle_stop plugin:
- improve time to object calculation to take into account ego front offset (for crossing object assessment)
- add obstacle type (dynamic or static) to debug string
- improve get_predicted_obj_pose_at_time() to extrapolate obj pose from kinematics if there is no predicted path
- update default parameter values

[Evaluator Result](https://evaluation.tier4.jp/evaluation/reports/1ca6f1e6-b45d-5b73-a80a-25dc749b6bdf/tests/05dc01c5-c673-5162-85c0-95746451c629?project_id=x2_dev)