### PR TITLE
feat(minimum_rule_based_planner): sync backup planners obstacle stop logic

### DIFF
--- a/planning/autoware_minimum_rule_based_planner/config/minimum_rule_based_planner.param.yaml
+++ b/planning/autoware_minimum_rule_based_planner/config/minimum_rule_based_planner.param.yaml
@@ -35,41 +35,26 @@
       enable: true
       use_objects: true
       use_pointcloud: true
+      enable_stop_for_objects: true
+      enable_stop_for_pointcloud: false
       stop_margin: 6.0
       nominal_stopping_decel: 1.0 # [m/s^2]
       maximum_stopping_decel: 4.0 # [m/s^2]
       stopping_jerk: 3.0 # [m/s^3]
       on_time_buffer: 0.5 # [s]
-      off_time_buffer: 1.0 # [s]
-      lateral_margin: 0.5     # lateral margin on top of ego width from trajectory to consider for obstacle stop [m]
-      longitudinal_margin: 10.0 # longitudinal margin applied to each trajectory-point footprint [m]
+      off_time_buffer: 0.7 # [s]
+      lateral_margin: 0.2     # lateral margin on top of ego width from trajectory to consider for obstacle stop [m]
 
       objects:
         object_types: ["car", "truck", "bus", "trailer", "motorcycle", "bicycle", "pedestrian", "unknown"] # object types to consider for obstacle stop
-        max_velocity_th: 1.0     # maximum velocity threshold for target object [m/s]
-        stopped_velocity_th: 0.25 # velocity threshold for target object to be considered as stopped [m/s]
+        max_velocity_th: 3.0     # maximum velocity threshold for target object [m/s]
+        stopped_velocity_th: 0.3 # velocity threshold for target object to be considered as stopped [m/s]
         max_lateral_velocity_th: 1.0 # maximum lateral velocity threshold for target object [m/s]
-        safety_buffer: 0.0       # safety buffer to expand object shape [m]
-
-      rss_params:
-        enable: true
-        object_decel:
-          car: 1.5
-          truck: 1.5
-          bus: 1.5
-          trailer: 1.5
-          motorcycle: 3.0
-          bicycle: 5.0
-          pedestrian: 5.0
-        ego_decel: 4.0           # [m/s^2]
-        reaction_time: 0.2       # [s]
-        safety_margin: 2.0       # [m]
-        lookahead_horizon: 1.5   # [s]
+        safety_buffer: 0.1       # safety buffer to expand object shape [m]
 
       pointcloud:
         height_buffer: 0.5  # height buffer to add above ego height [m]
         min_height: 0.2  # minimum height of pointcloud [m]
-        detection_range: 100.0 # detection range [m]
         voxel_grid_filter:
           x: 0.2
           y: 0.2
@@ -80,6 +65,21 @@
           min_height: 0.5
           min_size: 10
           max_size: 10000
+
+      rss_params:
+        enable: true
+        object_decel:
+          car: 1.5
+          truck: 1.5
+          bus: 1.5
+          trailer: 1.5
+          motorcycle: 2.0
+          bicycle: 3.0
+          pedestrian: 5.0
+        ego_decel: 2.5           # [m/s^2]
+        reaction_time: 0.2       # [s]
+        safety_margin: 2.0       # [m]
+        lookahead_horizon: 1.5   # [s]
 
     velocity_smoother:
       nearest_dist_threshold_m: 1.5

--- a/planning/autoware_minimum_rule_based_planner/config/minimum_rule_based_planner.param.yaml
+++ b/planning/autoware_minimum_rule_based_planner/config/minimum_rule_based_planner.param.yaml
@@ -44,6 +44,7 @@
       on_time_buffer: 0.5 # [s]
       off_time_buffer: 0.7 # [s]
       lateral_margin: 0.2     # lateral margin on top of ego width from trajectory to consider for obstacle stop [m]
+      arrived_distance_threshold: 0.5 # threshold to check if the ego vehicle has arrived at the stop point [m]
 
       objects:
         object_types: ["car", "truck", "bus", "trailer", "motorcycle", "bicycle", "pedestrian", "unknown"] # object types to consider for obstacle stop

