### PR TITLE
feat(trajectory_validator): refactor validation/metric report messages

### DIFF
--- a/evaluator/autoware_planning_evaluator/include/autoware/planning_evaluator/metric_accumulators/trajectory_validation_accumulator.hpp
+++ b/evaluator/autoware_planning_evaluator/include/autoware/planning_evaluator/metric_accumulators/trajectory_validation_accumulator.hpp
@@ -31,6 +31,7 @@
 
 namespace planning_diagnostics
 {
+using autoware_trajectory_validator::msg::RiskLevel;
 using autoware_trajectory_validator::msg::ValidationReportArray;
 using autoware_utils::Accumulator;
 using MetricMsg = tier4_metric_msgs::msg::Metric;
@@ -42,7 +43,7 @@ using json = nlohmann::json;
  * @brief Accumulates trajectory validation error statistics from ValidationReportArray.
  *
  * Two scopes (published under metric_to_str(Metric::trajectory_validation) + "/" + <scope> + "/…"):
- * 1) Whole trajectory (per candidate / generator), from ValidationReport.level —
+ * 1) Whole trajectory (per candidate / generator), from ValidationReport.risk.level —
  *    <scope> = <generator_name>
  * 2) Each MetricReport row —
  *    <scope> = <generator_name>/<validator_name>/<metric_name>

--- a/evaluator/autoware_planning_evaluator/src/metric_accumulators/trajectory_validation_accumulator.cpp
+++ b/evaluator/autoware_planning_evaluator/src/metric_accumulators/trajectory_validation_accumulator.cpp
@@ -20,12 +20,12 @@ namespace planning_diagnostics
 {
 namespace
 {
-bool levelIndicatesError(const uint8_t level, const bool count_warn_as_error)
+bool levelIndicatesError(const RiskLevel::_level_type level, const bool count_warn_as_error)
 {
-  if (level >= 2) {
+  if (level >= RiskLevel::DANGER) {
     return true;
   }
-  return count_warn_as_error && level == 1;
+  return count_warn_as_error && level > RiskLevel::LOW_CAUTION;
 }
 
 /// Skip one-off object-id rows: metric_name like check_<prefix>_<32-hex> or
@@ -100,7 +100,7 @@ void TrajectoryValidationAccumulator::update(const ValidationReportArray & msg)
 
     const bool warn_as_err = parameters.count_warn_as_error;
     const double initial_span_duration_s = parameters.initial_span_duration_s;
-    const bool traj_err = levelIndicatesError(report.level, warn_as_err);
+    const bool traj_err = levelIndicatesError(report.risk.level, warn_as_err);
     stats_by_scope_[gen].update(traj_err, report_time_s, initial_span_duration_s);
 
     // Rows in this report (last row wins if the same scope appears more than once).
@@ -110,7 +110,7 @@ void TrajectoryValidationAccumulator::update(const ValidationReportArray & msg)
         continue;
       }
       const std::string scope = gen + "/" + row.validator_name + "/" + row.metric_name;
-      present_error_by_scope[scope] = levelIndicatesError(row.level, warn_as_err);
+      present_error_by_scope[scope] = levelIndicatesError(row.risk.level, warn_as_err);
     }
 
     for (const auto & [scope, m_err] : present_error_by_scope) {

--- a/planning/autoware_trajectory_validator/CMakeLists.txt
+++ b/planning/autoware_trajectory_validator/CMakeLists.txt
@@ -48,6 +48,7 @@ unset(PYTHON_EXECUTABLE)
 
 rosidl_generate_interfaces(${PROJECT_NAME}
   "msg/MetricReport.msg"
+  "msg/RiskLevel.msg"
   "msg/ValidationReport.msg"
   "msg/ValidationReportArray.msg"
   DEPENDENCIES

--- a/planning/autoware_trajectory_validator/include/autoware/trajectory_validator/validator_interface.hpp
+++ b/planning/autoware_trajectory_validator/include/autoware/trajectory_validator/validator_interface.hpp
@@ -40,6 +40,7 @@ using VehicleInfo = autoware::vehicle_info_utils::VehicleInfo;
 using autoware_internal_planning_msgs::msg::CandidateTrajectory;
 using autoware_internal_planning_msgs::msg::PlanningFactorArray;
 using autoware_trajectory_validator::msg::MetricReport;
+using autoware_trajectory_validator::msg::RiskLevel;
 
 /** @brief Result of a single plugin's feasibility check. */
 struct ValidationResult

--- a/planning/autoware_trajectory_validator/msg/MetricReport.msg
+++ b/planning/autoware_trajectory_validator/msg/MetricReport.msg
@@ -1,9 +1,10 @@
 # This message represents a metric report from a trajectory validator.
 
 # Possible levels for a metric report.
-uint8 OK = 0
-uint8 WARN = 1
-uint8 ERROR = 2
+uint8 SAFE = 0
+uint8 LOW_CAUTION = 1
+uint8 HIGH_CAUTION = 2
+uint8 DANGER = 3
 
 # The name of the validator that generated this report.
 string validator_name

--- a/planning/autoware_trajectory_validator/msg/MetricReport.msg
+++ b/planning/autoware_trajectory_validator/msg/MetricReport.msg
@@ -1,11 +1,5 @@
 # This message represents a metric report from a trajectory validator.
 
-# Possible levels for a metric report.
-uint8 SAFE = 0
-uint8 LOW_CAUTION = 1
-uint8 HIGH_CAUTION = 2
-uint8 DANGER = 3
-
 # The name of the validator that generated this report.
 string validator_name
 # The category of the validator that generated this report.
@@ -14,5 +8,5 @@ string validator_category
 string metric_name
 # The value of the metric that was reported.
 float64 metric_value
-# The level of the metric report.
-uint8 level
+# The risk severity of the metric report.
+RiskLevel risk

--- a/planning/autoware_trajectory_validator/msg/RiskLevel.msg
+++ b/planning/autoware_trajectory_validator/msg/RiskLevel.msg
@@ -1,0 +1,9 @@
+# This message represents the possible levels of risk severity.
+
+uint8 SAFE = 0
+uint8 LOW_CAUTION = 1
+uint8 HIGH_CAUTION = 2
+uint8 DANGER = 3
+uint8 FATAL = 4
+
+uint8 level

--- a/planning/autoware_trajectory_validator/msg/ValidationReport.msg
+++ b/planning/autoware_trajectory_validator/msg/ValidationReport.msg
@@ -1,9 +1,10 @@
 # This message represents a validation report for a trajectory.
 
 # Possible levels of validation report severity.
-uint8 OK = 0
-uint8 WARN = 1
-uint8 ERROR = 2
+uint8 SAFE = 0
+uint8 LOW_CAUTION = 1
+uint8 HIGH_CAUTION = 2
+uint8 DANGER = 3
 
 builtin_interfaces/Time trajectory_stamp
 unique_identifier_msgs/UUID generator_id

--- a/planning/autoware_trajectory_validator/msg/ValidationReport.msg
+++ b/planning/autoware_trajectory_validator/msg/ValidationReport.msg
@@ -1,13 +1,7 @@
 # This message represents a validation report for a trajectory.
 
-# Possible levels of validation report severity.
-uint8 SAFE = 0
-uint8 LOW_CAUTION = 1
-uint8 HIGH_CAUTION = 2
-uint8 DANGER = 3
-
 builtin_interfaces/Time trajectory_stamp
 unique_identifier_msgs/UUID generator_id
 string generator_name
-uint8 level
+RiskLevel risk
 MetricReport[] metrics

--- a/planning/autoware_trajectory_validator/src/detail/trajectory_validator.cpp
+++ b/planning/autoware_trajectory_validator/src/detail/trajectory_validator.cpp
@@ -74,15 +74,15 @@ TrajectoryValidatorReport TrajectoryValidator::process(
           std::back_inserter(report.planning_factors.factors));
       }
 
+      RiskLevel risk_level;
+      risk_level.level = evaluation.is_feasible ? RiskLevel::SAFE : RiskLevel::DANGER;
       combined_metrics.push_back(
         autoware_trajectory_validator::build<autoware_trajectory_validator::msg::MetricReport>()
           .validator_name(plugin->get_name())
           .validator_category(plugin->category())
           .metric_name("trajectory_feasibility")
           .metric_value(evaluation.is_feasible ? 1.0 : 0.0)
-          .level(
-            evaluation.is_feasible ? autoware_trajectory_validator::msg::MetricReport::SAFE
-                                   : autoware_trajectory_validator::msg::MetricReport::DANGER));
+          .risk(risk_level));
       report.processing_time_ms[evaluation.plugin_name] += stop_watch.toc(evaluation.plugin_name);
 
       table.plugin_evaluations.push_back(evaluation);

--- a/planning/autoware_trajectory_validator/src/detail/trajectory_validator.cpp
+++ b/planning/autoware_trajectory_validator/src/detail/trajectory_validator.cpp
@@ -25,6 +25,8 @@
 
 namespace autoware::trajectory_validator
 {
+using autoware_trajectory_validator::msg::ValidationReport;
+
 TrajectoryValidatorReport TrajectoryValidator::process(
   const autoware_internal_planning_msgs::msg::CandidateTrajectories & input_trajectories,
   const ValidatorContext & context) const
@@ -78,8 +80,8 @@ TrajectoryValidatorReport TrajectoryValidator::process(
           .metric_name("trajectory_feasibility")
           .metric_value(evaluation.is_feasible ? 1.0 : 0.0)
           .level(
-            evaluation.is_feasible ? autoware_trajectory_validator::msg::MetricReport::OK
-                                   : autoware_trajectory_validator::msg::MetricReport::ERROR));
+            evaluation.is_feasible ? autoware_trajectory_validator::msg::MetricReport::SAFE
+                                   : autoware_trajectory_validator::msg::MetricReport::DANGER));
       report.processing_time_ms[evaluation.plugin_name] += stop_watch.toc(evaluation.plugin_name);
 
       table.plugin_evaluations.push_back(evaluation);
