### PR TITLE
feat(trajectory_validator, ccf): add first collision timing info

### DIFF
--- a/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/assessment.cpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/assessment.cpp
@@ -98,18 +98,22 @@ std::optional<CollisionDetail> find_collision_timing(
     TimeRange test_time_range;
   };
 
-  const auto make_finding = [&](const CandidateFinding & candidate) -> CollisionDetail {
+  const auto make_collision_detail =
+    [&](
+      const CandidateFinding & worst_pet,
+      const CandidateFinding & first_collision) -> CollisionDetail {
     return CollisionDetail{
       test_trajectory.getObjectIdentification(),
-      candidate.pet,
-      candidate.ttc,
+      CollisionTiming{worst_pet.ttc, worst_pet.pet},
+      CollisionTiming{first_collision.ttc, first_collision.pet},
       ref_trajectory.getPoses(),
       test_trajectory.getPoses(),
-      ref_trajectory.get_or_compute_convex(candidate.ref_index_range),
-      test_trajectory.get_or_compute_convex(candidate.test_time_range)};
+      ref_trajectory.get_or_compute_convex(worst_pet.ref_index_range),
+      test_trajectory.get_or_compute_convex(worst_pet.test_time_range)};
   };
 
-  std::optional<CandidateFinding> candidate_finding{};
+  std::optional<CandidateFinding> first_collision_timing{};
+  std::optional<CandidateFinding> worst_pet_timing{};
   for (size_t i = 0; i < ref_trajectory.size(); ++i) {
     size_t prev_i = (i == 0) ? 0 : i - 1;
     const double ref_start_time = ref_trajectory.getTimes().at(prev_i);
@@ -120,7 +124,7 @@ std::optional<CollisionDetail> find_collision_timing(
     const Polygon2d & ref_convex = ref_trajectory.get_or_compute_convex(ref_index_range);
 
     const double current_pet_limit =
-      candidate_finding.has_value() ? std::abs(candidate_finding->pet) : max_pet_threshold;
+      worst_pet_timing.has_value() ? std::abs(worst_pet_timing->pet) : max_pet_threshold;
 
     if (!boost::geometry::intersects(
           ref_envelope, test_trajectory.get_or_compute_envelope(
@@ -155,19 +159,22 @@ std::optional<CollisionDetail> find_collision_timing(
       const TimeRange test_time_range =
         has_intersects_before ? test_time_range_before : test_time_range_after;
 
-      candidate_finding = CandidateFinding{ref_start_time, pet, ref_index_range, test_time_range};
+      worst_pet_timing = CandidateFinding{ref_start_time, pet, ref_index_range, test_time_range};
+      if (!first_collision_timing.has_value()) {
+        first_collision_timing = worst_pet_timing;
+      }
       break;
     }
-    if (candidate_finding.has_value() && candidate_finding->pet == 0.0) {
-      return make_finding(candidate_finding.value());
+    if (worst_pet_timing.has_value() && worst_pet_timing->pet == 0.0) {
+      return make_collision_detail(worst_pet_timing.value(), first_collision_timing.value());
     }
   }
 
-  if (!candidate_finding.has_value()) {
+  if (!worst_pet_timing.has_value()) {
     return std::nullopt;
   }
 
-  return make_finding(candidate_finding.value());
+  return make_collision_detail(worst_pet_timing.value(), first_collision_timing.value());
 }
 
 PetArtifact assess_planned_speed_collision_timing(

--- a/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/assessment.cpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/assessment.cpp
@@ -83,9 +83,10 @@ std::optional<CollisionDetail> find_collision_timing(
 
   if (!boost::geometry::intersects(
         ref_trajectory.get_or_compute_overall_envelope(),
-        test_trajectory.get_or_compute_envelope(TimeRange{
-          ref_trajectory.getTimes().front() - pet_find_range.object_first_passing_time_gap,
-          ref_trajectory.getTimes().back() + pet_find_range.ego_first_passing_time_gap}))) {
+        test_trajectory.get_or_compute_envelope(
+          TimeRange{
+            ref_trajectory.getTimes().front() - pet_find_range.object_first_passing_time_gap,
+            ref_trajectory.getTimes().back() + pet_find_range.ego_first_passing_time_gap}))) {
     return std::nullopt;
   }
 
@@ -126,9 +127,10 @@ std::optional<CollisionDetail> find_collision_timing(
       worst_pet_timing.has_value() ? std::abs(worst_pet_timing->pet) : max_pet_threshold;
 
     if (!boost::geometry::intersects(
-          ref_envelope, test_trajectory.get_or_compute_envelope(TimeRange{
-                          ref_start_time - current_pet_limit,
-                          ref_trajectory.getTimes().back() + current_pet_limit}))) {
+          ref_envelope, test_trajectory.get_or_compute_envelope(
+                          TimeRange{
+                            ref_start_time - current_pet_limit,
+                            ref_trajectory.getTimes().back() + current_pet_limit}))) {
       continue;
     }
 
@@ -297,8 +299,9 @@ DracArtifact assess_drac(
         continue;
       }
 
-      collision_evaluations.push_back(CollisionEvaluation{
-        nominal_motion_risk_level, std::move(finding_nominal_object_motion.value())});
+      collision_evaluations.push_back(
+        CollisionEvaluation{
+          nominal_motion_risk_level, std::move(finding_nominal_object_motion.value())});
       collision_evaluations.push_back(
         CollisionEvaluation{dec_motion_risk_level, std::move(finding_dec_object_motion.value())});
     }
@@ -338,17 +341,19 @@ std::vector<TrajectoryData> generate_object_trajectories(
       const bool is_require_map_based =
         drac_param.assessment_trajectories.map_based || pet_param.assessment_trajectories.map_based;
       if (is_require_map_based && !object.kinematics.predicted_paths.empty()) {
-        object_trajectories.push_back(trajectory::generate_predicted_path_trajectory(
-          object, 0.0, object_assumed_acceleration, objects_reference_time, required_time_horizon,
-          context.predicted_objects->header.stamp, time_resolution));
+        object_trajectories.push_back(
+          trajectory::generate_predicted_path_trajectory(
+            object, 0.0, object_assumed_acceleration, objects_reference_time, required_time_horizon,
+            context.predicted_objects->header.stamp, time_resolution));
       }
 
       if (
         drac_param.assessment_trajectories.constant_curvature ||
         pet_param.assessment_trajectories.constant_curvature) {
-        object_trajectories.push_back(trajectory::generate_constant_curvature_trajectory(
-          object, 0.0, object_assumed_acceleration, objects_reference_time, required_time_horizon,
-          context.predicted_objects->header.stamp, time_resolution));
+        object_trajectories.push_back(
+          trajectory::generate_constant_curvature_trajectory(
+            object, 0.0, object_assumed_acceleration, objects_reference_time, required_time_horizon,
+            context.predicted_objects->header.stamp, time_resolution));
       }
     }
   }
@@ -368,9 +373,10 @@ std::vector<TrajectoryData> generate_object_trajectories(
       const bool is_require_diffusion_based = drac_param.assessment_trajectories.diffusion_based ||
                                               pet_param.assessment_trajectories.diffusion_based;
       if (is_require_diffusion_based) {
-        object_trajectories.push_back(trajectory::generate_diffusion_based_trajectory(
-          object, neural_network_objects_reference_time, required_time_horizon,
-          context.neural_network_predicted_objects->header.stamp, time_resolution));
+        object_trajectories.push_back(
+          trajectory::generate_diffusion_based_trajectory(
+            object, neural_network_objects_reference_time, required_time_horizon,
+            context.neural_network_predicted_objects->header.stamp, time_resolution));
       }
     }
   }

--- a/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/assessment.cpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/assessment.cpp
@@ -83,10 +83,9 @@ std::optional<CollisionDetail> find_collision_timing(
 
   if (!boost::geometry::intersects(
         ref_trajectory.get_or_compute_overall_envelope(),
-        test_trajectory.get_or_compute_envelope(
-          TimeRange{
-            ref_trajectory.getTimes().front() - pet_find_range.object_first_passing_time_gap,
-            ref_trajectory.getTimes().back() + pet_find_range.ego_first_passing_time_gap}))) {
+        test_trajectory.get_or_compute_envelope(TimeRange{
+          ref_trajectory.getTimes().front() - pet_find_range.object_first_passing_time_gap,
+          ref_trajectory.getTimes().back() + pet_find_range.ego_first_passing_time_gap}))) {
     return std::nullopt;
   }
 
@@ -104,8 +103,8 @@ std::optional<CollisionDetail> find_collision_timing(
       const CandidateFinding & first_collision) -> CollisionDetail {
     return CollisionDetail{
       test_trajectory.getObjectIdentification(),
-      CollisionTiming{worst_pet.ttc, worst_pet.pet},
       CollisionTiming{first_collision.ttc, first_collision.pet},
+      CollisionTiming{worst_pet.ttc, worst_pet.pet},
       ref_trajectory.getPoses(),
       test_trajectory.getPoses(),
       ref_trajectory.get_or_compute_convex(worst_pet.ref_index_range),
@@ -127,10 +126,9 @@ std::optional<CollisionDetail> find_collision_timing(
       worst_pet_timing.has_value() ? std::abs(worst_pet_timing->pet) : max_pet_threshold;
 
     if (!boost::geometry::intersects(
-          ref_envelope, test_trajectory.get_or_compute_envelope(
-                          TimeRange{
-                            ref_start_time - current_pet_limit,
-                            ref_trajectory.getTimes().back() + current_pet_limit}))) {
+          ref_envelope, test_trajectory.get_or_compute_envelope(TimeRange{
+                          ref_start_time - current_pet_limit,
+                          ref_trajectory.getTimes().back() + current_pet_limit}))) {
       continue;
     }
 
@@ -207,8 +205,8 @@ PetArtifact assess_planned_speed_collision_timing(
       ego_trajectory, object_trajectory, pet_params.warn_threshold, global_params.time_resolution);
 
     if (collision.has_value()) {
-      const auto risk_level =
-        to_pet_risk_level(collision->pet, pet_params.error_threshold, pet_params.warn_threshold);
+      const auto risk_level = to_pet_risk_level(
+        collision->worst_pet_timing.pet, pet_params.error_threshold, pet_params.warn_threshold);
       if (risk_level == RiskLevel::SAFE) {
         continue;
       }
@@ -271,7 +269,8 @@ DracArtifact assess_drac(
 
       const RiskLevel nominal_motion_risk_level =
         finding_nominal_object_motion.has_value()
-          ? to_pet_risk_level(finding_nominal_object_motion->pet, error_pet_th, error_pet_th)
+          ? to_pet_risk_level(
+              finding_nominal_object_motion->worst_pet_timing.pet, error_pet_th, error_pet_th)
           : RiskLevel::SAFE;
       if (nominal_motion_risk_level != RiskLevel::ERROR) {
         continue;
@@ -290,16 +289,16 @@ DracArtifact assess_drac(
 
       const RiskLevel dec_motion_risk_level =
         finding_dec_object_motion.has_value()
-          ? to_pet_risk_level(finding_dec_object_motion->pet, error_pet_th, error_pet_th)
+          ? to_pet_risk_level(
+              finding_dec_object_motion->worst_pet_timing.pet, error_pet_th, error_pet_th)
           : RiskLevel::SAFE;
 
       if (dec_motion_risk_level != RiskLevel::ERROR) {
         continue;
       }
 
-      collision_evaluations.push_back(
-        CollisionEvaluation{
-          nominal_motion_risk_level, std::move(finding_nominal_object_motion.value())});
+      collision_evaluations.push_back(CollisionEvaluation{
+        nominal_motion_risk_level, std::move(finding_nominal_object_motion.value())});
       collision_evaluations.push_back(
         CollisionEvaluation{dec_motion_risk_level, std::move(finding_dec_object_motion.value())});
     }
@@ -339,19 +338,17 @@ std::vector<TrajectoryData> generate_object_trajectories(
       const bool is_require_map_based =
         drac_param.assessment_trajectories.map_based || pet_param.assessment_trajectories.map_based;
       if (is_require_map_based && !object.kinematics.predicted_paths.empty()) {
-        object_trajectories.push_back(
-          trajectory::generate_predicted_path_trajectory(
-            object, 0.0, object_assumed_acceleration, objects_reference_time, required_time_horizon,
-            context.predicted_objects->header.stamp, time_resolution));
+        object_trajectories.push_back(trajectory::generate_predicted_path_trajectory(
+          object, 0.0, object_assumed_acceleration, objects_reference_time, required_time_horizon,
+          context.predicted_objects->header.stamp, time_resolution));
       }
 
       if (
         drac_param.assessment_trajectories.constant_curvature ||
         pet_param.assessment_trajectories.constant_curvature) {
-        object_trajectories.push_back(
-          trajectory::generate_constant_curvature_trajectory(
-            object, 0.0, object_assumed_acceleration, objects_reference_time, required_time_horizon,
-            context.predicted_objects->header.stamp, time_resolution));
+        object_trajectories.push_back(trajectory::generate_constant_curvature_trajectory(
+          object, 0.0, object_assumed_acceleration, objects_reference_time, required_time_horizon,
+          context.predicted_objects->header.stamp, time_resolution));
       }
     }
   }
@@ -371,10 +368,9 @@ std::vector<TrajectoryData> generate_object_trajectories(
       const bool is_require_diffusion_based = drac_param.assessment_trajectories.diffusion_based ||
                                               pet_param.assessment_trajectories.diffusion_based;
       if (is_require_diffusion_based) {
-        object_trajectories.push_back(
-          trajectory::generate_diffusion_based_trajectory(
-            object, neural_network_objects_reference_time, required_time_horizon,
-            context.neural_network_predicted_objects->header.stamp, time_resolution));
+        object_trajectories.push_back(trajectory::generate_diffusion_based_trajectory(
+          object, neural_network_objects_reference_time, required_time_horizon,
+          context.neural_network_predicted_objects->header.stamp, time_resolution));
       }
     }
   }

--- a/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/collision_check_filter.cpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/collision_check_filter.cpp
@@ -106,7 +106,9 @@ std::vector<MetricReport> CollisionCheckFilter::generate_metric_reports(
       if (evaluation.detail.object_identification.trajectory_type.find(type) == std::string::npos) {
         continue;
       }
-      if (std::isnan(pet_val) || std::abs(evaluation.detail.worst_pet_timing.pet) < std::abs(pet_val)) {
+      if (
+        std::isnan(pet_val) ||
+        std::abs(evaluation.detail.worst_pet_timing.pet) < std::abs(pet_val)) {
         pet_val = evaluation.detail.worst_pet_timing.pet;
         pet_risk = evaluation.risk;
       }

--- a/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/collision_check_filter.cpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/collision_check_filter.cpp
@@ -106,8 +106,8 @@ std::vector<MetricReport> CollisionCheckFilter::generate_metric_reports(
       if (evaluation.detail.object_identification.trajectory_type.find(type) == std::string::npos) {
         continue;
       }
-      if (std::isnan(pet_val) || std::abs(evaluation.detail.pet) < std::abs(pet_val)) {
-        pet_val = evaluation.detail.pet;
+      if (std::isnan(pet_val) || std::abs(evaluation.detail.worst_pet_timing.pet) < std::abs(pet_val)) {
+        pet_val = evaluation.detail.worst_pet_timing.pet;
         pet_risk = evaluation.risk;
       }
     }

--- a/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/reporter.cpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/reporter.cpp
@@ -75,8 +75,9 @@ autoware_internal_planning_msgs::msg::SafetyFactorArray make_safety_factor_array
   SafetyFactor safety_factor;
   safety_factor.type = SafetyFactor::OBJECT;
   safety_factor.object_id = collision_detail.object_identification.uuid;
-  safety_factor.ttc_begin = static_cast<float>(collision_detail.ttc);
-  safety_factor.ttc_end = static_cast<float>(collision_detail.ttc + time_resolution);
+  safety_factor.ttc_begin = static_cast<float>(collision_detail.first_collision_timing.ttc);
+  safety_factor.ttc_end =
+    static_cast<float>(collision_detail.first_collision_timing.ttc + time_resolution);
   safety_factor.is_safe = false;
   if (!collision_detail.object_trajectory.empty()) {
     safety_factor.points.push_back(collision_detail.object_trajectory.front().position);
@@ -139,8 +140,8 @@ void process_pet_artifacts(
       continue;
     }
 
-    const auto & timing = evaluation.detail;
-    const auto & obj_id = timing.object_identification;
+    const auto & detail = evaluation.detail;
+    const auto & obj_id = detail.object_identification;
     const bool is_error = evaluation.risk == RiskLevel::ERROR;
     if (is_error) {
       log_level = MetricReport::ERROR;
@@ -148,17 +149,18 @@ void process_pet_artifacts(
 
     const auto finding_msg = fmt::format(
       "PET collision, classification: {}, ID: {}, PET: {}, TTC: {}, duration: {}, stamp: {}.{};",
-      obj_id.classification, obj_id.trajectory_id_string(), timing.pet, timing.ttc,
+      obj_id.classification, obj_id.trajectory_id_string(), detail.worst_pet_timing.pet,
+      detail.first_collision_timing.ttc,
       pet_continuous_times.get_time(obj_id.trajectory_id_string()), obj_id.stamp.sec,
       obj_id.stamp.nanosec);
     log_messages += finding_msg;
     reporter::append_text_marker_message(marker_messages, finding_msg);
     reporter::add_debug_markers(
       debug_markers, current_time, "planned_speed_collision", obj_id.trajectory_id_string(),
-      timing.ego_trajectory, timing.object_trajectory, timing.ego_hull, timing.object_hull);
+      detail.ego_trajectory, detail.object_trajectory, detail.ego_hull, detail.object_hull);
     if (is_error) {
       add_collision_planning_factor(
-        time_resolution, odometry.header.stamp, odometry.pose.pose, timing, "PET",
+        time_resolution, odometry.header.stamp, odometry.pose.pose, detail, "PET",
         artifacts.planning_factors);
     }
   }
@@ -193,7 +195,8 @@ void process_drac_artifacts(
     const auto finding_msg = fmt::format(
       "DRAC collision, classification: {}, ID: {}, PET: {}, TTC: {}, DRAC: {}, duration: {}, "
       "stamp: {}.{};",
-      obj_id.classification, obj_id.trajectory_id_string(), timing.pet, timing.ttc,
+      obj_id.classification, obj_id.trajectory_id_string(), timing.worst_pet_timing.pet,
+      timing.first_collision_timing.ttc,
       drac_artifact.required_acceleration.has_value()
         ? std::to_string(drac_artifact.required_acceleration.value())
         : "Cant be avoided",

--- a/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/types.hpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/types.hpp
@@ -75,11 +75,18 @@ struct TrajectoryIdentification
 };
 
 enum class RiskLevel { SAFE, WARN, ERROR };
+
+struct CollisionTiming
+{
+  double ttc;
+  double pet;
+};
+
 struct CollisionDetail
 {
   TrajectoryIdentification object_identification;
-  double pet;
-  double ttc;
+  CollisionTiming first_collision_timing;
+  CollisionTiming worst_pet_timing;
   std::vector<geometry_msgs::msg::Pose> ego_trajectory;
   std::vector<geometry_msgs::msg::Pose> object_trajectory;
   Polygon2d ego_hull;


### PR DESCRIPTION
衝突領域にegoと物体のどちらが先に入ったかを判定するための情報を追加します。

https://evaluation.tier4.jp/evaluation/reports/ac04bd93-6ac1-5383-90f3-ecf951e7950b?project_id=x2_dev