### PR TITLE
fix(pid_longitudinal_controller): reset temporal phase on trajectory replan

### DIFF
--- a/control/autoware_pid_longitudinal_controller/include/autoware/pid_longitudinal_controller/longitudinal_controller_utils.hpp
+++ b/control/autoware_pid_longitudinal_controller/include/autoware/pid_longitudinal_controller/longitudinal_controller_utils.hpp
@@ -146,7 +146,8 @@ std::pair<TrajectoryPoint, size_t> lerpTrajectoryPointByTime(
  * @param [in] max_yaw nearest-search yaw threshold
  * @param [in] min_time_window_sec lower bound of search window [s]
  * @param [in] max_time_window_sec upper bound of search window [s]
- * @return estimated trajectory time if a candidate exists in the window
+ * @return estimated trajectory time; if the bounded window has no candidates, falls back to the
+ * global spatial nearest point (same behavior as temporal MPC)
  */
 std::optional<double> estimateTrajectoryTimeFromPose(
   const std::vector<TrajectoryPoint> & points, const Pose & pose, const double max_dist,

--- a/control/autoware_pid_longitudinal_controller/include/autoware/pid_longitudinal_controller/pid_longitudinal_controller.hpp
+++ b/control/autoware_pid_longitudinal_controller/include/autoware/pid_longitudinal_controller/pid_longitudinal_controller.hpp
@@ -290,8 +290,11 @@ private:
   /**
    * @brief set reference trajectory with received message
    * @param [in] msg trajectory message
+   * @param [in] current_kinematics current ego odometry used to reset temporal phase on replan
    */
-  void setTrajectory(const autoware_planning_msgs::msg::Trajectory & msg);
+  void setTrajectory(
+    const autoware_planning_msgs::msg::Trajectory & msg,
+    const nav_msgs::msg::Odometry & current_kinematics);
 
   bool isReady(const trajectory_follower::InputData & input_data) override;
 

--- a/control/autoware_pid_longitudinal_controller/src/longitudinal_controller_utils.cpp
+++ b/control/autoware_pid_longitudinal_controller/src/longitudinal_controller_utils.cpp
@@ -261,43 +261,49 @@ std::optional<double> estimateTrajectoryTimeFromPose(
 
   const double min_time_sec = std::min(min_time_window_sec, max_time_window_sec);
   const double max_time_sec = std::max(min_time_window_sec, max_time_window_sec);
-  std::vector<size_t> candidates;
-  candidates.reserve(points.size());
-  for (size_t i = 0; i < points.size(); ++i) {
-    const double t = rclcpp::Duration(points.at(i).time_from_start).seconds();
-    if (min_time_sec <= t && t <= max_time_sec) {
-      candidates.push_back(i);
+  const bool use_bounded_time_window =
+    min_time_sec > -std::numeric_limits<double>::infinity() ||
+    max_time_sec < std::numeric_limits<double>::infinity();
+
+  size_t nearest_index = autoware::motion_utils::findFirstNearestIndexWithSoftConstraints(
+    points, pose, max_dist, max_yaw);
+
+  if (use_bounded_time_window) {
+    std::vector<size_t> candidates;
+    candidates.reserve(points.size());
+    for (size_t i = 0; i < points.size(); ++i) {
+      const double t = rclcpp::Duration(points.at(i).time_from_start).seconds();
+      if (min_time_sec <= t && t <= max_time_sec) {
+        candidates.push_back(i);
+      }
+    }
+    if (!candidates.empty()) {
+      const double self_yaw = tf2::getYaw(pose.orientation);
+      size_t best_relaxed_idx = candidates.front();
+      double best_relaxed_dist2 = std::numeric_limits<double>::max();
+      size_t best_strict_idx = candidates.front();
+      double best_strict_dist2 = std::numeric_limits<double>::max();
+      bool has_strict_candidate = false;
+      for (const auto idx : candidates) {
+        const double dx = points.at(idx).pose.position.x - pose.position.x;
+        const double dy = points.at(idx).pose.position.y - pose.position.y;
+        const double dist2 = dx * dx + dy * dy;
+        if (dist2 < best_relaxed_dist2) {
+          best_relaxed_dist2 = dist2;
+          best_relaxed_idx = idx;
+        }
+
+        const double yaw_error = std::fabs(autoware_utils::normalize_radian(
+          self_yaw - tf2::getYaw(points.at(idx).pose.orientation)));
+        if (std::sqrt(dist2) <= max_dist && yaw_error <= max_yaw && dist2 < best_strict_dist2) {
+          best_strict_dist2 = dist2;
+          best_strict_idx = idx;
+          has_strict_candidate = true;
+        }
+      }
+      nearest_index = has_strict_candidate ? best_strict_idx : best_relaxed_idx;
     }
   }
-  if (candidates.empty()) {
-    return std::nullopt;
-  }
-
-  const double self_yaw = tf2::getYaw(pose.orientation);
-  size_t best_relaxed_idx = candidates.front();
-  double best_relaxed_dist2 = std::numeric_limits<double>::max();
-  size_t best_strict_idx = candidates.front();
-  double best_strict_dist2 = std::numeric_limits<double>::max();
-  bool has_strict_candidate = false;
-  for (const auto idx : candidates) {
-    const double dx = points.at(idx).pose.position.x - pose.position.x;
-    const double dy = points.at(idx).pose.position.y - pose.position.y;
-    const double dist2 = dx * dx + dy * dy;
-    if (dist2 < best_relaxed_dist2) {
-      best_relaxed_dist2 = dist2;
-      best_relaxed_idx = idx;
-    }
-
-    const double yaw_error = std::fabs(
-      autoware_utils::normalize_radian(self_yaw - tf2::getYaw(points.at(idx).pose.orientation)));
-    if (std::sqrt(dist2) <= max_dist && yaw_error <= max_yaw && dist2 < best_strict_dist2) {
-      best_strict_dist2 = dist2;
-      best_strict_idx = idx;
-      has_strict_candidate = true;
-    }
-  }
-
-  const size_t nearest_index = has_strict_candidate ? best_strict_idx : best_relaxed_idx;
   if (points.size() == 1) {
     return rclcpp::Duration(points.front().time_from_start).seconds();
   }

--- a/control/autoware_pid_longitudinal_controller/src/longitudinal_controller_utils.cpp
+++ b/control/autoware_pid_longitudinal_controller/src/longitudinal_controller_utils.cpp
@@ -261,9 +261,8 @@ std::optional<double> estimateTrajectoryTimeFromPose(
 
   const double min_time_sec = std::min(min_time_window_sec, max_time_window_sec);
   const double max_time_sec = std::max(min_time_window_sec, max_time_window_sec);
-  const bool use_bounded_time_window =
-    min_time_sec > -std::numeric_limits<double>::infinity() ||
-    max_time_sec < std::numeric_limits<double>::infinity();
+  const bool use_bounded_time_window = min_time_sec > -std::numeric_limits<double>::infinity() ||
+                                       max_time_sec < std::numeric_limits<double>::infinity();
 
   size_t nearest_index = autoware::motion_utils::findFirstNearestIndexWithSoftConstraints(
     points, pose, max_dist, max_yaw);
@@ -293,8 +292,9 @@ std::optional<double> estimateTrajectoryTimeFromPose(
           best_relaxed_idx = idx;
         }
 
-        const double yaw_error = std::fabs(autoware_utils::normalize_radian(
-          self_yaw - tf2::getYaw(points.at(idx).pose.orientation)));
+        const double yaw_error = std::fabs(
+          autoware_utils::normalize_radian(
+            self_yaw - tf2::getYaw(points.at(idx).pose.orientation)));
         if (std::sqrt(dist2) <= max_dist && yaw_error <= max_yaw && dist2 < best_strict_dist2) {
           best_strict_dist2 = dist2;
           best_strict_idx = idx;

--- a/control/autoware_pid_longitudinal_controller/src/pid_longitudinal_controller.cpp
+++ b/control/autoware_pid_longitudinal_controller/src/pid_longitudinal_controller.cpp
@@ -260,7 +260,9 @@ void PidLongitudinalController::setCurrentOperationMode(const OperationModeState
   m_current_operation_mode = msg;
 }
 
-void PidLongitudinalController::setTrajectory(const autoware_planning_msgs::msg::Trajectory & msg)
+void PidLongitudinalController::setTrajectory(
+  const autoware_planning_msgs::msg::Trajectory & msg,
+  const nav_msgs::msg::Odometry & current_kinematics)
 {
   if (!longitudinal_utils::isValidTrajectory(msg, m_use_temporal_trajectory)) {
     RCLCPP_ERROR_THROTTLE(logger_, *clock_, 3000, "received invalid trajectory. ignore.");
@@ -272,14 +274,30 @@ void PidLongitudinalController::setTrajectory(const autoware_planning_msgs::msg:
     return;
   }
 
+  bool trajectory_stamp_changed = false;
   if (m_use_temporal_trajectory) {
     const rclcpp::Time current_stamp(msg.header.stamp);
+    trajectory_stamp_changed =
+      m_prev_trajectory_stamp.has_value() && current_stamp != *m_prev_trajectory_stamp;
     m_prev_trajectory_stamp = current_stamp;
   } else {
     m_prev_trajectory_stamp.reset();
   }
 
   m_trajectory = msg;
+
+  if (m_use_temporal_trajectory && trajectory_stamp_changed && msg.points.size() >= 2) {
+    const auto spatial_nearest_time = longitudinal_utils::estimateTrajectoryTimeFromPose(
+      msg.points, current_kinematics.pose.pose, m_ego_nearest_dist_threshold,
+      m_ego_nearest_yaw_threshold);
+    if (spatial_nearest_time.has_value()) {
+      // Planner trajectories restart time_from_start near t=0 on each update. Reuse the previous
+      // phase time and getControlData()'s narrow temporal window cannot observe ego near t~0.
+      m_prev_nearest_time = *spatial_nearest_time;
+    } else {
+      m_prev_nearest_time.reset();
+    }
+  }
 }
 
 rcl_interfaces::msg::SetParametersResult PidLongitudinalController::paramCallback(
@@ -435,7 +453,7 @@ trajectory_follower::LongitudinalOutput PidLongitudinalController::run(
   trajectory_follower::InputData const & input_data)
 {
   // set input data
-  setTrajectory(input_data.current_trajectory);
+  setTrajectory(input_data.current_trajectory, input_data.current_odometry);
   setKinematicState(input_data.current_odometry);
   setCurrentAcceleration(input_data.current_accel);
   setCurrentOperationMode(input_data.current_operation_mode);

--- a/control/autoware_pid_longitudinal_controller/test/test_longitudinal_controller_utils.cpp
+++ b/control/autoware_pid_longitudinal_controller/test/test_longitudinal_controller_utils.cpp
@@ -553,6 +553,29 @@ TEST(TestLongitudinalControllerUtils, estimateTrajectoryTimeFromPoseWithinWindow
   EXPECT_LE(*estimated_time, 2.2);
 }
 
+TEST(TestLongitudinalControllerUtils, estimateTrajectoryTimeFromPoseFallsBackToSpatialNearest)
+{
+  using autoware_planning_msgs::msg::TrajectoryPoint;
+  std::vector<TrajectoryPoint> points;
+
+  for (size_t i = 0; i < 4; ++i) {
+    TrajectoryPoint p;
+    p.pose.position.x = static_cast<double>(i);
+    p.pose.orientation.w = 1.0;
+    p.time_from_start = rclcpp::Duration::from_seconds(static_cast<double>(i));
+    points.push_back(p);
+  }
+
+  geometry_msgs::msg::Pose pose;
+  pose.position.x = 0.2;
+  pose.orientation.w = 1.0;
+
+  const auto estimated_time =
+    longitudinal_utils::estimateTrajectoryTimeFromPose(points, pose, 10.0, M_PI, 1.8, 2.2);
+  ASSERT_TRUE(estimated_time.has_value());
+  EXPECT_NEAR(*estimated_time, 0.2, 1e-6);
+}
+
 TEST(TestLongitudinalControllerUtils, estimateLocalTrajectoryTimeStep)
 {
   using autoware_planning_msgs::msg::TrajectoryPoint;

--- a/control/autoware_pid_longitudinal_controller/test/test_longitudinal_controller_utils.cpp
+++ b/control/autoware_pid_longitudinal_controller/test/test_longitudinal_controller_utils.cpp
@@ -570,8 +570,10 @@ TEST(TestLongitudinalControllerUtils, estimateTrajectoryTimeFromPoseFallsBackToS
   pose.position.x = 0.2;
   pose.orientation.w = 1.0;
 
+  // Window must not overlap trajectory times; otherwise index t=2 remains a candidate and the
+  // bounded search (not spatial fallback) returns t=1 after segment interpolation.
   const auto estimated_time =
-    longitudinal_utils::estimateTrajectoryTimeFromPose(points, pose, 10.0, M_PI, 1.8, 2.2);
+    longitudinal_utils::estimateTrajectoryTimeFromPose(points, pose, 10.0, M_PI, 10.0, 11.0);
   ASSERT_TRUE(estimated_time.has_value());
   EXPECT_NEAR(*estimated_time, 0.2, 1e-6);
 }


### PR DESCRIPTION
## Summary

Fixes the same **temporal phase-tracking bug** addressed for lateral MPC in #3050, applied to the PID longitudinal controller. After a planner replan (`header.stamp` change), stale `m_prev_nearest_time` could keep the controller aligned to an old time slice (e.g. ~3 s) while the new trajectory restarts near t=0, causing wrong target velocity/acceleration.

## Related PRs

- https://github.com/tier4/autoware_universe/pull/3050 — MPC lateral: reset `m_prev_nearest_time` from spatial nearest on trajectory stamp change (same root cause, same fix pattern)

## Updates

### `PidLongitudinalController::setTrajectory()`
- Accept current odometry (mirrors MPC `setReferenceTrajectory()`).
- Detect `header.stamp` change via `m_prev_trajectory_stamp`.
- On replan in temporal mode, compute **spatial** nearest time (unbounded window) and set `m_prev_nearest_time`; reset if search fails.

### `estimateTrajectoryTimeFromPose()`
- When the bounded temporal window has **no candidates**, fall back to the **global spatial nearest** point instead of returning `nullopt` (aligned with `MPCUtils::calcNearestPoseInterp()` behavior).
- Enables gradual phase recovery even when the window temporarily misses ego.

### Tests
- Added `estimateTrajectoryTimeFromPoseFallsBackToSpatialNearest` unit test.
- Existing package unit tests pass via `colcon test --packages-select autoware_pid_longitudinal_controller`.

### Files changed (5)
- `pid_longitudinal_controller.cpp` / `.hpp`
- `longitudinal_controller_utils.cpp` / `.hpp`
- `test_longitudinal_controller_utils.cpp`

## Symptom (before fix)

After `setTrajectory()` receives a message with a new `header.stamp`:

| State | Value |
| --- | --- |
| Ego on new plan (spatial) | `t ≈ 0.1 s` |
| `m_prev_nearest_time` (stale) | `t ≈ 3.0 s` |
| Temporal search window | ~`[2.9, 3.3] s` only |
| Points at `t ≈ 0.1 s` | **Excluded from search** |

PID then used `nearest_time ≈ 3 s` for target vel/acc lookup until phase could recover (often never, because observation returned `nullopt` and phase marched forward).

## What this does *not* change

- Spatial trajectory mode unchanged.
- Repeated trajectories with the **same stamp** (e.g. MRM hold) — phase continues to grow naturally along one plan.
- Stop-distance calculation still uses spatial nearest (`calcStopDistance()`).

## Test status

> **Not tested on vehicle or planning simulator yet.**

- [x] Unit tests (`colcon test --packages-select autoware_pid_longitudinal_controller`)
- [ ] Planning simulator / rosbag with `trajectory_reference_mode: "temporal"` and frequent replans
- [ ] After replan: debug `TEMPORAL_FUSED_TIME` stays near ego time (~0 s on new plan)
- [ ] After replan: `TARGET_VEL` / `NEAREST_VEL` no longer jump to a future time slice
- [ ] Vehicle experiment (pending)