### PR TITLE
feat(traffic_light_stop): add missing parameter treat_unknown_light_as_red

### DIFF
--- a/planning/autoware_trajectory_modifier/config/trajectory_modifier.param.yaml
+++ b/planning/autoware_trajectory_modifier/config/trajectory_modifier.param.yaml
@@ -85,6 +85,7 @@
       stop_for_red_light: true
       stop_for_amber_light: false
       treat_amber_light_as_red: false
+      treat_unknown_light_as_red: false
       overshoot_tolerance: 0.0 # [m]
       th_stable_duration_red: 0.2 # [s]
       th_stable_duration_amber: 0.2 # [s]

--- a/planning/autoware_trajectory_modifier/docs/TrafficLightStop.md
+++ b/planning/autoware_trajectory_modifier/docs/TrafficLightStop.md
@@ -71,14 +71,15 @@ The module utilizes the following data from `TrajectoryModifierContext` & `Input
 
 The module parameters are grouped under `traffic_light_stop` section of `trajectory_modifier.param.yaml`
 
-| Parameter name                   | Type   | Default | Description                                                                                                       |
-| -------------------------------- | ------ | ------- | ----------------------------------------------------------------------------------------------------------------- |
-| `stop_margin`                    | double | 0.75    | [m] Distance to keep from stop line (measured from ego front)                                                     |
-| `stop_for_red_light`             | bool   | true    | Flag to enable/disable stopping for red light violation                                                           |
-| `stop_for_amber_light`           | bool   | false   | Flag to enable/disable stopping for amber light violation                                                         |
-| `treat_amber_light_as_red_light` | bool   | false   | When true, amber lights are treated identically to red lights (rejection on intersection regardless of distance). |
-| `overshoot_tolerance`            | double | 0.0     | [m] Maximum distance between the stop line and the trajectory stop point to consider the trajectory feasible.     |
-| `th_stable_duration_red`         | double | 0.2     | [s] Minimum duration a RED light must be seen before it is considered active (only when ego is moving).           |
-| `th_stable_duration_amber`       | double | 0.2     | [s] Minimum duration an AMBER light must be seen before it is considered active (only when ego is moving).        |
-| `th_amber_rejection_hysteresis`  | double | 0.5     | [s] Duration to persist an amber rejection state to prevent "flipping" due to minor velocity/distance changes.    |
-| `crossing_time_limit`            | double | 2.75    | [s] Maximum time allowed for the ego vehicle to cross the stop line after an amber light appears.                 |
+| Parameter name                  | Type   | Default | Description                                                                                                       |
+| ------------------------------- | ------ | ------- | ----------------------------------------------------------------------------------------------------------------- |
+| `stop_margin`                   | double | 0.75    | [m] Distance to keep from stop line (measured from ego front)                                                     |
+| `stop_for_red_light`            | bool   | true    | Flag to enable/disable stopping for red light violation                                                           |
+| `stop_for_amber_light`          | bool   | false   | Flag to enable/disable stopping for amber light violation                                                         |
+| `treat_amber_light_as_red`      | bool   | false   | When true, amber lights are treated identically to red lights (rejection on intersection regardless of distance). |
+| `treat_unknown_light_as_red`    | bool   | false   | When true, unknown lights are treated identically to red lights (rejection on intersection).                      |
+| `overshoot_tolerance`           | double | 0.0     | [m] Maximum distance between the stop line and the trajectory stop point to consider the trajectory feasible.     |
+| `th_stable_duration_red`        | double | 0.2     | [s] Minimum duration a RED light must be seen before it is considered active (only when ego is moving).           |
+| `th_stable_duration_amber`      | double | 0.2     | [s] Minimum duration an AMBER light must be seen before it is considered active (only when ego is moving).        |
+| `th_amber_rejection_hysteresis` | double | 0.5     | [s] Duration to persist an amber rejection state to prevent "flipping" due to minor velocity/distance changes.    |
+| `crossing_time_limit`           | double | 2.75    | [s] Maximum time allowed for the ego vehicle to cross the stop line after an amber light appears.                 |

--- a/planning/autoware_trajectory_modifier/param/trajectory_modifier_parameter_struct.yaml
+++ b/planning/autoware_trajectory_modifier/param/trajectory_modifier_parameter_struct.yaml
@@ -396,6 +396,11 @@ trajectory_modifier_params:
       default_value: false
       description: Treat amber light as red light
       read_only: false
+    treat_unknown_light_as_red:
+      type: bool
+      default_value: false
+      description: Treat unknown light as red light
+      read_only: false
     overshoot_tolerance:
       type: double
       default_value: 0.5

--- a/planning/autoware_trajectory_modifier/schema/trajectory_modifier.schema.json
+++ b/planning/autoware_trajectory_modifier/schema/trajectory_modifier.schema.json
@@ -437,6 +437,11 @@
               "description": "Treat amber light as red light",
               "default": false
             },
+            "treat_unknown_light_as_red": {
+              "type": "boolean",
+              "description": "Treat unknown light as red light",
+              "default": false
+            },
             "overshoot_tolerance": {
               "type": "number",
               "description": "Overshoot tolerance [m]",

--- a/planning/autoware_trajectory_modifier/src/trajectory_modifier_plugins/traffic_light_stop.cpp
+++ b/planning/autoware_trajectory_modifier/src/trajectory_modifier_plugins/traffic_light_stop.cpp
@@ -33,6 +33,7 @@ autoware::traffic_light_compliance_checker::Parameters to_checker_params(
   p.jerk_limit = stopping_params.jerk_limit;
   p.crossing_time_limit = tl_stop_p.crossing_time_limit;
   p.treat_amber_light_as_red_light = tl_stop_p.treat_amber_light_as_red;
+  p.treat_unknown_light_as_red_light = tl_stop_p.treat_unknown_light_as_red;
   p.stop_overshoot_margin = tl_stop_p.overshoot_tolerance;
   p.stable_duration_threshold_red = tl_stop_p.th_stable_duration_red;
   p.stable_duration_threshold_amber = tl_stop_p.th_stable_duration_amber;

--- a/planning/autoware_trajectory_modifier/tests/test_traffic_light_stop_integration.cpp
+++ b/planning/autoware_trajectory_modifier/tests/test_traffic_light_stop_integration.cpp
@@ -226,6 +226,7 @@ protected:
     tl.stop_for_red_light = true;
     tl.stop_for_amber_light = true;
     tl.treat_amber_light_as_red = false;
+    tl.treat_unknown_light_as_red = false;
     tl.overshoot_tolerance = 0.0;
     tl.th_stable_duration_red = 0.0;
     tl.th_stable_duration_amber = 0.0;
@@ -454,4 +455,21 @@ TEST_F(TrafficLightStopIntegrationTest, TrajectoryNotModifiedWithUnknownLight)
   expect_not_modified(
     trajectory, make_default_input(),
     "Unknown light without treat-as-red parameter should not modify trajectory");
+}
+
+TEST_F(TrafficLightStopIntegrationTest, TrajectoryModifiedWithUnknownLightAsRedLight)
+{
+  const lanelet::Id light_id = 302;
+  const double stop_x = 10.0;
+
+  create_and_set_map(light_id, stop_x);
+  set_traffic_light_signal(light_id, TrafficLightElement::UNKNOWN);
+
+  params_.traffic_light_stop.treat_unknown_light_as_red = true;
+  plugin_->update_params(params_);
+
+  auto trajectory = create_straight_trajectory(0.0, 16.0, 10.0);
+  const bool modified = plugin_->modify_trajectory(trajectory, make_default_input(10.0));
+  EXPECT_TRUE(modified)
+    << "Unknown treated as red should insert stop point even when not stoppable";
 }


### PR DESCRIPTION
add missing parameter `treat_unknown_light_as_red` to enable handling and stopping for unknown traffic light status

[launcher PR](https://github.com/tier4/autoware_launch.x2/pull/2539)