### PR TITLE
refactor(trajectory_validator): rename metrics in vehicle constraint filter

### DIFF
--- a/planning/autoware_trajectory_validator/src/filters/safety/vehicle_constraint_filter.cpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/vehicle_constraint_filter.cpp
@@ -141,7 +141,7 @@ MetricReport VehicleConstraintFilter::check_speed(const TrajectoryPoints & traj_
   return autoware_trajectory_validator::build<MetricReport>()
     .validator_name(get_name())
     .validator_category(category())
-    .metric_name("check_speed")
+    .metric_name("speed")
     .metric_value(max_observed)
     .level(is_ok ? MetricReport::OK : MetricReport::ERROR);
 }
@@ -153,7 +153,7 @@ MetricReport VehicleConstraintFilter::check_acceleration(const TrajectoryPoints 
   return autoware_trajectory_validator::build<MetricReport>()
     .validator_name(get_name())
     .validator_category(category())
-    .metric_name("check_acceleration")
+    .metric_name("acceleration")
     .metric_value(max_observed)
     .level(is_ok ? MetricReport::OK : MetricReport::ERROR);
 }
@@ -165,7 +165,7 @@ MetricReport VehicleConstraintFilter::check_deceleration(const TrajectoryPoints 
   return autoware_trajectory_validator::build<MetricReport>()
     .validator_name(get_name())
     .validator_category(category())
-    .metric_name("check_deceleration")
+    .metric_name("deceleration")
     .metric_value(max_observed)
     .level(is_ok ? MetricReport::OK : MetricReport::ERROR);
 }
@@ -179,7 +179,7 @@ MetricReport VehicleConstraintFilter::check_steering_angle(
   return autoware_trajectory_validator::build<MetricReport>()
     .validator_name(get_name())
     .validator_category(category())
-    .metric_name("check_steering_angle")
+    .metric_name("steering_angle")
     .metric_value(max_observed)
     .level(is_ok ? MetricReport::OK : MetricReport::ERROR);
 }
@@ -193,7 +193,7 @@ MetricReport VehicleConstraintFilter::check_steering_rate(
   return autoware_trajectory_validator::build<MetricReport>()
     .validator_name(get_name())
     .validator_category(category())
-    .metric_name("check_steering_rate")
+    .metric_name("steering_rate")
     .metric_value(max_observed)
     .level(is_ok ? MetricReport::OK : MetricReport::ERROR);
 }


### PR DESCRIPTION
## What

This pull request standardizes the metric names used in the `MetricReport` objects returned by the `VehicleConstraintFilter` methods in `vehicle_constraint_filter.cpp`. The metric names have been updated to be more concise and consistent across different checks.

**Metric name standardization:**

|Before| After|
|---------|--------|
|`check_speed` | `speed`|
|`check_acceleration` | `acceleration`|
|`check_deceleration` | `deceleration`|
|`check_steering_angle`|`steering_angle`|
|`check_steering_rate` | `steering_rate`|