--- a/planning/autoware_minimum_rule_based_planner/param/minimum_rule_based_planner_parameters.yaml
+++ b/planning/autoware_minimum_rule_based_planner/param/minimum_rule_based_planner_parameters.yaml
@@ -110,6 +110,14 @@ minimum_rule_based_planner:
       type: bool
       default_value: true
       description: use pointcloud for obstacle stop
+    enable_stop_for_objects:
+      type: bool
+      default_value: true
+      description: enable stop for objects
+    enable_stop_for_pointcloud:
+      type: bool
+      default_value: false
+      description: enable stop for pointcloud
     stop_margin:
       type: double
       default_value: 6.0
@@ -136,24 +144,26 @@ minimum_rule_based_planner:
       description: time buffer after obstacle stop [s]
     lateral_margin:
       type: double
-      default_value: 0.5
+      default_value: 0.2
       description: lateral margin for obstacle stop [m]
-    longitudinal_margin:
+    arrived_distance_threshold:
       type: double
-      default_value: 10.0
-      description: longitudinal margin applied to each trajectory-point footprint; also acts as a floor on the detection corridor length to prevent chatter as ego decelerates [m]
+      default_value: 0.5
+      description: threshold to check if the ego vehicle has arrived at the stop point [m]
+      validation:
+        bounds<>: [0.0, 10.0]
     objects:
       object_types:
         type: string_array
-        default_value: [car, truck, bus, trailer, motorcycle, bicycle, pedestrian, unknown]
+        default_value: [car, truck, bus, trailer, motorcycle, bicycle, pedestrian]
         description: object types to consider for obstacle stop
       max_velocity_th:
         type: double
-        default_value: 1.0
+        default_value: 3.0
         description: maximum velocity threshold for target object [m/s]
       stopped_velocity_th:
         type: double
-        default_value: 0.25
+        default_value: 0.3
         description: velocity threshold for target object to be considered as stopped [m/s]
       max_lateral_velocity_th:
         type: double
@@ -163,10 +173,73 @@ minimum_rule_based_planner:
           bounds<>: [0.0, 10.0]
       safety_buffer:
         type: double
-        default_value: 0.0
+        default_value: 0.1
         description: safety buffer to expand object shape [m]
         validation:
           bounds<>: [0.0, 10.0]
+    pointcloud:
+      height_buffer:
+        type: double
+        default_value: 0.5
+        description: height buffer to add above ego height [m]
+        validation:
+          bounds<>: [0.0, 10.0]
+      min_height:
+        type: double
+        default_value: 0.2
+        description: minimum height of pointcloud [m]
+        validation:
+          bounds<>: [0.0, 10.0]
+      voxel_grid_filter:
+        x:
+          type: double
+          default_value: 0.2
+          description: x size of voxel grid filter [m]
+          validation:
+            bounds<>: [0.0, 1.0]
+        y:
+          type: double
+          default_value: 0.2
+          description: y size of voxel grid filter [m]
+          validation:
+            bounds<>: [0.0, 1.0]
+        z:
+          type: double
+          default_value: 0.2
+          description: z size of voxel grid filter [m]
+          validation:
+            bounds<>: [0.0, 1.0]
+        min_size:
+          type: int
+          default_value: 3
+          description: minimum size of voxel grid filter
+          validation:
+            bounds<>: [1, 100]
+      clustering:
+        tolerance:
+          type: double
+          default_value: 0.5
+          description: tolerance for clustering [m]
+          validation:
+            bounds<>: [0.0, 1.0]
+        min_height:
+          type: double
+          default_value: 0.5
+          description: minimum height for clustering [m]
+          validation:
+            bounds<>: [0.0, 1.0]
+        min_size:
+          type: int
+          default_value: 10
+          description: minimum size for clustering
+          validation:
+            bounds<>: [1, 100]
+        max_size:
+          type: int
+          default_value: 10000
+          description: maximum size for clustering
+          validation:
+            bounds<>: [1, 10000]
     rss_params:
       enable:
         type: bool
@@ -177,93 +250,68 @@ minimum_rule_based_planner:
           type: double
           default_value: 1.5
           description: deceleration for car type objects [m/s^2]
