### PR TITLE
feat(pid_longitudinal_controller): add option to return drive from emergency without stop for v0.64 e2e

### DIFF
--- a/control/autoware_pid_longitudinal_controller/include/autoware/pid_longitudinal_controller/pid_longitudinal_controller.hpp
+++ b/control/autoware_pid_longitudinal_controller/include/autoware/pid_longitudinal_controller/pid_longitudinal_controller.hpp
@@ -155,6 +155,7 @@ private:
   bool m_enable_overshoot_emergency;
   bool m_enable_slope_compensation;
   bool m_enable_large_tracking_error_emergency;
+  bool m_enable_emergency_exit_without_stop;
   bool m_enable_keep_stopped_until_steer_convergence;
 
   // smooth stop transition

--- a/control/autoware_pid_longitudinal_controller/schema/autoware_pid_longitudinal_controller.schema.json
+++ b/control/autoware_pid_longitudinal_controller/schema/autoware_pid_longitudinal_controller.schema.json
@@ -31,6 +31,11 @@
           "description": "flag to modify output acceleration for slope compensation. The source of the slope angle can be selected from ego-pose or trajectory angle",
           "default": "true"
         },
+        "enable_emergency_exit_without_stop": {
+          "type": "boolean",
+          "description": "flag to allow transition from EMERGENCY to DRIVE while still moving when the stop distance exceeds `emergency_state_overshoot_stop_dist`. Intended for the MRM in-lane-stop controller.",
+          "default": "false"
+        },
         "enable_keep_stopped_until_steer_convergence": {
           "type": "boolean",
           "description": "flag to keep stopped condition until until the steer converges",

--- a/control/autoware_pid_longitudinal_controller/src/pid_longitudinal_controller.cpp
+++ b/control/autoware_pid_longitudinal_controller/src/pid_longitudinal_controller.cpp
@@ -909,8 +909,7 @@ void PidLongitudinalController::updateControlState(const ControlData & control_d
         return changeControlState(ControlState::DRIVE);
       }
       if (
-        m_enable_emergency_exit_without_stop &&
-        stop_dist > p.emergency_state_overshoot_stop_dist) {
+        m_enable_emergency_exit_without_stop && stop_dist > p.emergency_state_overshoot_stop_dist) {
         m_pid_vel.reset();
         m_lpf_vel_error->reset(0.0);
         return changeControlState(ControlState::DRIVE);

--- a/control/autoware_pid_longitudinal_controller/src/pid_longitudinal_controller.cpp
+++ b/control/autoware_pid_longitudinal_controller/src/pid_longitudinal_controller.cpp
@@ -71,6 +71,8 @@ PidLongitudinalController::PidLongitudinalController(
   m_enable_overshoot_emergency = node.declare_parameter<bool>("enable_overshoot_emergency");
   m_enable_large_tracking_error_emergency =
     node.declare_parameter<bool>("enable_large_tracking_error_emergency");
+  m_enable_emergency_exit_without_stop =
+    node.declare_parameter<bool>("enable_emergency_exit_without_stop", false);
   m_enable_slope_compensation = node.declare_parameter<bool>("enable_slope_compensation");
   m_enable_keep_stopped_until_steer_convergence =
     node.declare_parameter<bool>("enable_keep_stopped_until_steer_convergence");
@@ -904,6 +906,13 @@ void PidLongitudinalController::updateControlState(const ControlData & control_d
     if (!emergency_condition.result) {
       if (!is_under_control) {
         // NOTE: On manual driving, no need stopping to exit the emergency.
+        return changeControlState(ControlState::DRIVE);
+      }
+      if (
+        m_enable_emergency_exit_without_stop &&
+        stop_dist > p.emergency_state_overshoot_stop_dist) {
+        m_pid_vel.reset();
+        m_lpf_vel_error->reset(0.0);
         return changeControlState(ControlState::DRIVE);
       }
     }


### PR DESCRIPTION
## Description

Add option to return drive state from emergency state without stop for `feat/v0.64/e2e`.

https://tier4.atlassian.net/wiki/spaces/AIP/pages/5274305002/2026-06-05+DP+MRM+Phase1+Debug#2%E6%AE%B5%E9%9A%8E%E5%81%9C%E6%AD%A2

## Test performed

Confirmed by the vehicle test on 2026-06-18.