### PR TITLE
fix(autoware_tensorrt_yolox): cherry-pick #12400 missing cstdint include

### DIFF
--- a/perception/autoware_tensorrt_yolox/include/autoware/tensorrt_yolox/label.hpp
+++ b/perception/autoware_tensorrt_yolox/include/autoware/tensorrt_yolox/label.hpp
@@ -15,6 +15,7 @@
 #ifndef AUTOWARE__TENSORRT_YOLOX__LABEL_HPP_
 #define AUTOWARE__TENSORRT_YOLOX__LABEL_HPP_
 
+#include <cstdint>
 #include <optional>
 #include <string>
 #include <unordered_map>

--- a/perception/autoware_tensorrt_yolox/package.xml
+++ b/perception/autoware_tensorrt_yolox/package.xml
@@ -36,6 +36,7 @@
 
   <exec_depend>autoware_image_transport_decompressor</exec_depend>
 
+  <test_depend>ament_index_cpp</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>autoware_lint_common</test_depend>
 


### PR DESCRIPTION
## Summary

Cherry-pick [autowarefoundation/autoware_universe#12400](https://github.com/autowarefoundation/autoware_universe/pull/12400) into `feat/v0.64/e2e`.

#12204 introduced `uint32_t` in `label.hpp` without `#include <cstdint>`, causing build failure on **Ubuntu 24.04 / ROS 2 Jazzy**. The fix was merged upstream in #12400 but was not included in #3071.

- Add `#include <cstdint>` to `label.hpp`
- Add missing `ament_index_cpp` test dependency in `package.xml`

## Test plan

- [x] Build `autoware_tensorrt_yolox` on Ubuntu 24.04 / ROS 2 Jazzy