+          validation:
+            bounds<>: [0.0, 10.0]
         truck:
           type: double
           default_value: 1.5
           description: deceleration for truck type objects [m/s^2]
+          validation:
+            bounds<>: [0.0, 10.0]
         bus:
           type: double
           default_value: 1.5
           description: deceleration for bus type objects [m/s^2]
+          validation:
+            bounds<>: [0.0, 10.0]
         trailer:
           type: double
           default_value: 1.5
           description: deceleration for trailer type objects [m/s^2]
+          validation:
+            bounds<>: [0.0, 10.0]
         motorcycle:
           type: double
-          default_value: 3.0
+          default_value: 2.0
           description: deceleration for motorcycle type objects [m/s^2]
+          validation:
+            bounds<>: [0.0, 10.0]
         bicycle:
           type: double
-          default_value: 5.0
+          default_value: 3.0
           description: deceleration for bicycle type objects [m/s^2]
+          validation:
+            bounds<>: [0.0, 10.0]
         pedestrian:
           type: double
           default_value: 5.0
           description: deceleration for pedestrian type objects [m/s^2]
+          validation:
+            bounds<>: [0.0, 10.0]
       ego_decel:
         type: double
-        default_value: 4.0
+        default_value: 2.5
         description: deceleration for ego vehicle used in RSS calculation [m/s^2]
+        validation:
+          bounds<>: [0.0, 10.0]
       reaction_time:
         type: double
         default_value: 0.2
         description: reaction time used in RSS calculation [s]
+        validation:
+          bounds<>: [0.0, 10.0]
       safety_margin:
         type: double
         default_value: 2.0
         description: safety margin used in RSS calculation [m]
+        validation:
+          bounds<>: [0.0, 10.0]
       lookahead_horizon:
         type: double
         default_value: 1.5
         description: lookahead horizon used in RSS calculation [s]
-    pointcloud:
-      height_buffer:
-        type: double
-        default_value: 0.5
-        description: height buffer to add above ego height [m]
-      min_height:
-        type: double
-        default_value: 0.2
-        description: minimum height of pointcloud [m]
-      detection_range:
-        type: double
-        default_value: 100.0
-        description: detection range [m]
-      voxel_grid_filter:
-        x:
-          type: double
-          default_value: 0.2
-          description: x size of voxel grid filter [m]
-        y:
-          type: double
-          default_value: 0.2
-          description: y size of voxel grid filter [m]
-        z:
-          type: double
-          default_value: 0.2
-          description: z size of voxel grid filter [m]
-        min_size:
-          type: int
-          default_value: 3
-          description: minimum size of voxel grid filter
-      clustering:
-        tolerance:
-          type: double
-          default_value: 0.5
-          description: tolerance for clustering [m]
-        min_height:
-          type: double
-          default_value: 0.5
-          description: minimum height for clustering [m]
-        min_size:
-          type: int
-          default_value: 10
-          description: minimum size for clustering
-        max_size:
-          type: int
-          default_value: 10000
-          description: maximum size for clustering
+        validation:
+          bounds<>: [0.0, 10.0]
 
   debug:
     enable_path:

--- a/planning/autoware_minimum_rule_based_planner/plugins/obstacle_stop.cpp
+++ b/planning/autoware_minimum_rule_based_planner/plugins/obstacle_stop.cpp
@@ -16,6 +16,7 @@
 
 #include <autoware/planning_factor_interface/planning_factor_interface.hpp>
 #include <autoware/trajectory_modifier/trajectory_modifier_utils/obstacle_stop_utils.hpp>
+#include <autoware/trajectory_modifier/trajectory_modifier_utils/utils.hpp>
 #include <autoware_utils/ros/marker_helper.hpp>
 #include <autoware_utils/transform/transforms.hpp>
 #include <tf2_eigen/tf2_eigen.hpp>
