### PR TITLE
fix(autoware_trajectory_optimizer): correct Apache-2.0 license header

### DIFF
--- a/planning/autoware_trajectory_optimizer/scripts/temporal_mpt_python_reference.py
+++ b/planning/autoware_trajectory_optimizer/scripts/temporal_mpt_python_reference.py
@@ -6,7 +6,7 @@
 #
 #     http://www.apache.org/licenses/LICENSE-2.0
 #
-# Unless required by law or agreed to in writing, software
+# Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and


### PR DESCRIPTION
## Description

The `temporal_mpt_python_reference.py` script (added in #2994) has a malformed Apache-2.0 license header: the word `applicable` was missing from the "Unless required by applicable law..." line. Because of this, `ament_copyright` could not match it against the canonical Apache-2.0 template and reported `license=<unknown>`, causing the `copyright` test of `autoware_trajectory_optimizer` to fail.

This was surfaced by the differential CI of #3059: that PR migrates `autoware_trajectory_optimizer` to the agnocast wrapper (touching `CMakeLists.txt` / `package.xml`), so the differential build re-tested the whole package and the pre-existing lint issue started failing.

This PR fixes only the license header so the `copyright` test passes again. It is independent of the agnocast migration. Once merged, #3059 will be updated onto this base and re-tested.

```diff
-# Unless required by law or agreed to in writing, software
+# Unless required by applicable law or agreed to in writing, software
```

## Related links

**Parent Issue:**

- Surfaced by #3059

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

## Effects on system behavior

None.