### PR TITLE
feat(mpc): add mpc zero weight steps

### DIFF
--- a/control/autoware_mpc_lateral_controller/include/autoware/mpc_lateral_controller/mpc.hpp
+++ b/control/autoware_mpc_lateral_controller/include/autoware/mpc_lateral_controller/mpc.hpp
@@ -100,6 +100,17 @@ struct MPCParam
   // Sampling time for the prediction horizon.
   double prediction_dt;
 
+  // Number of initial prediction steps for which the state-error weight Q and the steering-input
+  // weight R are forced to zero. This relaxes the over-sensitive optimization against the path
+  // immediately ahead of the vehicle. 0 keeps the original behavior. The smoothing weights
+  // (steer_rate, steer_acc, lat_jerk) are NOT affected by this; use zero_smoothing_weight_steps.
+  int zero_weight_steps;
+
+  // Number of initial prediction steps for which the smoothing weights (steer_rate, steer_acc and
+  // lat_jerk) are forced to zero. 0 keeps the original behavior. This is independent from
+  // zero_weight_steps.
+  int zero_smoothing_weight_steps;
+
   // Threshold at which the feed-forward steering angle becomes zero.
   double zero_ff_steer_deg;
 

--- a/control/autoware_mpc_lateral_controller/param/lateral_controller_defaults.param.yaml
+++ b/control/autoware_mpc_lateral_controller/param/lateral_controller_defaults.param.yaml
@@ -20,6 +20,8 @@
     qp_solver_type: "osqp"                       # optimization solver option (unconstraint_fast or osqp)
     mpc_prediction_horizon: 50                   # prediction horizon step
     mpc_prediction_dt: 0.1                       # prediction horizon period [s]
+    mpc_zero_weight_steps: 0                      # number of initial steps whose Q and R weights are forced to zero (0: original behavior)
+    mpc_zero_smoothing_weight_steps: 0           # number of initial steps whose smoothing weights (steer_rate/steer_acc/lat_jerk) are forced to zero (0: original behavior)
     mpc_weight_lat_error: 1.0                    # lateral error weight in matrix Q
     mpc_weight_heading_error: 0.0                # heading error weight in matrix Q
     mpc_weight_heading_error_squared_vel: 0.3    # heading error * velocity weight in matrix Q