@@ -30,6 +31,8 @@
 
 namespace autoware::minimum_rule_based_planner::plugin
 {
+using autoware::trajectory_modifier::utils::clamp_stop_point_arc_length;
+using autoware::trajectory_modifier::utils::insert_stop_point;
 using autoware::trajectory_modifier::utils::obstacle_stop::get_nearest_object_collision;
 using autoware::trajectory_modifier::utils::obstacle_stop::get_nearest_pcd_collision;
 using autoware::trajectory_modifier::utils::obstacle_stop::get_trajectory_shape;
@@ -75,11 +78,6 @@ void ObstacleStop::run(TrajectoryPoints & traj_points)
   if (!detected) return;
   if (!nearest_collision_point_) return;
 
-  RCLCPP_WARN_THROTTLE(
-    get_node_ptr()->get_logger(), *get_clock(), 500,
-    "[Backup Planner ObstacleStop] Detected collision point at arc length %f m",
-    nearest_collision_point_->arc_length);
-
   set_stop_point(traj_points);
 }
 
@@ -91,12 +89,17 @@ bool ObstacleStop::is_obstacle_detected(const TrajectoryPoints & traj_points)
     traj_points, data_->odometry_ptr->pose.pose, vehicle_info_,
     data_->odometry_ptr->twist.twist.linear.x, data_->acceleration_ptr->accel.accel.linear.x,
     params_.nominal_stopping_decel, params_.stopping_jerk, params_.stop_margin,
-    params_.lateral_margin, params_.longitudinal_margin);
+    params_.lateral_margin);
   const auto collision_point_pcd = check_pointcloud(traj_points);
   update_collision_points_buffer(collision_points_buffer_.pcd, traj_points, collision_point_pcd);
   const auto collision_point_objects = check_predicted_objects(traj_points);
   update_collision_points_buffer(
     collision_points_buffer_.objects, traj_points, collision_point_objects);
+
+  const auto nearest_pcd_collision_point =
+    get_nearest_collision_point(collision_points_buffer_.pcd);
+  const auto nearest_objects_collision_point =
+    get_nearest_collision_point(collision_points_buffer_.objects);
 
   const auto make_safety_factor =
     [](const geometry_msgs::msg::Point & point, const SafetyFactor::_type_type type) {
@@ -106,19 +109,42 @@ bool ObstacleStop::is_obstacle_detected(const TrajectoryPoints & traj_points)
       factor.is_safe = false;
       return factor;
     };