@@ -97,13 +99,11 @@ TrajectoryValidatorReport TrajectoryValidator::process(
     }
 
     report.validation_reports.push_back(
-      autoware_trajectory_validator::build<autoware_trajectory_validator::msg::ValidationReport>()
+      autoware_trajectory_validator::build<ValidationReport>()
         .trajectory_stamp(candidate_trajectory.header.stamp)
         .generator_id(candidate_trajectory.generator_id)
         .generator_name(uuid_to_name.at(hex_generator_id))
-        .level(
-          all_feasible ? autoware_trajectory_validator::msg::ValidationReport::OK
-                       : autoware_trajectory_validator::msg::ValidationReport::ERROR)
+        .level(all_feasible ? ValidationReport::SAFE : ValidationReport::DANGER)
         .metrics(std::move(combined_metrics)));
   }
 

--- a/planning/autoware_trajectory_validator/src/detail/trajectory_validator.cpp
+++ b/planning/autoware_trajectory_validator/src/detail/trajectory_validator.cpp
@@ -25,6 +25,7 @@
 
 namespace autoware::trajectory_validator
 {
+using autoware_trajectory_validator::msg::RiskLevel;
 using autoware_trajectory_validator::msg::ValidationReport;
 
 TrajectoryValidatorReport TrajectoryValidator::process(
@@ -98,12 +99,14 @@ TrajectoryValidatorReport TrajectoryValidator::process(
       report.num_feasible_trajectories++;
     }
 
+    RiskLevel risk_level;
+    risk_level.level = all_feasible ? RiskLevel::SAFE : RiskLevel::DANGER;
     report.validation_reports.push_back(
       autoware_trajectory_validator::build<ValidationReport>()
         .trajectory_stamp(candidate_trajectory.header.stamp)
         .generator_id(candidate_trajectory.generator_id)
         .generator_name(uuid_to_name.at(hex_generator_id))
-        .level(all_feasible ? ValidationReport::SAFE : ValidationReport::DANGER)
+        .risk(risk_level)
         .metrics(std::move(combined_metrics)));
   }
 

--- a/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/assessment.cpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/assessment.cpp
@@ -41,7 +41,8 @@ bool is_target_trajectory_type(
   return false;
 }
 
-RiskLevel to_pet_risk_level(double pet, const PetThreshold & error_th, const PetThreshold & warn_th)
+RiskLevel::_level_type to_pet_risk_level(
+  double pet, const PetThreshold & error_th, const PetThreshold & warn_th)
 {
   const bool is_error =
     pet <= error_th.ego_first_passing_time_gap && pet >= -error_th.object_first_passing_time_gap;
@@ -54,7 +55,8 @@ RiskLevel to_pet_risk_level(double pet, const PetThreshold & error_th, const Pet
   return is_warn ? RiskLevel::HIGH_CAUTION : RiskLevel::SAFE;
 }
 
-RiskLevel to_drac_risk_level(const std::optional<double> & acc, const DracParams & drac_params)
+RiskLevel::_level_type to_drac_risk_level(
+  const std::optional<double> & acc, const DracParams & drac_params)
 {
   if (!acc.has_value() || acc.value() < drac_params.error_threshold.ego_acceleration) {
     return RiskLevel::DANGER;
@@ -269,7 +271,7 @@ DracArtifact assess_drac(
         ego_deceleration_trajectory, object_trajectory, error_pet_th,
         global_params.time_resolution);
 
-      const RiskLevel nominal_motion_risk_level =
+      const RiskLevel::_level_type nominal_motion_risk_level =
         finding_nominal_object_motion.has_value()
           ? to_pet_risk_level(
               finding_nominal_object_motion->worst_pet_timing.pet, error_pet_th, error_pet_th)
@@ -289,7 +291,7 @@ DracArtifact assess_drac(
         ego_deceleration_trajectory, object_deceleration_trajectory, error_pet_th,
         global_params.time_resolution);
 
-      const RiskLevel dec_motion_risk_level =
+      const RiskLevel::_level_type dec_motion_risk_level =
         finding_dec_object_motion.has_value()
           ? to_pet_risk_level(
               finding_dec_object_motion->worst_pet_timing.pet, error_pet_th, error_pet_th)

--- a/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/assessment.cpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/assessment.cpp
@@ -46,21 +46,21 @@ RiskLevel to_pet_risk_level(double pet, const PetThreshold & error_th, const Pet
   const bool is_error =
     pet <= error_th.ego_first_passing_time_gap && pet >= -error_th.object_first_passing_time_gap;
   if (is_error) {
-    return RiskLevel::ERROR;
+    return RiskLevel::DANGER;
   }
 
   const bool is_warn =
     pet <= warn_th.ego_first_passing_time_gap && pet >= -warn_th.object_first_passing_time_gap;
-  return is_warn ? RiskLevel::WARN : RiskLevel::SAFE;
+  return is_warn ? RiskLevel::HIGH_CAUTION : RiskLevel::SAFE;
 }
 
 RiskLevel to_drac_risk_level(const std::optional<double> & acc, const DracParams & drac_params)
 {
   if (!acc.has_value() || acc.value() < drac_params.error_threshold.ego_acceleration) {
-    return RiskLevel::ERROR;
+    return RiskLevel::DANGER;
   }
   if (acc.value() < drac_params.warn_threshold.ego_acceleration) {
-    return RiskLevel::WARN;
+    return RiskLevel::HIGH_CAUTION;
   }
   return RiskLevel::SAFE;
 }
@@ -274,7 +274,7 @@ DracArtifact assess_drac(
           ? to_pet_risk_level(
               finding_nominal_object_motion->worst_pet_timing.pet, error_pet_th, error_pet_th)
           : RiskLevel::SAFE;
-      if (nominal_motion_risk_level != RiskLevel::ERROR) {
+      if (nominal_motion_risk_level != RiskLevel::DANGER) {
         continue;
       }
 
@@ -295,7 +295,7 @@ DracArtifact assess_drac(
               finding_dec_object_motion->worst_pet_timing.pet, error_pet_th, error_pet_th)
           : RiskLevel::SAFE;
 
-      if (dec_motion_risk_level != RiskLevel::ERROR) {
+      if (dec_motion_risk_level != RiskLevel::DANGER) {
         continue;
       }
 
@@ -500,7 +500,7 @@ RssArtifact assess(
       ego_trajectory, context.odometry->twist.twist, object, rss_params,
       context.predicted_objects->header.stamp);
     const auto risk_level =
-      rss_detail.rss_acceleration < rss_params.error_threshold.ego_acceleration ? RiskLevel::ERROR
+      rss_detail.rss_acceleration < rss_params.error_threshold.ego_acceleration ? RiskLevel::DANGER
                                                                                 : RiskLevel::SAFE;
     rss_evaluations.push_back(RssEvaluation{risk_level, rss_detail});
   }

--- a/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/collision_check_filter.cpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/collision_check_filter.cpp
@@ -56,9 +56,9 @@ std::vector<MetricReport> CollisionCheckFilter::generate_metric_reports(
     switch (risk_level) {
       case RiskLevel::SAFE:
         return MetricReport::SAFE;
-      case RiskLevel::WARN:
+      case RiskLevel::HIGH_CAUTION:
         return MetricReport::HIGH_CAUTION;
-      case RiskLevel::ERROR:
+      case RiskLevel::DANGER:
         return MetricReport::DANGER;
       default:
         throw std::runtime_error("invalid argument");
@@ -159,7 +159,8 @@ CollisionCheckFilter::result_t CollisionCheckFilter::is_feasible(
     rss_artifact, rss_continuous_times_, debug_markers_, global_params_.time_resolution);
 
   return ValidationResult{
-    calc_worst_risk({pet_artifact.risk, drac_artifact.risk, rss_artifact.risk}) != RiskLevel::ERROR,
+    calc_worst_risk({pet_artifact.risk, drac_artifact.risk, rss_artifact.risk}) !=
+      RiskLevel::DANGER,
     generate_metric_reports(drac_artifact, pet_artifact, rss_artifact),
     std::move(planning_factors)};
 }

--- a/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/collision_check_filter.cpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/collision_check_filter.cpp
@@ -55,11 +55,11 @@ std::vector<MetricReport> CollisionCheckFilter::generate_metric_reports(
   const auto convert_metrics_level = [](const RiskLevel risk_level) {
     switch (risk_level) {
       case RiskLevel::SAFE:
-        return MetricReport::OK;
+        return MetricReport::SAFE;
       case RiskLevel::WARN:
-        return MetricReport::WARN;
+        return MetricReport::HIGH_CAUTION;
       case RiskLevel::ERROR:
-        return MetricReport::ERROR;
+        return MetricReport::DANGER;
       default:
         throw std::runtime_error("invalid argument");
     }

--- a/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/collision_check_filter.cpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/collision_check_filter.cpp
@@ -52,29 +52,19 @@ std::vector<MetricReport> CollisionCheckFilter::generate_metric_reports(
 {
   std::vector<MetricReport> reports;
 
-  const auto convert_metrics_level = [](const RiskLevel risk_level) {
-    switch (risk_level) {
-      case RiskLevel::SAFE:
-        return MetricReport::SAFE;
-      case RiskLevel::HIGH_CAUTION:
-        return MetricReport::HIGH_CAUTION;
-      case RiskLevel::DANGER:
-        return MetricReport::DANGER;
-      default:
-        throw std::runtime_error("invalid argument");
-    }
+  const auto add_report = [&](
+                            const std::string_view metric_name, double metric_value,
+                            RiskLevel::_level_type risk_level) {
+    RiskLevel risk;
+    risk.level = risk_level;
+    reports.push_back(
+      autoware_trajectory_validator::build<MetricReport>()
+        .validator_name(get_name())
+        .validator_category(category())
+        .metric_name(std::string(metric_name))
+        .metric_value(metric_value)
+        .risk(risk));
   };
-
-  const auto add_report =
-    [&](const std::string_view metric_name, double metric_value, RiskLevel risk) {
-      reports.push_back(
-        autoware_trajectory_validator::build<MetricReport>()
-          .validator_name(get_name())
-          .validator_category(category())
-          .metric_name(std::string(metric_name))
-          .metric_value(metric_value)
-          .level(convert_metrics_level(risk)));
-    };
 
   static constexpr std::array<const char *, 3> kCanonicalTrajectoryTypes = {
     "map_based_predicted_path",
@@ -94,14 +84,14 @@ std::vector<MetricReport> CollisionCheckFilter::generate_metric_reports(
     const double drac_val = has_finding && drac_artifact.required_acceleration.has_value()
                               ? drac_artifact.required_acceleration.value()
                               : std::numeric_limits<double>::quiet_NaN();
-    const RiskLevel drac_risk = has_finding ? drac_artifact.risk : RiskLevel::SAFE;
+    const RiskLevel::_level_type drac_risk = has_finding ? drac_artifact.risk : RiskLevel::SAFE;
     add_report(fmt::format("DRAC_{}", type), drac_val, drac_risk);
   }
 
   // PET
   for (const auto * type : kCanonicalTrajectoryTypes) {
     double pet_val = std::numeric_limits<double>::quiet_NaN();
-    RiskLevel pet_risk = RiskLevel::SAFE;
+    RiskLevel::_level_type pet_risk = RiskLevel::SAFE;
     for (const auto & evaluation : pet_artifact.object_evaluations) {
       if (evaluation.detail.object_identification.trajectory_type.find(type) == std::string::npos) {
         continue;

--- a/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/reporter.cpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/reporter.cpp
@@ -134,7 +134,7 @@ void process_pet_artifacts(
 
   std::string log_messages{};
   std::string marker_messages{};
-  uint8_t log_level = MetricReport::WARN;
+  uint8_t log_level = MetricReport::HIGH_CAUTION;
   for (const auto & evaluation : pet_artifact.object_evaluations) {
     if (evaluation.risk == RiskLevel::SAFE) {
       continue;
@@ -144,7 +144,7 @@ void process_pet_artifacts(
     const auto & obj_id = detail.object_identification;
     const bool is_error = evaluation.risk == RiskLevel::ERROR;
     if (is_error) {
-      log_level = MetricReport::ERROR;
+      log_level = MetricReport::DANGER;
     }
 
     const auto finding_msg = fmt::format(
@@ -187,7 +187,7 @@ void process_drac_artifacts(
   std::string log_messages{};
   std::string marker_messages{};
   const bool has_error = drac_artifact.risk == RiskLevel::ERROR;
-  const uint8_t log_level = has_error ? MetricReport::ERROR : MetricReport::WARN;
+  const uint8_t log_level = has_error ? MetricReport::DANGER : MetricReport::HIGH_CAUTION;
   for (const auto & evaluation : drac_artifact.object_evaluations) {
     const auto & timing = evaluation.detail;
     const auto & obj_id = timing.object_identification;
@@ -255,7 +255,7 @@ void process_rss_artifacts(
   }
 
   artifacts.error_msg += marker_messages;
-  reporter::log_collision_messages(MetricReport::ERROR, log_messages);
+  reporter::log_collision_messages(MetricReport::DANGER, log_messages);
 }
 }  // namespace
 
@@ -396,7 +396,7 @@ void log_collision_messages(const uint8_t level, const std::string & messages)
   if (messages.empty()) {
     return;
   }
-  if (level == MetricReport::ERROR) {
+  if (level == MetricReport::DANGER) {
     RCLCPP_ERROR(rclcpp::get_logger("CollisionCheckFilter"), "Not feasible: %s", messages.c_str());
     return;
   }

--- a/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/reporter.cpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/reporter.cpp
@@ -134,7 +134,7 @@ void process_pet_artifacts(
 
   std::string log_messages{};
   std::string marker_messages{};
-  uint8_t log_level = MetricReport::HIGH_CAUTION;
+  RiskLevel::_level_type log_level = RiskLevel::HIGH_CAUTION;
   for (const auto & evaluation : pet_artifact.object_evaluations) {
     if (evaluation.risk == RiskLevel::SAFE) {
       continue;
@@ -144,7 +144,7 @@ void process_pet_artifacts(
     const auto & obj_id = detail.object_identification;
     const bool is_error = evaluation.risk == RiskLevel::DANGER;
     if (is_error) {
-      log_level = MetricReport::DANGER;
+      log_level = RiskLevel::DANGER;
     }
 
     const auto finding_msg = fmt::format(
@@ -187,7 +187,7 @@ void process_drac_artifacts(
   std::string log_messages{};
   std::string marker_messages{};
   const bool has_error = drac_artifact.risk == RiskLevel::DANGER;
-  const uint8_t log_level = has_error ? MetricReport::DANGER : MetricReport::HIGH_CAUTION;
+  const RiskLevel::_level_type log_level = has_error ? RiskLevel::DANGER : RiskLevel::HIGH_CAUTION;
   for (const auto & evaluation : drac_artifact.object_evaluations) {
     const auto & timing = evaluation.detail;
     const auto & obj_id = timing.object_identification;
@@ -255,7 +255,7 @@ void process_rss_artifacts(
   }
 
   artifacts.error_msg += marker_messages;
-  reporter::log_collision_messages(MetricReport::DANGER, log_messages);
+  reporter::log_collision_messages(RiskLevel::DANGER, log_messages);
 }
 }  // namespace
 
@@ -389,14 +389,12 @@ void append_text_marker_message(std::string & text, const std::string & message)
   }
 }
 
-void log_collision_messages(const uint8_t level, const std::string & messages)
+void log_collision_messages(const RiskLevel::_level_type level, const std::string & messages)
 {
-  using autoware_trajectory_validator::msg::MetricReport;
-
   if (messages.empty()) {
     return;
   }
-  if (level == MetricReport::DANGER) {
+  if (level == RiskLevel::DANGER) {
     RCLCPP_ERROR(rclcpp::get_logger("CollisionCheckFilter"), "Not feasible: %s", messages.c_str());
     return;
   }

--- a/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/reporter.cpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/reporter.cpp
@@ -142,7 +142,7 @@ void process_pet_artifacts(
 
     const auto & detail = evaluation.detail;
     const auto & obj_id = detail.object_identification;
-    const bool is_error = evaluation.risk == RiskLevel::ERROR;
+    const bool is_error = evaluation.risk == RiskLevel::DANGER;
     if (is_error) {
       log_level = MetricReport::DANGER;
     }
@@ -186,7 +186,7 @@ void process_drac_artifacts(
 
   std::string log_messages{};
   std::string marker_messages{};
-  const bool has_error = drac_artifact.risk == RiskLevel::ERROR;
+  const bool has_error = drac_artifact.risk == RiskLevel::DANGER;
   const uint8_t log_level = has_error ? MetricReport::DANGER : MetricReport::HIGH_CAUTION;
   for (const auto & evaluation : drac_artifact.object_evaluations) {
     const auto & timing = evaluation.detail;

--- a/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/reporter.hpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/reporter.hpp
@@ -82,7 +82,7 @@ void add_error_text_marker(
 
 void append_text_marker_message(std::string & text, const std::string & message);
 
-void log_collision_messages(const uint8_t level, const std::string & messages);
+void log_collision_messages(const RiskLevel::_level_type level, const std::string & messages);
 
 autoware_internal_planning_msgs::msg::PlanningFactorArray process_collision_artifacts(
   const nav_msgs::msg::Odometry & odometry, const PetArtifact & pet_artifact,

--- a/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/types.hpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/types.hpp
@@ -74,7 +74,7 @@ struct TrajectoryIdentification
   }
 };
 
-enum class RiskLevel { SAFE, WARN, ERROR };
+enum class RiskLevel { SAFE, LOW_CAUTION, HIGH_CAUTION, DANGER };
 
 struct CollisionTiming
 {
@@ -138,7 +138,7 @@ RiskLevel calc_worst_risk(const Container & evaluations)
     if (eval.risk > worst) {
       worst = eval.risk;
     }
-    if (worst == RiskLevel::ERROR) {
+    if (worst == RiskLevel::DANGER) {
       break;
     }
   }
@@ -153,7 +153,7 @@ inline RiskLevel calc_worst_risk(std::initializer_list<RiskLevel> risks)
     if (risk > worst) {
       worst = risk;
     }
-    if (worst == RiskLevel::ERROR) {
+    if (worst == RiskLevel::DANGER) {
       break;
     }
   }

--- a/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/types.hpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/types.hpp
@@ -17,6 +17,7 @@
 
 #include "parameter.hpp"
 
+#include <autoware_trajectory_validator/msg/risk_level.hpp>
 #include <autoware_utils_geometry/geometry.hpp>
 #include <autoware_utils_uuid/uuid_helper.hpp>
 #include <builtin_interfaces/msg/time.hpp>
@@ -34,6 +35,7 @@
 
 namespace autoware::trajectory_validator::plugin::safety
 {
+using autoware_trajectory_validator::msg::RiskLevel;
 using autoware_utils_geometry::Box2d;
 using autoware_utils_geometry::MultiPoint2d;
 using autoware_utils_geometry::Point2d;
@@ -74,8 +76,6 @@ struct TrajectoryIdentification
   }
 };
 
-enum class RiskLevel { SAFE, LOW_CAUTION, HIGH_CAUTION, DANGER };
-
 struct CollisionTiming
 {
   double ttc;
@@ -95,7 +95,7 @@ struct CollisionDetail
 
 struct CollisionEvaluation
 {
-  RiskLevel risk;
+  RiskLevel::_level_type risk;
   CollisionDetail detail;
 };
 struct RssDetail
@@ -106,33 +106,33 @@ struct RssDetail
 
 struct RssEvaluation
 {
-  RiskLevel risk;
+  RiskLevel::_level_type risk;
   RssDetail detail;
 };
 
 struct DracArtifact
 {
-  RiskLevel risk{RiskLevel::SAFE};
+  RiskLevel::_level_type risk{RiskLevel::SAFE};
   std::optional<double> required_acceleration;
   std::vector<CollisionEvaluation> object_evaluations;
 };
 
 struct PetArtifact
 {
-  RiskLevel risk{RiskLevel::SAFE};
+  RiskLevel::_level_type risk{RiskLevel::SAFE};
   std::vector<CollisionEvaluation> object_evaluations;
 };
 
 struct RssArtifact
 {
-  RiskLevel risk{RiskLevel::SAFE};
+  RiskLevel::_level_type risk{RiskLevel::SAFE};
   std::vector<RssEvaluation> object_evaluations;
 };
 
 template <typename Container>
-RiskLevel calc_worst_risk(const Container & evaluations)
+RiskLevel::_level_type calc_worst_risk(const Container & evaluations)
 {
-  RiskLevel worst = RiskLevel::SAFE;
+  RiskLevel::_level_type worst = RiskLevel::SAFE;
 
   for (const auto & eval : evaluations) {
     if (eval.risk > worst) {
@@ -145,9 +145,9 @@ RiskLevel calc_worst_risk(const Container & evaluations)
   return worst;
 }
 
-inline RiskLevel calc_worst_risk(std::initializer_list<RiskLevel> risks)
+inline RiskLevel::_level_type calc_worst_risk(std::initializer_list<RiskLevel::_level_type> risks)
 {
-  RiskLevel worst = RiskLevel::SAFE;
+  RiskLevel::_level_type worst = RiskLevel::SAFE;
 
   for (const auto & risk : risks) {
     if (risk > worst) {

--- a/planning/autoware_trajectory_validator/src/filters/safety/uncrossable_boundary_departure.cpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/uncrossable_boundary_departure.cpp
@@ -56,7 +56,7 @@ UncrossableBoundaryDepartureFilter::result_t UncrossableBoundaryDepartureFilter:
       .validator_category(category())
       .metric_name("check_critical_departure")
       .metric_value(is_feasible ? 1.0 : 0.0)
-      .level(!is_feasible ? MetricReport::ERROR : MetricReport::OK)};
+      .level(!is_feasible ? MetricReport::DANGER : MetricReport::SAFE)};
 
   return ValidationResult{is_feasible, std::move(metrics)};
 }

--- a/planning/autoware_trajectory_validator/src/filters/safety/uncrossable_boundary_departure.cpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/uncrossable_boundary_departure.cpp
@@ -50,13 +50,14 @@ UncrossableBoundaryDepartureFilter::result_t UncrossableBoundaryDepartureFilter:
       std::back_inserter(debug_markers_.markers));
   }
 
-  std::vector<MetricReport> metrics{
-    autoware_trajectory_validator::build<MetricReport>()
-      .validator_name(get_name())
-      .validator_category(category())
-      .metric_name("check_critical_departure")
-      .metric_value(is_feasible ? 1.0 : 0.0)
-      .level(!is_feasible ? MetricReport::DANGER : MetricReport::SAFE)};
+  RiskLevel risk_level;
+  risk_level.level = is_feasible ? RiskLevel::SAFE : RiskLevel::DANGER;
+  std::vector<MetricReport> metrics{autoware_trajectory_validator::build<MetricReport>()
+                                      .validator_name(get_name())
+                                      .validator_category(category())
+                                      .metric_name("check_critical_departure")
+                                      .metric_value(is_feasible ? 1.0 : 0.0)
+                                      .risk(risk_level)};
 
   return ValidationResult{is_feasible, std::move(metrics)};
 }

--- a/planning/autoware_trajectory_validator/src/filters/safety/vehicle_constraint_filter.cpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/vehicle_constraint_filter.cpp
@@ -128,7 +128,7 @@ VehicleConstraintFilter::result_t VehicleConstraintFilter::is_feasible(
   std::vector<MetricReport> metrics;
   for (const auto & checker : checkers_) {
     auto report = (this->*checker)(traj_points);
-    is_feasible &= report.level == MetricReport::OK;
+    is_feasible &= report.level == MetricReport::SAFE;
     metrics.push_back(report);
   }
 
@@ -144,7 +144,7 @@ MetricReport VehicleConstraintFilter::check_speed(const TrajectoryPoints & traj_
     .validator_category(category())
     .metric_name("speed")
     .metric_value(max_observed)
-    .level(is_ok ? MetricReport::OK : MetricReport::ERROR);
+    .level(is_ok ? MetricReport::SAFE : MetricReport::DANGER);
 }
 
 MetricReport VehicleConstraintFilter::check_acceleration(const TrajectoryPoints & traj_points) const
@@ -156,7 +156,7 @@ MetricReport VehicleConstraintFilter::check_acceleration(const TrajectoryPoints 
     .validator_category(category())
     .metric_name("acceleration")
     .metric_value(max_observed)
-    .level(is_ok ? MetricReport::OK : MetricReport::ERROR);
+    .level(is_ok ? MetricReport::SAFE : MetricReport::DANGER);
 }
 
 MetricReport VehicleConstraintFilter::check_deceleration(const TrajectoryPoints & traj_points) const
@@ -168,7 +168,7 @@ MetricReport VehicleConstraintFilter::check_deceleration(const TrajectoryPoints 
     .validator_category(category())
     .metric_name("deceleration")
     .metric_value(max_observed)
-    .level(is_ok ? MetricReport::OK : MetricReport::ERROR);
+    .level(is_ok ? MetricReport::SAFE : MetricReport::DANGER);
 }
 
 MetricReport VehicleConstraintFilter::check_steering_angle(
@@ -182,7 +182,7 @@ MetricReport VehicleConstraintFilter::check_steering_angle(
     .validator_category(category())
     .metric_name("steering_angle")
     .metric_value(max_observed)
-    .level(is_ok ? MetricReport::OK : MetricReport::ERROR);
+    .level(is_ok ? MetricReport::SAFE : MetricReport::DANGER);
 }
 
 MetricReport VehicleConstraintFilter::check_steering_rate(
@@ -196,7 +196,7 @@ MetricReport VehicleConstraintFilter::check_steering_rate(
     .validator_category(category())
     .metric_name("steering_rate")
     .metric_value(max_observed)
-    .level(is_ok ? MetricReport::OK : MetricReport::ERROR);
+    .level(is_ok ? MetricReport::SAFE : MetricReport::DANGER);
 }
 
 // --- Helper functions for constraint checks ---

--- a/planning/autoware_trajectory_validator/src/filters/safety/vehicle_constraint_filter.cpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/vehicle_constraint_filter.cpp
@@ -128,7 +128,7 @@ VehicleConstraintFilter::result_t VehicleConstraintFilter::is_feasible(
   std::vector<MetricReport> metrics;
   for (const auto & checker : checkers_) {
     auto report = (this->*checker)(traj_points);
-    is_feasible &= report.level == MetricReport::SAFE;
+    is_feasible &= report.risk.level == RiskLevel::SAFE;
     metrics.push_back(report);
   }
 
@@ -139,36 +139,42 @@ MetricReport VehicleConstraintFilter::check_speed(const TrajectoryPoints & traj_
 {
   const auto [max_observed, is_ok] = is_speed_ok(traj_points, params_.max_speed);
 
+  RiskLevel risk_level;
+  risk_level.level = is_ok ? RiskLevel::SAFE : RiskLevel::DANGER;
   return autoware_trajectory_validator::build<MetricReport>()
     .validator_name(get_name())
     .validator_category(category())
     .metric_name("speed")
     .metric_value(max_observed)
-    .level(is_ok ? MetricReport::SAFE : MetricReport::DANGER);
+    .risk(risk_level);
 }
 
 MetricReport VehicleConstraintFilter::check_acceleration(const TrajectoryPoints & traj_points) const
 {
   const auto [max_observed, is_ok] = is_acceleration_ok(traj_points, params_.max_acceleration);
 
+  RiskLevel risk_level;
+  risk_level.level = is_ok ? RiskLevel::SAFE : RiskLevel::DANGER;
   return autoware_trajectory_validator::build<MetricReport>()
     .validator_name(get_name())
     .validator_category(category())
     .metric_name("acceleration")
     .metric_value(max_observed)
-    .level(is_ok ? MetricReport::SAFE : MetricReport::DANGER);
+    .risk(risk_level);
 }
 
 MetricReport VehicleConstraintFilter::check_deceleration(const TrajectoryPoints & traj_points) const
 {
   const auto [max_observed, is_ok] = is_deceleration_ok(traj_points, params_.max_deceleration);
 
+  RiskLevel risk_level;
+  risk_level.level = is_ok ? RiskLevel::SAFE : RiskLevel::DANGER;
   return autoware_trajectory_validator::build<MetricReport>()
     .validator_name(get_name())
     .validator_category(category())
     .metric_name("deceleration")
     .metric_value(max_observed)
-    .level(is_ok ? MetricReport::SAFE : MetricReport::DANGER);
+    .risk(risk_level);
 }
 
 MetricReport VehicleConstraintFilter::check_steering_angle(
@@ -177,12 +183,14 @@ MetricReport VehicleConstraintFilter::check_steering_angle(
   const auto [max_observed, is_ok] =
     is_steering_angle_ok(traj_points, *vehicle_info_ptr_, params_.max_steering_angle);
 
+  RiskLevel risk_level;
+  risk_level.level = is_ok ? RiskLevel::SAFE : RiskLevel::DANGER;
   return autoware_trajectory_validator::build<MetricReport>()
     .validator_name(get_name())
     .validator_category(category())
     .metric_name("steering_angle")
     .metric_value(max_observed)
-    .level(is_ok ? MetricReport::SAFE : MetricReport::DANGER);
+    .risk(risk_level);
 }
 
 MetricReport VehicleConstraintFilter::check_steering_rate(
@@ -191,12 +199,14 @@ MetricReport VehicleConstraintFilter::check_steering_rate(
   const auto [max_observed, is_ok] =
     is_steering_rate_ok(traj_points, *vehicle_info_ptr_, params_.max_steering_rate);
 
+  RiskLevel risk_level;
+  risk_level.level = is_ok ? RiskLevel::SAFE : RiskLevel::DANGER;
   return autoware_trajectory_validator::build<MetricReport>()
     .validator_name(get_name())
     .validator_category(category())
     .metric_name("steering_rate")
     .metric_value(max_observed)
-    .level(is_ok ? MetricReport::SAFE : MetricReport::DANGER);
+    .risk(risk_level);
 }
 
 // --- Helper functions for constraint checks ---

--- a/planning/autoware_trajectory_validator/src/filters/traffic_rule/traffic_light_filter.cpp
+++ b/planning/autoware_trajectory_validator/src/filters/traffic_rule/traffic_light_filter.cpp
@@ -165,13 +165,20 @@ TrafficLightFilter::result_t TrafficLightFilter::is_feasible(
     context.odometry->pose.pose.position.z);
 
   std::vector<MetricReport> metrics;
+
+  auto get_risk_level = [](bool is_crossing) {
+    RiskLevel risk_level;
+    risk_level.level = is_crossing ? RiskLevel::DANGER : RiskLevel::SAFE;
+    return risk_level;
+  };
+
   metrics.push_back(
     autoware_trajectory_validator::build<MetricReport>()
       .validator_name(get_name())
       .validator_category(category())
       .metric_name("check_crossing_red_light")
       .metric_value(0.0)
-      .level(is_crossing_red ? MetricReport::DANGER : MetricReport::SAFE));
+      .risk(get_risk_level(is_crossing_red)));
 
   metrics.push_back(
     autoware_trajectory_validator::build<MetricReport>()
@@ -179,7 +186,7 @@ TrafficLightFilter::result_t TrafficLightFilter::is_feasible(
       .validator_category(category())
       .metric_name("check_crossing_amber_light")
       .metric_value(0.0)
-      .level(is_crossing_amber ? MetricReport::DANGER : MetricReport::SAFE));
+      .risk(get_risk_level(is_crossing_amber)));
 
   const bool is_feasible = !is_crossing_red && !is_crossing_amber;
 

--- a/planning/autoware_trajectory_validator/src/filters/traffic_rule/traffic_light_filter.cpp
+++ b/planning/autoware_trajectory_validator/src/filters/traffic_rule/traffic_light_filter.cpp
@@ -171,7 +171,7 @@ TrafficLightFilter::result_t TrafficLightFilter::is_feasible(
       .validator_category(category())
       .metric_name("check_crossing_red_light")
       .metric_value(0.0)
-      .level(is_crossing_red ? MetricReport::ERROR : MetricReport::OK));
+      .level(is_crossing_red ? MetricReport::DANGER : MetricReport::SAFE));
 
   metrics.push_back(
     autoware_trajectory_validator::build<MetricReport>()
@@ -179,7 +179,7 @@ TrafficLightFilter::result_t TrafficLightFilter::is_feasible(
       .validator_category(category())
       .metric_name("check_crossing_amber_light")
       .metric_value(0.0)
-      .level(is_crossing_amber ? MetricReport::ERROR : MetricReport::OK));
+      .level(is_crossing_amber ? MetricReport::DANGER : MetricReport::SAFE));
 
   const bool is_feasible = !is_crossing_red && !is_crossing_amber;
 

--- a/planning/autoware_trajectory_validator/test/plugins/collision_check_filter/test_reporter.cpp
+++ b/planning/autoware_trajectory_validator/test/plugins/collision_check_filter/test_reporter.cpp
@@ -229,8 +229,8 @@ TEST_F(CollisionCheckFilterTest, PetCollisionWarnDoesNotRejectTrajectory)
 
   ASSERT_TRUE(result.has_value());
   EXPECT_TRUE(result.value().is_feasible);
-  EXPECT_TRUE(has_pet_metric_with_level(result.value().metrics, MetricReport::WARN));
-  EXPECT_FALSE(has_pet_metric_with_level(result.value().metrics, MetricReport::ERROR));
+  EXPECT_TRUE(has_pet_metric_with_level(result.value().metrics, MetricReport::HIGH_CAUTION));
+  EXPECT_FALSE(has_pet_metric_with_level(result.value().metrics, MetricReport::DANGER));
   EXPECT_TRUE(result.value().planning_factors.factors.empty());
 
   const auto markers = filter_->take_debug_markers();
@@ -252,7 +252,7 @@ TEST_F(CollisionCheckFilterTest, PetCollisionErrorRejectsTrajectory)
 
   ASSERT_TRUE(result.has_value());
   EXPECT_FALSE(result.value().is_feasible);
-  EXPECT_TRUE(has_pet_metric_with_level(result.value().metrics, MetricReport::ERROR));
+  EXPECT_TRUE(has_pet_metric_with_level(result.value().metrics, MetricReport::DANGER));
   EXPECT_FALSE(result.value().planning_factors.factors.empty());
 
   const auto markers = filter_->take_debug_markers();
@@ -274,8 +274,8 @@ TEST_F(CollisionCheckFilterTest, DracWarnDoesNotRejectTrajectory)
 
   ASSERT_TRUE(result.has_value());
   EXPECT_TRUE(result.value().is_feasible);
-  EXPECT_TRUE(has_drac_metric_with_level(result.value().metrics, MetricReport::WARN));
-  EXPECT_FALSE(has_drac_metric_with_level(result.value().metrics, MetricReport::ERROR));
+  EXPECT_TRUE(has_drac_metric_with_level(result.value().metrics, MetricReport::HIGH_CAUTION));
+  EXPECT_FALSE(has_drac_metric_with_level(result.value().metrics, MetricReport::DANGER));
   EXPECT_TRUE(result.value().planning_factors.factors.empty());
 }
 
@@ -289,7 +289,7 @@ TEST_F(CollisionCheckFilterTest, DracErrorRejectsTrajectory)
 
   ASSERT_TRUE(result.has_value());
   EXPECT_FALSE(result.value().is_feasible);
-  EXPECT_TRUE(has_drac_metric_with_level(result.value().metrics, MetricReport::ERROR));
+  EXPECT_TRUE(has_drac_metric_with_level(result.value().metrics, MetricReport::DANGER));
   EXPECT_FALSE(result.value().planning_factors.factors.empty());
 }
 

--- a/planning/autoware_trajectory_validator/test/plugins/collision_check_filter/test_reporter.cpp
+++ b/planning/autoware_trajectory_validator/test/plugins/collision_check_filter/test_reporter.cpp
@@ -229,8 +229,8 @@ TEST_F(CollisionCheckFilterTest, PetCollisionWarnDoesNotRejectTrajectory)
 
   ASSERT_TRUE(result.has_value());
   EXPECT_TRUE(result.value().is_feasible);
-  EXPECT_TRUE(has_pet_metric_with_level(result.value().metrics, MetricReport::HIGH_CAUTION));
-  EXPECT_FALSE(has_pet_metric_with_level(result.value().metrics, MetricReport::DANGER));
+  EXPECT_TRUE(has_pet_metric_with_level(result.value().metrics, RiskLevel::HIGH_CAUTION));
+  EXPECT_FALSE(has_pet_metric_with_level(result.value().metrics, RiskLevel::DANGER));
   EXPECT_TRUE(result.value().planning_factors.factors.empty());
 
   const auto markers = filter_->take_debug_markers();
@@ -252,7 +252,7 @@ TEST_F(CollisionCheckFilterTest, PetCollisionErrorRejectsTrajectory)
 
   ASSERT_TRUE(result.has_value());
   EXPECT_FALSE(result.value().is_feasible);
-  EXPECT_TRUE(has_pet_metric_with_level(result.value().metrics, MetricReport::DANGER));
+  EXPECT_TRUE(has_pet_metric_with_level(result.value().metrics, RiskLevel::DANGER));
   EXPECT_FALSE(result.value().planning_factors.factors.empty());
 
   const auto markers = filter_->take_debug_markers();
@@ -274,8 +274,8 @@ TEST_F(CollisionCheckFilterTest, DracWarnDoesNotRejectTrajectory)
 
   ASSERT_TRUE(result.has_value());
   EXPECT_TRUE(result.value().is_feasible);
-  EXPECT_TRUE(has_drac_metric_with_level(result.value().metrics, MetricReport::HIGH_CAUTION));
-  EXPECT_FALSE(has_drac_metric_with_level(result.value().metrics, MetricReport::DANGER));
+  EXPECT_TRUE(has_drac_metric_with_level(result.value().metrics, RiskLevel::HIGH_CAUTION));
+  EXPECT_FALSE(has_drac_metric_with_level(result.value().metrics, RiskLevel::DANGER));
   EXPECT_TRUE(result.value().planning_factors.factors.empty());
 }
 
@@ -289,7 +289,7 @@ TEST_F(CollisionCheckFilterTest, DracErrorRejectsTrajectory)
 
   ASSERT_TRUE(result.has_value());
   EXPECT_FALSE(result.value().is_feasible);
-  EXPECT_TRUE(has_drac_metric_with_level(result.value().metrics, MetricReport::DANGER));
+  EXPECT_TRUE(has_drac_metric_with_level(result.value().metrics, RiskLevel::DANGER));
   EXPECT_FALSE(result.value().planning_factors.factors.empty());
 }
 


### PR DESCRIPTION
## Description
- Change validator severity levels from `{OK, WARN, ERROR}` to `{SAFE, LOW_CAUTION, HIGH_CAUTION, DANGER, FATAL}`
- Create separate msg `RiskLevel.msg`
- Update `Metric/ValidationReport.msg` to use `RiskLevel.msg`
- Modify `collision_check_filter` logic to use `RiskLevel.msg` instead of locally defined enum
- Update `trajectory_validation_accumulator` in `planning_evaluator`

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?
- `colcon build --packages-above autoware_trajectory_validator --symlink-install --cmake-args -DCMAKE_BUILD_TYPE=Release`
- `colcon test --packages-select autoware_trajectory_validator`

## Notes for reviewers

None.

## Interface changes

### 1. `ValidationReport.msg`
| Before | After |
| :--- | :--- |
| <pre># Possible levels of validation report severity.<br>uint8 OK = 0<br>uint8 WARN = 1<br>uint8 ERROR = 2<br><br>builtin_interfaces/Time trajectory_stamp<br>unique_identifier_msgs/UUID generator_id<br>string generator_name<br><b>uint8 level</b><br>MetricReport[] metrics</pre> | <pre>builtin_interfaces/Time trajectory_stamp<br>unique_identifier_msgs/UUID generator_id<br>string generator_name<br><b>RiskLevel risk</b><br>MetricReport[] metrics</pre> |

### 2. `MetricReport.msg`
| Before | After |
| :--- | :--- |
| <pre># Possible levels for a metric report.<br>uint8 OK = 0<br>uint8 WARN = 1<br>uint8 ERROR = 2<br><br>string validator_name<br>string validator_category<br>string metric_name<br>float64 metric_value<br><b>uint8 level</b></pre> | <pre>string validator_name<br>string validator_category<br>string metric_name<br>float64 metric_value<br><b>RiskLevel risk</b></pre> |

### 3. `RiskLevel.msg` (Newly Added)
```
# This message represents the possible levels of risk severity.

uint8 SAFE = 0
uint8 LOW_CAUTION = 1
uint8 HIGH_CAUTION = 2
uint8 DANGER = 3
uint8 FATAL = 4

uint8 level
```

## Effects on system behavior

None.