--- a/control/autoware_mpc_lateral_controller/src/mpc.cpp
+++ b/control/autoware_mpc_lateral_controller/src/mpc.cpp
@@ -782,6 +782,14 @@ MPCMatrix MPC::generateMPCMatrix(
     Q_adaptive(1, 1) += ref_vx_squared * mpc_weight.heading_error_squared_vel;
     R_adaptive(0, 0) += ref_vx_squared * mpc_weight.steering_input_squared_vel;
 
+    // Zero out the state-error weight Q and the steering-input weight R for the first
+    // `zero_weight_steps` steps so that the optimization is not over-sensitive to the path
+    // immediately ahead. Smoothing weights (steer_rate/steer_acc/lat_jerk) are kept intact.
+    if (i < m_param.zero_weight_steps) {
+      Q_adaptive = MatrixXd::Zero(DIM_Y, DIM_Y);
+      R_adaptive = MatrixXd::Zero(DIM_U, DIM_U);
+    }
+
     // update mpc matrix
     int idx_x_i = i * DIM_X;
     int idx_u_i = i * DIM_U;
@@ -816,6 +824,10 @@ MPCMatrix MPC::generateMPCMatrix(
 
   // add lateral jerk : weight for (v * {u(i) - u(i-1)} )^2
   for (int i = 0; i < N - 1; ++i) {
+    // skip smoothing penalty for the first steps when requested
+    if (i < m_param.zero_smoothing_weight_steps) {
+      continue;
+    }
     const double ref_vx = reference_trajectory.vx.at(i);
     const double ref_k = reference_trajectory.k.at(i) * sign_vx;
     const double j = ref_vx * ref_vx * getWeight(ref_k).lat_jerk / (DT * DT);
@@ -913,14 +925,21 @@ void MPC::addSteerWeightR(const double prediction_dt, MatrixXd & R) const
   const int N = m_param.prediction_horizon;
   const double DT = prediction_dt;
 
+  // Number of initial steps for which the smoothing penalty is skipped. When > 0, the boundary
+  // terms coupling step 0/1 with the previous command are skipped as well (see addSteerWeightF).
+  const int skip = m_param.zero_smoothing_weight_steps;
+
   // add steering rate : weight for (u(i) - u(i-1) / dt )^2
   {
     const double steer_rate_r = m_param.nominal_weight.steer_rate / (DT * DT);
     const Eigen::Matrix2d D = steer_rate_r * (Eigen::Matrix2d() << 1.0, -1.0, -1.0, 1.0).finished();
     for (int i = 0; i < N - 1; ++i) {
+      if (i < skip) {
+        continue;
+      }
       R.block(i, i, 2, 2) += D;
     }
-    if (N > 1) {
+    if (N > 1 && skip == 0) {
       // steer rate i = 0
       R(0, 0) += m_param.nominal_weight.steer_rate / (m_ctrl_period * m_ctrl_period);
     }
@@ -937,9 +956,12 @@ void MPC::addSteerWeightR(const double prediction_dt, MatrixXd & R) const
       steer_acc_r *
       (Eigen::Matrix3d() << 1.0, -2.0, 1.0, -2.0, 4.0, -2.0, 1.0, -2.0, 1.0).finished();
     for (int i = 1; i < N - 1; ++i) {
+      if (i < skip) {
+        continue;
+      }
       R.block(i - 1, i - 1, 3, 3) += D;
     }
-    if (N > 1) {
+    if (N > 1 && skip == 0) {
       // steer acc i = 1
       R(0, 0) += steer_acc_r * 1.0 + steer_acc_r_cp2 * 1.0 + steer_acc_r_cp1 * 2.0;
       R(1, 0) += steer_acc_r * -1.0 + steer_acc_r_cp1 * -1.0;
@@ -954,6 +976,12 @@ void MPC::addSteerWeightR(const double prediction_dt, MatrixXd & R) const
 void MPC::addSteerWeightF(const double prediction_dt, MatrixXd & f) const
 {
   if (f.rows() < 2) {
+    return;
+  }
+
+  // These linear terms only couple step 0/1 with the previous command, so skip them entirely
+  // when the smoothing weight is zeroed for the initial steps.
+  if (m_param.zero_smoothing_weight_steps > 0) {
     return;
   }
 

--- a/control/autoware_mpc_lateral_controller/src/mpc_lateral_controller.cpp
+++ b/control/autoware_mpc_lateral_controller/src/mpc_lateral_controller.cpp
@@ -588,6 +588,9 @@ void MpcLateralController::declareMPCparameters(rclcpp::Node & node)
 {
   m_mpc->m_param.prediction_horizon = node.declare_parameter<int>("mpc_prediction_horizon");
   m_mpc->m_param.prediction_dt = node.declare_parameter<double>("mpc_prediction_dt");
+  m_mpc->m_param.zero_weight_steps = node.declare_parameter<int>("mpc_zero_weight_steps");
+  m_mpc->m_param.zero_smoothing_weight_steps =
+    node.declare_parameter<int>("mpc_zero_smoothing_weight_steps");
 
   const auto dp = [&](const auto & param) { return node.declare_parameter<double>(param); };
 
@@ -637,6 +640,8 @@ rcl_interfaces::msg::SetParametersResult MpcLateralController::paramCallback(
 
     update_param(parameters, "mpc_prediction_horizon", param.prediction_horizon);
     update_param(parameters, "mpc_prediction_dt", param.prediction_dt);
+    update_param(parameters, "mpc_zero_weight_steps", param.zero_weight_steps);
+    update_param(parameters, "mpc_zero_smoothing_weight_steps", param.zero_smoothing_weight_steps);
 
     const std::string ns_nw = "mpc_weight_";
     update_param(parameters, ns_nw + "lat_error", nw.lat_error);

--- a/control/autoware_mpc_lateral_controller/test/test_mpc.cpp
+++ b/control/autoware_mpc_lateral_controller/test/test_mpc.cpp
@@ -103,6 +103,8 @@ protected:
   {
     param.prediction_horizon = 50;
     param.prediction_dt = 0.1;
+    param.zero_weight_steps = 0;
+    param.zero_smoothing_weight_steps = 0;
     param.zero_ff_steer_deg = 0.5;
     param.input_delay = 0.0;
     param.acceleration_limit = 2.0;

--- a/control/autoware_trajectory_follower_node/param/lateral/mpc.param.yaml
+++ b/control/autoware_trajectory_follower_node/param/lateral/mpc.param.yaml
@@ -18,6 +18,8 @@
     qp_solver_type: "osqp"                       # optimization solver option (unconstraint_fast or osqp)
     mpc_prediction_horizon: 50                   # prediction horizon step
     mpc_prediction_dt: 0.1                       # prediction horizon period [s]
+    mpc_zero_weight_steps: 0                      # number of initial steps whose Q and R weights are forced to zero (0: original behavior)
+    mpc_zero_smoothing_weight_steps: 0           # number of initial steps whose smoothing weights (steer_rate/steer_acc/lat_jerk) are forced to zero (0: original behavior)
     mpc_weight_lat_error: 1.0                    # lateral error weight in matrix Q
     mpc_weight_heading_error: 0.0                # heading error weight in matrix Q
     mpc_weight_heading_error_squared_vel: 0.3    # heading error * velocity weight in matrix Q


### PR DESCRIPTION
(this feature is experimental)
add zero weight steps parameter. If this parameter is larger than 0, first these parameter value steps weights is set to 0.

required: https://github.com/tier4/autoware_launch.x2/pull/2504