-  if (collision_point_objects && debug_data_.colliding_object) {
-    auto factor = make_safety_factor(
-      debug_data_.colliding_object->kinematics.initial_pose_with_covariance.pose.position,
-      SafetyFactor::OBJECT);
-    factor.object_id = debug_data_.colliding_object->object_id;
-    safety_factors_.factors.push_back(factor);
-  }
-  if (collision_point_pcd) {
-    safety_factors_.factors.push_back(
-      make_safety_factor(collision_point_pcd->point, SafetyFactor::POINTCLOUD));
+  if (nearest_objects_collision_point) {
+    RCLCPP_WARN_THROTTLE(
+      get_node_ptr()->get_logger(), *get_clock(), 500,
+      "[Backup Planner ObstacleStop] Detected collision with object at arc length %f m",
+      nearest_objects_collision_point->arc_length);
+    if (debug_data_.colliding_object) {
+      auto factor = make_safety_factor(
+        debug_data_.colliding_object->kinematics.initial_pose_with_covariance.pose.position,
+        SafetyFactor::OBJECT);
+      factor.object_id = debug_data_.colliding_object->object_id;
+      safety_factors_.factors.push_back(factor);
+    }
   }
 
-  nearest_collision_point_ = get_nearest_collision_point();
+  if (nearest_pcd_collision_point) {
+    RCLCPP_WARN_THROTTLE(
+      get_node_ptr()->get_logger(), *get_clock(), 500,
+      "[Backup Planner ObstacleStop] Detected collision with pointcloud at arc length %f m",
+      nearest_pcd_collision_point->arc_length);
+    safety_factors_.factors.push_back(
+      make_safety_factor(nearest_pcd_collision_point->point, SafetyFactor::POINTCLOUD));
+  }
+
+  nearest_collision_point_ = std::invoke([&]() -> std::optional<CollisionPoint> {
+    const auto is_collision_point_pcd =
+      params_.enable_stop_for_pointcloud && nearest_pcd_collision_point;
+    const auto is_collision_point_objects =
+      params_.enable_stop_for_objects && nearest_objects_collision_point;
+    if (!is_collision_point_pcd && !is_collision_point_objects) return std::nullopt;
+    if (!is_collision_point_pcd) return nearest_objects_collision_point.value();
+    if (!is_collision_point_objects) return nearest_pcd_collision_point.value();
+    return nearest_pcd_collision_point->arc_length < nearest_objects_collision_point->arc_length
+             ? nearest_pcd_collision_point.value()
+             : nearest_objects_collision_point.value();
+  });
+
   debug_data_.active_collision_point =
     nearest_collision_point_ ? nearest_collision_point_->point : geometry_msgs::msg::Point();
 
@@ -128,13 +154,31 @@ bool ObstacleStop::is_obstacle_detected(const TrajectoryPoints & traj_points)
 void ObstacleStop::set_stop_point(TrajectoryPoints & traj_points)
 {
   const auto stop_margin = params_.stop_margin + vehicle_info_.max_longitudinal_offset_m;
-  const auto target_stop_point_arc_length =
-    std::max(nearest_collision_point_->arc_length - stop_margin, 0.0);
+  const auto target_stop_point_arc_length = clamp_stop_point_arc_length(
+    nearest_collision_point_->arc_length - stop_margin,
+    debug_data_.trajectory_shape.trajectory_length, data_->odometry_ptr->twist.twist.linear.x,
+    data_->acceleration_ptr->accel.accel.linear.x, params_.nominal_stopping_decel,
+    params_.stopping_jerk);
 
-  const auto stop_index = motion_utils::insertStopPoint(target_stop_point_arc_length, traj_points);
-  if (!stop_index) return;
+  if (!insert_stop_point(
+        traj_points, target_stop_point_arc_length, debug_data_.trajectory_shape.trajectory_length))
+    return;
 
-  const auto & stop_pose = traj_points.at(*stop_index).pose;
+  if (
+    target_stop_point_arc_length < params_.arrived_distance_threshold ||
+    !insert_stop_point(
+      traj_points, target_stop_point_arc_length, debug_data_.trajectory_shape.trajectory_length)) {
+    auto p = traj_points.front();
+    traj_points.clear();
+    p.longitudinal_velocity_mps = 0.0;
+    p.acceleration_mps2 = 0.0;
+    p.time_from_start = rclcpp::Duration::from_seconds(0.0);
+    traj_points.push_back(p);
+    p.time_from_start = rclcpp::Duration::from_seconds(0.1);
+    traj_points.push_back(p);
+  }
+
+  const auto & stop_pose = traj_points.back().pose;
   const auto & ego_pose = data_->odometry_ptr->pose.pose;
   planning_factor_interface_->add(
     traj_points, ego_pose, stop_pose, PlanningFactor::STOP, safety_factors_);
@@ -294,19 +338,14 @@ void ObstacleStop::update_collision_points_buffer(
   }
 }
 
-std::optional<CollisionPoint> ObstacleStop::get_nearest_collision_point() const
+std::optional<CollisionPoint> ObstacleStop::get_nearest_collision_point(
+  const std::vector<CollisionPoint> & collision_points_buffer) const
 {
   std::optional<CollisionPoint> nearest_collision_point = std::nullopt;
-  if (collision_points_buffer_.empty()) return nearest_collision_point;
+  if (collision_points_buffer.empty()) return nearest_collision_point;
 
   auto minimum_arc_length = std::numeric_limits<double>::max();
-  for (const auto & cp : collision_points_buffer_.pcd) {
-    if (cp.is_active > minimum_arc_length || !cp.is_active) continue;
-    nearest_collision_point = cp;
-    minimum_arc_length = cp.arc_length;
-  }
-
-  for (const auto & cp : collision_points_buffer_.objects) {
+  for (const auto & cp : collision_points_buffer) {
     if (cp.is_active > minimum_arc_length || !cp.is_active) continue;
     nearest_collision_point = cp;
     minimum_arc_length = cp.arc_length;

--- a/planning/autoware_minimum_rule_based_planner/plugins/obstacle_stop.hpp
+++ b/planning/autoware_minimum_rule_based_planner/plugins/obstacle_stop.hpp
@@ -127,7 +127,8 @@ private:
     std::vector<CollisionPoint> & collision_points_buffer, const TrajectoryPoints & traj_points,
     const std::optional<CollisionPoint> & collision_point);
 
-  std::optional<CollisionPoint> get_nearest_collision_point() const;
+  std::optional<CollisionPoint> get_nearest_collision_point(
+    const std::vector<CollisionPoint> & collision_points_buffer) const;
 
   void set_stop_point(TrajectoryPoints & traj_points);
 

--- a/planning/autoware_minimum_rule_based_planner/schema/minimum_rule_based_planner.schema.json
+++ b/planning/autoware_minimum_rule_based_planner/schema/minimum_rule_based_planner.schema.json
@@ -220,6 +220,12 @@
               "default": 0.5,
               "minimum": 0.0
             },
+            "arrived_distance_threshold": {
+              "type": "number",
+              "description": "Threshold to check if the ego vehicle has arrived at the stop point [m]",
+              "default": 0.5,
+              "minimum": 0.0
+            },
             "objects": {
               "type": "object",
               "properties": {

--- a/planning/autoware_minimum_rule_based_planner/schema/minimum_rule_based_planner.schema.json
+++ b/planning/autoware_minimum_rule_based_planner/schema/minimum_rule_based_planner.schema.json
@@ -168,6 +168,16 @@
               "description": "Enable pointcloud detection [m]",
               "default": true
             },
+            "enable_stop_for_objects": {
+              "type": "boolean",
+              "description": "Enable stop for objects",
+              "default": true
+            },
+            "enable_stop_for_pointcloud": {
+              "type": "boolean",
+              "description": "Enable stop for pointcloud",
+              "default": false
+            },
             "stop_margin": {
               "type": "number",
               "description": "Stop margin [m]",
@@ -210,12 +220,6 @@
               "default": 0.5,
               "minimum": 0.0
             },
-            "longitudinal_margin": {
-              "type": "number",
-              "description": "Longitudinal margin applied to each trajectory-point footprint; also acts as a floor on the detection corridor length to prevent chatter as ego decelerates [m]",
-              "default": 10.0,
-              "minimum": 0.0
-            },
             "objects": {
               "type": "object",
               "properties": {
@@ -229,8 +233,7 @@
                     "trailer",
                     "motorcycle",
                     "bicycle",
-                    "pedestrian",
-                    "unknown"
+                    "pedestrian"
                   ],
                   "items": {
                     "type": "string"
@@ -261,91 +264,6 @@
                   "default": 0.0,
                   "minimum": 0.0,
                   "maximum": 10.0
-                }
-              },
-              "required": [],
-              "additionalProperties": false
-            },
-            "rss_params": {
-              "type": "object",
-              "properties": {
-                "enable": {
-                  "type": "boolean",
-                  "description": "Enable RSS-based stop logic",
-                  "default": true
-                },
-                "object_decel": {
-                  "type": "object",
-                  "properties": {
-                    "car": {
-                      "type": "number",
-                      "description": "Deceleration for car type objects [m/s^2]",
-                      "default": 1.5,
-                      "minimum": 0.0
-                    },
-                    "truck": {
-                      "type": "number",
-                      "description": "Deceleration for truck type objects [m/s^2]",
-                      "default": 1.5,
-                      "minimum": 0.0
-                    },
-                    "bus": {
-                      "type": "number",
-                      "description": "Deceleration for bus type objects [m/s^2]",
-                      "default": 1.5,
-                      "minimum": 0.0
-                    },
-                    "trailer": {
-                      "type": "number",
-                      "description": "Deceleration for trailer type objects [m/s^2]",
-                      "default": 1.5,
-                      "minimum": 0.0
-                    },
-                    "motorcycle": {
-                      "type": "number",
-                      "description": "Deceleration for motorcycle type objects [m/s^2]",
-                      "default": 3.0,
-                      "minimum": 0.0
-                    },
-                    "bicycle": {
-                      "type": "number",
-                      "description": "Deceleration for bicycle type objects [m/s^2]",
-                      "default": 5.0,
-                      "minimum": 0.0
-                    },
-                    "pedestrian": {
-                      "type": "number",
-                      "description": "Deceleration for pedestrian type objects [m/s^2]",
-                      "default": 5.0,
-                      "minimum": 0.0
-                    }
-                  },
-                  "required": [],
-                  "additionalProperties": false
-                },
-                "ego_decel": {
-                  "type": "number",
-                  "description": "Deceleration for ego vehicle used in RSS calculation [m/s^2]",
-                  "default": 4.0,
-                  "minimum": 0.0
-                },
-                "reaction_time": {
-                  "type": "number",
-                  "description": "Reaction time used in RSS calculation [s]",
-                  "default": 0.2,
-                  "minimum": 0.0
-                },
-                "safety_margin": {
-                  "type": "number",
-                  "description": "Safety margin used in RSS calculation [m]",
-                  "default": 2.0,
-                  "minimum": 0.0
-                },
-                "lookahead_horizon": {
-                  "type": "number",
-                  "description": "Lookahead horizon used in RSS calculation [s]",
-                  "default": 1.5,
-                  "minimum": 0.0
                 }
               },
               "required": [],
@@ -433,6 +351,91 @@
                   },
                   "required": [],
                   "additionalProperties": false
+                }
+              },
+              "required": [],
+              "additionalProperties": false
+            },
+            "rss_params": {
+              "type": "object",
+              "properties": {
+                "enable": {
+                  "type": "boolean",
+                  "description": "Enable RSS-based stop logic",
+                  "default": true
+                },
+                "object_decel": {
+                  "type": "object",
+                  "properties": {
+                    "car": {
+                      "type": "number",
+                      "description": "Deceleration for car type objects [m/s^2]",
+                      "default": 1.5,
+                      "minimum": 0.0
+                    },
+                    "truck": {
+                      "type": "number",
+                      "description": "Deceleration for truck type objects [m/s^2]",
+                      "default": 1.5,
+                      "minimum": 0.0
+                    },
+                    "bus": {
+                      "type": "number",
+                      "description": "Deceleration for bus type objects [m/s^2]",
+                      "default": 1.5,
+                      "minimum": 0.0
+                    },
+                    "trailer": {
+                      "type": "number",
+                      "description": "Deceleration for trailer type objects [m/s^2]",
+                      "default": 1.5,
+                      "minimum": 0.0
+                    },
+                    "motorcycle": {
+                      "type": "number",
+                      "description": "Deceleration for motorcycle type objects [m/s^2]",
+                      "default": 3.0,
+                      "minimum": 0.0
+                    },
+                    "bicycle": {
+                      "type": "number",
+                      "description": "Deceleration for bicycle type objects [m/s^2]",
+                      "default": 5.0,
+                      "minimum": 0.0
+                    },
+                    "pedestrian": {
+                      "type": "number",
+                      "description": "Deceleration for pedestrian type objects [m/s^2]",
+                      "default": 5.0,
+                      "minimum": 0.0
+                    }
+                  },
+                  "required": [],
+                  "additionalProperties": false
+                },
+                "ego_decel": {
+                  "type": "number",
+                  "description": "Deceleration for ego vehicle used in RSS calculation [m/s^2]",
+                  "default": 4.0,
+                  "minimum": 0.0
+                },
+                "reaction_time": {
+                  "type": "number",
+                  "description": "Reaction time used in RSS calculation [s]",
+                  "default": 0.2,
+                  "minimum": 0.0
+                },
+                "safety_margin": {
+                  "type": "number",
+                  "description": "Safety margin used in RSS calculation [m]",
+                  "default": 2.0,
+                  "minimum": 0.0
+                },
+                "lookahead_horizon": {
+                  "type": "number",
+                  "description": "Lookahead horizon used in RSS calculation [s]",
+                  "default": 1.5,
+                  "minimum": 0.0
                 }
               },
               "required": [],


### PR DESCRIPTION
- add missing parameters
- implement logic to enable/disable stopping for objects
- implement logic to enable/disable stopping for pcd
- update set_stop_point logic to enforce kinematic limitations

requires https://github.com/tier4/autoware_launch.x2/pull/2489