### PR TITLE
feat(autoware_mppi_optimizer): add package and integrate in DP node

### DIFF
--- a/planning/autoware_diffusion_planner/CMakeLists.txt
+++ b/planning/autoware_diffusion_planner/CMakeLists.txt
@@ -2,6 +2,13 @@ cmake_minimum_required(VERSION 3.14)
 project(autoware_diffusion_planner)
 
 find_package(autoware_cmake REQUIRED)
+find_package(autoware_mppi_optimizer REQUIRED)
+if(EXISTS "${autoware_mppi_optimizer_DIR}/ament_cmake_export_libraries-extras.cmake")
+  include("${autoware_mppi_optimizer_DIR}/ament_cmake_export_libraries-extras.cmake")
+endif()
+if(EXISTS "${autoware_mppi_optimizer_DIR}/ament_cmake_export_dependencies-extras.cmake")
+  include("${autoware_mppi_optimizer_DIR}/ament_cmake_export_dependencies-extras.cmake")
+endif()
 autoware_package()
 find_package(Boost REQUIRED)
 find_package(onnxruntime QUIET)
@@ -122,7 +129,9 @@ if(TRT_AVAIL AND CUDA_AVAIL)
     ${NVONNXPARSER}
     ${CUDA_LIBRARIES}
     ${CUBLAS_LIBRARIES}
+    ${autoware_mppi_optimizer_LIBRARIES}
   )
+  ament_target_dependencies(autoware_diffusion_planner_component autoware_mppi_optimizer)
 
   if(onnxruntime_FOUND)
     if(TARGET onnxruntime::onnxruntime)

--- a/planning/autoware_diffusion_planner/config/diffusion_planner.param.yaml
+++ b/planning/autoware_diffusion_planner/config/diffusion_planner.param.yaml
@@ -23,7 +23,7 @@
       centerline_guidance:
         start_time_s: 2.0
     planning_frequency_hz: 10.0
-    ignore_neighbors: true
+    ignore_neighbors: false
     ignore_unknown_neighbors: true
     traffic_light_group_msg_timeout_seconds: 0.2
     batch_size: 1
@@ -36,7 +36,7 @@
     delay_step: 0
     line_string_max_step_m: 5.0
     use_time_interpolation: false
-    use_mppi_optimizer: true
+    use_mppi_optimizer: false
     shadow_mode: false
     planning_factor:
       enable_stop: true

--- a/planning/autoware_diffusion_planner/config/diffusion_planner.param.yaml
+++ b/planning/autoware_diffusion_planner/config/diffusion_planner.param.yaml
@@ -23,7 +23,7 @@
       centerline_guidance:
         start_time_s: 2.0
     planning_frequency_hz: 10.0
-    ignore_neighbors: false
+    ignore_neighbors: true
     ignore_unknown_neighbors: true
     traffic_light_group_msg_timeout_seconds: 0.2
     batch_size: 1
@@ -36,6 +36,8 @@
     delay_step: 0
     line_string_max_step_m: 5.0
     use_time_interpolation: false
+    use_mppi_optimizer: true
+    shadow_mode: false
     planning_factor:
       enable_stop: true
       enable_slowdown: false

--- a/planning/autoware_diffusion_planner/include/autoware/diffusion_planner/diffusion_planner_core.hpp
+++ b/planning/autoware_diffusion_planner/include/autoware/diffusion_planner/diffusion_planner_core.hpp
@@ -140,6 +140,8 @@ struct DiffusionPlannerParams
   double start_guidance_max_scale;
   double stop_guidance_stop_acceleration_mps2;
   double centerline_guidance_start_time_s;
+  bool use_mppi_optimizer;
+  bool shadow_mode;
 };
 
 /**

--- a/planning/autoware_diffusion_planner/include/autoware/diffusion_planner/diffusion_planner_node.hpp
+++ b/planning/autoware_diffusion_planner/include/autoware/diffusion_planner/diffusion_planner_node.hpp
@@ -17,6 +17,8 @@
 
 #include "autoware/diffusion_planner/diffusion_planner_core.hpp"
 #include "autoware/diffusion_planner/utils/planning_factor_utils.hpp"
+#include "autoware/mppi_optimizer/first_order_dubins_mppi_interface.hpp"
+#include "autoware/mppi_optimizer/mppi_debug_markers.hpp"
 
 #include <autoware/lanelet2_utils/conversion.hpp>
 #include <autoware/planning_factor_interface/planning_factor_interface.hpp>
@@ -38,6 +40,7 @@
 #include <autoware_perception_msgs/msg/predicted_objects.hpp>
 #include <autoware_perception_msgs/msg/traffic_light_group.hpp>
 #include <autoware_planning_msgs/msg/trajectory.hpp>
+#include <autoware_vehicle_msgs/msg/steering_report.hpp>
 #include <autoware_vehicle_msgs/msg/turn_indicators_command.hpp>
 #include <std_msgs/msg/float32_multi_array.hpp>
 #include <std_msgs/msg/float64.hpp>
@@ -55,6 +58,7 @@ using autoware_internal_planning_msgs::msg::CandidateTrajectories;
 using autoware_map_msgs::msg::LaneletMapBin;
 using autoware_perception_msgs::msg::PredictedObjects;
 using autoware_planning_msgs::msg::Trajectory;
+using autoware_vehicle_msgs::msg::SteeringReport;
 using autoware_vehicle_msgs::msg::TurnIndicatorsCommand;
 using HADMapBin = autoware_map_msgs::msg::LaneletMapBin;
 using autoware::vehicle_info_utils::VehicleInfo;
@@ -170,6 +174,10 @@ private:
    */
   void publish_planning_factor(const Trajectory & trajectory);
 
+  void publish_mppi_debug(
+    const autoware::mppi_optimizer::FirstOrderDubinsMppiDebug & debug, const std::string & frame_id,
+    const rclcpp::Time & stamp);
+
   /**
    * @brief Publish guidance triggered status as a debug message.
    * @param guidance_triggered Map of guidance name to triggered flags per batch.
@@ -219,6 +227,9 @@ private:
   rclcpp::Publisher<autoware_internal_debug_msgs::msg::Float64Stamped>::SharedPtr
     debug_processing_time_pub_{nullptr};
   rclcpp::Publisher<Trajectory>::SharedPtr pub_trajectory_{nullptr};
+  rclcpp::Publisher<Trajectory>::SharedPtr pub_mppi_reference_trajectory_{nullptr};
+  rclcpp::Publisher<Trajectory>::SharedPtr pub_mppi_optimized_trajectory_{nullptr};
+  rclcpp::Publisher<MarkerArray>::SharedPtr pub_mppi_markers_{nullptr};
   rclcpp::Publisher<CandidateTrajectories>::SharedPtr pub_trajectories_{nullptr};
   rclcpp::Publisher<PredictedObjects>::SharedPtr pub_objects_{nullptr};
   rclcpp::Publisher<MarkerArray>::SharedPtr pub_lane_marker_{nullptr};
@@ -237,6 +248,8 @@ private:
   mutable std::shared_ptr<autoware_utils::TimeKeeper> time_keeper_{nullptr};
   autoware_utils::InterProcessPollingSubscriber<Odometry> sub_current_odometry_{
     this, "~/input/odometry"};
+  autoware_utils::InterProcessPollingSubscriber<SteeringReport> sub_steering_status_{
+    this, "~/input/steering_status"};
   autoware_utils::InterProcessPollingSubscriber<AccelWithCovarianceStamped>
     sub_current_acceleration_{this, "~/input/acceleration"};
   autoware_utils::InterProcessPollingSubscriber<TrackedObjects> sub_tracked_objects_{
@@ -264,6 +277,8 @@ private:
   std::unique_ptr<autoware::planning_factor_interface::PlanningFactorInterface>
     planning_factor_interface_;
   DiffusionPlannerPlanningFactorParams planning_factor_params_;
+
+  std::unique_ptr<autoware::mppi_optimizer::FirstOrderDubinsMppiInterface> mppi_optimizer_;
 };
 
 }  // namespace autoware::diffusion_planner

--- a/planning/autoware_diffusion_planner/launch/diffusion_planner.launch.xml
+++ b/planning/autoware_diffusion_planner/launch/diffusion_planner.launch.xml
@@ -1,13 +1,18 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <launch>
   <arg name="diffusion_planner_param_path" default="$(find-pkg-share autoware_diffusion_planner)/config/diffusion_planner.param.yaml"/>
-  <arg name="vehicle_info_param_path" default="$(find-pkg-share autoware_vehicle_info_utils)/config/vehicle_info.param.yaml"/>
+  <arg name="mppi_optimizer_param_path" default="$(find-pkg-share autoware_mppi_optimizer)/config/mppi_optimizer.param.yaml"/>
+  <arg name="data_path" default="$(env HOME)/autoware_data/ml_models/diffusion_planner" description="diffusion planner artifacts (onnx model, args json) directory"/>
+  <arg name="vehicle_model" default="sample_vehicle"/>
+  <arg name="vehicle_info_param_path" default="$(find-pkg-share $(var vehicle_model)_description)/config/vehicle_info.param.yaml"/>
+  <arg name="simulator_model_param_path" default="$(find-pkg-share $(var vehicle_model)_description)/config/simulator_model.param.yaml"/>
   <arg name="output_trajectory" default="~/output/trajectory"/>
   <arg name="output_trajectories" default="~/output/trajectories"/>
   <arg name="output_predicted_objects" default="~/output/predicted_objects"/>
   <arg name="output_turn_indicators" default="~/output/turn_indicators"/>
   <arg name="debug/output_traffic_signal" default="~/output/debug/traffic_signal"/>
   <arg name="input_odometry" default="~/input/odometry"/>
+  <arg name="input_steering_status" default="/vehicle/status/steering_status"/>
   <arg name="input_acceleration" default="~/input/acceleration"/>
   <arg name="input_route" default="~/input/route"/>
   <arg name="input_traffic_signals" default="~/input/traffic_signals"/>
@@ -18,6 +23,8 @@
 
   <node pkg="autoware_diffusion_planner" exec="autoware_diffusion_planner_node" name="diffusion_planner_node" output="both">
     <param from="$(var diffusion_planner_param_path)" allow_substs="true"/>
+    <param from="$(var simulator_model_param_path)"/>
+    <param from="$(var mppi_optimizer_param_path)"/>
     <param from="$(var vehicle_info_param_path)" allow_substs="true"/>
     <remap from="~/output/trajectory" to="$(var output_trajectory)"/>
     <remap from="~/output/trajectories" to="$(var output_trajectories)"/>
@@ -25,6 +32,7 @@
     <remap from="~/output/turn_indicators" to="$(var output_turn_indicators)"/>
     <remap from="~/output/debug/traffic_signal" to="$(var debug/output_traffic_signal)"/>
     <remap from="~/input/odometry" to="$(var input_odometry)"/>
+    <remap from="~/input/steering_status" to="$(var input_steering_status)"/>
     <remap from="~/input/acceleration" to="$(var input_acceleration)"/>
     <remap from="~/input/route" to="$(var input_route)"/>
     <remap from="~/input/traffic_signals" to="$(var input_traffic_signals)"/>

--- a/planning/autoware_diffusion_planner/package.xml
+++ b/planning/autoware_diffusion_planner/package.xml
@@ -37,8 +37,8 @@
   <depend>autoware_utils_geometry</depend>
   <depend>autoware_utils_uuid</depend>
   <depend>autoware_vehicle_info_utils</depend>
-  <depend>boost</depend>
   <depend>autoware_vehicle_msgs</depend>
+  <depend>boost</depend>
   <depend>geometry_msgs</depend>
   <depend>lanelet2_core</depend>
   <depend>lanelet2_routing</depend>

--- a/planning/autoware_diffusion_planner/package.xml
+++ b/planning/autoware_diffusion_planner/package.xml
@@ -24,6 +24,7 @@
   <depend>autoware_lanelet2_utils</depend>
   <depend>autoware_map_msgs</depend>
   <depend>autoware_motion_utils</depend>
+  <depend>autoware_mppi_optimizer</depend>
   <depend>autoware_object_recognition_utils</depend>
   <depend>autoware_perception_msgs</depend>
   <depend>autoware_planning_factor_interface</depend>
@@ -37,6 +38,7 @@
   <depend>autoware_utils_uuid</depend>
   <depend>autoware_vehicle_info_utils</depend>
   <depend>boost</depend>
+  <depend>autoware_vehicle_msgs</depend>
   <depend>geometry_msgs</depend>
   <depend>lanelet2_core</depend>
   <depend>lanelet2_routing</depend>

--- a/planning/autoware_diffusion_planner/src/diffusion_planner_node.cpp
+++ b/planning/autoware_diffusion_planner/src/diffusion_planner_node.cpp
@@ -640,8 +640,8 @@ void DiffusionPlanner::on_timer()
       autoware_utils_debug::ScopedTimeTrack optimize_trajectory_st(
         "mppi_optimizer/optimize_trajectory", *time_keeper_);
       stop_watch_ptr_->tic("mppi_optimizer/optimize_trajectory");
-      const std::optional<geometry_msgs::msg::AccelWithCovarianceStamped>
-        ego_acceleration_for_mppi{frame_context->ego_acceleration};
+      const std::optional<geometry_msgs::msg::AccelWithCovarianceStamped> ego_acceleration_for_mppi{
+        frame_context->ego_acceleration};
       const auto steering_status = sub_steering_status_.take_data();
       const std::optional<SteeringReport> ego_steering =
         steering_status ? std::make_optional(*steering_status) : std::nullopt;

--- a/planning/autoware_diffusion_planner/src/diffusion_planner_node.cpp
+++ b/planning/autoware_diffusion_planner/src/diffusion_planner_node.cpp
@@ -498,9 +498,10 @@ void DiffusionPlanner::publish_debug_markers(
 
 void DiffusionPlanner::on_timer()
 {
+  // Timer callback function
   autoware_utils_debug::ScopedTimeTrack st(__func__, *time_keeper_);
   stop_watch_ptr_ = std::make_unique<autoware_utils_system::StopWatch<std::chrono::milliseconds>>();
-  stop_watch_ptr_->tic("total");
+  stop_watch_ptr_->tic("processing_time");
 
   diagnostics_inference_->clear();
 
@@ -523,51 +524,43 @@ void DiffusionPlanner::on_timer()
     return;
   }
 
-  std::optional<FrameContext> frame_context;
-  std::optional<autoware_perception_msgs::msg::TrackedObjects> tracked_objects_for_mppi;
-  {
-    autoware_utils_debug::ScopedTimeTrack prepare_st("prepare_frame_context", *time_keeper_);
-    stop_watch_ptr_->tic("prepare_frame_context");
+  // Take data from subscribers
+  auto objects = sub_tracked_objects_.take_data();
+  auto ego_kinematic_state = sub_current_odometry_.take_data();
+  auto ego_acceleration = sub_current_acceleration_.take_data();
+  auto traffic_signals = sub_traffic_signals_.take_data();
+  auto temp_route_ptr = route_subscriber_.take_data();
+  auto turn_indicators_ptr = sub_turn_indicators_.take_data();
 
-    auto objects = sub_tracked_objects_.take_data();
-    if (objects) {
-      tracked_objects_for_mppi = *objects;
-    }
-    auto ego_kinematic_state = sub_current_odometry_.take_data();
-    auto ego_acceleration = sub_current_acceleration_.take_data();
-    auto traffic_signals = sub_traffic_signals_.take_data();
-    auto temp_route_ptr = route_subscriber_.take_data();
-    auto turn_indicators_ptr = sub_turn_indicators_.take_data();
+  // Prepare frame context using core
+  const std::optional<FrameContext> frame_context = core_->create_frame_context(
+    ego_kinematic_state, ego_acceleration, objects, traffic_signals, turn_indicators_ptr,
+    temp_route_ptr, this->now());
 
-    frame_context = core_->create_frame_context(
-      ego_kinematic_state, ego_acceleration, objects, traffic_signals, turn_indicators_ptr,
-      temp_route_ptr, this->now());
+  if (!frame_context) {
+    // Log detailed information about missing inputs
+    RCLCPP_WARN_STREAM_THROTTLE(
+      get_logger(), *this->get_clock(), constants::LOG_THROTTLE_INTERVAL_MS,
+      "There is no input data. objects: "
+        << (objects ? "true" : "false")
+        << ", ego_kinematic_state: " << (ego_kinematic_state ? "true" : "false")
+        << ", ego_acceleration: " << (ego_acceleration ? "true" : "false")
+        << ", route: " << (core_->get_route() ? "true" : "false")
+        << ", turn_indicators: " << (turn_indicators_ptr ? "true" : "false"));
+    diagnostics_inference_->update_level_and_message(
+      DiagnosticStatus::WARN, "No input data available for inference");
+    diagnostics_inference_->publish(current_time);
+    return;
+  }
 
-    if (!frame_context) {
-      RCLCPP_WARN_STREAM_THROTTLE(
-        get_logger(), *this->get_clock(), constants::LOG_THROTTLE_INTERVAL_MS,
-        "There is no input data. objects: "
-          << (objects ? "true" : "false")
-          << ", ego_kinematic_state: " << (ego_kinematic_state ? "true" : "false")
-          << ", ego_acceleration: " << (ego_acceleration ? "true" : "false")
-          << ", route: " << (core_->get_route() ? "true" : "false")
-          << ", turn_indicators: " << (turn_indicators_ptr ? "true" : "false"));
-      diagnostics_inference_->update_level_and_message(
-        DiagnosticStatus::WARN, "No input data available for inference");
-      diagnostics_inference_->publish(current_time);
-      return;
-    }
-
-    if (traffic_signals.empty()) {
-      RCLCPP_WARN_THROTTLE(
-        this->get_logger(), *this->get_clock(), constants::LOG_THROTTLE_INTERVAL_MS,
-        "no traffic signal received. traffic light info will not be updated");
-    }
-
-    record_section_time(*stop_watch_ptr_, "prepare_frame_context", *diagnostics_inference_);
+  if (traffic_signals.empty()) {
+    RCLCPP_WARN_THROTTLE(
+      this->get_logger(), *this->get_clock(), constants::LOG_THROTTLE_INTERVAL_MS,
+      "no traffic signal received. traffic light info will not be updated");
   }
 
   const rclcpp::Time frame_time(frame_context->frame_time);
+  InputDataMap input_data_map = core_->create_input_data(*frame_context);
 
   publish_debug_markers(input_data_map, frame_context->ego_to_map_transform, frame_time);
 
@@ -629,13 +622,6 @@ void DiffusionPlanner::on_timer()
     pub_denoising_steps_->publish(planner_output.denoising_steps);
   }
 
-  publish_guidance_status(planner_output.guidance_triggered, frame_time);
-
-  pub_trajectory_->publish(planner_output.trajectory);
-  pub_trajectories_->publish(planner_output.candidate_trajectories);
-  pub_objects_->publish(planner_output.predicted_objects);
-  pub_turn_indicators_->publish(planner_output.turn_indicator_command);
-
   if (params_.use_mppi_optimizer) {
     autoware_utils_debug::ScopedTimeTrack mppi_st("mppi_optimizer", *time_keeper_);
     stop_watch_ptr_->tic("mppi_optimizer");
@@ -648,10 +634,6 @@ void DiffusionPlanner::on_timer()
     }
 
     try {
-      const autoware_perception_msgs::msg::TrackedObjects& mppi_tracked_objects =
-        tracked_objects_for_mppi ? *tracked_objects_for_mppi
-                                 : autoware_perception_msgs::msg::TrackedObjects{};
-
       autoware_utils_debug::ScopedTimeTrack optimize_trajectory_st("mppi_optimizer/optimize_trajectory", *time_keeper_);
       stop_watch_ptr_->tic("mppi_optimizer/optimize_trajectory");
       const std::optional<geometry_msgs::msg::AccelWithCovarianceStamped> ego_acceleration{
@@ -661,7 +643,7 @@ void DiffusionPlanner::on_timer()
         steering_status ? std::make_optional(*steering_status) : std::nullopt;
       const auto mppi_result = mppi_optimizer_->optimizeTrajectory(
         planner_output.trajectory, frame_context->ego_kinematic_state, ego_acceleration,
-        ego_steering, mppi_tracked_objects);
+        ego_steering, *objects);
       record_section_time(*stop_watch_ptr_, "mppi_optimizer/optimize_trajectory", *diagnostics_inference_);
       if (!params_.shadow_mode) {
         planner_output.trajectory = mppi_result.trajectory;
@@ -684,27 +666,22 @@ void DiffusionPlanner::on_timer()
     record_section_time(*stop_watch_ptr_, "mppi_optimizer", *diagnostics_inference_);
   }
 
-  {
-    autoware_utils_debug::ScopedTimeTrack publish_st("publish_outputs", *time_keeper_);
-    stop_watch_ptr_->tic("publish_outputs");
+  publish_guidance_status(planner_output.guidance_triggered, frame_time);
 
-    pub_trajectory_->publish(planner_output.trajectory);
-    pub_trajectories_->publish(planner_output.candidate_trajectories);
-    pub_objects_->publish(planner_output.predicted_objects);
-    pub_turn_indicators_->publish(planner_output.turn_indicator_command);
+  pub_trajectory_->publish(planner_output.trajectory);
+  pub_trajectories_->publish(planner_output.candidate_trajectories);
+  pub_objects_->publish(planner_output.predicted_objects);
+  pub_turn_indicators_->publish(planner_output.turn_indicator_command);
 
-    publish_planning_factor(planner_output.trajectory);
+  publish_planning_factor(planner_output.trajectory);
 
-    record_section_time(*stop_watch_ptr_, "publish_outputs", *diagnostics_inference_);
-  }
-
-  const double total_processing_time_ms = stop_watch_ptr_->toc("total");
-  diagnostics_inference_->add_key_value("total_processing_time_ms", total_processing_time_ms);
+  // Publish diagnostics
   diagnostics_inference_->publish(frame_time);
 
+  // Publish processing time
   autoware_internal_debug_msgs::msg::Float64Stamped processing_time_msg;
   processing_time_msg.stamp = get_clock()->now();
-  processing_time_msg.data = total_processing_time_ms;
+  processing_time_msg.data = stop_watch_ptr_->toc("processing_time", true);
   debug_processing_time_pub_->publish(processing_time_msg);
 }
 

--- a/planning/autoware_diffusion_planner/src/diffusion_planner_node.cpp
+++ b/planning/autoware_diffusion_planner/src/diffusion_planner_node.cpp
@@ -34,6 +34,7 @@
 #include <memory>
 #include <optional>
 #include <sstream>
+#include <stdexcept>
 #include <string>
 #include <string_view>
 #include <unordered_map>
@@ -639,13 +640,13 @@ void DiffusionPlanner::on_timer()
       autoware_utils_debug::ScopedTimeTrack optimize_trajectory_st(
         "mppi_optimizer/optimize_trajectory", *time_keeper_);
       stop_watch_ptr_->tic("mppi_optimizer/optimize_trajectory");
-      const std::optional<geometry_msgs::msg::AccelWithCovarianceStamped> ego_acceleration{
-        frame_context->ego_acceleration};
+      const std::optional<geometry_msgs::msg::AccelWithCovarianceStamped>
+        ego_acceleration_for_mppi{frame_context->ego_acceleration};
       const auto steering_status = sub_steering_status_.take_data();
       const std::optional<SteeringReport> ego_steering =
         steering_status ? std::make_optional(*steering_status) : std::nullopt;
       const auto mppi_result = mppi_optimizer_->optimizeTrajectory(
-        planner_output.trajectory, frame_context->ego_kinematic_state, ego_acceleration,
+        planner_output.trajectory, frame_context->ego_kinematic_state, ego_acceleration_for_mppi,
         ego_steering, *objects);
       record_section_time(
         *stop_watch_ptr_, "mppi_optimizer/optimize_trajectory", *diagnostics_inference_);
@@ -663,7 +664,7 @@ void DiffusionPlanner::on_timer()
       }
       record_section_time(
         *stop_watch_ptr_, "mppi_optimizer/publish_debug", *diagnostics_inference_);
-    } catch (const std::exception & e) {
+    } catch (const std::runtime_error & e) {
       RCLCPP_ERROR_STREAM(get_logger(), "MPPI optimization failed: " << e.what());
       diagnostics_inference_->update_level_and_message(DiagnosticStatus::ERROR, e.what());
       diagnostics_inference_->publish(frame_time);

--- a/planning/autoware_diffusion_planner/src/diffusion_planner_node.cpp
+++ b/planning/autoware_diffusion_planner/src/diffusion_planner_node.cpp
@@ -19,6 +19,8 @@
 #include "autoware/diffusion_planner/preprocessing/preprocessing_utils.hpp"
 #include "autoware/diffusion_planner/utils/marker_utils.hpp"
 #include "autoware/diffusion_planner/utils/utils.hpp"
+#include "autoware/mppi_optimizer/first_order_dubins_mppi_cost_params_ros.hpp"
+#include "autoware/mppi_optimizer/first_order_dubins_mppi_vehicle_params_ros.hpp"
 
 #include <rclcpp/duration.hpp>
 #include <rclcpp/logging.hpp>
@@ -67,6 +69,13 @@ std::string compute_file_hash_hex(const std::string & path)
   oss << std::hex << std::setw(sizeof(std::size_t) * 2) << std::setfill('0') << combined;
   return oss.str();
 }
+
+void record_section_time(
+  autoware_utils_system::StopWatch<std::chrono::milliseconds> & stop_watch,
+  const std::string & section_name, DiagnosticsInterface & diagnostics)
+{
+  diagnostics.add_key_value(section_name, stop_watch.toc(section_name));
+}
 }  // namespace
 
 DiffusionPlanner::DiffusionPlanner(const rclcpp::NodeOptions & options)
@@ -74,6 +83,11 @@ DiffusionPlanner::DiffusionPlanner(const rclcpp::NodeOptions & options)
 {
   // Initialize the node
   pub_trajectory_ = this->create_publisher<Trajectory>("~/output/trajectory", 1);
+  pub_mppi_reference_trajectory_ =
+    this->create_publisher<Trajectory>("~/debug/mppi/reference_trajectory", 1);
+  pub_mppi_optimized_trajectory_ =
+    this->create_publisher<Trajectory>("~/debug/mppi/optimized_trajectory", 1);
+  pub_mppi_markers_ = this->create_publisher<MarkerArray>("~/debug/mppi/markers", 1);
   pub_trajectories_ = this->create_publisher<CandidateTrajectories>("~/output/trajectories", 1);
   pub_objects_ =
     this->create_publisher<PredictedObjects>("~/output/predicted_objects", rclcpp::QoS(1));
@@ -201,6 +215,10 @@ void DiffusionPlanner::set_up_params()
     this->declare_parameter<double>("guidance.stop_guidance.stop_acceleration_mps2", 1.0);
   params_.centerline_guidance_start_time_s =
     this->declare_parameter<double>("guidance.centerline_guidance.start_time_s", 2.0);
+  params_.use_mppi_optimizer = this->declare_parameter<bool>("use_mppi_optimizer", false);
+  params_.shadow_mode = this->declare_parameter<bool>("shadow_mode", false);
+  autoware::mppi_optimizer::declare_first_order_dubins_mppi_cost_params(*this);
+  autoware::mppi_optimizer::declare_first_order_dubins_mppi_vehicle_dynamics_params(*this);
 
   // planning factor params
   planning_factor_params_.enable_stop =
@@ -253,6 +271,18 @@ void DiffusionPlanner::load_model()
   RCLCPP_INFO_STREAM(
     get_logger(), "Loaded args_path=" << params_.args_path << " (hash="
                                       << compute_file_hash_hex(params_.args_path) << ")");
+  if (params_.ignore_neighbors) {
+    RCLCPP_INFO(
+      get_logger(), "Neighbor agents disabled for diffusion inference (ignore_neighbors)");
+  }
+  if (params_.use_mppi_optimizer) {
+    RCLCPP_INFO(
+      get_logger(), "MPPI will track diffusion reference trajectory (poses + velocities)");
+  }
+  if (params_.shadow_mode) {
+    RCLCPP_INFO(
+      get_logger(), "Shadow mode enabled. MPPI will not track diffusion reference trajectory (poses + velocities)");
+  }
 }
 
 SetParametersResult DiffusionPlanner::on_parameter(
@@ -343,6 +373,8 @@ SetParametersResult DiffusionPlanner::on_parameter(
 #endif
       return result;
     }
+    update_param<bool>(parameters, "use_mppi_optimizer", temp_params.use_mppi_optimizer);
+    update_param<bool>(parameters, "shadow_mode", temp_params.shadow_mode);
     const bool args_path_changed = temp_params.args_path != previous_args_path;
     const bool model_paths_changed =
       temp_params.model_type != previous_model_type ||
@@ -466,10 +498,9 @@ void DiffusionPlanner::publish_debug_markers(
 
 void DiffusionPlanner::on_timer()
 {
-  // Timer callback function
   autoware_utils_debug::ScopedTimeTrack st(__func__, *time_keeper_);
   stop_watch_ptr_ = std::make_unique<autoware_utils_system::StopWatch<std::chrono::milliseconds>>();
-  stop_watch_ptr_->tic("processing_time");
+  stop_watch_ptr_->tic("total");
 
   diagnostics_inference_->clear();
 
@@ -492,43 +523,51 @@ void DiffusionPlanner::on_timer()
     return;
   }
 
-  // Take data from subscribers
-  auto objects = sub_tracked_objects_.take_data();
-  auto ego_kinematic_state = sub_current_odometry_.take_data();
-  auto ego_acceleration = sub_current_acceleration_.take_data();
-  auto traffic_signals = sub_traffic_signals_.take_data();
-  auto temp_route_ptr = route_subscriber_.take_data();
-  auto turn_indicators_ptr = sub_turn_indicators_.take_data();
+  std::optional<FrameContext> frame_context;
+  std::optional<autoware_perception_msgs::msg::TrackedObjects> tracked_objects_for_mppi;
+  {
+    autoware_utils_debug::ScopedTimeTrack prepare_st("prepare_frame_context", *time_keeper_);
+    stop_watch_ptr_->tic("prepare_frame_context");
 
-  // Prepare frame context using core
-  const std::optional<FrameContext> frame_context = core_->create_frame_context(
-    ego_kinematic_state, ego_acceleration, objects, traffic_signals, turn_indicators_ptr,
-    temp_route_ptr, this->now());
+    auto objects = sub_tracked_objects_.take_data();
+    if (objects) {
+      tracked_objects_for_mppi = *objects;
+    }
+    auto ego_kinematic_state = sub_current_odometry_.take_data();
+    auto ego_acceleration = sub_current_acceleration_.take_data();
+    auto traffic_signals = sub_traffic_signals_.take_data();
+    auto temp_route_ptr = route_subscriber_.take_data();
+    auto turn_indicators_ptr = sub_turn_indicators_.take_data();
 
-  if (!frame_context) {
-    // Log detailed information about missing inputs
-    RCLCPP_WARN_STREAM_THROTTLE(
-      get_logger(), *this->get_clock(), constants::LOG_THROTTLE_INTERVAL_MS,
-      "There is no input data. objects: "
-        << (objects ? "true" : "false")
-        << ", ego_kinematic_state: " << (ego_kinematic_state ? "true" : "false")
-        << ", ego_acceleration: " << (ego_acceleration ? "true" : "false")
-        << ", route: " << (core_->get_route() ? "true" : "false")
-        << ", turn_indicators: " << (turn_indicators_ptr ? "true" : "false"));
-    diagnostics_inference_->update_level_and_message(
-      DiagnosticStatus::WARN, "No input data available for inference");
-    diagnostics_inference_->publish(current_time);
-    return;
-  }
+    frame_context = core_->create_frame_context(
+      ego_kinematic_state, ego_acceleration, objects, traffic_signals, turn_indicators_ptr,
+      temp_route_ptr, this->now());
 
-  if (traffic_signals.empty()) {
-    RCLCPP_WARN_THROTTLE(
-      this->get_logger(), *this->get_clock(), constants::LOG_THROTTLE_INTERVAL_MS,
-      "no traffic signal received. traffic light info will not be updated");
+    if (!frame_context) {
+      RCLCPP_WARN_STREAM_THROTTLE(
+        get_logger(), *this->get_clock(), constants::LOG_THROTTLE_INTERVAL_MS,
+        "There is no input data. objects: "
+          << (objects ? "true" : "false")
+          << ", ego_kinematic_state: " << (ego_kinematic_state ? "true" : "false")
+          << ", ego_acceleration: " << (ego_acceleration ? "true" : "false")
+          << ", route: " << (core_->get_route() ? "true" : "false")
+          << ", turn_indicators: " << (turn_indicators_ptr ? "true" : "false"));
+      diagnostics_inference_->update_level_and_message(
+        DiagnosticStatus::WARN, "No input data available for inference");
+      diagnostics_inference_->publish(current_time);
+      return;
+    }
+
+    if (traffic_signals.empty()) {
+      RCLCPP_WARN_THROTTLE(
+        this->get_logger(), *this->get_clock(), constants::LOG_THROTTLE_INTERVAL_MS,
+        "no traffic signal received. traffic light info will not be updated");
+    }
+
+    record_section_time(*stop_watch_ptr_, "prepare_frame_context", *diagnostics_inference_);
   }
 
   const rclcpp::Time frame_time(frame_context->frame_time);
-  InputDataMap input_data_map = core_->create_input_data(*frame_context);
 
   publish_debug_markers(input_data_map, frame_context->ego_to_map_transform, frame_time);
 
@@ -597,15 +636,75 @@ void DiffusionPlanner::on_timer()
   pub_objects_->publish(planner_output.predicted_objects);
   pub_turn_indicators_->publish(planner_output.turn_indicator_command);
 
-  publish_planning_factor(planner_output.trajectory);
+  if (params_.use_mppi_optimizer) {
+    autoware_utils_debug::ScopedTimeTrack mppi_st("mppi_optimizer", *time_keeper_);
+    stop_watch_ptr_->tic("mppi_optimizer");
+    if (!mppi_optimizer_) {
+      mppi_optimizer_ = std::make_unique<autoware::mppi_optimizer::FirstOrderDubinsMppiInterface>();
+      mppi_optimizer_->setCostParams(
+        autoware::mppi_optimizer::get_first_order_dubins_mppi_cost_params(*this));
+      mppi_optimizer_->setVehicleParams(
+        autoware::mppi_optimizer::get_first_order_dubins_mppi_vehicle_params(*this));
+    }
 
-  // Publish diagnostics
+    try {
+      const autoware_perception_msgs::msg::TrackedObjects& mppi_tracked_objects =
+        tracked_objects_for_mppi ? *tracked_objects_for_mppi
+                                 : autoware_perception_msgs::msg::TrackedObjects{};
+
+      autoware_utils_debug::ScopedTimeTrack optimize_trajectory_st("mppi_optimizer/optimize_trajectory", *time_keeper_);
+      stop_watch_ptr_->tic("mppi_optimizer/optimize_trajectory");
+      const std::optional<geometry_msgs::msg::AccelWithCovarianceStamped> ego_acceleration{
+        frame_context->ego_acceleration};
+      const auto steering_status = sub_steering_status_.take_data();
+      const std::optional<SteeringReport> ego_steering =
+        steering_status ? std::make_optional(*steering_status) : std::nullopt;
+      const auto mppi_result = mppi_optimizer_->optimizeTrajectory(
+        planner_output.trajectory, frame_context->ego_kinematic_state, ego_acceleration,
+        ego_steering, mppi_tracked_objects);
+      record_section_time(*stop_watch_ptr_, "mppi_optimizer/optimize_trajectory", *diagnostics_inference_);
+      if (!params_.shadow_mode) {
+        planner_output.trajectory = mppi_result.trajectory;
+      }
+
+      autoware_utils_debug::ScopedTimeTrack publish_debug_st("mppi_optimizer/publish_debug", *time_keeper_);
+      stop_watch_ptr_->tic("mppi_optimizer/publish_debug");
+      publish_mppi_debug(mppi_result.debug, planner_output.trajectory.header.frame_id, frame_time);
+      if (!planner_output.candidate_trajectories.candidate_trajectories.empty()) {
+        planner_output.candidate_trajectories.candidate_trajectories.front().points =
+          planner_output.trajectory.points;
+      }
+      record_section_time(*stop_watch_ptr_, "mppi_optimizer/publish_debug", *diagnostics_inference_);
+    } catch (const std::exception & e) {
+      RCLCPP_ERROR_STREAM(get_logger(), "MPPI optimization failed: " << e.what());
+      diagnostics_inference_->update_level_and_message(DiagnosticStatus::ERROR, e.what());
+      diagnostics_inference_->publish(frame_time);
+      return;
+    }
+    record_section_time(*stop_watch_ptr_, "mppi_optimizer", *diagnostics_inference_);
+  }
+
+  {
+    autoware_utils_debug::ScopedTimeTrack publish_st("publish_outputs", *time_keeper_);
+    stop_watch_ptr_->tic("publish_outputs");
+
+    pub_trajectory_->publish(planner_output.trajectory);
+    pub_trajectories_->publish(planner_output.candidate_trajectories);
+    pub_objects_->publish(planner_output.predicted_objects);
+    pub_turn_indicators_->publish(planner_output.turn_indicator_command);
+
+    publish_planning_factor(planner_output.trajectory);
+
+    record_section_time(*stop_watch_ptr_, "publish_outputs", *diagnostics_inference_);
+  }
+
+  const double total_processing_time_ms = stop_watch_ptr_->toc("total");
+  diagnostics_inference_->add_key_value("total_processing_time_ms", total_processing_time_ms);
   diagnostics_inference_->publish(frame_time);
 
-  // Publish processing time
   autoware_internal_debug_msgs::msg::Float64Stamped processing_time_msg;
   processing_time_msg.stamp = get_clock()->now();
-  processing_time_msg.data = stop_watch_ptr_->toc("processing_time", true);
+  processing_time_msg.data = total_processing_time_ms;
   debug_processing_time_pub_->publish(processing_time_msg);
 }
 
@@ -647,6 +746,23 @@ void DiffusionPlanner::publish_guidance_status(
   msg.data = result;
 
   pub_guidance_status_->publish(msg);
+}
+
+void DiffusionPlanner::publish_mppi_debug(
+  const autoware::mppi_optimizer::FirstOrderDubinsMppiDebug & debug, const std::string & frame_id,
+  const rclcpp::Time & stamp)
+{
+  auto reference = debug.reference_trajectory;
+  auto optimized = debug.optimized_trajectory;
+  reference.header.stamp = stamp;
+  reference.header.frame_id = frame_id;
+  optimized.header.stamp = stamp;
+  optimized.header.frame_id = frame_id;
+
+  pub_mppi_reference_trajectory_->publish(reference);
+  pub_mppi_optimized_trajectory_->publish(optimized);
+  pub_mppi_markers_->publish(
+    autoware::mppi_optimizer::createMppiDebugMarkers(debug, frame_id, stamp));
 }
 
 void DiffusionPlanner::publish_planning_factor(const Trajectory & trajectory)

--- a/planning/autoware_diffusion_planner/src/diffusion_planner_node.cpp
+++ b/planning/autoware_diffusion_planner/src/diffusion_planner_node.cpp
@@ -281,7 +281,9 @@ void DiffusionPlanner::load_model()
   }
   if (params_.shadow_mode) {
     RCLCPP_INFO(
-      get_logger(), "Shadow mode enabled. MPPI will not track diffusion reference trajectory (poses + velocities)");
+      get_logger(),
+      "Shadow mode enabled. MPPI will not track diffusion reference trajectory (poses + "
+      "velocities)");
   }
 }
 
@@ -634,7 +636,8 @@ void DiffusionPlanner::on_timer()
     }
 
     try {
-      autoware_utils_debug::ScopedTimeTrack optimize_trajectory_st("mppi_optimizer/optimize_trajectory", *time_keeper_);
+      autoware_utils_debug::ScopedTimeTrack optimize_trajectory_st(
+        "mppi_optimizer/optimize_trajectory", *time_keeper_);
       stop_watch_ptr_->tic("mppi_optimizer/optimize_trajectory");
       const std::optional<geometry_msgs::msg::AccelWithCovarianceStamped> ego_acceleration{
         frame_context->ego_acceleration};
@@ -644,19 +647,22 @@ void DiffusionPlanner::on_timer()
       const auto mppi_result = mppi_optimizer_->optimizeTrajectory(
         planner_output.trajectory, frame_context->ego_kinematic_state, ego_acceleration,
         ego_steering, *objects);
-      record_section_time(*stop_watch_ptr_, "mppi_optimizer/optimize_trajectory", *diagnostics_inference_);
+      record_section_time(
+        *stop_watch_ptr_, "mppi_optimizer/optimize_trajectory", *diagnostics_inference_);
       if (!params_.shadow_mode) {
         planner_output.trajectory = mppi_result.trajectory;
       }
 
-      autoware_utils_debug::ScopedTimeTrack publish_debug_st("mppi_optimizer/publish_debug", *time_keeper_);
+      autoware_utils_debug::ScopedTimeTrack publish_debug_st(
+        "mppi_optimizer/publish_debug", *time_keeper_);
       stop_watch_ptr_->tic("mppi_optimizer/publish_debug");
       publish_mppi_debug(mppi_result.debug, planner_output.trajectory.header.frame_id, frame_time);
       if (!planner_output.candidate_trajectories.candidate_trajectories.empty()) {
         planner_output.candidate_trajectories.candidate_trajectories.front().points =
           planner_output.trajectory.points;
       }
-      record_section_time(*stop_watch_ptr_, "mppi_optimizer/publish_debug", *diagnostics_inference_);
+      record_section_time(
+        *stop_watch_ptr_, "mppi_optimizer/publish_debug", *diagnostics_inference_);
     } catch (const std::exception & e) {
       RCLCPP_ERROR_STREAM(get_logger(), "MPPI optimization failed: " << e.what());
       diagnostics_inference_->update_level_and_message(DiagnosticStatus::ERROR, e.what());

--- a/planning/autoware_mppi_optimizer/CHANGELOG.rst
+++ b/planning/autoware_mppi_optimizer/CHANGELOG.rst
@@ -1,0 +1,9 @@
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+Changelog for package autoware_mppi_optimizer
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+0.51.0 (2026-06-10)
+-------------------
+* feat: add autoware_mppi_optimizer package scaffold
+* feat: vendor MPPI-Generic and first-order Dubins extensions
+* feat: add FirstOrderDubinsMppiInterface CUDA library

--- a/planning/autoware_mppi_optimizer/CMakeLists.txt
+++ b/planning/autoware_mppi_optimizer/CMakeLists.txt
@@ -1,0 +1,124 @@
+cmake_minimum_required(VERSION 3.14)
+project(autoware_mppi_optimizer)
+
+find_package(autoware_cmake REQUIRED)
+autoware_package()
+
+# Find CUDA
+option(CUDA_AVAIL "CUDA available" OFF)
+find_package(CUDA)
+if(CUDA_FOUND)
+  find_library(CUBLAS_LIBRARIES cublas HINTS
+    ${CUDA_TOOLKIT_ROOT_DIR}/lib64
+    ${CUDA_TOOLKIT_ROOT_DIR}/lib
+  )
+  if(CUDA_VERBOSE)
+    message(STATUS "CUDA is available!")
+    message(STATUS "CUDA Libs: ${CUDA_LIBRARIES}")
+    message(STATUS "CUDA Headers: ${CUDA_INCLUDE_DIRS}")
+  endif()
+  unset(CUDA_cublas_device_LIBRARY CACHE)
+  set(CUDA_AVAIL ON)
+else()
+  message(WARNING "CUDA NOT FOUND")
+  set(CUDA_AVAIL OFF)
+endif()
+
+# Find TensorRT libraries
+option(TRT_AVAIL "TensorRT available" OFF)
+find_library(NVINFER nvinfer)
+find_library(NVONNXPARSER nvonnxparser)
+if(NVINFER AND NVONNXPARSER)
+  if(CUDA_VERBOSE)
+    message(STATUS "TensorRT is available!")
+    message(STATUS "NVINFER: ${NVINFER}")
+    message(STATUS "NVONNXPARSER: ${NVONNXPARSER}")
+  endif()
+  set(TRT_AVAIL ON)
+else()
+  message(WARNING "TensorRT is NOT Available")
+  set(TRT_AVAIL OFF)
+endif()
+
+if(CUDA_AVAIL AND TRT_AVAIL)
+  find_package(MPPI-Generic REQUIRED)
+  add_library(mppi_extensions INTERFACE)
+  add_library(MppiExtensions::extensions ALIAS mppi_extensions)
+  target_include_directories(mppi_extensions BEFORE INTERFACE
+    "$<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>")
+  target_link_libraries(mppi_extensions INTERFACE MPPI::MPPI)
+
+  set(CUDA_PROPAGATE_HOST_FLAGS OFF)
+  list(APPEND CUDA_NVCC_FLAGS "--expt-relaxed-constexpr -diag-suppress 20012")
+  list(APPEND CUDA_NVCC_FLAGS "--extended-lambda")
+  list(APPEND CUDA_NVCC_FLAGS "-Xcompiler=-std=c++17")
+  list(APPEND CUDA_NVCC_FLAGS "-gencode arch=compute_75,code=sm_75")
+  list(APPEND CUDA_NVCC_FLAGS "-gencode arch=compute_86,code=sm_86")
+  list(APPEND CUDA_NVCC_FLAGS "-gencode arch=compute_87,code=sm_87")
+  list(APPEND CUDA_NVCC_FLAGS "-gencode arch=compute_89,code=sm_89")
+  if(CUDA_VERSION VERSION_GREATER_EQUAL "12.8")
+    if(CUDA_VERSION VERSION_LESS "13.0")
+      list(APPEND CUDA_NVCC_FLAGS "-gencode arch=compute_101,code=sm_101")
+    else()  # CUDA 13.0 renamed SM101 to SM110
+      list(APPEND CUDA_NVCC_FLAGS "-gencode arch=compute_110,code=sm_110")
+    endif()
+    list(APPEND CUDA_NVCC_FLAGS "-gencode arch=compute_120,code=sm_120")
+    list(APPEND CUDA_NVCC_FLAGS "-gencode arch=compute_120,code=compute_120")
+  else()
+    list(APPEND CUDA_NVCC_FLAGS "-gencode arch=compute_89,code=compute_89")
+  endif()
+
+  cuda_add_library(first_order_dubins_mppi SHARED
+    src/first_order_dubins/first_order_dubins_mppi_interface.cu
+  )
+  target_include_directories(first_order_dubins_mppi PUBLIC
+    $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
+    $<INSTALL_INTERFACE:include>
+    SYSTEM ${CUDA_INCLUDE_DIRS}
+  )
+  target_link_libraries(first_order_dubins_mppi
+    mppi_extensions
+    rclcpp::rclcpp
+    tf2_geometry_msgs::tf2_geometry_msgs
+    autoware_perception_msgs::autoware_perception_msgs__rosidl_generator_cpp
+    autoware_planning_msgs::autoware_planning_msgs__rosidl_generator_cpp
+    autoware_vehicle_msgs::autoware_vehicle_msgs__rosidl_generator_cpp
+    geometry_msgs::geometry_msgs__rosidl_generator_cpp
+    nav_msgs::nav_msgs__rosidl_generator_cpp
+  )
+  set_target_properties(first_order_dubins_mppi PROPERTIES
+    POSITION_INDEPENDENT_CODE ON
+    CXX_STANDARD 17
+    CUDA_STANDARD 17
+  )
+
+  ament_auto_add_library(${PROJECT_NAME} SHARED
+    src/mppi_optimizer.cpp
+    src/first_order_dubins_mppi_cost_params_ros.cpp
+    src/first_order_dubins_mppi_vehicle_params_ros.cpp
+  )
+  target_link_libraries(${PROJECT_NAME} first_order_dubins_mppi)
+
+  rclcpp_components_register_node(${PROJECT_NAME}
+    PLUGIN "autoware::mppi_optimizer::MppiOptimizer"
+    EXECUTABLE autoware_mppi_optimizer_node
+  )
+
+  if(BUILD_TESTING)
+    find_package(ament_lint_auto REQUIRED)
+    ament_lint_auto_find_test_dependencies()
+  endif()
+
+  install(TARGETS first_order_dubins_mppi
+    ARCHIVE DESTINATION lib
+    LIBRARY DESTINATION lib
+    RUNTIME DESTINATION lib/${PROJECT_NAME}
+  )
+endif()
+
+ament_export_include_directories(include)
+if(CUDA_AVAIL AND TRT_AVAIL)
+  ament_export_libraries(first_order_dubins_mppi)
+  ament_export_dependencies(MPPI-Generic)
+endif()
+ament_auto_package(INSTALL_TO_SHARE config launch)

--- a/planning/autoware_mppi_optimizer/README.md
+++ b/planning/autoware_mppi_optimizer/README.md
@@ -1,0 +1,37 @@
+# Autoware MPPI Optimizer
+
+The `autoware_mppi_optimizer` package optimizes trajectories using Model Predictive Path Integral (MPPI) control.
+
+## Overview
+
+This package depends on the external [mppi_generic_vendor](https://github.com/autowarefoundation/mppi_generic_vendor) package (`MPPI-Generic`) and ships first-order Dubins path-tracking extensions under `include/mppi/`. A CUDA library interface (`FirstOrderDubinsMppiInterface`) wraps the two-lane double-park MPPI example for use from C++ / ROS nodes.
+
+### Layout
+
+```text
+autoware_mppi_optimizer/
+├── include/mppi/         # First-order Dubins dynamics, cost, path utilities
+├── include/autoware/mppi_optimizer/
+│   └── first_order_dubins_mppi_interface.hpp
+└── src/first_order_dubins/
+    └── first_order_dubins_mppi_interface.cu
+```
+
+### Requirements
+
+- CUDA Toolkit (curand, cufft)
+- Eigen3
+
+## Inputs / Outputs
+
+| Topic                 | Type                                    | Description          |
+| --------------------- | --------------------------------------- | -------------------- |
+| `~/input/trajectory`  | `autoware_planning_msgs/msg/Trajectory` | Reference trajectory |
+| `~/input/odometry`    | `nav_msgs/msg/Odometry`                 | Current ego state    |
+| `~/output/trajectory` | `autoware_planning_msgs/msg/Trajectory` | Optimized trajectory |
+
+## Launch
+
+```bash
+ros2 launch autoware_mppi_optimizer mppi_optimizer.launch.xml
+```

--- a/planning/autoware_mppi_optimizer/config/mppi_optimizer.param.yaml
+++ b/planning/autoware_mppi_optimizer/config/mppi_optimizer.param.yaml
@@ -1,0 +1,23 @@
+/**:
+  ros__parameters:
+    # Vehicle actuation dynamics are loaded from $(vehicle_model)_description/config/simulator_model.param.yaml
+
+    # FirstOrderDubinsBicycleCostParams (see first_order_dubins_bicycle_cost.cuh)
+    desired_speed: 2.5
+    speed_coeff: 100.0
+    track_coeff: 1000.0
+    heading_coeff: 500.0
+    crash_coeff: 100000.0
+    boundary_threshold: 0.8
+    boundary_threshold_left: -1.0
+    boundary_threshold_right: -1.0
+    lateral_acceleration_coeff: 300.0
+    lateral_jerk_coeff: 1000.0
+    longitudinal_jerk_coeff: 10.0
+    accel_cmd_coeff: 0.0
+    steer_cmd_coeff: 500.0
+    goal_pos_coeff: 1000.0
+    goal_speed_coeff: 200.0
+    goal_yaw_coeff: 500.0
+    goal_terminal_scale: 10.0
+    obstacle_collision_margin: 0.2

--- a/planning/autoware_mppi_optimizer/cspell.json
+++ b/planning/autoware_mppi_optimizer/cspell.json
@@ -1,0 +1,5 @@
+{
+  "version": "0.2",
+  "language": "en",
+  "words": ["cudacc", "cufft", "curand", "cuh", "dubins", "MPPI", "mppi", "rollouts"]
+}

--- a/planning/autoware_mppi_optimizer/include/autoware/mppi_optimizer/first_order_dubins_mppi_cost_params.hpp
+++ b/planning/autoware_mppi_optimizer/include/autoware/mppi_optimizer/first_order_dubins_mppi_cost_params.hpp
@@ -1,0 +1,47 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef AUTOWARE__MPPI_OPTIMIZER__FIRST_ORDER_DUBINS_MPPI_COST_PARAMS_HPP_
+#define AUTOWARE__MPPI_OPTIMIZER__FIRST_ORDER_DUBINS_MPPI_COST_PARAMS_HPP_
+
+namespace autoware::mppi_optimizer
+{
+
+/** Host-side cost weights; defaults match first_order_dubins_bicycle_cost.cuh and
+ * mppi_optimizer.param.yaml */
+struct FirstOrderDubinsMppiCostParams
+{
+  float desired_speed{3.0F};
+  float speed_coeff{500.0F};
+  float track_coeff{1000.0F};
+  float heading_coeff{500.0F};
+  float crash_coeff{100000.0F};
+  float boundary_threshold{1.5F};
+  float boundary_threshold_left{-1.0F};
+  float boundary_threshold_right{-1.0F};
+  float accel_cmd_coeff{0.0F};
+  float steer_cmd_coeff{0.0F};
+  float lateral_acceleration_coeff{300.0F};
+  float lateral_jerk_coeff{300.0F};
+  float longitudinal_jerk_coeff{10.0F};
+  float obstacle_collision_margin{0.5F};
+  float goal_pos_coeff{1000.0F};
+  float goal_speed_coeff{0.0F};
+  float goal_yaw_coeff{500.0F};
+  float goal_terminal_scale{10.0F};
+};
+
+}  // namespace autoware::mppi_optimizer
+
+#endif  // AUTOWARE__MPPI_OPTIMIZER__FIRST_ORDER_DUBINS_MPPI_COST_PARAMS_HPP_

--- a/planning/autoware_mppi_optimizer/include/autoware/mppi_optimizer/first_order_dubins_mppi_cost_params_ros.hpp
+++ b/planning/autoware_mppi_optimizer/include/autoware/mppi_optimizer/first_order_dubins_mppi_cost_params_ros.hpp
@@ -1,0 +1,37 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef AUTOWARE__MPPI_OPTIMIZER__FIRST_ORDER_DUBINS_MPPI_COST_PARAMS_ROS_HPP_
+#define AUTOWARE__MPPI_OPTIMIZER__FIRST_ORDER_DUBINS_MPPI_COST_PARAMS_ROS_HPP_
+
+#include "autoware/mppi_optimizer/first_order_dubins_mppi_cost_params.hpp"
+
+#include <rclcpp/rclcpp.hpp>
+
+#include <string>
+
+namespace autoware::mppi_optimizer
+{
+
+/** Declare ROS parameters with defaults from FirstOrderDubinsBicycleCostParams. */
+void declare_first_order_dubins_mppi_cost_params(
+  rclcpp::Node & node, const std::string & prefix = "");
+
+/** Read declared MPPI cost parameters from a node. */
+FirstOrderDubinsMppiCostParams get_first_order_dubins_mppi_cost_params(
+  const rclcpp::Node & node, const std::string & prefix = "");
+
+}  // namespace autoware::mppi_optimizer
+
+#endif  // AUTOWARE__MPPI_OPTIMIZER__FIRST_ORDER_DUBINS_MPPI_COST_PARAMS_ROS_HPP_

--- a/planning/autoware_mppi_optimizer/include/autoware/mppi_optimizer/first_order_dubins_mppi_interface.hpp
+++ b/planning/autoware_mppi_optimizer/include/autoware/mppi_optimizer/first_order_dubins_mppi_interface.hpp
@@ -1,0 +1,137 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef AUTOWARE__MPPI_OPTIMIZER__FIRST_ORDER_DUBINS_MPPI_INTERFACE_HPP_
+#define AUTOWARE__MPPI_OPTIMIZER__FIRST_ORDER_DUBINS_MPPI_INTERFACE_HPP_
+
+#include "autoware/mppi_optimizer/first_order_dubins_mppi_cost_params.hpp"
+#include "autoware/mppi_optimizer/first_order_dubins_mppi_vehicle_params.hpp"
+
+#include <autoware_perception_msgs/msg/tracked_objects.hpp>
+#include <autoware_planning_msgs/msg/trajectory.hpp>
+#include <autoware_vehicle_msgs/msg/steering_report.hpp>
+#include <geometry_msgs/msg/accel_with_covariance_stamped.hpp>
+#include <nav_msgs/msg/odometry.hpp>
+
+#include <memory>
+#include <optional>
+#include <utility>
+#include <vector>
+
+namespace autoware::mppi_optimizer
+{
+
+using autoware_perception_msgs::msg::TrackedObjects;
+using autoware_planning_msgs::msg::Trajectory;
+using nav_msgs::msg::Odometry;
+
+struct FirstOrderDubinsMppiState
+{
+  float x{0.0F};
+  float y{0.0F};
+  float yaw{0.0F};
+  float vel_x{0.0F};
+};
+
+struct FirstOrderDubinsMppiControl
+{
+  float accel_cmd{0.0F};
+  float steer_cmd{0.0F};
+};
+
+struct FirstOrderDubinsMppiRollout
+{
+  std::vector<std::pair<float, float>> points;
+  float cost{0.0F};
+};
+
+struct FirstOrderDubinsMppiDebug
+{
+  Trajectory reference_trajectory;
+  Trajectory optimized_trajectory;
+  std::vector<std::pair<float, float>> optimal_horizon;
+  std::vector<FirstOrderDubinsMppiRollout> rollouts;
+  float baseline_cost{0.0F};
+};
+
+struct FirstOrderDubinsMppiOptimizationResult
+{
+  Trajectory trajectory;
+  FirstOrderDubinsMppiDebug debug;
+};
+
+/**
+ * @brief Host-side interface to the first-order Dubins MPPI controller used in the
+ *        two-lane double-park path-tracking example.
+ */
+class FirstOrderDubinsMppiInterface
+{
+public:
+  FirstOrderDubinsMppiInterface();
+  ~FirstOrderDubinsMppiInterface();
+
+  FirstOrderDubinsMppiInterface(const FirstOrderDubinsMppiInterface &) = delete;
+  FirstOrderDubinsMppiInterface & operator=(const FirstOrderDubinsMppiInterface &) = delete;
+  FirstOrderDubinsMppiInterface(FirstOrderDubinsMppiInterface &&) noexcept;
+  FirstOrderDubinsMppiInterface & operator=(FirstOrderDubinsMppiInterface &&) noexcept;
+
+  /** Initialize GPU resources and the two-lane double-park scenario. */
+  void initialize();
+
+  /** Whether initialize() completed successfully. */
+  bool isInitialized() const;
+
+  /** Configure vehicle geometry and limits from Autoware vehicle_info. */
+  void setVehicleParams(const FirstOrderDubinsMppiVehicleParams & params);
+
+  /** Configure MPPI cost weights (FirstOrderDubinsBicycleCostParams). */
+  void setCostParams(const FirstOrderDubinsMppiCostParams & params);
+
+  /**
+   * @brief Run one MPPI control step and propagate the vehicle state forward.
+   * @param state Current ego state (updated in place).
+   * @param arc_length Current arc length along the reference path (updated in place).
+   * @param sim_time Current simulation time [s].
+   */
+  FirstOrderDubinsMppiControl computeStep(
+    FirstOrderDubinsMppiState & state, float & arc_length, float sim_time);
+
+  /**
+   * @brief Track a diffusion-planner reference (poses + velocities) with one MPPI step.
+   *
+   * Uses the diffusion trajectory directly as the MPPI reference horizon (x, y, yaw, v),
+   * keeps warm-started controls between calls, and returns the MPPI-predicted feasible
+   * state rollout that best tracks that reference.
+   *
+   * @param input Reference trajectory from the diffusion planner (map frame).
+   * @param odometry Current ego odometry in the same frame as the trajectory.
+   * @param acceleration Optional ego longitudinal acceleration [m/s^2] in base_link.
+   * @param steering_status Optional ego tire steering angle [rad] from vehicle status.
+   * @param tracked_objects Perception tracked objects used as dynamic obstacles
+   * (constant-velocity).
+   */
+  FirstOrderDubinsMppiOptimizationResult optimizeTrajectory(
+    const Trajectory & input, const Odometry & odometry,
+    const std::optional<geometry_msgs::msg::AccelWithCovarianceStamped> & acceleration,
+    const std::optional<autoware_vehicle_msgs::msg::SteeringReport> & steering_status,
+    const TrackedObjects & tracked_objects);
+
+private:
+  struct Impl;
+  std::unique_ptr<Impl> impl_;
+};
+
+}  // namespace autoware::mppi_optimizer
+
+#endif  // AUTOWARE__MPPI_OPTIMIZER__FIRST_ORDER_DUBINS_MPPI_INTERFACE_HPP_

--- a/planning/autoware_mppi_optimizer/include/autoware/mppi_optimizer/first_order_dubins_mppi_vehicle_params.hpp
+++ b/planning/autoware_mppi_optimizer/include/autoware/mppi_optimizer/first_order_dubins_mppi_vehicle_params.hpp
@@ -1,0 +1,46 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef AUTOWARE__MPPI_OPTIMIZER__FIRST_ORDER_DUBINS_MPPI_VEHICLE_PARAMS_HPP_
+#define AUTOWARE__MPPI_OPTIMIZER__FIRST_ORDER_DUBINS_MPPI_VEHICLE_PARAMS_HPP_
+
+namespace autoware::mppi_optimizer
+{
+
+struct FirstOrderDubinsMppiVehicleParams
+{
+  /** Oriented-box footprint for obstacle collision (rear axle = state x,y). */
+  float ego_length{0.825F};
+  float ego_width{0.42F};
+  float ego_axle_to_box_center{0.2F};
+
+  /** Bicycle geometry and control limits from vehicle_info. */
+  float wheel_base{0.32F};
+  float max_steer_angle{0.45F};
+
+  /** Actuation dynamics; names match simulator_model.param.yaml. */
+  float acc_time_constant{0.1F};
+  float steer_time_constant{0.27F};
+  float steer_rate_lim{5.0F};
+  float vel_rate_lim{7.0F};
+  float acc_time_delay{0.1F};
+  float steer_time_delay{0.24F};
+
+  float min_accel() const { return -vel_rate_lim; }
+  float max_accel() const { return vel_rate_lim; }
+};
+
+}  // namespace autoware::mppi_optimizer
+
+#endif  // AUTOWARE__MPPI_OPTIMIZER__FIRST_ORDER_DUBINS_MPPI_VEHICLE_PARAMS_HPP_

--- a/planning/autoware_mppi_optimizer/include/autoware/mppi_optimizer/first_order_dubins_mppi_vehicle_params_conversion.hpp
+++ b/planning/autoware_mppi_optimizer/include/autoware/mppi_optimizer/first_order_dubins_mppi_vehicle_params_conversion.hpp
@@ -1,0 +1,42 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef AUTOWARE__MPPI_OPTIMIZER__FIRST_ORDER_DUBINS_MPPI_VEHICLE_PARAMS_CONVERSION_HPP_
+#define AUTOWARE__MPPI_OPTIMIZER__FIRST_ORDER_DUBINS_MPPI_VEHICLE_PARAMS_CONVERSION_HPP_
+
+#include "autoware/mppi_optimizer/first_order_dubins_mppi_vehicle_params.hpp"
+
+#include <autoware/vehicle_info_utils/vehicle_info.hpp>
+
+namespace autoware::mppi_optimizer
+{
+
+using autoware::vehicle_info_utils::VehicleInfo;
+
+inline FirstOrderDubinsMppiVehicleParams makeVehicleParams(const VehicleInfo & vehicle_info)
+{
+  FirstOrderDubinsMppiVehicleParams params;
+  params.ego_length = static_cast<float>(vehicle_info.vehicle_length_m);
+  params.ego_width = static_cast<float>(vehicle_info.vehicle_width_m);
+  // Rear-axle (base_link) to geometric center of the vehicle bounding box.
+  params.ego_axle_to_box_center =
+    static_cast<float>(0.5F * vehicle_info.vehicle_length_m - vehicle_info.rear_overhang_m);
+  params.wheel_base = static_cast<float>(vehicle_info.wheel_base_m);
+  params.max_steer_angle = static_cast<float>(vehicle_info.max_steer_angle_rad);
+  return params;
+}
+
+}  // namespace autoware::mppi_optimizer
+
+#endif  // AUTOWARE__MPPI_OPTIMIZER__FIRST_ORDER_DUBINS_MPPI_VEHICLE_PARAMS_CONVERSION_HPP_

--- a/planning/autoware_mppi_optimizer/include/autoware/mppi_optimizer/first_order_dubins_mppi_vehicle_params_ros.hpp
+++ b/planning/autoware_mppi_optimizer/include/autoware/mppi_optimizer/first_order_dubins_mppi_vehicle_params_ros.hpp
@@ -1,0 +1,36 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef AUTOWARE__MPPI_OPTIMIZER__FIRST_ORDER_DUBINS_MPPI_VEHICLE_PARAMS_ROS_HPP_
+#define AUTOWARE__MPPI_OPTIMIZER__FIRST_ORDER_DUBINS_MPPI_VEHICLE_PARAMS_ROS_HPP_
+
+#include "autoware/mppi_optimizer/first_order_dubins_mppi_vehicle_params.hpp"
+
+#include <rclcpp/rclcpp.hpp>
+
+namespace autoware::mppi_optimizer
+{
+
+/**
+ * Declare vehicle actuation parameters using the same names as simulator_model.param.yaml so a
+ * vehicle description simulator config can be loaded on the same node.
+ */
+void declare_first_order_dubins_mppi_vehicle_dynamics_params(rclcpp::Node & node);
+
+/** Geometry from vehicle_info plus actuation dynamics from the parameter server. */
+FirstOrderDubinsMppiVehicleParams get_first_order_dubins_mppi_vehicle_params(rclcpp::Node & node);
+
+}  // namespace autoware::mppi_optimizer
+
+#endif  // AUTOWARE__MPPI_OPTIMIZER__FIRST_ORDER_DUBINS_MPPI_VEHICLE_PARAMS_ROS_HPP_

--- a/planning/autoware_mppi_optimizer/include/autoware/mppi_optimizer/mppi_debug_markers.hpp
+++ b/planning/autoware_mppi_optimizer/include/autoware/mppi_optimizer/mppi_debug_markers.hpp
@@ -1,0 +1,149 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef AUTOWARE__MPPI_OPTIMIZER__MPPI_DEBUG_MARKERS_HPP_
+#define AUTOWARE__MPPI_OPTIMIZER__MPPI_DEBUG_MARKERS_HPP_
+
+#include "autoware/mppi_optimizer/first_order_dubins_mppi_interface.hpp"
+
+#include <builtin_interfaces/msg/duration.hpp>
+#include <rclcpp/time.hpp>
+
+#include <geometry_msgs/msg/point.hpp>
+#include <std_msgs/msg/color_rgba.hpp>
+#include <visualization_msgs/msg/marker.hpp>
+#include <visualization_msgs/msg/marker_array.hpp>
+
+#include <algorithm>
+#include <cmath>
+#include <string>
+#include <vector>
+
+namespace autoware::mppi_optimizer
+{
+
+using std_msgs::msg::ColorRGBA;
+using visualization_msgs::msg::Marker;
+using visualization_msgs::msg::MarkerArray;
+
+inline ColorRGBA makeColor(const float r, const float g, const float b, const float a)
+{
+  ColorRGBA color;
+  color.r = r;
+  color.g = g;
+  color.b = b;
+  color.a = a;
+  return color;
+}
+
+inline ColorRGBA costGradientColor(const float cost, const float min_cost, const float max_cost)
+{
+  float t = 0.5F;
+  if (max_cost > min_cost) {
+    t = (cost - min_cost) / (max_cost - min_cost);
+  }
+  t = std::clamp(t, 0.0F, 1.0F);
+  return makeColor(t, 1.0F - t, 0.0F, 0.35F);
+}
+
+inline Marker makeDeleteAllMarker(
+  const rclcpp::Time & stamp, const std::string & frame_id, const std::string & ns)
+{
+  Marker marker;
+  marker.header.stamp = stamp;
+  marker.header.frame_id = frame_id;
+  marker.ns = ns;
+  marker.id = 0;
+  marker.action = Marker::DELETEALL;
+  return marker;
+}
+
+inline Marker makeLineStripMarker(
+  const rclcpp::Time & stamp, const std::string & frame_id, const std::string & ns, const int id,
+  const ColorRGBA & color, const double line_width,
+  const std::vector<std::pair<float, float>> & points)
+{
+  Marker marker;
+  marker.header.stamp = stamp;
+  marker.header.frame_id = frame_id;
+  marker.ns = ns;
+  marker.id = id;
+  marker.type = Marker::LINE_STRIP;
+  marker.action = Marker::ADD;
+  marker.pose.orientation.w = 1.0;
+  marker.scale.x = line_width;
+  marker.color = color;
+  marker.lifetime = builtin_interfaces::msg::Duration{}.set__sec(0).set__nanosec(500000000);
+  marker.points.reserve(points.size());
+  for (const auto & [x, y] : points) {
+    geometry_msgs::msg::Point point;
+    point.x = x;
+    point.y = y;
+    point.z = 0.0;
+    marker.points.push_back(point);
+  }
+  return marker;
+}
+
+inline MarkerArray createMppiDebugMarkers(
+  const FirstOrderDubinsMppiDebug & debug, const std::string & frame_id, const rclcpp::Time & stamp)
+{
+  MarkerArray marker_array;
+
+  if (!debug.reference_trajectory.points.empty()) {
+    std::vector<std::pair<float, float>> reference_points;
+    reference_points.reserve(debug.reference_trajectory.points.size());
+    for (const auto & point : debug.reference_trajectory.points) {
+      reference_points.emplace_back(
+        static_cast<float>(point.pose.position.x), static_cast<float>(point.pose.position.y));
+    }
+    marker_array.markers.push_back(makeLineStripMarker(
+      stamp, frame_id, "mppi_reference", 0, makeColor(0.0F, 1.0F, 1.0F, 0.9F), 0.15,
+      reference_points));
+  }
+
+  if (!debug.optimal_horizon.empty()) {
+    marker_array.markers.push_back(makeLineStripMarker(
+      stamp, frame_id, "mppi_optimal", 0, makeColor(1.0F, 0.0F, 0.0F, 1.0F), 0.2,
+      debug.optimal_horizon));
+  }
+
+  marker_array.markers.push_back(makeDeleteAllMarker(stamp, frame_id, "mppi_rollout"));
+
+  if (!debug.rollouts.empty()) {
+    float min_cost = debug.rollouts.front().cost;
+    float max_cost = debug.rollouts.front().cost;
+    for (const auto & rollout : debug.rollouts) {
+      min_cost = std::min(min_cost, rollout.cost);
+      max_cost = std::max(max_cost, rollout.cost);
+    }
+
+    int rollout_id = 1;
+    for (const auto & rollout : debug.rollouts) {
+      if (rollout.points.size() < 2U) {
+        continue;
+      }
+      marker_array.markers.push_back(makeLineStripMarker(
+        stamp, frame_id, "mppi_rollout", rollout_id,
+        costGradientColor(rollout.cost, min_cost, max_cost), 0.04, rollout.points));
+      ++rollout_id;
+    }
+  }
+
+  return marker_array;
+}
+
+}  // namespace autoware::mppi_optimizer
+
+#endif  // AUTOWARE__MPPI_OPTIMIZER__MPPI_DEBUG_MARKERS_HPP_

--- a/planning/autoware_mppi_optimizer/include/autoware/mppi_optimizer/mppi_optimizer.hpp
+++ b/planning/autoware_mppi_optimizer/include/autoware/mppi_optimizer/mppi_optimizer.hpp
@@ -1,0 +1,56 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef AUTOWARE__MPPI_OPTIMIZER__MPPI_OPTIMIZER_HPP_
+#define AUTOWARE__MPPI_OPTIMIZER__MPPI_OPTIMIZER_HPP_
+
+#include <autoware_utils/ros/polling_subscriber.hpp>
+#include <rclcpp/rclcpp.hpp>
+
+#include <autoware_planning_msgs/msg/trajectory.hpp>
+#include <autoware_vehicle_msgs/msg/steering_report.hpp>
+#include <nav_msgs/msg/odometry.hpp>
+
+#include <memory>
+
+namespace autoware::mppi_optimizer
+{
+
+class FirstOrderDubinsMppiInterface;
+
+using autoware_planning_msgs::msg::Trajectory;
+using autoware_vehicle_msgs::msg::SteeringReport;
+using nav_msgs::msg::Odometry;
+
+class MppiOptimizer : public rclcpp::Node
+{
+public:
+  explicit MppiOptimizer(const rclcpp::NodeOptions & options);
+
+private:
+  void on_trajectory(const Trajectory::ConstSharedPtr msg);
+
+  rclcpp::Subscription<Trajectory>::SharedPtr trajectory_sub_;
+  rclcpp::Publisher<Trajectory>::SharedPtr trajectory_pub_;
+
+  autoware_utils::InterProcessPollingSubscriber<Odometry> sub_odometry_{this, "~/input/odometry"};
+  autoware_utils::InterProcessPollingSubscriber<SteeringReport> sub_steering_{
+    this, "~/input/steering_status"};
+
+  std::unique_ptr<FirstOrderDubinsMppiInterface> mppi_interface_;
+};
+
+}  // namespace autoware::mppi_optimizer
+
+#endif  // AUTOWARE__MPPI_OPTIMIZER__MPPI_OPTIMIZER_HPP_

--- a/planning/autoware_mppi_optimizer/include/autoware/mppi_optimizer/predicted_objects_obstacles.hpp
+++ b/planning/autoware_mppi_optimizer/include/autoware/mppi_optimizer/predicted_objects_obstacles.hpp
@@ -1,0 +1,125 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef AUTOWARE__MPPI_OPTIMIZER__PREDICTED_OBJECTS_OBSTACLES_HPP_
+#define AUTOWARE__MPPI_OPTIMIZER__PREDICTED_OBJECTS_OBSTACLES_HPP_
+
+#include <autoware_perception_msgs/msg/predicted_objects.hpp>
+
+#include <tf2/utils.h>
+
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <vector>
+
+namespace autoware::mppi_optimizer
+{
+
+using autoware_perception_msgs::msg::PredictedObjects;
+
+constexpr size_t kMaxMppiObstacles = 64U;
+constexpr float kDefaultObstacleLength = 0.55F * 1.5F;
+constexpr float kDefaultObstacleWidth = 0.28F * 1.5F;
+
+inline float durationSeconds(const builtin_interfaces::msg::Duration & duration)
+{
+  return static_cast<float>(duration.sec) + static_cast<float>(duration.nanosec) * 1.0e-9F;
+}
+
+inline const autoware_perception_msgs::msg::PredictedPath * selectPredictedPath(
+  const autoware_perception_msgs::msg::PredictedObject & object)
+{
+  if (object.kinematics.predicted_paths.empty()) {
+    return nullptr;
+  }
+  const auto best_it = std::max_element(
+    object.kinematics.predicted_paths.begin(), object.kinematics.predicted_paths.end(),
+    [](const auto & a, const auto & b) { return a.confidence < b.confidence; });
+  return &(*best_it);
+}
+
+inline void obstacleFootprintFromShape(
+  const autoware_perception_msgs::msg::Shape & shape, float & length, float & width)
+{
+  length =
+    shape.dimensions.x > 1.0e-3 ? static_cast<float>(shape.dimensions.x) : kDefaultObstacleLength;
+  width =
+    shape.dimensions.y > 1.0e-3 ? static_cast<float>(shape.dimensions.y) : kDefaultObstacleWidth;
+}
+
+/**
+ * @brief Sample diffusion-predicted object paths into MPPI obstacle-major trajectory buffers.
+ *
+ * Predicted paths are interpreted relative to the current planning cycle (t = 0 at inference).
+ * Up to kMaxMppiObstacles objects are used.
+ */
+inline void buildObstacleTrajectoryBuffersFromPredictedObjects(
+  const PredictedObjects & objects, const float dt, const int num_timesteps, std::vector<float> & x,
+  std::vector<float> & y, std::vector<float> & yaw, std::vector<float> & half_length,
+  std::vector<float> & half_width)
+{
+  const size_t obstacle_count =
+    std::min(objects.objects.size(), static_cast<size_t>(kMaxMppiObstacles));
+  const int nt = std::max(1, num_timesteps);
+
+  x.assign(obstacle_count * static_cast<size_t>(nt), -1.0E4F);
+  y.assign(obstacle_count * static_cast<size_t>(nt), -1.0E4F);
+  yaw.assign(obstacle_count * static_cast<size_t>(nt), 0.0F);
+  half_length.assign(obstacle_count, 0.0F);
+  half_width.assign(obstacle_count, 0.0F);
+
+  for (size_t obstacle_idx = 0; obstacle_idx < obstacle_count; ++obstacle_idx) {
+    const auto & object = objects.objects[obstacle_idx];
+    float length = kDefaultObstacleLength;
+    float width = kDefaultObstacleWidth;
+    obstacleFootprintFromShape(object.shape, length, width);
+    half_length[obstacle_idx] = length * 0.5F;
+    half_width[obstacle_idx] = width * 0.5F;
+
+    const auto * predicted_path = selectPredictedPath(object);
+    const auto & fallback_pose = object.kinematics.initial_pose_with_covariance.pose;
+    const float fallback_yaw = static_cast<float>(tf2::getYaw(fallback_pose.orientation));
+
+    for (int timestep = 0; timestep < nt; ++timestep) {
+      const size_t buffer_idx =
+        obstacle_idx * static_cast<size_t>(nt) + static_cast<size_t>(timestep);
+      const float relative_time = static_cast<float>(timestep) * dt;
+
+      if (predicted_path != nullptr && !predicted_path->path.empty()) {
+        const float path_dt = std::max(durationSeconds(predicted_path->time_step), 1.0e-3F);
+        const int path_idx = std::min(
+          static_cast<int>(std::lround(relative_time / path_dt)),
+          static_cast<int>(predicted_path->path.size()) - 1);
+        const auto & pose = predicted_path->path[static_cast<size_t>(path_idx)];
+        x[buffer_idx] = static_cast<float>(pose.position.x);
+        y[buffer_idx] = static_cast<float>(pose.position.y);
+        yaw[buffer_idx] = static_cast<float>(tf2::getYaw(pose.orientation));
+      } else {
+        x[buffer_idx] = static_cast<float>(fallback_pose.position.x);
+        y[buffer_idx] = static_cast<float>(fallback_pose.position.y);
+        yaw[buffer_idx] = fallback_yaw;
+      }
+    }
+  }
+}
+
+inline int predictedObjectObstacleCount(const PredictedObjects & objects)
+{
+  return static_cast<int>(std::min(objects.objects.size(), static_cast<size_t>(kMaxMppiObstacles)));
+}
+
+}  // namespace autoware::mppi_optimizer
+
+#endif  // AUTOWARE__MPPI_OPTIMIZER__PREDICTED_OBJECTS_OBSTACLES_HPP_

--- a/planning/autoware_mppi_optimizer/include/autoware/mppi_optimizer/tracked_objects_obstacles.hpp
+++ b/planning/autoware_mppi_optimizer/include/autoware/mppi_optimizer/tracked_objects_obstacles.hpp
@@ -1,0 +1,90 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef AUTOWARE__MPPI_OPTIMIZER__TRACKED_OBJECTS_OBSTACLES_HPP_
+#define AUTOWARE__MPPI_OPTIMIZER__TRACKED_OBJECTS_OBSTACLES_HPP_
+
+#include "autoware/mppi_optimizer/predicted_objects_obstacles.hpp"
+
+#include <autoware_perception_msgs/msg/tracked_objects.hpp>
+
+#include <tf2/utils.h>
+
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <vector>
+
+namespace autoware::mppi_optimizer
+{
+
+using autoware_perception_msgs::msg::TrackedObjects;
+
+/**
+ * @brief Extrapolate perception tracked objects with constant longitudinal velocity.
+ *
+ * Twist is treated as object-frame longitudinal speed (linear.x), matching common Autoware usage.
+ * Up to kMaxMppiObstacles objects are used.
+ */
+inline void buildObstacleTrajectoryBuffersFromTrackedObjects(
+  const TrackedObjects & objects, const float dt, const int num_timesteps, std::vector<float> & x,
+  std::vector<float> & y, std::vector<float> & yaw, std::vector<float> & half_length,
+  std::vector<float> & half_width)
+{
+  const size_t obstacle_count =
+    std::min(objects.objects.size(), static_cast<size_t>(kMaxMppiObstacles));
+  const int nt = std::max(1, num_timesteps);
+
+  x.assign(obstacle_count * static_cast<size_t>(nt), -1.0E4F);
+  y.assign(obstacle_count * static_cast<size_t>(nt), -1.0E4F);
+  yaw.assign(obstacle_count * static_cast<size_t>(nt), 0.0F);
+  half_length.assign(obstacle_count, 0.0F);
+  half_width.assign(obstacle_count, 0.0F);
+
+  for (size_t obstacle_idx = 0; obstacle_idx < obstacle_count; ++obstacle_idx) {
+    const auto & object = objects.objects[obstacle_idx];
+    const auto & pose = object.kinematics.pose_with_covariance.pose;
+    const float x0 = static_cast<float>(pose.position.x);
+    const float y0 = static_cast<float>(pose.position.y);
+    const float object_yaw = static_cast<float>(tf2::getYaw(pose.orientation));
+    const float speed = static_cast<float>(object.kinematics.twist_with_covariance.twist.linear.x);
+
+    float length = kDefaultObstacleLength;
+    float width = kDefaultObstacleWidth;
+    obstacleFootprintFromShape(object.shape, length, width);
+    half_length[obstacle_idx] = length * 0.5F;
+    half_width[obstacle_idx] = width * 0.5F;
+
+    const float vx = speed * std::cos(object_yaw);
+    const float vy = speed * std::sin(object_yaw);
+
+    for (int timestep = 0; timestep < nt; ++timestep) {
+      const size_t buffer_idx =
+        obstacle_idx * static_cast<size_t>(nt) + static_cast<size_t>(timestep);
+      const float relative_time = static_cast<float>(timestep) * dt;
+      x[buffer_idx] = x0 + vx * relative_time;
+      y[buffer_idx] = y0 + vy * relative_time;
+      yaw[buffer_idx] = object_yaw;
+    }
+  }
+}
+
+inline int trackedObjectObstacleCount(const TrackedObjects & objects)
+{
+  return static_cast<int>(std::min(objects.objects.size(), static_cast<size_t>(kMaxMppiObstacles)));
+}
+
+}  // namespace autoware::mppi_optimizer
+
+#endif  // AUTOWARE__MPPI_OPTIMIZER__TRACKED_OBJECTS_OBSTACLES_HPP_

--- a/planning/autoware_mppi_optimizer/include/mppi/CPPLINT.cfg
+++ b/planning/autoware_mppi_optimizer/include/mppi/CPPLINT.cfg
@@ -1,0 +1,3 @@
+# mppi-path-tracking extension headers — skip cpplint.
+set noparent
+exclude_files=.*

--- a/planning/autoware_mppi_optimizer/include/mppi/cost_functions/dubins/first_order_dubins_bicycle_cost.cu
+++ b/planning/autoware_mppi_optimizer/include/mppi/cost_functions/dubins/first_order_dubins_bicycle_cost.cu
@@ -1,0 +1,625 @@
+#include <mppi/cost_functions/dubins/first_order_dubins_bicycle_cost.cuh>
+#include <mppi/cost_functions/path_tracking_geometry.cuh>
+#include <mppi/utils/angle_utils.cuh>
+
+#include <algorithm>
+#include <cmath>
+
+namespace
+{
+using O = FirstOrderDubinsBicycleParams::OutputIndex;
+using C = FirstOrderDubinsBicycleParams::ControlIndex;
+using mppi::cost::detail::distancePointToSegment;
+using mppi::cost::detail::orientedBoxCorners;
+using mppi::cost::detail::orientedBoxesOverlap;
+using mppi::cost::detail::pointInPolygon;
+using mppi::cost::detail::signedLateralOffsetPointToSegment;
+using mppi::cost::detail::vectorLength;
+
+template <int NUM_TIMESTEPS>
+__host__ __device__ float referenceEndYaw(
+  const float * x, const float * y, const float * yaw, int count)
+{
+  if (count <= 0) {
+    return 0.0F;
+  }
+  if (yaw != nullptr) {
+    return yaw[count - 1];
+  }
+  if (count >= 2) {
+#ifdef __CUDA_ARCH__
+    return atan2f(y[count - 1] - y[count - 2], x[count - 1] - x[count - 2]);
+#else
+    return std::atan2(y[count - 1] - y[count - 2], x[count - 1] - x[count - 2]);
+#endif
+  }
+  return 0.0F;
+}
+
+template <class PARAMS_T>
+__host__ __device__ void comfortTerms(
+  const PARAMS_T & params, const float * u, const float * y, float & lateral_accel,
+  float & lateral_jerk, float & longitudinal_jerk)
+{
+  const float v = y[static_cast<int>(O::BASELINK_VEL_B_X)];
+  const float steer = y[static_cast<int>(O::STEER_ANGLE)];
+  const float accel = y[static_cast<int>(O::ACCELERATION)];
+  const float accel_cmd = u[static_cast<int>(C::ACCELERATION_CMD)];
+  const float steer_cmd = u[static_cast<int>(C::STEER_CMD)];
+
+  const float accel_tau = fmaxf(params.accel_time_constant, 1.0E-4F);
+  const float steer_tau = fmaxf(params.steer_time_constant, 1.0E-4F);
+  const float wheel_base = fmaxf(params.wheel_base, 1.0E-4F);
+
+  longitudinal_jerk = (accel_cmd - accel) / accel_tau;
+
+  const float steer_rate = (steer_cmd - steer) / steer_tau;
+  const float curvature = tanf(steer) / wheel_base;
+#ifdef __CUDA_ARCH__
+  const float sec_sq = 1.0F / fmaxf(cosf(steer) * cosf(steer), 1.0E-6F);
+#else
+  const float sec_sq = 1.0F / std::max(std::cos(steer) * std::cos(steer), 1.0E-6F);
+#endif
+  const float curvature_dot = sec_sq * steer_rate / wheel_base;
+
+  lateral_accel = v * v * curvature;
+  lateral_jerk = v * v * curvature_dot + 2.0F * v * accel * curvature;
+}
+}  // namespace
+
+template <class CLASS_T, int NUM_TIMESTEPS, class PARAMS_T, class DYN_PARAMS_T>
+FirstOrderDubinsBicycleCostImpl<CLASS_T, NUM_TIMESTEPS, PARAMS_T, DYN_PARAMS_T>::
+  FirstOrderDubinsBicycleCostImpl(cudaStream_t stream)
+{
+  this->bindToStream(stream);
+}
+
+template <class CLASS_T, int NUM_TIMESTEPS, class PARAMS_T, class DYN_PARAMS_T>
+void FirstOrderDubinsBicycleCostImpl<
+  CLASS_T, NUM_TIMESTEPS, PARAMS_T, DYN_PARAMS_T>::paramsToDevice()
+{
+  PARENT_CLASS::paramsToDevice();
+}
+
+template <class CLASS_T, int NUM_TIMESTEPS, class PARAMS_T, class DYN_PARAMS_T>
+void FirstOrderDubinsBicycleCostImpl<CLASS_T, NUM_TIMESTEPS, PARAMS_T, DYN_PARAMS_T>::dataToDevice()
+{
+  if (!this->GPUMemStatus_) {
+    return;
+  }
+
+  HANDLE_ERROR(cudaMemcpyAsync(
+    this->cost_d_->ref_x_, ref_x_, sizeof(ref_x_), cudaMemcpyHostToDevice, this->stream_));
+  HANDLE_ERROR(cudaMemcpyAsync(
+    this->cost_d_->ref_y_, ref_y_, sizeof(ref_y_), cudaMemcpyHostToDevice, this->stream_));
+  HANDLE_ERROR(cudaMemcpyAsync(
+    this->cost_d_->ref_v_, ref_v_, sizeof(ref_v_), cudaMemcpyHostToDevice, this->stream_));
+  HANDLE_ERROR(cudaMemcpyAsync(
+    this->cost_d_->ref_yaw_, ref_yaw_, sizeof(ref_yaw_), cudaMemcpyHostToDevice, this->stream_));
+  HANDLE_ERROR(cudaMemcpyAsync(
+    &this->cost_d_->num_obstacles_, &num_obstacles_, sizeof(num_obstacles_), cudaMemcpyHostToDevice,
+    this->stream_));
+  HANDLE_ERROR(cudaMemcpyAsync(
+    this->cost_d_->obs_x_, obs_x_, sizeof(obs_x_), cudaMemcpyHostToDevice, this->stream_));
+  HANDLE_ERROR(cudaMemcpyAsync(
+    this->cost_d_->obs_y_, obs_y_, sizeof(obs_y_), cudaMemcpyHostToDevice, this->stream_));
+  HANDLE_ERROR(cudaMemcpyAsync(
+    this->cost_d_->obs_yaw_, obs_yaw_, sizeof(obs_yaw_), cudaMemcpyHostToDevice, this->stream_));
+  HANDLE_ERROR(cudaMemcpyAsync(
+    this->cost_d_->obs_half_length_, obs_half_length_, sizeof(obs_half_length_),
+    cudaMemcpyHostToDevice, this->stream_));
+  HANDLE_ERROR(cudaMemcpyAsync(
+    this->cost_d_->obs_half_width_, obs_half_width_, sizeof(obs_half_width_),
+    cudaMemcpyHostToDevice, this->stream_));
+  HANDLE_ERROR(cudaMemcpyAsync(
+    &this->cost_d_->num_drivable_vertices_, &num_drivable_vertices_, sizeof(num_drivable_vertices_),
+    cudaMemcpyHostToDevice, this->stream_));
+  HANDLE_ERROR(cudaMemcpyAsync(
+    this->cost_d_->drivable_poly_x_, drivable_poly_x_, sizeof(drivable_poly_x_),
+    cudaMemcpyHostToDevice, this->stream_));
+  HANDLE_ERROR(cudaMemcpyAsync(
+    this->cost_d_->drivable_poly_y_, drivable_poly_y_, sizeof(drivable_poly_y_),
+    cudaMemcpyHostToDevice, this->stream_));
+}
+
+template <class CLASS_T, int NUM_TIMESTEPS, class PARAMS_T, class DYN_PARAMS_T>
+void FirstOrderDubinsBicycleCostImpl<CLASS_T, NUM_TIMESTEPS, PARAMS_T, DYN_PARAMS_T>::
+  setReferenceTrajectory(
+    const float * x, const float * y, const float * v, const int count, const float * yaw)
+{
+  const int n = std::max(0, std::min(count, NUM_TIMESTEPS));
+  const float end_yaw = referenceEndYaw<NUM_TIMESTEPS>(x, y, yaw, n);
+  for (int i = 0; i < n; ++i) {
+    ref_x_[i] = x[i];
+    ref_y_[i] = y[i];
+    ref_v_[i] = v != nullptr ? v[i] : this->params_.desired_speed;
+    if (yaw != nullptr) {
+      ref_yaw_[i] = yaw[i];
+    } else if (i >= 1) {
+#ifdef __CUDA_ARCH__
+      ref_yaw_[i] = atan2f(y[i] - y[i - 1], x[i] - x[i - 1]);
+#else
+      ref_yaw_[i] = std::atan2(y[i] - y[i - 1], x[i] - x[i - 1]);
+#endif
+    } else {
+      ref_yaw_[i] = end_yaw;
+    }
+  }
+  if (n > 0) {
+    for (int i = n; i < NUM_TIMESTEPS; ++i) {
+      ref_x_[i] = x[n - 1];
+      ref_y_[i] = y[n - 1];
+      ref_v_[i] = v != nullptr ? v[n - 1] : this->params_.desired_speed;
+      ref_yaw_[i] = end_yaw;
+    }
+  }
+  dataToDevice();
+}
+
+template <class CLASS_T, int NUM_TIMESTEPS, class PARAMS_T, class DYN_PARAMS_T>
+void FirstOrderDubinsBicycleCostImpl<CLASS_T, NUM_TIMESTEPS, PARAMS_T, DYN_PARAMS_T>::
+  setOrientedBoxObstacles(
+    const float * x, const float * y, const float * yaw, const float * half_length,
+    const float * half_width, const int count)
+{
+  const int n = std::max(0, std::min(count, kMaxObstacles));
+  num_obstacles_ = n;
+  for (int i = 0; i < n; ++i) {
+    obs_half_length_[i] = half_length[i];
+    obs_half_width_[i] = half_width[i];
+    for (int t = 0; t < NUM_TIMESTEPS; ++t) {
+      obs_x_[i][t] = x[i];
+      obs_y_[i][t] = y[i];
+      obs_yaw_[i][t] = yaw[i];
+    }
+  }
+  dataToDevice();
+}
+
+template <class CLASS_T, int NUM_TIMESTEPS, class PARAMS_T, class DYN_PARAMS_T>
+void FirstOrderDubinsBicycleCostImpl<CLASS_T, NUM_TIMESTEPS, PARAMS_T, DYN_PARAMS_T>::
+  setOrientedBoxObstacleTrajectories(
+    const float * x, const float * y, const float * yaw, const float * half_length,
+    const float * half_width, const int obstacle_count, const int num_timesteps)
+{
+  const int n = std::max(0, std::min(obstacle_count, kMaxObstacles));
+  const int nt = std::max(0, std::min(num_timesteps, NUM_TIMESTEPS));
+  num_obstacles_ = n;
+  for (int i = 0; i < n; ++i) {
+    obs_half_length_[i] = half_length[i];
+    obs_half_width_[i] = half_width[i];
+    for (int t = 0; t < nt; ++t) {
+      const int idx = i * nt + t;
+      obs_x_[i][t] = x[idx];
+      obs_y_[i][t] = y[idx];
+      obs_yaw_[i][t] = yaw[idx];
+    }
+    for (int t = nt; t < NUM_TIMESTEPS; ++t) {
+      obs_x_[i][t] = obs_x_[i][nt - 1];
+      obs_y_[i][t] = obs_y_[i][nt - 1];
+      obs_yaw_[i][t] = obs_yaw_[i][nt - 1];
+    }
+  }
+  dataToDevice();
+}
+
+template <class CLASS_T, int NUM_TIMESTEPS, class PARAMS_T, class DYN_PARAMS_T>
+void FirstOrderDubinsBicycleCostImpl<
+  CLASS_T, NUM_TIMESTEPS, PARAMS_T, DYN_PARAMS_T>::clearObstacles()
+{
+  num_obstacles_ = 0;
+  dataToDevice();
+}
+
+template <class CLASS_T, int NUM_TIMESTEPS, class PARAMS_T, class DYN_PARAMS_T>
+void FirstOrderDubinsBicycleCostImpl<CLASS_T, NUM_TIMESTEPS, PARAMS_T, DYN_PARAMS_T>::
+  setDrivableAreaPolygon(const float * x, const float * y, const int count)
+{
+  const int n = std::max(0, std::min(count, kMaxDrivablePolygonVertices));
+  num_drivable_vertices_ = n;
+  for (int i = 0; i < n; ++i) {
+    drivable_poly_x_[i] = x[i];
+    drivable_poly_y_[i] = y[i];
+  }
+  dataToDevice();
+}
+
+template <class CLASS_T, int NUM_TIMESTEPS, class PARAMS_T, class DYN_PARAMS_T>
+void FirstOrderDubinsBicycleCostImpl<
+  CLASS_T, NUM_TIMESTEPS, PARAMS_T, DYN_PARAMS_T>::clearDrivableArea()
+{
+  num_drivable_vertices_ = 0;
+  dataToDevice();
+}
+
+template <class CLASS_T, int NUM_TIMESTEPS, class PARAMS_T, class DYN_PARAMS_T>
+__host__ __device__ float
+FirstOrderDubinsBicycleCostImpl<CLASS_T, NUM_TIMESTEPS, PARAMS_T, DYN_PARAMS_T>::computeTrackValue(
+  float x, float y) const
+{
+  float min_dist = 0.0F;
+  if (NUM_TIMESTEPS <= 1) {
+    min_dist = vectorLength(x - ref_x_[0], y - ref_y_[0]);
+  } else {
+    min_dist = 1.0E8F;
+    for (int i = 0; i < NUM_TIMESTEPS - 1; ++i) {
+      const float segment_dist =
+        distancePointToSegment(x, y, ref_x_[i], ref_y_[i], ref_x_[i + 1], ref_y_[i + 1]);
+#ifdef __CUDA_ARCH__
+      min_dist = fminf(min_dist, segment_dist);
+#else
+      min_dist = std::min(min_dist, segment_dist);
+#endif
+    }
+  }
+
+  return min_dist;
+}
+
+template <class CLASS_T, int NUM_TIMESTEPS, class PARAMS_T, class DYN_PARAMS_T>
+__host__ __device__ float FirstOrderDubinsBicycleCostImpl<
+  CLASS_T, NUM_TIMESTEPS, PARAMS_T,
+  DYN_PARAMS_T>::computeHeadingValue(const float yaw, const int timestep) const
+{
+  int t = timestep;
+  if (t < 0) {
+    t = 0;
+  } else if (t >= NUM_TIMESTEPS) {
+    t = NUM_TIMESTEPS - 1;
+  }
+
+  const float yaw_diff = angle_utils::shortestAngularDistance(yaw, ref_yaw_[t]);
+  return yaw_diff * yaw_diff;
+}
+
+template <class CLASS_T, int NUM_TIMESTEPS, class PARAMS_T, class DYN_PARAMS_T>
+__host__ __device__ float
+FirstOrderDubinsBicycleCostImpl<CLASS_T, NUM_TIMESTEPS, PARAMS_T, DYN_PARAMS_T>::computeGoalCost(
+  const float x, const float y, const float yaw, const float vel) const
+{
+  constexpr int kEnd = NUM_TIMESTEPS - 1;
+  float cost = 0.0F;
+
+  if (this->params_.goal_pos_coeff > 0.0F) {
+    cost += this->params_.goal_pos_coeff * vectorLength(x - ref_x_[kEnd], y - ref_y_[kEnd]);
+  }
+  if (this->params_.goal_speed_coeff > 0.0F) {
+    const float vel_diff = vel - ref_v_[kEnd];
+    cost += this->params_.goal_speed_coeff * vel_diff * vel_diff;
+  }
+  if (this->params_.goal_yaw_coeff > 0.0F) {
+    const float yaw_diff = angle_utils::shortestAngularDistance(yaw, ref_yaw_[kEnd]);
+#ifdef __CUDA_ARCH__
+    cost += this->params_.goal_yaw_coeff * fabsf(yaw_diff);
+#else
+    cost += this->params_.goal_yaw_coeff * std::abs(yaw_diff);
+#endif
+  }
+
+  return cost;
+}
+
+template <class CLASS_T, int NUM_TIMESTEPS, class PARAMS_T, class DYN_PARAMS_T>
+__host__ __device__ float FirstOrderDubinsBicycleCostImpl<
+  CLASS_T, NUM_TIMESTEPS, PARAMS_T,
+  DYN_PARAMS_T>::computeSignedLateralOffset(const float x, const float y) const
+{
+  if (NUM_TIMESTEPS <= 1) {
+    return x - ref_x_[0];
+  }
+
+  float best_abs = 1.0E8F;
+  float best_signed = 0.0F;
+  for (int i = 0; i < NUM_TIMESTEPS - 1; ++i) {
+    const float signed_offset =
+      signedLateralOffsetPointToSegment(x, y, ref_x_[i], ref_y_[i], ref_x_[i + 1], ref_y_[i + 1]);
+#ifdef __CUDA_ARCH__
+    const float abs_offset = fabsf(signed_offset);
+    if (abs_offset < best_abs) {
+      best_abs = abs_offset;
+      best_signed = signed_offset;
+    }
+#else
+    const float abs_offset = std::fabs(signed_offset);
+    if (abs_offset < best_abs) {
+      best_abs = abs_offset;
+      best_signed = signed_offset;
+    }
+#endif
+  }
+
+  return best_signed;
+}
+
+template <class CLASS_T, int NUM_TIMESTEPS, class PARAMS_T, class DYN_PARAMS_T>
+__host__ __device__ bool
+FirstOrderDubinsBicycleCostImpl<CLASS_T, NUM_TIMESTEPS, PARAMS_T, DYN_PARAMS_T>::isOffRoad(
+  const float x, const float y) const
+{
+  const bool asymmetric =
+    this->params_.boundary_threshold_left >= 0.0F || this->params_.boundary_threshold_right >= 0.0F;
+  if (!asymmetric) {
+    return computeTrackValue(x, y) >= this->params_.boundary_threshold;
+  }
+
+  const float left_limit = this->params_.boundary_threshold_left >= 0.0F
+                             ? this->params_.boundary_threshold_left
+                             : this->params_.boundary_threshold;
+  const float right_limit = this->params_.boundary_threshold_right >= 0.0F
+                              ? this->params_.boundary_threshold_right
+                              : this->params_.boundary_threshold;
+  const float signed_lat = computeSignedLateralOffset(x, y);
+  return signed_lat > left_limit || signed_lat < -right_limit;
+}
+
+template <class CLASS_T, int NUM_TIMESTEPS, class PARAMS_T, class DYN_PARAMS_T>
+__host__ __device__ bool FirstOrderDubinsBicycleCostImpl<
+  CLASS_T, NUM_TIMESTEPS, PARAMS_T,
+  DYN_PARAMS_T>::isEgoOutsideDrivableArea(const float x, const float y, const float yaw) const
+{
+  (void)yaw;
+  if (num_drivable_vertices_ < 3) {
+    return isOffRoad(x, y);
+  }
+
+  // Rear-axle containment in the drivable polygon. Corner checks are too strict on tight curves.
+  if (pointInPolygon(x, y, drivable_poly_x_, drivable_poly_y_, num_drivable_vertices_)) {
+    return false;
+  }
+
+  // Polygon boundary is piecewise-linear; defer to ref lateral offset near the corridor edge.
+  return isOffRoad(x, y);
+}
+
+template <class CLASS_T, int NUM_TIMESTEPS, class PARAMS_T, class DYN_PARAMS_T>
+__host__ __device__ bool
+FirstOrderDubinsBicycleCostImpl<CLASS_T, NUM_TIMESTEPS, PARAMS_T, DYN_PARAMS_T>::
+  egoIntersectsObstacleAtStep(
+    const float x, const float y, const float yaw, const int timestep) const
+{
+  int t = timestep;
+  if (t < 0) {
+    t = 0;
+  } else if (t >= NUM_TIMESTEPS) {
+    t = NUM_TIMESTEPS - 1;
+  }
+
+#ifdef __CUDA_ARCH__
+  const float ego_cos = cosf(yaw);
+  const float ego_sin = sinf(yaw);
+#else
+  const float ego_cos = std::cos(yaw);
+  const float ego_sin = std::sin(yaw);
+#endif
+  const float ego_cx = x + this->params_.ego_axle_to_box_center * ego_cos;
+  const float ego_cy = y + this->params_.ego_axle_to_box_center * ego_sin;
+  const float margin = this->params_.obstacle_collision_margin;
+  const float ego_hl = this->params_.ego_length * 0.5F + margin;
+  const float ego_hw = this->params_.ego_width * 0.5F + margin;
+
+#ifdef __CUDA_ARCH__
+#pragma unroll
+#endif
+  for (int i = 0; i < num_obstacles_; ++i) {
+#ifdef __CUDA_ARCH__
+    const float obs_cos = cosf(obs_yaw_[i][t]);
+    const float obs_sin = sinf(obs_yaw_[i][t]);
+#else
+    const float obs_cos = std::cos(obs_yaw_[i][t]);
+    const float obs_sin = std::sin(obs_yaw_[i][t]);
+#endif
+    if (orientedBoxesOverlap(
+          ego_cx, ego_cy, ego_cos, ego_sin, ego_hl, ego_hw, obs_x_[i][t], obs_y_[i][t], obs_cos,
+          obs_sin, obs_half_length_[i], obs_half_width_[i])) {
+      return true;
+    }
+  }
+  return false;
+}
+
+template <class CLASS_T, int NUM_TIMESTEPS, class PARAMS_T, class DYN_PARAMS_T>
+__host__ __device__ bool
+FirstOrderDubinsBicycleCostImpl<CLASS_T, NUM_TIMESTEPS, PARAMS_T, DYN_PARAMS_T>::isCrashLatched(
+  const int * crash_status) const
+{
+  return crash_status != nullptr && crash_status[0] > 0;
+}
+
+template <class CLASS_T, int NUM_TIMESTEPS, class PARAMS_T, class DYN_PARAMS_T>
+__host__ __device__ bool
+FirstOrderDubinsBicycleCostImpl<CLASS_T, NUM_TIMESTEPS, PARAMS_T, DYN_PARAMS_T>::
+  detectAndLatchCrash(
+    const float x, const float y, const float yaw, const int timestep, int * crash_status) const
+{
+  const bool off_road = isEgoOutsideDrivableArea(x, y, yaw);
+  const bool hit_car = egoIntersectsObstacleAtStep(x, y, yaw, timestep);
+  const int violations = static_cast<int>(off_road) + static_cast<int>(hit_car);
+  if (violations > 0) {
+    if (crash_status != nullptr) {
+      crash_status[0] = violations;
+    }
+    return true;
+  }
+  return false;
+}
+
+template <class CLASS_T, int NUM_TIMESTEPS, class PARAMS_T, class DYN_PARAMS_T>
+__host__ __device__ float
+FirstOrderDubinsBicycleCostImpl<CLASS_T, NUM_TIMESTEPS, PARAMS_T, DYN_PARAMS_T>::latchedCrashCost(
+  const int * crash_status) const
+{
+  return isCrashLatched(crash_status)
+           ? static_cast<float>(crash_status[0]) * this->params_.crash_coeff
+           : 0.0F;
+}
+
+template <class CLASS_T, int NUM_TIMESTEPS, class PARAMS_T, class DYN_PARAMS_T>
+__device__ float
+FirstOrderDubinsBicycleCostImpl<CLASS_T, NUM_TIMESTEPS, PARAMS_T, DYN_PARAMS_T>::computeStateCost(
+  float * y, int timestep, float * theta_c, int * crash_status)
+{
+  (void)theta_c;
+
+  const float x_pos = y[static_cast<int>(O::BASELINK_POS_I_X)];
+  const float y_pos = y[static_cast<int>(O::BASELINK_POS_I_Y)];
+  const float yaw = y[static_cast<int>(O::YAW)];
+  const float vel = y[static_cast<int>(O::TOTAL_VELOCITY)];
+
+  const float track_val = computeTrackValue(x_pos, y_pos);
+  const float vel_diff = vel - ref_v_[timestep];
+  const float speed_cost = this->params_.speed_coeff * (vel_diff * vel_diff);
+  const float track_cost = this->params_.track_coeff * track_val;
+  const float heading_cost = this->params_.heading_coeff * computeHeadingValue(yaw, timestep);
+  const float goal_cost = computeGoalCost(x_pos, y_pos, yaw, vel);
+  const float crash_cost =
+    isCrashLatched(crash_status) || detectAndLatchCrash(x_pos, y_pos, yaw, timestep, crash_status)
+      ? latchedCrashCost(crash_status)
+      : 0.0F;
+
+  return speed_cost + track_cost + heading_cost + goal_cost + crash_cost;
+}
+
+template <class CLASS_T, int NUM_TIMESTEPS, class PARAMS_T, class DYN_PARAMS_T>
+float FirstOrderDubinsBicycleCostImpl<CLASS_T, NUM_TIMESTEPS, PARAMS_T, DYN_PARAMS_T>::
+  computeStateCost(const Eigen::Ref<const output_array> & y, int timestep, int * crash_status)
+{
+  const float x_pos = y[static_cast<int>(O::BASELINK_POS_I_X)];
+  const float y_pos = y[static_cast<int>(O::BASELINK_POS_I_Y)];
+  const float yaw = y[static_cast<int>(O::YAW)];
+  const float vel = y[static_cast<int>(O::TOTAL_VELOCITY)];
+
+  const float track_val = computeTrackValue(x_pos, y_pos);
+  const float vel_diff = vel - ref_v_[timestep];
+  const float speed_cost = this->params_.speed_coeff * (vel_diff * vel_diff);
+  const float track_cost = this->params_.track_coeff * track_val;
+  const float heading_cost = this->params_.heading_coeff * computeHeadingValue(yaw, timestep);
+  const float goal_cost = computeGoalCost(x_pos, y_pos, yaw, vel);
+  const float crash_cost =
+    isCrashLatched(crash_status) || detectAndLatchCrash(x_pos, y_pos, yaw, timestep, crash_status)
+      ? latchedCrashCost(crash_status)
+      : 0.0F;
+
+  return speed_cost + track_cost + heading_cost + goal_cost + crash_cost;
+}
+
+template <class CLASS_T, int NUM_TIMESTEPS, class PARAMS_T, class DYN_PARAMS_T>
+__device__ float
+FirstOrderDubinsBicycleCostImpl<CLASS_T, NUM_TIMESTEPS, PARAMS_T, DYN_PARAMS_T>::computeControlCost(
+  float * u, int timestep, float * theta_c, int * crash)
+{
+  (void)timestep;
+  (void)theta_c;
+  (void)crash;
+  const float accel_cmd = u[static_cast<int>(C::ACCELERATION_CMD)];
+  const float steer_cmd = u[static_cast<int>(C::STEER_CMD)];
+  return this->params_.accel_cmd_coeff * (accel_cmd * accel_cmd) +
+         this->params_.steer_cmd_coeff * (steer_cmd * steer_cmd);
+}
+
+template <class CLASS_T, int NUM_TIMESTEPS, class PARAMS_T, class DYN_PARAMS_T>
+float FirstOrderDubinsBicycleCostImpl<CLASS_T, NUM_TIMESTEPS, PARAMS_T, DYN_PARAMS_T>::
+  computeControlCost(const Eigen::Ref<const control_array> & u, int timestep, int * crash)
+{
+  (void)timestep;
+  (void)crash;
+  const float accel_cmd = u(static_cast<int>(C::ACCELERATION_CMD));
+  const float steer_cmd = u(static_cast<int>(C::STEER_CMD));
+  return this->params_.accel_cmd_coeff * (accel_cmd * accel_cmd) +
+         this->params_.steer_cmd_coeff * (steer_cmd * steer_cmd);
+}
+
+template <class CLASS_T, int NUM_TIMESTEPS, class PARAMS_T, class DYN_PARAMS_T>
+__device__ float
+FirstOrderDubinsBicycleCostImpl<CLASS_T, NUM_TIMESTEPS, PARAMS_T, DYN_PARAMS_T>::terminalCost(
+  float * y, float * theta_c)
+{
+  (void)theta_c;
+  const float x_pos = y[static_cast<int>(O::BASELINK_POS_I_X)];
+  const float y_pos = y[static_cast<int>(O::BASELINK_POS_I_Y)];
+  const float yaw = y[static_cast<int>(O::YAW)];
+  const float vel = y[static_cast<int>(O::TOTAL_VELOCITY)];
+  const float track_val = computeTrackValue(x_pos, y_pos);
+  const float track_cost = this->params_.track_coeff * track_val * 10.0F;
+  const float heading_cost =
+    this->params_.heading_coeff * computeHeadingValue(yaw, NUM_TIMESTEPS - 1) * 10.0F;
+  const float goal_cost =
+    computeGoalCost(x_pos, y_pos, yaw, vel) * this->params_.goal_terminal_scale;
+  return track_cost + heading_cost + goal_cost;
+}
+
+template <class CLASS_T, int NUM_TIMESTEPS, class PARAMS_T, class DYN_PARAMS_T>
+float FirstOrderDubinsBicycleCostImpl<CLASS_T, NUM_TIMESTEPS, PARAMS_T, DYN_PARAMS_T>::
+  computeComfortCost(
+    const Eigen::Ref<const control_array> & u, const Eigen::Ref<const output_array> & y,
+    int timestep)
+{
+  (void)timestep;
+  float lateral_accel = 0.0F;
+  float lateral_jerk = 0.0F;
+  float longitudinal_jerk = 0.0F;
+  comfortTerms(this->params_, u.data(), y.data(), lateral_accel, lateral_jerk, longitudinal_jerk);
+  return this->params_.lateral_acceleration_coeff * std::abs(lateral_accel) +
+         this->params_.lateral_jerk_coeff * std::abs(lateral_jerk) +
+         this->params_.longitudinal_jerk_coeff * std::abs(longitudinal_jerk);
+}
+
+template <class CLASS_T, int NUM_TIMESTEPS, class PARAMS_T, class DYN_PARAMS_T>
+__device__ float
+FirstOrderDubinsBicycleCostImpl<CLASS_T, NUM_TIMESTEPS, PARAMS_T, DYN_PARAMS_T>::computeComfortCost(
+  float * u, float * y, int timestep)
+{
+  (void)timestep;
+  float lateral_accel = 0.0F;
+  float lateral_jerk = 0.0F;
+  float longitudinal_jerk = 0.0F;
+  comfortTerms(this->params_, u, y, lateral_accel, lateral_jerk, longitudinal_jerk);
+  return this->params_.lateral_acceleration_coeff * fabsf(lateral_accel) +
+         this->params_.lateral_jerk_coeff * fabsf(lateral_jerk) +
+         this->params_.longitudinal_jerk_coeff * fabsf(longitudinal_jerk);
+}
+
+template <class CLASS_T, int NUM_TIMESTEPS, class PARAMS_T, class DYN_PARAMS_T>
+float FirstOrderDubinsBicycleCostImpl<CLASS_T, NUM_TIMESTEPS, PARAMS_T, DYN_PARAMS_T>::
+  computeRunningCost(
+    const Eigen::Ref<const output_array> & y, const Eigen::Ref<const control_array> & u,
+    int timestep, int * crash)
+{
+  if (isCrashLatched(crash)) {
+    return latchedCrashCost(crash);
+  }
+
+  const float state_cost = computeStateCost(y, timestep, crash);
+  if (isCrashLatched(crash)) {
+    return state_cost;
+  }
+
+  return state_cost + computeControlCost(u, timestep, crash) + computeComfortCost(u, y, timestep);
+}
+
+template <class CLASS_T, int NUM_TIMESTEPS, class PARAMS_T, class DYN_PARAMS_T>
+__device__ float
+FirstOrderDubinsBicycleCostImpl<CLASS_T, NUM_TIMESTEPS, PARAMS_T, DYN_PARAMS_T>::computeRunningCost(
+  float * y, float * u, int timestep, float * theta_c, int * crash)
+{
+  if (threadIdx.y == 0) {
+    if (isCrashLatched(crash)) {
+      return latchedCrashCost(crash);
+    }
+
+    const float state_cost = computeStateCost(y, timestep, theta_c, crash);
+    if (isCrashLatched(crash)) {
+      return state_cost;
+    }
+
+    return state_cost + computeControlCost(u, timestep, theta_c, crash) +
+           computeComfortCost(u, y, timestep);
+  }
+  return 0.0F;
+}
+
+template <class CLASS_T, int NUM_TIMESTEPS, class PARAMS_T, class DYN_PARAMS_T>
+constexpr int
+  FirstOrderDubinsBicycleCostImpl<CLASS_T, NUM_TIMESTEPS, PARAMS_T, DYN_PARAMS_T>::kMaxObstacles;
+template <class CLASS_T, int NUM_TIMESTEPS, class PARAMS_T, class DYN_PARAMS_T>
+constexpr int FirstOrderDubinsBicycleCostImpl<
+  CLASS_T, NUM_TIMESTEPS, PARAMS_T, DYN_PARAMS_T>::kMaxDrivablePolygonVertices;

--- a/planning/autoware_mppi_optimizer/include/mppi/cost_functions/dubins/first_order_dubins_bicycle_cost.cuh
+++ b/planning/autoware_mppi_optimizer/include/mppi/cost_functions/dubins/first_order_dubins_bicycle_cost.cuh
@@ -1,0 +1,172 @@
+/**
+ * Analytic path-tracking cost for FirstOrderDubinsBicycle (reference polyline + parked-car OBBs).
+ */
+#pragma once
+
+#ifndef MPPI_COST_FUNCTIONS_FIRST_ORDER_DUBINS_BICYCLE_COST_CUH_
+#define MPPI_COST_FUNCTIONS_FIRST_ORDER_DUBINS_BICYCLE_COST_CUH_
+
+#include <mppi/cost_functions/cost.cuh>
+#include <mppi/dynamics/dubins/first_order_dubins_bicycle.cuh>
+
+template <int NUM_TIMESTEPS>
+struct FirstOrderDubinsBicycleCostParams : public CostParams<2>
+{
+  float desired_speed = 2.5F;
+  float speed_coeff = 500.0F;
+  float track_coeff = 1000.0F;
+  /** Pull toward ref heading at each horizon step: coeff * (yaw - ref_yaw[t])^2; 0 disables. */
+  float heading_coeff = 500.0F;
+  /** Per-violation crash penalty; latched crash_status counts violations (1=off-road or hit,
+   * 2=both). */
+  float crash_coeff = 100000.0F;
+  float boundary_threshold = 0.8F;
+  /** Off-road if signed lateral offset exceeds these (path-left = +); <0 falls back to
+   * boundary_threshold. */
+  float boundary_threshold_left = -1.0F;
+  float boundary_threshold_right = -1.0F;
+  float accel_cmd_coeff = 0.0F;
+  float steer_cmd_coeff = 0.0F;
+  float lateral_acceleration_coeff = 300.0F;
+  float lateral_jerk_coeff = 300.0F;
+  float longitudinal_jerk_coeff = 10.0F;
+  float wheel_base = 0.32F;
+  float accel_time_constant = 0.15F;
+  float steer_time_constant = 0.08F;
+  /** Ego OBB for parked-car collision (rear axle at pose; box center offset forward). */
+  float ego_length = 0.55F * 1.5F;
+  float ego_width = 0.28F * 1.5F;
+  float ego_axle_to_box_center = 0.2F;
+  /** Added to ego half-length/width in OBB collision test (~standoff to obstacle surfaces). */
+  float obstacle_collision_margin = 0.2F;
+  /** Pull toward ref end position (Euclidean distance [m]); 0 disables. */
+  float goal_pos_coeff = 1000.0F;
+  /** Pull toward ref end speed: coeff * (v - ref_v_end)^2; 0 disables. */
+  float goal_speed_coeff = 0.0F;
+  /** Pull toward ref end heading: coeff * |yaw - ref_yaw_end|; 0 disables. */
+  float goal_yaw_coeff = 500.0F;
+  /** Multiplier on goal terms in terminalCost (running state cost uses scale 1). */
+  float goal_terminal_scale = 10.0F;
+};
+
+template <
+  class CLASS_T, int NUM_TIMESTEPS,
+  class PARAMS_T = FirstOrderDubinsBicycleCostParams<NUM_TIMESTEPS>,
+  class DYN_PARAMS_T = FirstOrderDubinsBicycleParams>
+class FirstOrderDubinsBicycleCostImpl : public Cost<CLASS_T, PARAMS_T, DYN_PARAMS_T>
+{
+public:
+  static constexpr int kMaxObstacles = 64;
+  static constexpr int kMaxDrivablePolygonVertices = 1024;
+
+  using PARENT_CLASS = Cost<CLASS_T, PARAMS_T, DYN_PARAMS_T>;
+  using output_array = typename PARENT_CLASS::output_array;
+  using control_array = typename PARENT_CLASS::control_array;
+
+  FirstOrderDubinsBicycleCostImpl(cudaStream_t stream = 0);
+
+  void paramsToDevice();
+
+  void setReferenceTrajectory(
+    const float * x, const float * y, const float * v, int count, const float * yaw = nullptr);
+
+  /** Static obstacles: same pose replicated at every MPPI horizon step. */
+  void setOrientedBoxObstacles(
+    const float * x, const float * y, const float * yaw, const float * half_length,
+    const float * half_width, int count);
+
+  void setOrientedBoxObstacleTrajectories(
+    const float * x, const float * y, const float * yaw, const float * half_length,
+    const float * half_width, int obstacle_count, int num_timesteps);
+
+  void clearObstacles();
+
+  void setDrivableAreaPolygon(const float * x, const float * y, int count);
+
+  void clearDrivableArea();
+
+  __host__ __device__ float computeTrackValue(float x, float y) const;
+
+  __host__ __device__ float computeHeadingValue(float yaw, int timestep) const;
+
+  /** Distance-to-goal cost vs ref[NUM_TIMESTEPS - 1] (position, speed, yaw). */
+  __host__ __device__ float computeGoalCost(float x, float y, float yaw, float vel) const;
+
+  __host__ __device__ float computeSignedLateralOffset(float x, float y) const;
+
+  __host__ __device__ bool isOffRoad(const float x, const float y) const;
+
+  /** True when outside drivable polygon (rear axle); falls back to ref lateral offset near the poly
+   * boundary. */
+  __host__ __device__ bool isEgoOutsideDrivableArea(
+    const float x, const float y, const float yaw) const;
+
+  __host__ __device__ bool egoIntersectsObstacleAtStep(
+    const float x, const float y, const float yaw, int timestep) const;
+
+  __host__ __device__ bool isCrashLatched(const int * crash_status) const;
+
+  __host__ __device__ bool detectAndLatchCrash(
+    const float x, const float y, const float yaw, int timestep, int * crash_status) const;
+
+  __host__ __device__ float latchedCrashCost(const int * crash_status) const;
+
+  float computeStateCost(
+    const Eigen::Ref<const output_array> & y, int timestep, int * crash_status);
+
+  __device__ float computeStateCost(float * y, int timestep, float * theta_c, int * crash_status);
+
+  float computeControlCost(const Eigen::Ref<const control_array> & u, int timestep, int * crash);
+
+  __device__ float computeControlCost(float * u, int timestep, float * theta_c, int * crash);
+
+  float computeComfortCost(
+    const Eigen::Ref<const control_array> & u, const Eigen::Ref<const output_array> & y,
+    int timestep);
+
+  __device__ float computeComfortCost(float * u, float * y, int timestep);
+
+  __device__ float terminalCost(float * y, float * theta_c);
+
+  float computeRunningCost(
+    const Eigen::Ref<const output_array> & y, const Eigen::Ref<const control_array> & u,
+    int timestep, int * crash);
+
+  __device__ float computeRunningCost(
+    float * y, float * u, int timestep, float * theta_c, int * crash);
+
+  float ref_x_[NUM_TIMESTEPS] = {};
+  float ref_y_[NUM_TIMESTEPS] = {};
+  float ref_v_[NUM_TIMESTEPS] = {};
+  float ref_yaw_[NUM_TIMESTEPS] = {};
+  int num_obstacles_ = 0;
+  float obs_x_[kMaxObstacles][NUM_TIMESTEPS] = {};
+  float obs_y_[kMaxObstacles][NUM_TIMESTEPS] = {};
+  float obs_yaw_[kMaxObstacles][NUM_TIMESTEPS] = {};
+  float obs_half_length_[kMaxObstacles] = {};
+  float obs_half_width_[kMaxObstacles] = {};
+  int num_drivable_vertices_ = 0;
+  float drivable_poly_x_[kMaxDrivablePolygonVertices] = {};
+  float drivable_poly_y_[kMaxDrivablePolygonVertices] = {};
+
+private:
+  void dataToDevice();
+};
+
+template <int NUM_TIMESTEPS>
+class FirstOrderDubinsBicycleCost
+: public FirstOrderDubinsBicycleCostImpl<FirstOrderDubinsBicycleCost<NUM_TIMESTEPS>, NUM_TIMESTEPS>
+{
+public:
+  FirstOrderDubinsBicycleCost(cudaStream_t stream = 0)
+  : FirstOrderDubinsBicycleCostImpl<FirstOrderDubinsBicycleCost<NUM_TIMESTEPS>, NUM_TIMESTEPS>(
+      stream)
+  {
+  }
+};
+
+#if __CUDACC__
+#include "first_order_dubins_bicycle_cost.cu"
+#endif
+
+#endif  // MPPI_COST_FUNCTIONS_FIRST_ORDER_DUBINS_BICYCLE_COST_CUH_

--- a/planning/autoware_mppi_optimizer/include/mppi/cost_functions/dubins/first_order_dubins_bicycle_cost_bridge.hpp
+++ b/planning/autoware_mppi_optimizer/include/mppi/cost_functions/dubins/first_order_dubins_bicycle_cost_bridge.hpp
@@ -1,0 +1,138 @@
+/**
+ * Host-side helpers to populate FirstOrderDubinsBicycleCost reference trajectories and obstacles.
+ */
+#pragma once
+
+#include <mppi/cost_functions/dubins/first_order_dubins_bicycle_cost.cuh>
+#include <mppi/cost_functions/parked_car_obstacles.hpp>
+#include <mppi/dynamics/dubins/first_order_dubins_bicycle.cuh>
+#include <mppi/path/drivable_area.hpp>
+#include <mppi/path/path_reference_generator.hpp>
+
+#include <algorithm>
+#include <vector>
+
+namespace mppi
+{
+namespace cost
+{
+
+template <int NUM_TIMESTEPS>
+inline void fillFirstOrderDubinsBicycleCostGeometry(
+  FirstOrderDubinsBicycleCostParams<NUM_TIMESTEPS> & cost_params,
+  const FirstOrderDubinsBicycleParams & dyn)
+{
+  cost_params.wheel_base = dyn.wheel_base;
+  cost_params.accel_time_constant = dyn.accel_time_constant;
+  cost_params.steer_time_constant = dyn.steer_time_constant;
+}
+
+template <int NUM_TIMESTEPS>
+inline void setFirstOrderDubinsBicycleCostEgoFootprint(
+  FirstOrderDubinsBicycleCostParams<NUM_TIMESTEPS> & params, const float wheel_base,
+  const float ego_length, const float ego_width)
+{
+  params.ego_length = ego_length;
+  params.ego_width = ego_width;
+  const float rear_overhang = 0.08F * wheel_base;
+  params.ego_axle_to_box_center = 0.5F * ego_length - rear_overhang;
+}
+
+template <int NUM_TIMESTEPS>
+inline void fillFirstOrderDubinsBicycleCostParkedCars(
+  FirstOrderDubinsBicycleCost<NUM_TIMESTEPS> & cost, const std::vector<ParkedCarObstacle> & cars)
+{
+  float obs_x[FirstOrderDubinsBicycleCost<NUM_TIMESTEPS>::kMaxObstacles] = {};
+  float obs_y[FirstOrderDubinsBicycleCost<NUM_TIMESTEPS>::kMaxObstacles] = {};
+  float obs_yaw[FirstOrderDubinsBicycleCost<NUM_TIMESTEPS>::kMaxObstacles] = {};
+  float obs_half_length[FirstOrderDubinsBicycleCost<NUM_TIMESTEPS>::kMaxObstacles] = {};
+  float obs_half_width[FirstOrderDubinsBicycleCost<NUM_TIMESTEPS>::kMaxObstacles] = {};
+
+  const int n = static_cast<int>(std::min(
+    cars.size(), static_cast<size_t>(FirstOrderDubinsBicycleCost<NUM_TIMESTEPS>::kMaxObstacles)));
+  for (int i = 0; i < n; ++i) {
+    const ParkedCarObstacle & car = cars[static_cast<size_t>(i)];
+    obs_x[i] = car.ox;
+    obs_y[i] = car.oy;
+    obs_yaw[i] = car.yaw;
+    obs_half_length[i] = car.length * 0.5F;
+    obs_half_width[i] = car.width * 0.5F;
+  }
+
+  cost.setOrientedBoxObstacles(obs_x, obs_y, obs_yaw, obs_half_length, obs_half_width, n);
+}
+
+template <int NUM_TIMESTEPS>
+inline void fillFirstOrderDubinsBicycleCostDrivablePolygon(
+  FirstOrderDubinsBicycleCost<NUM_TIMESTEPS> & cost, const mppi::path::Polygon2D & polygon)
+{
+  if (polygon.empty()) {
+    cost.clearDrivableArea();
+    return;
+  }
+
+  constexpr int kMax = FirstOrderDubinsBicycleCost<NUM_TIMESTEPS>::kMaxDrivablePolygonVertices;
+  const int n_in = static_cast<int>(polygon.size());
+  if (n_in <= kMax) {
+    cost.setDrivableAreaPolygon(polygon.x.data(), polygon.y.data(), n_in);
+    return;
+  }
+
+  std::vector<float> x(static_cast<size_t>(kMax));
+  std::vector<float> y(static_cast<size_t>(kMax));
+  for (int i = 0; i < kMax; ++i) {
+    const int src = (i * n_in) / kMax;
+    x[static_cast<size_t>(i)] = polygon.x[static_cast<size_t>(src)];
+    y[static_cast<size_t>(i)] = polygon.y[static_cast<size_t>(src)];
+  }
+  cost.setDrivableAreaPolygon(x.data(), y.data(), kMax);
+}
+
+/** Drivable surface for a stadium-style closed path. */
+template <int NUM_TIMESTEPS>
+inline void fillFirstOrderDubinsBicycleCostStadiumDrivablePolygon(
+  FirstOrderDubinsBicycleCost<NUM_TIMESTEPS> & cost, const mppi::path::Path2D & path,
+  const float road_half_width, const float extra_half_width = 0.0F)
+{
+  constexpr int kMax = FirstOrderDubinsBicycleCost<NUM_TIMESTEPS>::kMaxDrivablePolygonVertices;
+  const float half_width = road_half_width + extra_half_width;
+  const mppi::path::Polygon2D drivable =
+    mppi::path::symmetricPathCorridorPolygon(path, half_width, 0.5F, kMax);
+  fillFirstOrderDubinsBicycleCostDrivablePolygon<NUM_TIMESTEPS>(cost, drivable);
+}
+
+/** Per-horizon obstacle poses: buffers sized obstacle_count * num_timesteps (obstacle-major). */
+template <int NUM_TIMESTEPS>
+inline void fillFirstOrderDubinsBicycleCostObstacleTrajectories(
+  FirstOrderDubinsBicycleCost<NUM_TIMESTEPS> & cost, const float * x, const float * y,
+  const float * yaw, const float * half_length, const float * half_width, const int obstacle_count,
+  const int num_timesteps)
+{
+  cost.setOrientedBoxObstacleTrajectories(
+    x, y, yaw, half_length, half_width, obstacle_count, num_timesteps);
+}
+
+template <int NUM_TIMESTEPS>
+inline void fillFirstOrderDubinsBicycleCostFromPathReference(
+  FirstOrderDubinsBicycleCost<NUM_TIMESTEPS> & cost,
+  const std::vector<mppi::path::PathReferenceSample> & ref)
+{
+  float ref_x[NUM_TIMESTEPS];
+  float ref_y[NUM_TIMESTEPS];
+  float ref_v[NUM_TIMESTEPS];
+  float ref_yaw[NUM_TIMESTEPS];
+
+  for (int t = 0; t < NUM_TIMESTEPS; ++t) {
+    const size_t idx =
+      ref.empty() ? 0U : static_cast<size_t>(std::min(t, static_cast<int>(ref.size()) - 1));
+    ref_x[t] = ref[idx].x;
+    ref_y[t] = ref[idx].y;
+    ref_v[t] = ref[idx].v;
+    ref_yaw[t] = ref[idx].yaw;
+  }
+
+  cost.setReferenceTrajectory(ref_x, ref_y, ref_v, NUM_TIMESTEPS, ref_yaw);
+}
+
+}  // namespace cost
+}  // namespace mppi

--- a/planning/autoware_mppi_optimizer/include/mppi/cost_functions/moving_car_obstacles.hpp
+++ b/planning/autoware_mppi_optimizer/include/mppi/cost_functions/moving_car_obstacles.hpp
@@ -1,0 +1,258 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * Constant-velocity vehicles for time-varying OBB collision costs (approach B).
+ */
+#pragma once
+
+#include <mppi/cost_functions/parked_car_obstacles.hpp>
+
+#include <algorithm>
+#include <cmath>
+#include <numeric>
+#include <vector>
+
+namespace mppi
+{
+namespace cost
+{
+
+/** Cross-traffic / dynamic vehicle with constant velocity. */
+struct MovingCarObstacle
+{
+  float x0 = 0.0F;
+  float y0 = 0.0F;
+  float vx = 0.0F;
+  float vy = 0.0F;
+  float yaw = 0.0F;
+  float length = 0.55F * 1.5F;
+  float width = 0.28F * 1.5F;
+  /** Obstacle pose is active in cost/viz when sim_time >= spawn_time. */
+  float spawn_time = 0.0F;
+
+  ParkedCarObstacle poseAt(const float t) const
+  {
+    ParkedCarObstacle car;
+    const float elapsed = t - spawn_time;
+    car.ox = x0 + vx * elapsed;
+    car.oy = y0 + vy * elapsed;
+    car.yaw = yaw;
+    car.length = length;
+    car.width = width;
+    return car;
+  }
+
+  bool isActiveAt(const float t) const { return t >= spawn_time; }
+};
+
+/** Active vehicles at simulation time sim_time (for visualization). */
+inline std::vector<ParkedCarObstacle> movingCarPosesAt(
+  const std::vector<MovingCarObstacle> & cars, const float sim_time)
+{
+  std::vector<ParkedCarObstacle> out;
+  out.reserve(cars.size());
+  for (const MovingCarObstacle & car : cars) {
+    if (car.isActiveAt(sim_time)) {
+      out.push_back(car.poseAt(sim_time));
+    }
+  }
+  return out;
+}
+
+/**
+ * Fill obstacle-major trajectory buffers for MPPI horizon [0, num_timesteps).
+ * Step t uses world time horizon_start_time + t * dt.
+ */
+inline void buildObstacleTrajectoryBuffers(
+  const std::vector<MovingCarObstacle> & cars, const float horizon_start_time, const float dt,
+  const int num_timesteps, std::vector<float> & x, std::vector<float> & y, std::vector<float> & yaw,
+  std::vector<float> & half_length, std::vector<float> & half_width)
+{
+  const size_t n = std::min(cars.size(), static_cast<size_t>(64));
+  const int nt = std::max(1, num_timesteps);
+  x.assign(n * static_cast<size_t>(nt), 0.0F);
+  y.assign(n * static_cast<size_t>(nt), 0.0F);
+  yaw.assign(n * static_cast<size_t>(nt), 0.0F);
+  half_length.assign(n, 0.0F);
+  half_width.assign(n, 0.0F);
+
+  std::vector<int> timesteps(static_cast<size_t>(nt));
+  std::iota(timesteps.begin(), timesteps.end(), 0);
+
+  size_t i = 0;
+  for (const MovingCarObstacle & car : cars) {
+    if (i >= n) {
+      break;
+    }
+    half_length[i] = car.length * 0.5F;
+    half_width[i] = car.width * 0.5F;
+    for (const int t : timesteps) {
+      const float world_t = horizon_start_time + static_cast<float>(t) * dt;
+      const size_t idx = i * static_cast<size_t>(nt) + static_cast<size_t>(t);
+      if (car.isActiveAt(world_t)) {
+        const ParkedCarObstacle pose = car.poseAt(world_t);
+        x[idx] = pose.ox;
+        y[idx] = pose.oy;
+        yaw[idx] = pose.yaw;
+      } else {
+        x[idx] = -1.0E4F;
+        y[idx] = -1.0E4F;
+        yaw[idx] = car.yaw;
+      }
+    }
+    ++i;
+  }
+}
+
+namespace detail
+{
+inline MovingCarObstacle makeCrossingCar(
+  const float x_at_spawn, const float y_lane, const float speed, const float spawn_time,
+  const float length_scale = 1.0F)
+{
+  MovingCarObstacle car;
+  car.x0 = x_at_spawn;
+  car.y0 = y_lane;
+  car.vx = speed;
+  car.vy = 0.0F;
+  car.yaw = 0.0F;
+  car.spawn_time = spawn_time;
+  car.length = 0.55F * 1.5F * length_scale;
+  car.width = 0.28F * 1.5F;
+  return car;
+}
+
+inline void appendLanePlatoon(
+  std::vector<MovingCarObstacle> & cars, const float y_lane, const float speed, const float first_x,
+  const float x_spacing, const float spawn_start, const float spawn_spacing, const int count,
+  const float length_scale = 1.0F)
+{
+  if (count <= 0) {
+    return;
+  }
+  std::vector<int> slots(static_cast<size_t>(count));
+  std::iota(slots.begin(), slots.end(), 0);
+  for (const int i : slots) {
+    cars.push_back(makeCrossingCar(
+      first_x - static_cast<float>(i) * x_spacing, y_lane, speed,
+      spawn_start + static_cast<float>(i) * spawn_spacing, length_scale));
+  }
+}
+}  // namespace detail
+
+/** Dense cross-traffic from the west (up to kMaxObstacles = 64 in first-order Dubins cost). */
+inline std::vector<MovingCarObstacle> defaultIntersectionCrossTraffic()
+{
+  constexpr float kSpeedFast = 5.8F;
+  constexpr float kSpeedMid = 4.8F;
+  constexpr float kSpeedSlow = 3.6F;
+  constexpr float kLaneSpacing = 8.5F;
+
+  std::vector<MovingCarObstacle> cars;
+  cars.reserve(64);
+
+  // Six eastbound lanes, seven vehicles each (42)
+  detail::appendLanePlatoon(cars, -2.2F, kSpeedFast, -16.0F, kLaneSpacing, 0.0F, 0.82F, 7);
+  detail::appendLanePlatoon(cars, -2.9F, kSpeedFast, -18.0F, kLaneSpacing, 0.15F, 0.88F, 7);
+  detail::appendLanePlatoon(cars, -3.6F, kSpeedFast, -22.0F, kLaneSpacing, 0.35F, 0.92F, 7);
+  detail::appendLanePlatoon(cars, -4.4F, kSpeedMid, -26.0F, kLaneSpacing, 0.55F, 0.98F, 7);
+  detail::appendLanePlatoon(cars, -5.2F, kSpeedMid, -30.0F, kLaneSpacing, 0.75F, 1.02F, 7);
+  detail::appendLanePlatoon(cars, -6.0F, kSpeedSlow, -34.0F, kLaneSpacing, 0.95F, 1.08F, 7);
+
+  // Five distant waves (20)
+  detail::appendLanePlatoon(cars, -2.6F, kSpeedMid, -64.0F, 9.0F, 4.2F, 1.05F, 4);
+  detail::appendLanePlatoon(cars, -3.3F, kSpeedMid, -68.0F, 9.0F, 4.6F, 1.1F, 4);
+  detail::appendLanePlatoon(cars, -4.1F, kSpeedMid, -72.0F, 9.0F, 5.0F, 1.12F, 4);
+  detail::appendLanePlatoon(cars, -5.0F, kSpeedSlow, -76.0F, 9.0F, 5.4F, 1.15F, 4);
+  detail::appendLanePlatoon(cars, -5.8F, kSpeedSlow, -80.0F, 9.0F, 5.8F, 1.18F, 4);
+
+  // Late heavy vehicles (2) — fills obstacle budget at 64
+  cars.push_back(detail::makeCrossingCar(-92.0F, -3.8F, kSpeedSlow, 6.8F, 1.35F));
+  cars.push_back(detail::makeCrossingCar(-98.0F, -5.4F, kSpeedSlow, 8.5F, 1.4F));
+
+  return cars;
+}
+
+/**
+ * One absurdly large eastbound vehicle timed for the left-turn intersection (~s≈22, ~7–8 s @ 3
+ * m/s). Center pose is rear-axle box center; length is along +x. East edge at t: x0 + vx*t +
+ * length/2.
+ */
+inline std::vector<MovingCarObstacle> intersectionGiantBlocker()
+{
+  constexpr float kEgoApproachTime = 7.5F;
+  constexpr float kGiantSpeed = 3.4F;
+  constexpr float kGiantLength = 52.0F;
+  constexpr float kCenterAtApproach = -8.0F;
+
+  MovingCarObstacle blocker;
+  blocker.x0 = kCenterAtApproach - kGiantSpeed * kEgoApproachTime;
+  blocker.y0 = -4.0F;
+  blocker.vx = kGiantSpeed;
+  blocker.vy = 0.0F;
+  blocker.yaw = 0.0F;
+  blocker.spawn_time = 0.0F;
+  blocker.length = kGiantLength;
+  blocker.width = 18.0F;
+  return {blocker};
+}
+
+/** Shared compact two-lane straight-road layout (+y forward, right lane at +x). */
+struct TwoLaneRoadLayout
+{
+  static constexpr float kRightLaneX = 0.9F;
+  static constexpr float kLeftLaneX = -0.9F;
+  static constexpr float kLaneHalfWidth = 0.85F;
+  static constexpr float kRoadYaw = 1.5707963267948966F;
+  static constexpr float kRoadYStart = -10.0F;
+  static constexpr float kRoadYEnd = 32.0F;
+};
+
+/**
+ * Left-lane ego goes around a stopped vehicle intruding from the left curb by nudging into
+ * the right lane, while a faster vehicle in the right lane approaches from behind.
+ */
+inline std::vector<MovingCarObstacle> twoLaneDoubleParkAndRearApproach()
+{
+  std::vector<MovingCarObstacle> obstacles;
+  obstacles.reserve(2);
+
+  MovingCarObstacle double_parked;
+  double_parked.x0 = TwoLaneRoadLayout::kLeftLaneX;
+  double_parked.y0 = 11.0F;
+  double_parked.vx = 0.0F;
+  double_parked.vy = 0.0F;
+  double_parked.yaw = TwoLaneRoadLayout::kRoadYaw;
+  double_parked.spawn_time = 0.0F;
+  double_parked.length = 0.55F * 1.5F * 1.08F;
+  double_parked.width = 0.28F * 1.5F * 1.12F * 2.0F;
+
+  MovingCarObstacle rear_right_lane;
+  rear_right_lane.x0 = TwoLaneRoadLayout::kRightLaneX - 0.5F;
+  rear_right_lane.y0 = -12.5F;
+  rear_right_lane.vx = 0.0F;
+  rear_right_lane.vy = 3.5F;
+  rear_right_lane.yaw = TwoLaneRoadLayout::kRoadYaw;
+  rear_right_lane.spawn_time = 0.0F;
+  rear_right_lane.length = 0.55F * 1.5F * 10.0F;
+  rear_right_lane.width = 0.28F * 1.5F * 1.12F;
+
+  obstacles.push_back(double_parked);
+  obstacles.push_back(rear_right_lane);
+  return obstacles;
+}
+
+}  // namespace cost
+}  // namespace mppi

--- a/planning/autoware_mppi_optimizer/include/mppi/cost_functions/parked_car_obstacles.hpp
+++ b/planning/autoware_mppi_optimizer/include/mppi/cost_functions/parked_car_obstacles.hpp
@@ -1,0 +1,94 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * Parked-car obstacle types and road-shoulder placement (shared by path-tracking cost bridges).
+ */
+#pragma once
+
+#include <mppi/path/path2d.hpp>
+
+#include <algorithm>
+#include <cmath>
+#include <random>
+#include <vector>
+
+namespace mppi
+{
+namespace cost
+{
+
+/** Parked vehicle on the road shoulder (oriented box for cost and viz). */
+struct ParkedCarObstacle
+{
+  float ox = 0.0F;
+  float oy = 0.0F;
+  float yaw = 0.0F;
+  float length = 0.55F * 1.5F;
+  float width = 0.28F * 1.5F;
+};
+
+/**
+ * Place parked cars along both shoulders near the road boundary, alternating left/right with gaps
+ * so the ego vehicle weaves through a traffic corridor. lateral offset is a fraction of
+ * road_half_width.
+ */
+inline std::vector<ParkedCarObstacle> generateParkedCarsAlongRoad(
+  const mppi::path::Path2D & path, const float road_half_width, const unsigned int seed,
+  const float along_spacing = 5.5F, const int max_cars = 48)
+{
+  std::vector<ParkedCarObstacle> cars;
+  if (path.empty() || road_half_width <= 0.0F) {
+    return cars;
+  }
+
+  std::mt19937 rng(seed);
+  std::uniform_real_distribution<float> dist_jitter_s(-0.9F, 0.9F);
+  std::uniform_real_distribution<float> dist_gap(0.0F, 1.0F);
+  std::uniform_real_distribution<float> dist_lat_frac(0.58F, 0.88F);
+
+  constexpr float kGapProbability = 0.24F;
+  float s = along_spacing * 0.35F;
+  int side_sign = 1;
+
+  while (s < path.length() && static_cast<int>(cars.size()) < max_cars) {
+    if (dist_gap(rng) < kGapProbability) {
+      s += along_spacing * 0.55F;
+      continue;
+    }
+
+    const float s_wrapped = path.wrapArcLength(s + dist_jitter_s(rng));
+    const mppi::path::Pose2D p = path.poseAt(s_wrapped);
+    float tx = 0.0F;
+    float ty = 0.0F;
+    path.tangentAt(s_wrapped, tx, ty);
+
+    const float lateral = road_half_width * dist_lat_frac(rng);
+    const float sign = (side_sign > 0) ? 1.0F : -1.0F;
+
+    ParkedCarObstacle car;
+    car.ox = p.x - sign * lateral * ty;
+    car.oy = p.y + sign * lateral * tx;
+    car.yaw = p.yaw;
+    cars.push_back(car);
+
+    side_sign = -side_sign;
+    s += along_spacing + dist_jitter_s(rng) * 0.35F;
+  }
+
+  return cars;
+}
+
+}  // namespace cost
+}  // namespace mppi

--- a/planning/autoware_mppi_optimizer/include/mppi/cost_functions/path_tracking_geometry.cuh
+++ b/planning/autoware_mppi_optimizer/include/mppi/cost_functions/path_tracking_geometry.cuh
@@ -1,0 +1,183 @@
+/**
+ * Shared host/device geometry for analytic path-tracking costs (polyline distance, OBB overlap).
+ */
+#pragma once
+
+#ifndef MPPI_COST_FUNCTIONS_PATH_TRACKING_GEOMETRY_CUH_
+#define MPPI_COST_FUNCTIONS_PATH_TRACKING_GEOMETRY_CUH_
+
+#include <algorithm>
+#include <cmath>
+
+namespace mppi
+{
+namespace cost
+{
+namespace detail
+{
+#ifdef __CUDA_ARCH__
+__device__ inline float clampUnitInterval(const float t)
+{
+  return fmaxf(0.0F, fminf(1.0F, t));
+}
+
+__device__ inline float vectorLength(const float dx, const float dy)
+{
+  return sqrtf(dx * dx + dy * dy);
+}
+#else
+inline float clampUnitInterval(const float t)
+{
+  return std::max(0.0F, std::min(1.0F, t));
+}
+
+inline float vectorLength(const float dx, const float dy)
+{
+  return std::sqrt(dx * dx + dy * dy);
+}
+#endif
+
+__host__ __device__ inline float distancePointToSegment(
+  const float px, const float py, const float x0, const float y0, const float x1, const float y1)
+{
+  const float dx = x1 - x0;
+  const float dy = y1 - y0;
+  const float len_sq = dx * dx + dy * dy;
+  if (len_sq < 1.0E-8F) {
+    return vectorLength(px - x0, py - y0);
+  }
+
+  const float t = clampUnitInterval(((px - x0) * dx + (py - y0) * dy) / len_sq);
+  return vectorLength(px - (x0 + t * dx), py - (y0 + t * dy));
+}
+
+/** Signed lateral offset from segment; positive = left of forward tangent. */
+__host__ __device__ inline float signedLateralOffsetPointToSegment(
+  const float px, const float py, const float x0, const float y0, const float x1, const float y1)
+{
+  const float dx = x1 - x0;
+  const float dy = y1 - y0;
+  const float len_sq = dx * dx + dy * dy;
+  if (len_sq < 1.0E-8F) {
+    return px - x0;
+  }
+
+  const float t = clampUnitInterval(((px - x0) * dx + (py - y0) * dy) / len_sq);
+  const float cx = x0 + t * dx;
+  const float cy = y0 + t * dy;
+  const float len = vectorLength(dx, dy);
+  return ((px - cx) * (-dy) + (py - cy) * dx) / len;
+}
+
+__host__ __device__ inline float dot2(
+  const float ax, const float ay, const float bx, const float by)
+{
+  return ax * bx + ay * by;
+}
+
+/** Separating-axis test for two oriented boxes (body x = forward, y = left). */
+__host__ __device__ inline bool orientedBoxesOverlap(
+  const float acx, const float acy, const float a_cos, const float a_sin, const float a_hl,
+  const float a_hw, const float bcx, const float bcy, const float b_cos, const float b_sin,
+  const float b_hl, const float b_hw)
+{
+  const float tx = bcx - acx;
+  const float ty = bcy - acy;
+
+  const float a0x = a_cos;
+  const float a0y = a_sin;
+  const float a1x = -a_sin;
+  const float a1y = a_cos;
+  const float b0x = b_cos;
+  const float b0y = b_sin;
+  const float b1x = -b_sin;
+  const float b1y = b_cos;
+
+#ifdef __CUDA_ARCH__
+#define MPPI_COST_ABS(x) fabsf(x)
+#else
+#define MPPI_COST_ABS(x) std::fabs(x)
+#endif
+
+  float t = MPPI_COST_ABS(dot2(tx, ty, a0x, a0y));
+  float r = a_hl + MPPI_COST_ABS(dot2(b0x, b0y, a0x, a0y)) * b_hl +
+            MPPI_COST_ABS(dot2(b1x, b1y, a0x, a0y)) * b_hw;
+  if (t > r) {
+    return false;
+  }
+
+  t = MPPI_COST_ABS(dot2(tx, ty, a1x, a1y));
+  r = a_hw + MPPI_COST_ABS(dot2(b0x, b0y, a1x, a1y)) * b_hl +
+      MPPI_COST_ABS(dot2(b1x, b1y, a1x, a1y)) * b_hw;
+  if (t > r) {
+    return false;
+  }
+
+  t = MPPI_COST_ABS(dot2(tx, ty, b0x, b0y));
+  r = b_hl + MPPI_COST_ABS(dot2(a0x, a0y, b0x, b0y)) * a_hl +
+      MPPI_COST_ABS(dot2(a1x, a1y, b0x, b0y)) * a_hw;
+  if (t > r) {
+    return false;
+  }
+
+  t = MPPI_COST_ABS(dot2(tx, ty, b1x, b1y));
+  r = b_hw + MPPI_COST_ABS(dot2(a0x, a0y, b1x, b1y)) * a_hl +
+      MPPI_COST_ABS(dot2(a1x, a1y, b1x, b1y)) * a_hw;
+  if (t > r) {
+    return false;
+  }
+
+#undef MPPI_COST_ABS
+  return true;
+}
+
+/** Four corners in body frame order: front-left, front-right, rear-right, rear-left. */
+__host__ __device__ inline void orientedBoxCorners(
+  const float cx, const float cy, const float cos_yaw, const float sin_yaw, const float half_length,
+  const float half_width, float corners_x[4], float corners_y[4])
+{
+  const float fx = cos_yaw;
+  const float fy = sin_yaw;
+  const float lx = -sin_yaw;
+  const float ly = cos_yaw;
+
+  corners_x[0] = cx + half_length * fx + half_width * lx;
+  corners_y[0] = cy + half_length * fy + half_width * ly;
+  corners_x[1] = cx + half_length * fx - half_width * lx;
+  corners_y[1] = cy + half_length * fy - half_width * ly;
+  corners_x[2] = cx - half_length * fx - half_width * lx;
+  corners_y[2] = cy - half_length * fy - half_width * ly;
+  corners_x[3] = cx - half_length * fx + half_width * lx;
+  corners_y[3] = cy - half_length * fy + half_width * ly;
+}
+
+/** Ray-casting point-in-polygon (closed boundary; vertices in order). */
+__host__ __device__ inline bool pointInPolygon(
+  const float px, const float py, const float * vertices_x, const float * vertices_y,
+  const int vertex_count)
+{
+  if (vertex_count < 3) {
+    return false;
+  }
+
+  bool inside = false;
+  int j = vertex_count - 1;
+  for (int i = 0; i < vertex_count; ++i) {
+    const float xi = vertices_x[i];
+    const float yi = vertices_y[i];
+    const float xj = vertices_x[j];
+    const float yj = vertices_y[j];
+    const bool intersects =
+      ((yi > py) != (yj > py)) && (px < (xj - xi) * (py - yi) / (yj - yi + 1.0E-12F) + xi);
+    if (intersects) {
+      inside = !inside;
+    }
+    j = i;
+  }
+  return inside;
+}
+}  // namespace detail
+}  // namespace cost
+}  // namespace mppi
+
+#endif  // MPPI_COST_FUNCTIONS_PATH_TRACKING_GEOMETRY_CUH_

--- a/planning/autoware_mppi_optimizer/include/mppi/cost_functions/racer/racer_cost.cu
+++ b/planning/autoware_mppi_optimizer/include/mppi/cost_functions/racer/racer_cost.cu
@@ -1,0 +1,334 @@
+#include <mppi/cost_functions/path_tracking_geometry.cuh>
+#include <mppi/cost_functions/racer/racer_cost.cuh>
+
+#include <algorithm>
+#include <cmath>
+
+namespace
+{
+using mppi::cost::detail::distancePointToSegment;
+using mppi::cost::detail::orientedBoxesOverlap;
+using mppi::cost::detail::vectorLength;
+
+__host__ __device__ inline float racerRolloutSpeed(const float * y)
+{
+  return fabsf(y[static_cast<int>(RacerDubinsParams::OutputIndex::BASELINK_VEL_B_X)]);
+}
+
+__host__ __device__ inline float racerRolloutSteerAngle(const float * y)
+{
+  return y[static_cast<int>(RacerDubinsParams::OutputIndex::BASELINK_POS_I_Z)];
+}
+
+__host__ __device__ inline float racerRolloutSteerRate(const float * y)
+{
+  return y[static_cast<int>(RacerDubinsParams::OutputIndex::ROLL)];
+}
+
+__host__ __device__ inline float racerRolloutYaw(const float * y)
+{
+  return y[static_cast<int>(RacerDubinsParams::OutputIndex::YAW)];
+}
+
+}  // namespace
+
+template <class CLASS_T, int NUM_TIMESTEPS, class PARAMS_T, class DYN_PARAMS_T>
+RacerCostImpl<CLASS_T, NUM_TIMESTEPS, PARAMS_T, DYN_PARAMS_T>::RacerCostImpl(cudaStream_t stream)
+{
+  this->bindToStream(stream);
+}
+
+template <class CLASS_T, int NUM_TIMESTEPS, class PARAMS_T, class DYN_PARAMS_T>
+void RacerCostImpl<CLASS_T, NUM_TIMESTEPS, PARAMS_T, DYN_PARAMS_T>::paramsToDevice()
+{
+  PARENT_CLASS::paramsToDevice();
+}
+
+template <class CLASS_T, int NUM_TIMESTEPS, class PARAMS_T, class DYN_PARAMS_T>
+void RacerCostImpl<CLASS_T, NUM_TIMESTEPS, PARAMS_T, DYN_PARAMS_T>::dataToDevice()
+{
+  if (!this->GPUMemStatus_) {
+    return;
+  }
+
+  HANDLE_ERROR(cudaMemcpyAsync(
+    this->cost_d_->ref_x_, ref_x_, sizeof(ref_x_), cudaMemcpyHostToDevice, this->stream_));
+  HANDLE_ERROR(cudaMemcpyAsync(
+    this->cost_d_->ref_y_, ref_y_, sizeof(ref_y_), cudaMemcpyHostToDevice, this->stream_));
+  HANDLE_ERROR(cudaMemcpyAsync(
+    &this->cost_d_->num_obstacles_, &num_obstacles_, sizeof(num_obstacles_), cudaMemcpyHostToDevice,
+    this->stream_));
+  HANDLE_ERROR(cudaMemcpyAsync(
+    this->cost_d_->obs_x_, obs_x_, sizeof(obs_x_), cudaMemcpyHostToDevice, this->stream_));
+  HANDLE_ERROR(cudaMemcpyAsync(
+    this->cost_d_->obs_y_, obs_y_, sizeof(obs_y_), cudaMemcpyHostToDevice, this->stream_));
+  HANDLE_ERROR(cudaMemcpyAsync(
+    this->cost_d_->obs_yaw_, obs_yaw_, sizeof(obs_yaw_), cudaMemcpyHostToDevice, this->stream_));
+  HANDLE_ERROR(cudaMemcpyAsync(
+    this->cost_d_->obs_half_length_, obs_half_length_, sizeof(obs_half_length_),
+    cudaMemcpyHostToDevice, this->stream_));
+  HANDLE_ERROR(cudaMemcpyAsync(
+    this->cost_d_->obs_half_width_, obs_half_width_, sizeof(obs_half_width_),
+    cudaMemcpyHostToDevice, this->stream_));
+}
+
+template <class CLASS_T, int NUM_TIMESTEPS, class PARAMS_T, class DYN_PARAMS_T>
+void RacerCostImpl<CLASS_T, NUM_TIMESTEPS, PARAMS_T, DYN_PARAMS_T>::setReferenceTrajectory(
+  const float * x, const float * y, const int count)
+{
+  const int n = std::max(0, std::min(count, NUM_TIMESTEPS));
+  for (int i = 0; i < n; ++i) {
+    ref_x_[i] = x[i];
+    ref_y_[i] = y[i];
+  }
+  if (n > 0) {
+    for (int i = n; i < NUM_TIMESTEPS; ++i) {
+      ref_x_[i] = x[n - 1];
+      ref_y_[i] = y[n - 1];
+    }
+  }
+  dataToDevice();
+}
+
+template <class CLASS_T, int NUM_TIMESTEPS, class PARAMS_T, class DYN_PARAMS_T>
+void RacerCostImpl<CLASS_T, NUM_TIMESTEPS, PARAMS_T, DYN_PARAMS_T>::setOrientedBoxObstacles(
+  const float * x, const float * y, const float * yaw, const float * half_length,
+  const float * half_width, const int count)
+{
+  const int n = std::max(0, std::min(count, kMaxObstacles));
+  num_obstacles_ = n;
+  for (int i = 0; i < n; ++i) {
+    obs_x_[i] = x[i];
+    obs_y_[i] = y[i];
+    obs_yaw_[i] = yaw[i];
+    obs_half_length_[i] = half_length[i];
+    obs_half_width_[i] = half_width[i];
+  }
+  dataToDevice();
+}
+
+template <class CLASS_T, int NUM_TIMESTEPS, class PARAMS_T, class DYN_PARAMS_T>
+__host__ __device__ float
+RacerCostImpl<CLASS_T, NUM_TIMESTEPS, PARAMS_T, DYN_PARAMS_T>::computeTrackValue(
+  float x, float y) const
+{
+  float min_dist = 0.0F;
+  if (NUM_TIMESTEPS <= 1) {
+    min_dist = vectorLength(x - ref_x_[0], y - ref_y_[0]);
+  } else {
+    min_dist = 1.0E8F;
+    for (int i = 0; i < NUM_TIMESTEPS - 1; ++i) {
+      const float segment_dist =
+        distancePointToSegment(x, y, ref_x_[i], ref_y_[i], ref_x_[i + 1], ref_y_[i + 1]);
+#ifdef __CUDA_ARCH__
+      min_dist = fminf(min_dist, segment_dist);
+#else
+      min_dist = std::min(min_dist, segment_dist);
+#endif
+    }
+  }
+
+  return min_dist;
+}
+
+template <class CLASS_T, int NUM_TIMESTEPS, class PARAMS_T, class DYN_PARAMS_T>
+__host__ __device__ bool
+RacerCostImpl<CLASS_T, NUM_TIMESTEPS, PARAMS_T, DYN_PARAMS_T>::egoIntersectsParkedCar(
+  const float x, const float y, const float yaw) const
+{
+#ifdef __CUDA_ARCH__
+  const float ego_cos = cosf(yaw);
+  const float ego_sin = sinf(yaw);
+#else
+  const float ego_cos = std::cos(yaw);
+  const float ego_sin = std::sin(yaw);
+#endif
+  const float ego_cx = x + this->params_.ego_axle_to_box_center * ego_cos;
+  const float ego_cy = y + this->params_.ego_axle_to_box_center * ego_sin;
+  const float margin = this->params_.obstacle_collision_margin;
+  const float ego_hl = this->params_.ego_length * 0.5F + margin;
+  const float ego_hw = this->params_.ego_width * 0.5F + margin;
+
+  for (int i = 0; i < num_obstacles_; ++i) {
+#ifdef __CUDA_ARCH__
+    const float obs_cos = cosf(obs_yaw_[i]);
+    const float obs_sin = sinf(obs_yaw_[i]);
+#else
+    const float obs_cos = std::cos(obs_yaw_[i]);
+    const float obs_sin = std::sin(obs_yaw_[i]);
+#endif
+    if (orientedBoxesOverlap(
+          ego_cx, ego_cy, ego_cos, ego_sin, ego_hl, ego_hw, obs_x_[i], obs_y_[i], obs_cos, obs_sin,
+          obs_half_length_[i], obs_half_width_[i])) {
+      return true;
+    }
+  }
+  return false;
+}
+
+template <class CLASS_T, int NUM_TIMESTEPS, class PARAMS_T, class DYN_PARAMS_T>
+__device__ float RacerCostImpl<CLASS_T, NUM_TIMESTEPS, PARAMS_T, DYN_PARAMS_T>::computeStateCost(
+  float * y, int timestep, float * theta_c, int * crash_status)
+{
+  (void)theta_c;
+
+  const float x_pos = y[static_cast<int>(RacerDubinsParams::OutputIndex::BASELINK_POS_I_X)];
+  const float y_pos = y[static_cast<int>(RacerDubinsParams::OutputIndex::BASELINK_POS_I_Y)];
+  const float yaw = racerRolloutYaw(y);
+  const float vel = racerRolloutSpeed(y);
+
+  const float track_val = computeTrackValue(x_pos, y_pos);
+
+  const float vel_diff = vel - this->params_.desired_speed;
+  const float speed_cost = this->params_.speed_coeff * (vel_diff * vel_diff);
+  const float track_cost = this->params_.track_coeff * track_val;
+  float crash_cost = 0.0F;
+  const bool off_road = track_val >= this->params_.boundary_threshold;
+  const bool hit_car = egoIntersectsParkedCar(x_pos, y_pos, yaw);
+  if (off_road || hit_car) {
+    crash_cost = this->params_.crash_coeff;
+    if (crash_status != nullptr) {
+      *crash_status = 1;
+      return crash_cost;
+    }
+  }
+
+  return speed_cost + track_cost + crash_cost;
+}
+
+template <class CLASS_T, int NUM_TIMESTEPS, class PARAMS_T, class DYN_PARAMS_T>
+float RacerCostImpl<CLASS_T, NUM_TIMESTEPS, PARAMS_T, DYN_PARAMS_T>::computeStateCost(
+  const Eigen::Ref<const output_array> & y, int timestep, int * crash_status)
+{
+  (void)timestep;
+  const float x_pos = y[static_cast<int>(RacerDubinsParams::OutputIndex::BASELINK_POS_I_X)];
+  const float y_pos = y[static_cast<int>(RacerDubinsParams::OutputIndex::BASELINK_POS_I_Y)];
+  const float yaw = racerRolloutYaw(y.data());
+  const float vel = racerRolloutSpeed(y.data());
+
+  const float track_val = computeTrackValue(x_pos, y_pos);
+
+  const float vel_diff = vel - this->params_.desired_speed;
+  const float speed_cost = this->params_.speed_coeff * (vel_diff * vel_diff);
+  const float track_cost = this->params_.track_coeff * track_val;
+  float crash_cost = 0.0F;
+  const bool off_road = track_val >= this->params_.boundary_threshold;
+  const bool hit_car = egoIntersectsParkedCar(x_pos, y_pos, yaw);
+  if (off_road || hit_car) {
+    crash_cost = this->params_.crash_coeff;
+    if (crash_status != nullptr) {
+      *crash_status = 1;
+      return crash_cost;
+    }
+  }
+
+  return speed_cost + track_cost + crash_cost;
+}
+
+template <class CLASS_T, int NUM_TIMESTEPS, class PARAMS_T, class DYN_PARAMS_T>
+__device__ float RacerCostImpl<CLASS_T, NUM_TIMESTEPS, PARAMS_T, DYN_PARAMS_T>::computeControlCost(
+  float * u, int timestep, float * theta_c, int * crash)
+{
+  (void)timestep;
+  (void)theta_c;
+  (void)crash;
+  const float steer = u[static_cast<int>(RacerDubinsParams::ControlIndex::STEER_CMD)];
+  return this->params_.steer_coeff * (steer * steer);
+}
+
+template <class CLASS_T, int NUM_TIMESTEPS, class PARAMS_T, class DYN_PARAMS_T>
+float RacerCostImpl<CLASS_T, NUM_TIMESTEPS, PARAMS_T, DYN_PARAMS_T>::computeControlCost(
+  const Eigen::Ref<const control_array> & u, int timestep, int * crash)
+{
+  (void)timestep;
+  (void)crash;
+  const float steer = u(static_cast<int>(RacerDubinsParams::ControlIndex::STEER_CMD));
+  return this->params_.steer_coeff * (steer * steer);
+}
+
+template <class CLASS_T, int NUM_TIMESTEPS, class PARAMS_T, class DYN_PARAMS_T>
+__device__ float RacerCostImpl<CLASS_T, NUM_TIMESTEPS, PARAMS_T, DYN_PARAMS_T>::terminalCost(
+  float * y, float * theta_c)
+{
+  (void)theta_c;
+  const float x_pos = y[static_cast<int>(RacerDubinsParams::OutputIndex::BASELINK_POS_I_X)];
+  const float y_pos = y[static_cast<int>(RacerDubinsParams::OutputIndex::BASELINK_POS_I_Y)];
+  const float track_val = computeTrackValue(x_pos, y_pos);
+  return this->params_.track_coeff * track_val * 10.0F;
+}
+
+template <class CLASS_T, int NUM_TIMESTEPS, class PARAMS_T, class DYN_PARAMS_T>
+float RacerCostImpl<CLASS_T, NUM_TIMESTEPS, PARAMS_T, DYN_PARAMS_T>::computeComfortCost(
+  const Eigen::Ref<const control_array> & u, const Eigen::Ref<const output_array> & y, int timestep)
+{
+  (void)u;
+  (void)timestep;
+  const float vel = racerRolloutSpeed(y.data());
+  const float steer_angle = racerRolloutSteerAngle(y.data());
+  const float steer_angle_rate = racerRolloutSteerRate(y.data());
+
+  const float phi = steer_angle / this->params_.steer_angle_scale;
+  const float cos_phi = std::cos(phi);
+  const float sec_sq_phi = 1.0F / std::max(cos_phi * cos_phi, 1.0E-6F);
+
+  // kappa = tan(phi) / L
+  const float curvature = std::tan(phi) / this->params_.wheel_base;
+  // kappa_dot = sec^2(phi) * phi_dot / L, with phi_dot = steer_angle_rate / steer_angle_scale
+  const float curvature_derivative =
+    (sec_sq_phi * steer_angle_rate) / (this->params_.wheel_base * this->params_.steer_angle_scale);
+
+  // a_y = v^2 * kappa; j_y ≈ v^2 * kappa_dot (longitudinal coupling omitted: ACCEL_X not in rollout
+  // output)
+  const float lateral_acceleration = vel * vel * curvature;
+  const float lateral_jerk = vel * vel * curvature_derivative;
+
+  return this->params_.lateral_acceleration_coeff * std::abs(lateral_acceleration) +
+         this->params_.lateral_jerk_coeff * std::abs(lateral_jerk);
+}
+
+template <class CLASS_T, int NUM_TIMESTEPS, class PARAMS_T, class DYN_PARAMS_T>
+__device__ float RacerCostImpl<CLASS_T, NUM_TIMESTEPS, PARAMS_T, DYN_PARAMS_T>::computeComfortCost(
+  float * u, float * y, int timestep)
+{
+  (void)u;
+  (void)timestep;
+  const float vel = racerRolloutSpeed(y);
+  const float steer_angle = racerRolloutSteerAngle(y);
+  const float steer_angle_rate = racerRolloutSteerRate(y);
+
+  const float phi = steer_angle / this->params_.steer_angle_scale;
+  const float cos_phi = cosf(phi);
+  const float sec_sq_phi = 1.0F / fmaxf(cos_phi * cos_phi, 1.0E-6F);
+
+  const float curvature = tanf(phi) / this->params_.wheel_base;
+  const float curvature_derivative =
+    (sec_sq_phi * steer_angle_rate) / (this->params_.wheel_base * this->params_.steer_angle_scale);
+
+  const float lateral_acceleration = vel * vel * curvature;
+  const float lateral_jerk = vel * vel * curvature_derivative;
+
+  return this->params_.lateral_acceleration_coeff * fabsf(lateral_acceleration) +
+         this->params_.lateral_jerk_coeff * fabsf(lateral_jerk);
+}
+
+template <class CLASS_T, int NUM_TIMESTEPS, class PARAMS_T, class DYN_PARAMS_T>
+float RacerCostImpl<CLASS_T, NUM_TIMESTEPS, PARAMS_T, DYN_PARAMS_T>::computeRunningCost(
+  const Eigen::Ref<const output_array> & y, const Eigen::Ref<const control_array> & u, int timestep,
+  int * crash)
+{
+  return this->computeStateCost(y, timestep, crash) + this->computeControlCost(u, timestep, crash) +
+         this->computeComfortCost(u, y, timestep);
+}
+
+template <class CLASS_T, int NUM_TIMESTEPS, class PARAMS_T, class DYN_PARAMS_T>
+__device__ float RacerCostImpl<CLASS_T, NUM_TIMESTEPS, PARAMS_T, DYN_PARAMS_T>::computeRunningCost(
+  float * y, float * u, int timestep, float * theta_c, int * crash)
+{
+  if (threadIdx.y == 0) {
+    return this->computeStateCost(y, timestep, theta_c, crash) +
+           this->computeControlCost(u, timestep, theta_c, crash) +
+           this->computeComfortCost(u, y, timestep);
+  } else {
+    return 0.0f;
+  }
+}

--- a/planning/autoware_mppi_optimizer/include/mppi/cost_functions/racer/racer_cost.cu
+++ b/planning/autoware_mppi_optimizer/include/mppi/cost_functions/racer/racer_cost.cu
@@ -17,12 +17,12 @@ __host__ __device__ inline float racerRolloutSpeed(const float * y)
 
 __host__ __device__ inline float racerRolloutSteerAngle(const float * y)
 {
-  return y[static_cast<int>(RacerDubinsParams::OutputIndex::BASELINK_POS_I_Z)];
+  return y[static_cast<int>(RacerDubinsParams::OutputIndex::STEER_ANGLE)];
 }
 
 __host__ __device__ inline float racerRolloutSteerRate(const float * y)
 {
-  return y[static_cast<int>(RacerDubinsParams::OutputIndex::ROLL)];
+  return y[static_cast<int>(RacerDubinsParams::OutputIndex::STEER_ANGLE_RATE)];
 }
 
 __host__ __device__ inline float racerRolloutYaw(const float * y)

--- a/planning/autoware_mppi_optimizer/include/mppi/cost_functions/racer/racer_cost.cuh
+++ b/planning/autoware_mppi_optimizer/include/mppi/cost_functions/racer/racer_cost.cuh
@@ -1,0 +1,110 @@
+/**
+ * Analytic path-tracking cost for RacerDubins (reference trajectory + obstacles, no costmap image).
+ */
+#pragma once
+
+#ifndef MPPI_COST_FUNCTIONS_RACER_COST_CUH_
+#define MPPI_COST_FUNCTIONS_RACER_COST_CUH_
+
+#include <mppi/cost_functions/cost.cuh>
+#include <mppi/dynamics/racer_dubins/racer_dubins.cuh>
+
+template <int NUM_TIMESTEPS>
+struct RacerCostParams : public CostParams<2>
+{
+  float desired_speed = 2.5F;
+  float speed_coeff = 100.0F;
+  float track_coeff = 300.0F;
+  float crash_coeff = 10000.0F;
+  float boundary_threshold = 0.8F;
+  float steer_coeff = 0.0F;
+  float lateral_acceleration_coeff = 50.0F;
+  float lateral_jerk_coeff = 100.0F;
+  float wheel_base = 0.3F;
+  float steer_angle_scale = -9.1F;
+  /** Ego OBB for parked-car collision (rear axle at pose; box center offset forward). */
+  float ego_length = 0.55 * 1.5F;
+  float ego_width = 0.28 * 1.5F;
+  float ego_axle_to_box_center = 0.2F;
+  float obstacle_collision_margin = 0.2F;
+};
+
+template <
+  class CLASS_T, int NUM_TIMESTEPS, class PARAMS_T = RacerCostParams<NUM_TIMESTEPS>,
+  class DYN_PARAMS_T = RacerDubinsParams>
+class RacerCostImpl : public Cost<CLASS_T, PARAMS_T, DYN_PARAMS_T>
+{
+public:
+  static constexpr int kMaxObstacles = 64;
+
+  using PARENT_CLASS = Cost<CLASS_T, PARAMS_T, DYN_PARAMS_T>;
+  using output_array = typename PARENT_CLASS::output_array;
+  using control_array = typename PARENT_CLASS::control_array;
+
+  RacerCostImpl(cudaStream_t stream = 0);
+
+  void paramsToDevice();
+
+  void setReferenceTrajectory(const float * x, const float * y, int count);
+
+  void setOrientedBoxObstacles(
+    const float * x, const float * y, const float * yaw, const float * half_length,
+    const float * half_width, int count);
+
+  __host__ __device__ float computeTrackValue(float x, float y) const;
+
+  __host__ __device__ bool egoIntersectsParkedCar(
+    const float x, const float y, const float yaw) const;
+
+  float computeStateCost(
+    const Eigen::Ref<const output_array> & y, int timestep, int * crash_status);
+
+  __device__ float computeStateCost(float * y, int timestep, float * theta_c, int * crash_status);
+
+  float computeControlCost(const Eigen::Ref<const control_array> & u, int timestep, int * crash);
+
+  __device__ float computeControlCost(float * u, int timestep, float * theta_c, int * crash);
+
+  float computeComfortCost(
+    const Eigen::Ref<const control_array> & u, const Eigen::Ref<const output_array> & y,
+    int timestep);
+
+  __device__ float computeComfortCost(float * u, float * y, int timestep);
+
+  __device__ float terminalCost(float * y, float * theta_c);
+
+  float computeRunningCost(
+    const Eigen::Ref<const output_array> & y, const Eigen::Ref<const control_array> & u,
+    int timestep, int * crash);
+
+  __device__ float computeRunningCost(
+    float * y, float * u, int timestep, float * theta_c, int * crash);
+
+  float ref_x_[NUM_TIMESTEPS] = {};
+  float ref_y_[NUM_TIMESTEPS] = {};
+  int num_obstacles_ = 0;
+  float obs_x_[kMaxObstacles] = {};
+  float obs_y_[kMaxObstacles] = {};
+  float obs_yaw_[kMaxObstacles] = {};
+  float obs_half_length_[kMaxObstacles] = {};
+  float obs_half_width_[kMaxObstacles] = {};
+
+private:
+  void dataToDevice();
+};
+
+template <int NUM_TIMESTEPS>
+class RacerCost : public RacerCostImpl<RacerCost<NUM_TIMESTEPS>, NUM_TIMESTEPS>
+{
+public:
+  RacerCost(cudaStream_t stream = 0)
+  : RacerCostImpl<RacerCost<NUM_TIMESTEPS>, NUM_TIMESTEPS>(stream)
+  {
+  }
+};
+
+#if __CUDACC__
+#include "racer_cost.cu"
+#endif
+
+#endif  // MPPI_COST_FUNCTIONS_RACER_COST_CUH_

--- a/planning/autoware_mppi_optimizer/include/mppi/cost_functions/racer/racer_cost_bridge.hpp
+++ b/planning/autoware_mppi_optimizer/include/mppi/cost_functions/racer/racer_cost_bridge.hpp
@@ -1,0 +1,86 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * Host-side helpers to populate RacerCost reference trajectories and obstacles.
+ */
+#pragma once
+
+#include <mppi/cost_functions/parked_car_obstacles.hpp>
+#include <mppi/cost_functions/racer/racer_cost.cuh>
+#include <mppi/path/path_reference_generator.hpp>
+
+#include <algorithm>
+#include <vector>
+
+namespace mppi
+{
+namespace cost
+{
+
+/** Ego OBB from rear axle: box center offset forward from axle using wheel_base overhang model. */
+template <int NUM_TIMESTEPS>
+inline void setRacerCostEgoFootprint(
+  RacerCostParams<NUM_TIMESTEPS> & params, const float wheel_base, const float ego_length,
+  const float ego_width)
+{
+  params.ego_length = ego_length;
+  params.ego_width = ego_width;
+  const float rear_overhang = 0.08F * wheel_base;
+  params.ego_axle_to_box_center = 0.5F * ego_length - rear_overhang;
+}
+
+template <int NUM_TIMESTEPS>
+inline void fillRacerCostParkedCars(
+  RacerCost<NUM_TIMESTEPS> & cost, const std::vector<ParkedCarObstacle> & cars)
+{
+  float obs_x[RacerCost<NUM_TIMESTEPS>::kMaxObstacles] = {};
+  float obs_y[RacerCost<NUM_TIMESTEPS>::kMaxObstacles] = {};
+  float obs_yaw[RacerCost<NUM_TIMESTEPS>::kMaxObstacles] = {};
+  float obs_half_length[RacerCost<NUM_TIMESTEPS>::kMaxObstacles] = {};
+  float obs_half_width[RacerCost<NUM_TIMESTEPS>::kMaxObstacles] = {};
+
+  const int n = static_cast<int>(
+    std::min(cars.size(), static_cast<size_t>(RacerCost<NUM_TIMESTEPS>::kMaxObstacles)));
+  for (int i = 0; i < n; ++i) {
+    const ParkedCarObstacle & car = cars[static_cast<size_t>(i)];
+    obs_x[i] = car.ox;
+    obs_y[i] = car.oy;
+    obs_yaw[i] = car.yaw;
+    obs_half_length[i] = car.length * 0.5F;
+    obs_half_width[i] = car.width * 0.5F;
+  }
+
+  cost.setOrientedBoxObstacles(obs_x, obs_y, obs_yaw, obs_half_length, obs_half_width, n);
+}
+
+template <int NUM_TIMESTEPS>
+inline void fillRacerCostFromPathReference(
+  RacerCost<NUM_TIMESTEPS> & cost, const std::vector<mppi::path::PathReferenceSample> & ref)
+{
+  float ref_x[NUM_TIMESTEPS];
+  float ref_y[NUM_TIMESTEPS];
+
+  for (int t = 0; t < NUM_TIMESTEPS; ++t) {
+    const size_t idx =
+      ref.empty() ? 0U : static_cast<size_t>(std::min(t, static_cast<int>(ref.size()) - 1));
+    ref_x[t] = ref[idx].x;
+    ref_y[t] = ref[idx].y;
+  }
+
+  cost.setReferenceTrajectory(ref_x, ref_y, NUM_TIMESTEPS);
+}
+
+}  // namespace cost
+}  // namespace mppi

--- a/planning/autoware_mppi_optimizer/include/mppi/cost_functions/racer/racer_cost_map.cu
+++ b/planning/autoware_mppi_optimizer/include/mppi/cost_functions/racer/racer_cost_map.cu
@@ -1,0 +1,218 @@
+#include <mppi/cost_functions/racer/racer_cost_map.cuh>
+
+#include <algorithm>
+#include <cstring>
+
+template <class CLASS_T, class PARAMS_T, class DYN_PARAMS_T>
+RacerCostMapImpl<CLASS_T, PARAMS_T, DYN_PARAMS_T>::RacerCostMapImpl(cudaStream_t stream)
+{
+  this->bindToStream(stream);
+}
+
+template <class CLASS_T, class PARAMS_T, class DYN_PARAMS_T>
+void RacerCostMapImpl<CLASS_T, PARAMS_T, DYN_PARAMS_T>::freeCudaMem()
+{
+  if (this->GPUMemStatus_) {
+    if (costmapArray_d_ != nullptr) {
+      HANDLE_ERROR(cudaFreeArray(costmapArray_d_));
+      costmapArray_d_ = nullptr;
+    }
+    if (costmap_tex_d_ != 0) {
+      HANDLE_ERROR(cudaDestroyTextureObject(costmap_tex_d_));
+      costmap_tex_d_ = 0;
+    }
+  }
+  PARENT_CLASS::freeCudaMem();
+}
+
+template <class CLASS_T, class PARAMS_T, class DYN_PARAMS_T>
+void RacerCostMapImpl<CLASS_T, PARAMS_T, DYN_PARAMS_T>::paramsToDevice()
+{
+  HANDLE_ERROR(cudaMemcpyAsync(
+    &this->cost_d_->params_, &this->params_, sizeof(PARAMS_T), cudaMemcpyHostToDevice,
+    this->stream_));
+}
+
+template <class CLASS_T, class PARAMS_T, class DYN_PARAMS_T>
+void RacerCostMapImpl<CLASS_T, PARAMS_T, DYN_PARAMS_T>::setWorldToCostmapBounds(
+  float x_min, float x_max, float y_min, float y_max)
+{
+  const float inv_x = 1.0F / (x_max - x_min);
+  const float inv_y = 1.0F / (y_max - y_min);
+  this->params_.r_c1 = make_float3(inv_x, 0.0F, 0.0F);
+  this->params_.r_c2 = make_float3(0.0F, inv_y, 0.0F);
+  this->params_.trs = make_float3(-x_min * inv_x, -y_min * inv_y, 1.0F);
+  if (this->GPUMemStatus_) {
+    paramsToDevice();
+  }
+}
+
+template <class CLASS_T, class PARAMS_T, class DYN_PARAMS_T>
+__host__ __device__ void RacerCostMapImpl<CLASS_T, PARAMS_T, DYN_PARAMS_T>::coorTransform(
+  float x, float y, float * u, float * v, float * w) const
+{
+  *u = this->params_.r_c1.x * x + this->params_.r_c2.x * y + this->params_.trs.x;
+  *v = this->params_.r_c1.y * x + this->params_.r_c2.y * y + this->params_.trs.y;
+  *w = this->params_.r_c1.z * x + this->params_.r_c2.z * y + this->params_.trs.z;
+}
+
+template <class CLASS_T, class PARAMS_T, class DYN_PARAMS_T>
+__device__ float4
+RacerCostMapImpl<CLASS_T, PARAMS_T, DYN_PARAMS_T>::queryTextureTransformed(float x, float y) const
+{
+  float u = 0.0F;
+  float v = 0.0F;
+  float w = 0.0F;
+  coorTransform(x, y, &u, &v, &w);
+  return tex2D<float4>(costmap_tex_d_, u / w, v / w);
+}
+
+template <class CLASS_T, class PARAMS_T, class DYN_PARAMS_T>
+__device__ float RacerCostMapImpl<CLASS_T, PARAMS_T, DYN_PARAMS_T>::computeStateCost(
+  float * y, int timestep, float * theta_c, int * crash_status)
+{
+  (void)timestep;
+  (void)theta_c;
+  (void)crash_status;
+
+  const float x = y[static_cast<int>(RacerDubinsParams::OutputIndex::BASELINK_POS_I_X)];
+  const float y_pos = y[static_cast<int>(RacerDubinsParams::OutputIndex::BASELINK_POS_I_Y)];
+  const float vel = y[static_cast<int>(RacerDubinsParams::OutputIndex::TOTAL_VELOCITY)];
+
+  const float track_val = queryTextureTransformed(x, y_pos).x;
+
+  const float vel_diff = vel - this->params_.desired_speed;
+  const float speed_cost = this->params_.speed_coeff * (vel_diff * vel_diff);
+  const float track_cost = this->params_.track_coeff * track_val;
+  float crash_cost = 0.0F;
+  if (track_val >= this->params_.boundary_threshold) {
+    crash_cost = this->params_.crash_coeff;
+  }
+
+  return speed_cost + track_cost + crash_cost;
+}
+
+template <class CLASS_T, class PARAMS_T, class DYN_PARAMS_T>
+float RacerCostMapImpl<CLASS_T, PARAMS_T, DYN_PARAMS_T>::computeStateCost(
+  const Eigen::Ref<const output_array> & y, int timestep, int * crash_status)
+{
+  (void)timestep;
+  if (cpu_costmap_.empty()) {
+    return 0.0F;
+  }
+
+  const float x = y[static_cast<int>(RacerDubinsParams::OutputIndex::BASELINK_POS_I_X)];
+  const float y_pos = y[static_cast<int>(RacerDubinsParams::OutputIndex::BASELINK_POS_I_Y)];
+  const float vel = y[static_cast<int>(RacerDubinsParams::OutputIndex::TOTAL_VELOCITY)];
+
+  float u = 0.0F;
+  float v = 0.0F;
+  float w = 0.0F;
+  coorTransform(x, y_pos, &u, &v, &w);
+
+  const float norm_u = u / w;
+  const float norm_v = v / w;
+
+  const int pixel_u =
+    std::max(0, std::min(static_cast<int>(norm_u * cpu_costmap_.cols), cpu_costmap_.cols - 1));
+  const int pixel_v =
+    std::max(0, std::min(static_cast<int>(norm_v * cpu_costmap_.rows), cpu_costmap_.rows - 1));
+
+  const float track_val = cpu_costmap_.at<float>(pixel_v, pixel_u);
+
+  const float vel_diff = vel - this->params_.desired_speed;
+  const float speed_cost = this->params_.speed_coeff * (vel_diff * vel_diff);
+  const float track_cost = this->params_.track_coeff * track_val;
+  float crash_cost = 0.0F;
+  if (track_val >= this->params_.boundary_threshold) {
+    crash_cost = this->params_.crash_coeff;
+    if (crash_status != nullptr) {
+      *crash_status = 1;
+    }
+  }
+
+  return speed_cost + track_cost + crash_cost;
+}
+
+template <class CLASS_T, class PARAMS_T, class DYN_PARAMS_T>
+__device__ float RacerCostMapImpl<CLASS_T, PARAMS_T, DYN_PARAMS_T>::computeControlCost(
+  float * u, int timestep, float * theta_c, int * crash)
+{
+  (void)timestep;
+  (void)theta_c;
+  (void)crash;
+  const float steer = u[static_cast<int>(RacerDubinsParams::ControlIndex::STEER_CMD)];
+  return this->params_.steer_coeff * (steer * steer);
+}
+
+template <class CLASS_T, class PARAMS_T, class DYN_PARAMS_T>
+float RacerCostMapImpl<CLASS_T, PARAMS_T, DYN_PARAMS_T>::computeControlCost(
+  const Eigen::Ref<const control_array> & u, int timestep, int * crash)
+{
+  (void)timestep;
+  (void)crash;
+  const float steer = u(static_cast<int>(RacerDubinsParams::ControlIndex::STEER_CMD));
+  return this->params_.steer_coeff * (steer * steer);
+}
+
+template <class CLASS_T, class PARAMS_T, class DYN_PARAMS_T>
+__device__ float RacerCostMapImpl<CLASS_T, PARAMS_T, DYN_PARAMS_T>::terminalCost(
+  float * y, float * theta_c)
+{
+  (void)theta_c;
+  const float x = y[static_cast<int>(RacerDubinsParams::OutputIndex::BASELINK_POS_I_X)];
+  const float y_pos = y[static_cast<int>(RacerDubinsParams::OutputIndex::BASELINK_POS_I_Y)];
+  const float track_val = queryTextureTransformed(x, y_pos).x;
+  return this->params_.track_coeff * track_val * 10.0F;
+}
+
+template <class CLASS_T, class PARAMS_T, class DYN_PARAMS_T>
+void RacerCostMapImpl<CLASS_T, PARAMS_T, DYN_PARAMS_T>::setCpuCostmap(const cv::Mat & costmap)
+{
+  cpu_costmap_ = costmap;
+}
+
+template <class CLASS_T, class PARAMS_T, class DYN_PARAMS_T>
+void RacerCostMapImpl<CLASS_T, PARAMS_T, DYN_PARAMS_T>::costmapToTexture(
+  int width, int height, float4 * host_data)
+{
+  width_ = width;
+  height_ = height;
+  channelDesc_ = cudaCreateChannelDesc(32, 32, 32, 32, cudaChannelFormatKindFloat);
+  HANDLE_ERROR(cudaMallocArray(&costmapArray_d_, &channelDesc_, width, height));
+  HANDLE_ERROR(cudaMemcpyToArray(
+    costmapArray_d_, 0, 0, host_data, width * height * sizeof(float4), cudaMemcpyHostToDevice));
+
+  cudaResourceDesc resDesc{};
+  memset(&resDesc, 0, sizeof(resDesc));
+  resDesc.resType = cudaResourceTypeArray;
+  resDesc.res.array.array = costmapArray_d_;
+
+  cudaTextureDesc texDesc{};
+  memset(&texDesc, 0, sizeof(texDesc));
+  texDesc.addressMode[0] = cudaAddressModeClamp;
+  texDesc.addressMode[1] = cudaAddressModeClamp;
+  texDesc.filterMode = cudaFilterModeLinear;
+  texDesc.readMode = cudaReadModeElementType;
+  texDesc.normalizedCoords = 1;
+
+  HANDLE_ERROR(cudaCreateTextureObject(&costmap_tex_d_, &resDesc, &texDesc, nullptr));
+
+  if (this->cost_d_ != nullptr) {
+    HANDLE_ERROR(cudaMemcpyAsync(
+      &this->cost_d_->costmap_tex_d_, &costmap_tex_d_, sizeof(cudaTextureObject_t),
+      cudaMemcpyHostToDevice, this->stream_));
+  }
+}
+
+template <class CLASS_T, class PARAMS_T, class DYN_PARAMS_T>
+void RacerCostMapImpl<CLASS_T, PARAMS_T, DYN_PARAMS_T>::updateCostmapTexture(float4 * host_data)
+{
+  if (costmapArray_d_ == nullptr) {
+    printf("Error: Costmap array not initialized! Call costmapToTexture first.\n");
+    return;
+  }
+
+  HANDLE_ERROR(cudaMemcpyToArray(
+    costmapArray_d_, 0, 0, host_data, width_ * height_ * sizeof(float4), cudaMemcpyHostToDevice));
+}

--- a/planning/autoware_mppi_optimizer/include/mppi/cost_functions/racer/racer_cost_map.cuh
+++ b/planning/autoware_mppi_optimizer/include/mppi/cost_functions/racer/racer_cost_map.cuh
@@ -1,0 +1,84 @@
+/**
+ * Costmap-based tracking cost for RacerDubins (GPU texture lookup + optional CPU mirror).
+ */
+#pragma once
+
+#ifndef MPPI_COST_FUNCTIONS_RACER_COST_MAP_CUH_
+#define MPPI_COST_FUNCTIONS_RACER_COST_MAP_CUH_
+
+#include <mppi/cost_functions/cost.cuh>
+#include <mppi/dynamics/racer_dubins/racer_dubins.cuh>
+#include <opencv2/core.hpp>
+
+struct RacerCostMapParams : public CostParams<2>
+{
+  float desired_speed = 2.5F;
+  float speed_coeff = 20.0F;
+  float track_coeff = 500.0F;
+  float crash_coeff = 10000.0F;
+  float boundary_threshold = 0.8F;
+  float steer_coeff = 50.0F;
+
+  float3 r_c1 = make_float3(1, 0, 0);
+  float3 r_c2 = make_float3(0, 1, 0);
+  float3 trs = make_float3(0, 0, 1);
+};
+
+template <
+  class CLASS_T, class PARAMS_T = RacerCostMapParams, class DYN_PARAMS_T = RacerDubinsParams>
+class RacerCostMapImpl : public Cost<CLASS_T, PARAMS_T, DYN_PARAMS_T>
+{
+public:
+  using PARENT_CLASS = Cost<CLASS_T, PARAMS_T, DYN_PARAMS_T>;
+  using output_array = typename PARENT_CLASS::output_array;
+  using control_array = typename PARENT_CLASS::control_array;
+
+  RacerCostMapImpl(cudaStream_t stream = 0);
+
+  void freeCudaMem();
+
+  void paramsToDevice();
+
+  __host__ __device__ void coorTransform(float x, float y, float * u, float * v, float * w) const;
+
+  __device__ float4 queryTextureTransformed(float x, float y) const;
+
+  __device__ float computeStateCost(float * y, int timestep, float * theta_c, int * crash_status);
+
+  float computeStateCost(
+    const Eigen::Ref<const output_array> & y, int timestep, int * crash_status);
+
+  __device__ float computeControlCost(float * u, int timestep, float * theta_c, int * crash);
+
+  float computeControlCost(const Eigen::Ref<const control_array> & u, int timestep, int * crash);
+
+  __device__ float terminalCost(float * y, float * theta_c);
+
+  void setCpuCostmap(const cv::Mat & costmap);
+
+  void setWorldToCostmapBounds(float x_min, float x_max, float y_min, float y_max);
+
+  void costmapToTexture(int width, int height, float4 * host_data);
+
+  void updateCostmapTexture(float4 * host_data);
+
+  cudaArray * costmapArray_d_ = nullptr;
+  cudaTextureObject_t costmap_tex_d_ = 0;
+  cudaChannelFormatDesc channelDesc_{};
+  int width_ = 0;
+  int height_ = 0;
+
+  cv::Mat cpu_costmap_;
+};
+
+class RacerCostMap : public RacerCostMapImpl<RacerCostMap>
+{
+public:
+  RacerCostMap(cudaStream_t stream = 0) : RacerCostMapImpl<RacerCostMap>(stream) {}
+};
+
+#if __CUDACC__
+#include "racer_cost_map.cu"
+#endif
+
+#endif  // MPPI_COST_FUNCTIONS_RACER_COST_MAP_CUH_

--- a/planning/autoware_mppi_optimizer/include/mppi/cost_functions/racer/racer_costmap_builder.hpp
+++ b/planning/autoware_mppi_optimizer/include/mppi/cost_functions/racer/racer_costmap_builder.hpp
@@ -1,0 +1,88 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * Host-side helpers to build OpenCV costmaps for RacerCostMap.
+ */
+#pragma once
+
+#include <mppi/path/path_reference_generator.hpp>
+#include <opencv2/opencv.hpp>
+
+#include <vector>
+
+namespace mppi
+{
+namespace cost
+{
+
+struct RacerCostmapObstacle
+{
+  float ox = 0.0F;
+  float oy = 0.0F;
+  float r = 0.0F;
+
+  RacerCostmapObstacle() = default;
+
+  RacerCostmapObstacle(const float ox_in, const float oy_in, const float r_in)
+  : ox(ox_in), oy(oy_in), r(r_in)
+  {
+  }
+};
+
+inline void updateRacerCostmap(
+  cv::Mat & costmap_img, const std::vector<mppi::path::PathReferenceSample> & ref,
+  const std::vector<RacerCostmapObstacle> & obstacles, const int width, const int height,
+  const float ppm, const float x_min, const float y_min, std::vector<float4> & cost_map_gpu_data)
+{
+  const auto world_to_map = [&](const float x, const float y) {
+    return cv::Point(static_cast<int>((x - x_min) * ppm), static_cast<int>((y - y_min) * ppm));
+  };
+
+  costmap_img = cv::Mat::ones(height, width, CV_32FC1);
+  cv::Mat center_img = cv::Mat::ones(height, width, CV_8UC1) * 255;
+
+  if (ref.size() >= 2) {
+    for (size_t i = 0; i + 1 < ref.size(); ++i) {
+      cv::line(
+        center_img, world_to_map(ref[i].x, ref[i].y), world_to_map(ref[i + 1].x, ref[i + 1].y),
+        cv::Scalar(0), 1);
+    }
+  }
+
+  cv::Mat dist_img;
+  cv::distanceTransform(center_img, dist_img, cv::DIST_L2, 3);
+  dist_img.convertTo(costmap_img, CV_32FC1, 1.0 / 25.0);
+  cv::threshold(costmap_img, costmap_img, 0.75, 0.75, cv::THRESH_TRUNC);
+
+  for (const RacerCostmapObstacle & obs : obstacles) {
+    cv::circle(
+      costmap_img, world_to_map(obs.ox, obs.oy), static_cast<int>(obs.r * ppm), cv::Scalar(1.0),
+      -1);
+  }
+
+  cv::GaussianBlur(costmap_img, costmap_img, cv::Size(5, 5), 1.0);
+
+  const int n = width * height;
+  cost_map_gpu_data.resize(static_cast<size_t>(n));
+  for (int i = 0; i < height; ++i) {
+    for (int j = 0; j < width; ++j) {
+      cost_map_gpu_data[static_cast<size_t>(i * width + j)] =
+        make_float4(costmap_img.at<float>(i, j), 0.0F, 0.0F, 0.0F);
+    }
+  }
+}
+
+}  // namespace cost
+}  // namespace mppi

--- a/planning/autoware_mppi_optimizer/include/mppi/dynamics/dubins/first_order_dubins_bicycle.cu
+++ b/planning/autoware_mppi_optimizer/include/mppi/dynamics/dubins/first_order_dubins_bicycle.cu
@@ -1,0 +1,173 @@
+#include <mppi/dynamics/dubins/first_order_dubins_bicycle.cuh>
+
+#include <cmath>
+
+namespace
+{
+using S = FirstOrderDubinsBicycleParams::StateIndex;
+using C = FirstOrderDubinsBicycleParams::ControlIndex;
+
+__host__ __device__ float clampSteerRate(
+  const FirstOrderDubinsBicycleParams & p, const float steer_dot)
+{
+  return fmaxf(fminf(steer_dot, p.max_steer_rate), -p.max_steer_rate);
+}
+
+__host__ __device__ void firstOrderDubinsBicycleDeriv(
+  const FirstOrderDubinsBicycleParams & p, const float * state, const float * control,
+  float * state_der)
+{
+  const float v = state[static_cast<int>(S::VEL_X)];
+  const float yaw = state[static_cast<int>(S::YAW)];
+  const float steer = state[static_cast<int>(S::STEER_ANGLE)];
+  const float accel = state[static_cast<int>(S::ACCELERATION)];
+  const float accel_cmd = control[static_cast<int>(C::ACCELERATION_CMD)];
+  const float steer_cmd = control[static_cast<int>(C::STEER_CMD)];
+
+  const float accel_tau = fmaxf(p.accel_time_constant, 1.0E-4F);
+  const float steer_tau = fmaxf(p.steer_time_constant, 1.0E-4F);
+
+  state_der[static_cast<int>(S::ACCELERATION)] = (accel_cmd - accel) / accel_tau;
+  state_der[static_cast<int>(S::VEL_X)] = accel;
+  state_der[static_cast<int>(S::YAW)] = (v / p.wheel_base) * tanf(steer);
+
+  float sin_yaw = 0.0F;
+  float cos_yaw = 0.0F;
+  sincosf(yaw, &sin_yaw, &cos_yaw);
+  state_der[static_cast<int>(S::POS_X)] = v * cos_yaw;
+  state_der[static_cast<int>(S::POS_Y)] = v * sin_yaw;
+
+  const float steer_dot = clampSteerRate(p, (steer_cmd - steer) / steer_tau);
+  state_der[static_cast<int>(S::STEER_ANGLE)] = steer_dot;
+}
+}  // namespace
+
+template <class CLASS_T, class PARAMS_T>
+FirstOrderDubinsBicycleImpl<CLASS_T, PARAMS_T>::FirstOrderDubinsBicycleImpl(cudaStream_t stream)
+: Dynamics<CLASS_T, PARAMS_T>(stream)
+{
+  this->params_ = PARAMS_T();
+}
+
+template <class CLASS_T, class PARAMS_T>
+FirstOrderDubinsBicycleImpl<CLASS_T, PARAMS_T>::FirstOrderDubinsBicycleImpl(
+  PARAMS_T & params, cudaStream_t stream)
+: Dynamics<CLASS_T, PARAMS_T>(params, stream)
+{
+}
+
+template <class CLASS_T, class PARAMS_T>
+void FirstOrderDubinsBicycleImpl<CLASS_T, PARAMS_T>::computeDynamics(
+  const Eigen::Ref<const state_array> & state, const Eigen::Ref<const control_array> & control,
+  Eigen::Ref<state_array> state_der)
+{
+  firstOrderDubinsBicycleDeriv(this->params_, state.data(), control.data(), state_der.data());
+}
+
+template <class CLASS_T, class PARAMS_T>
+bool FirstOrderDubinsBicycleImpl<CLASS_T, PARAMS_T>::computeGrad(
+  const Eigen::Ref<const state_array> &, const Eigen::Ref<const control_array> &, Eigen::Ref<dfdx>,
+  Eigen::Ref<dfdu>)
+{
+  return false;
+}
+
+template <class CLASS_T, class PARAMS_T>
+void FirstOrderDubinsBicycleImpl<CLASS_T, PARAMS_T>::updateState(
+  const Eigen::Ref<const state_array> state, Eigen::Ref<state_array> next_state,
+  Eigen::Ref<state_array> state_der, const float dt)
+{
+  next_state = state + state_der * dt;
+  next_state(static_cast<int>(S::YAW)) =
+    angle_utils::normalizeAngle(next_state(static_cast<int>(S::YAW)));
+  next_state(static_cast<int>(S::STEER_ANGLE)) = fmaxf(
+    fminf(next_state(static_cast<int>(S::STEER_ANGLE)), this->params_.max_steer_angle),
+    -this->params_.max_steer_angle);
+  next_state(static_cast<int>(S::ACCELERATION)) = fmaxf(
+    fminf(next_state(static_cast<int>(S::ACCELERATION)), this->params_.max_accel),
+    this->params_.min_accel);
+}
+
+template <class CLASS_T, class PARAMS_T>
+FirstOrderDubinsBicycleImpl<CLASS_T, PARAMS_T>::state_array
+FirstOrderDubinsBicycleImpl<CLASS_T, PARAMS_T>::interpolateState(
+  const Eigen::Ref<state_array> state_1, const Eigen::Ref<state_array> state_2, const float alpha)
+{
+  state_array result = (1.0F - alpha) * state_1 + alpha * state_2;
+  result(static_cast<int>(S::YAW)) = angle_utils::interpolateEulerAngleLinear(
+    state_1(static_cast<int>(S::YAW)), state_2(static_cast<int>(S::YAW)), alpha);
+  return result;
+}
+
+template <class CLASS_T, class PARAMS_T>
+__device__ void FirstOrderDubinsBicycleImpl<CLASS_T, PARAMS_T>::updateState(
+  float * state, float * next_state, float * state_der, const float dt)
+{
+  for (int i = threadIdx.y; i < PARENT_CLASS::STATE_DIM; i += blockDim.y) {
+    next_state[i] = state[i] + state_der[i] * dt;
+    if (i == static_cast<int>(S::YAW)) {
+      next_state[i] = angle_utils::normalizeAngle(next_state[i]);
+    }
+    if (i == static_cast<int>(S::STEER_ANGLE)) {
+      next_state[i] =
+        fmaxf(fminf(next_state[i], this->params_.max_steer_angle), -this->params_.max_steer_angle);
+    }
+    if (i == static_cast<int>(S::ACCELERATION)) {
+      next_state[i] = fmaxf(fminf(next_state[i], this->params_.max_accel), this->params_.min_accel);
+    }
+  }
+}
+
+template <class CLASS_T, class PARAMS_T>
+__device__ void FirstOrderDubinsBicycleImpl<CLASS_T, PARAMS_T>::computeDynamics(
+  float * state, float * control, float * state_der, float *)
+{
+  firstOrderDubinsBicycleDeriv(this->params_, state, control, state_der);
+}
+
+template <class CLASS_T, class PARAMS_T>
+void FirstOrderDubinsBicycleImpl<CLASS_T, PARAMS_T>::stateToOutput(
+  const Eigen::Ref<const state_array> & state, Eigen::Ref<output_array> output)
+{
+  stateToOutput(state.data(), output.data());
+}
+
+template <class CLASS_T, class PARAMS_T>
+__host__ __device__ void FirstOrderDubinsBicycleImpl<CLASS_T, PARAMS_T>::stateToOutput(
+  const float * state, float * output)
+{
+  using O = FirstOrderDubinsBicycleParams::OutputIndex;
+  const float v = state[static_cast<int>(S::VEL_X)];
+
+  output[static_cast<int>(O::BASELINK_VEL_B_X)] = v;
+  output[static_cast<int>(O::BASELINK_VEL_B_Y)] = 0.0F;
+  output[static_cast<int>(O::BASELINK_POS_I_X)] = state[static_cast<int>(S::POS_X)];
+  output[static_cast<int>(O::BASELINK_POS_I_Y)] = state[static_cast<int>(S::POS_Y)];
+  output[static_cast<int>(O::YAW)] = state[static_cast<int>(S::YAW)];
+  output[static_cast<int>(O::STEER_ANGLE)] = state[static_cast<int>(S::STEER_ANGLE)];
+  output[static_cast<int>(O::ACCELERATION)] = state[static_cast<int>(S::ACCELERATION)];
+  output[static_cast<int>(O::TOTAL_VELOCITY)] = fabsf(v);
+  output[static_cast<int>(O::LONGITUDINAL_JERK)] = 0.0F;
+  output[static_cast<int>(O::LATERAL_JERK)] = 0.0F;
+}
+
+template <class CLASS_T, class PARAMS_T>
+FirstOrderDubinsBicycleImpl<CLASS_T, PARAMS_T>::state_array
+FirstOrderDubinsBicycleImpl<CLASS_T, PARAMS_T>::stateFromMap(
+  const std::map<std::string, float> & map)
+{
+  state_array s = state_array::Zero();
+  const auto set_if = [&map, &s](const char * key, const int idx) {
+    const auto it = map.find(key);
+    if (it != map.end()) {
+      s(idx) = it->second;
+    }
+  };
+  set_if("VEL_X", static_cast<int>(S::VEL_X));
+  set_if("YAW", static_cast<int>(S::YAW));
+  set_if("POS_X", static_cast<int>(S::POS_X));
+  set_if("POS_Y", static_cast<int>(S::POS_Y));
+  set_if("STEER_ANGLE", static_cast<int>(S::STEER_ANGLE));
+  set_if("ACCELERATION", static_cast<int>(S::ACCELERATION));
+  return s;
+}

--- a/planning/autoware_mppi_optimizer/include/mppi/dynamics/dubins/first_order_dubins_bicycle.cuh
+++ b/planning/autoware_mppi_optimizer/include/mppi/dynamics/dubins/first_order_dubins_bicycle.cuh
@@ -1,0 +1,130 @@
+/**
+ * Kinematic Dubins bicycle with first-order actuation on longitudinal acceleration and steering.
+ *
+ * State: speed, yaw, position, steer angle, applied acceleration.
+ * Controls: acceleration command [m/s^2], steer angle command [rad].
+ *
+ *   d(accel)/dt = (u_accel - accel) / accel_time_constant
+ *   d(v)/dt     = accel
+ *   d(steer)/dt = (u_steer - steer) / steer_time_constant   (rate-limited)
+ *   d(yaw)/dt   = (v / L) * tan(steer)
+ *   d(x,y)/dt   = v * [cos(yaw), sin(yaw)]
+ */
+#pragma once
+
+#ifndef MPPIGENERIC_FIRST_ORDER_DUBINS_BICYCLE_CUH
+#define MPPIGENERIC_FIRST_ORDER_DUBINS_BICYCLE_CUH
+
+#include <mppi/dynamics/dynamics.cuh>
+#include <mppi/utils/angle_utils.cuh>
+
+struct FirstOrderDubinsBicycleParams : public DynamicsParams
+{
+  enum class StateIndex : int {
+    VEL_X = 0,
+    YAW,
+    POS_X,
+    POS_Y,
+    STEER_ANGLE,
+    ACCELERATION,
+    NUM_STATES
+  };
+
+  enum class ControlIndex : int { ACCELERATION_CMD = 0, STEER_CMD, NUM_CONTROLS };
+
+  enum class OutputIndex : int {
+    BASELINK_VEL_B_X = 0,
+    BASELINK_VEL_B_Y,
+    BASELINK_POS_I_X,
+    BASELINK_POS_I_Y,
+    YAW,
+    STEER_ANGLE,
+    ACCELERATION,
+    TOTAL_VELOCITY,
+    LATERAL_JERK,
+    LONGITUDINAL_JERK,
+    NUM_OUTPUTS
+  };
+
+  float wheel_base = 0.32F;
+  /** PathTrackerFeedback: steer_cmd [rad] = atan(kappa * L) * steer_angle_scale /
+   * steer_command_angle_scale */
+  float steer_angle_scale = 1.0F;
+  float steer_command_angle_scale = 1.0F;
+  /** First-order lag: accel_dot = (u_accel - accel) / accel_time_constant */
+  float accel_time_constant = 0.15F;
+  /** First-order lag: steer_dot = (u_steer - steer) / steer_time_constant */
+  float steer_time_constant = 0.08F;
+  float max_steer_angle = 0.45F;
+  float max_steer_rate = 3.0F;
+  float min_accel = -6.0F;
+  float max_accel = 4.0F;
+};
+
+using namespace MPPI_internal;
+
+template <class CLASS_T, class PARAMS_T = FirstOrderDubinsBicycleParams>
+class FirstOrderDubinsBicycleImpl : public Dynamics<CLASS_T, PARAMS_T>
+{
+public:
+  using PARENT_CLASS = Dynamics<CLASS_T, PARAMS_T>;
+  using state_array = typename PARENT_CLASS::state_array;
+  using control_array = typename PARENT_CLASS::control_array;
+  using output_array = typename PARENT_CLASS::output_array;
+  using dfdx = typename PARENT_CLASS::dfdx;
+  using dfdu = typename PARENT_CLASS::dfdu;
+  using PARENT_CLASS::updateState;
+
+  FirstOrderDubinsBicycleImpl(cudaStream_t stream = nullptr);
+
+  FirstOrderDubinsBicycleImpl(PARAMS_T & params, cudaStream_t stream = nullptr);
+
+  std::string getDynamicsModelName() const override { return "First-Order Dubins Bicycle"; }
+
+  void computeDynamics(
+    const Eigen::Ref<const state_array> & state, const Eigen::Ref<const control_array> & control,
+    Eigen::Ref<state_array> state_der);
+
+  void updateState(
+    const Eigen::Ref<const state_array> state, Eigen::Ref<state_array> next_state,
+    Eigen::Ref<state_array> state_der, const float dt);
+
+  __device__ void updateState(float * state, float * next_state, float * state_der, const float dt);
+
+  state_array interpolateState(
+    const Eigen::Ref<state_array> state_1, const Eigen::Ref<state_array> state_2,
+    const float alpha);
+
+  bool computeGrad(
+    const Eigen::Ref<const state_array> & state, const Eigen::Ref<const control_array> & control,
+    Eigen::Ref<dfdx> A, Eigen::Ref<dfdu> B);
+
+  __device__ void computeDynamics(
+    float * state, float * control, float * state_der, float * theta = nullptr);
+
+  void stateToOutput(const Eigen::Ref<const state_array> & state, Eigen::Ref<output_array> output);
+
+  __host__ __device__ void stateToOutput(const float * state, float * output);
+
+  state_array stateFromMap(const std::map<std::string, float> & map) override;
+};
+
+class FirstOrderDubinsBicycle : public FirstOrderDubinsBicycleImpl<FirstOrderDubinsBicycle>
+{
+public:
+  FirstOrderDubinsBicycle(cudaStream_t stream = nullptr)
+  : FirstOrderDubinsBicycleImpl<FirstOrderDubinsBicycle>(stream)
+  {
+  }
+
+  FirstOrderDubinsBicycle(FirstOrderDubinsBicycleParams & params, cudaStream_t stream = nullptr)
+  : FirstOrderDubinsBicycleImpl<FirstOrderDubinsBicycle>(params, stream)
+  {
+  }
+};
+
+#if __CUDACC__
+#include "first_order_dubins_bicycle.cu"
+#endif
+
+#endif  // MPPIGENERIC_FIRST_ORDER_DUBINS_BICYCLE_CUH

--- a/planning/autoware_mppi_optimizer/include/mppi/dynamics/racer_dubins/racer_dubins.cuh
+++ b/planning/autoware_mppi_optimizer/include/mppi/dynamics/racer_dubins/racer_dubins.cuh
@@ -1,0 +1,200 @@
+#ifndef MPPIGENERIC_RACER_DUBINS_CUH
+#define MPPIGENERIC_RACER_DUBINS_CUH
+
+#include <mppi/dynamics/dynamics.cuh>
+#include <mppi/utils/angle_utils.cuh>
+
+namespace RACER
+{
+template <class OUTPUT_T, class TEX_T>
+__device__ __host__ static void computeStaticSettling(
+  TEX_T * tex_helper, const float yaw, const float x, const float y, float & roll, float & pitch,
+  float * output);
+};
+
+struct RacerDubinsParams : public DynamicsParams
+{
+  enum class StateIndex : int {
+    VEL_X = 0,
+    YAW,
+    POS_X,
+    POS_Y,
+    STEER_ANGLE,
+    BRAKE_STATE,
+    STEER_ANGLE_RATE,
+    NUM_STATES
+  };
+
+  enum class ControlIndex : int { THROTTLE_BRAKE = 0, STEER_CMD, NUM_CONTROLS };
+
+  enum class OutputIndex : int {
+    BASELINK_VEL_B_X = 0,
+    BASELINK_VEL_B_Y,
+    BASELINK_POS_I_X,
+    BASELINK_POS_I_Y,
+    BASELINK_POS_I_Z,
+    YAW,
+    ROLL,
+    PITCH,
+    STEER_ANGLE,
+    STEER_ANGLE_RATE,
+    WHEEL_FORCE_UP_MAX,
+    WHEEL_FORCE_FWD_MAX,
+    WHEEL_FORCE_SIDE_MAX,
+    // WHEEL_FORCE_UP_FL,
+    // WHEEL_FORCE_UP_FR,
+    // WHEEL_FORCE_UP_RL,
+    // WHEEL_FORCE_UP_RR,
+    // WHEEL_FORCE_FWD_FL,
+    // WHEEL_FORCE_FWD_FR,
+    // WHEEL_FORCE_FWD_RL,
+    // WHEEL_FORCE_FWD_RR,
+    // WHEEL_FORCE_SIDE_FL,
+    // WHEEL_FORCE_SIDE_FR,
+    // WHEEL_FORCE_SIDE_RL,
+    // WHEEL_FORCE_SIDE_RR,
+    ACCEL_X,
+    ACCEL_Y,
+    OMEGA_Z,
+    TOTAL_VELOCITY,
+    UNCERTAINTY_POS_X,
+    UNCERTAINTY_POS_Y,
+    UNCERTAINTY_YAW,
+    UNCERTAINTY_VEL_X,
+    UNCERTAINTY_POS_X_Y,
+    UNCERTAINTY_POS_X_YAW,
+    UNCERTAINTY_POS_X_VEL_X,
+    UNCERTAINTY_POS_Y_YAW,
+    UNCERTAINTY_POS_Y_VEL_X,
+    UNCERTAINTY_YAW_VEL_X,
+    FILLER_1,
+    NUM_OUTPUTS
+  };
+
+  // engine model: d(vel)/dt = c_t*u - c_v*vel + c_0  →  v_ss ≈ (c_t[0]+c_0)/c_v[0] at u=1
+  float c_t[3] = {4.0F, 8.0F, 12.0F};
+  float c_b[3] = {2.5F, 3.5F, 4.5F};
+  float c_v[3] = {3.7F, 4.7F, 5.7F};
+  float c_0 = 16.4F;
+  // steering component
+  float steering_constant = .6;
+  float steer_command_angle_scale = 5;
+  float steer_angle_scale = -9.1;
+  float max_steer_angle = 0.5;
+  float max_steer_rate = 5;
+  float steer_accel_constant = 12.1f;
+  float steer_accel_drag_constant = 1.0f;
+  // brake parametric component
+  float brake_delay_constant = 6.6;
+  float brake_delay_constant_neg = 8.2;
+  float max_brake_rate_neg = 0.9;
+  float max_brake_rate_pos = 0.33;
+  // system parameters
+  float wheel_base = 0.3;
+  float low_min_throttle = 0.13;
+  float gravity = -9.81;
+  int gear_sign = 1;
+};
+
+using namespace MPPI_internal;
+
+template <class CLASS_T, class PARAMS_T = RacerDubinsParams>
+class RacerDubinsImpl : public Dynamics<CLASS_T, PARAMS_T>
+{
+public:
+  typedef Dynamics<CLASS_T, PARAMS_T> PARENT_CLASS;
+  typedef typename PARENT_CLASS::state_array state_array;
+  typedef typename PARENT_CLASS::control_array control_array;
+  typedef typename PARENT_CLASS::output_array output_array;
+  typedef typename PARENT_CLASS::dfdx dfdx;
+  typedef typename PARENT_CLASS::dfdu dfdu;
+  using PARENT_CLASS::updateState;  // needed as overloading updateState here hides all parent
+                                    // versions of updateState
+
+  RacerDubinsImpl(cudaStream_t stream = nullptr) : PARENT_CLASS(stream) {}
+
+  RacerDubinsImpl(PARAMS_T & params, cudaStream_t stream = nullptr) : PARENT_CLASS(params, stream)
+  {
+  }
+  std::string getDynamicsModelName() const override { return "RACER Dubins Model"; }
+
+  void computeDynamics(
+    const Eigen::Ref<const state_array> & state, const Eigen::Ref<const control_array> & control,
+    Eigen::Ref<state_array> state_der);
+
+  // void computeStateDeriv(const Eigen::Ref<const state_array>& state, const Eigen::Ref<const
+  // control_array>& control,
+  //                         Eigen::Ref<state_array> state_der, output_array* output=nullptr); //
+  //                         TODO
+
+  void computeParametricDelayDeriv(
+    const Eigen::Ref<const state_array> & state, const Eigen::Ref<const control_array> & control,
+    Eigen::Ref<state_array> state_der);
+
+  void computeParametricSteerDeriv(
+    const Eigen::Ref<const state_array> & state, const Eigen::Ref<const control_array> & control,
+    Eigen::Ref<state_array> state_der);
+
+  __device__ void computeParametricDelayDeriv(
+    float * state, float * control, float * state_der, PARAMS_T * params_p);
+
+  __device__ void computeParametricSteerDeriv(
+    float * state, float * control, float * state_der, PARAMS_T * params_p);
+
+  void updateState(
+    const Eigen::Ref<const state_array> state, Eigen::Ref<state_array> next_state,
+    Eigen::Ref<state_array> state_der, const float dt);
+
+  __device__ void updateState(float * state, float * next_state, float * state_der, const float dt);
+
+  state_array interpolateState(
+    const Eigen::Ref<state_array> state_1, const Eigen::Ref<state_array> state_2,
+    const float alpha);
+
+  bool computeGrad(
+    const Eigen::Ref<const state_array> & state, const Eigen::Ref<const control_array> & control,
+    Eigen::Ref<dfdx> A, Eigen::Ref<dfdu> B);
+
+  __device__ void computeDynamics(
+    float * state, float * control, float * state_der, float * theta = nullptr);
+
+  __host__ __device__ void setOutputs(
+    const float * state_der, const float * next_state, float * output);
+
+  // __device__ void computeStateDeriv(float* state, float* control, float* state_der, float*
+  // theta_s, float *output=nullptr); // TODO
+
+  void getStoppingControl(const Eigen::Ref<const state_array> & state, Eigen::Ref<control_array> u);
+
+  Eigen::Quaternionf attitudeFromState(const Eigen::Ref<const state_array> & state);
+  Eigen::Vector3f positionFromState(const Eigen::Ref<const state_array> & state);
+  Eigen::Vector3f velocityFromState(const Eigen::Ref<const state_array> & state);
+  Eigen::Vector3f angularRateFromState(const Eigen::Ref<const state_array> & state);
+  state_array stateFromOdometry(
+    const Eigen::Quaternionf & q, const Eigen::Vector3f & pos, const Eigen::Vector3f & vel,
+    const Eigen::Vector3f & omega);
+
+  void enforceLeash(
+    const Eigen::Ref<const state_array> & state_true,
+    const Eigen::Ref<const state_array> & state_nominal,
+    const Eigen::Ref<const state_array> & leash_values, Eigen::Ref<state_array> state_output);
+
+  state_array stateFromMap(const std::map<std::string, float> & map) override;
+};
+
+class RacerDubins : public RacerDubinsImpl<RacerDubins>
+{
+public:
+  RacerDubins(cudaStream_t stream = nullptr) : RacerDubinsImpl<RacerDubins>(stream) {}
+
+  RacerDubins(RacerDubinsParams & params, cudaStream_t stream = nullptr)
+  : RacerDubinsImpl<RacerDubins>(params, stream)
+  {
+  }
+};
+
+#if __CUDACC__
+#include "racer_dubins.cu"
+#endif
+
+#endif  // MPPIGENERIC_RACER_DUBINS_CUH

--- a/planning/autoware_mppi_optimizer/include/mppi/feedback_controllers/path_tracker_feedback.cuh
+++ b/planning/autoware_mppi_optimizer/include/mppi/feedback_controllers/path_tracker_feedback.cuh
@@ -1,0 +1,488 @@
+/**
+ * Path-tracking feedforward feedback: steer from pure-pursuit lookahead on the reference path.
+ *
+ * At horizon step t, the vehicle pose is the current state (t = 0) or the goal trajectory (t > 0).
+ * A lookahead point is taken on the reference polyline at arc length s(t) + L_d, with
+ * L_d = clamp(lookahead_time * v, min_lookahead_distance, max_lookahead_distance).
+ * Steer uses the bicycle pure-pursuit law: kappa = 2*sin(alpha)/L_d, delta = atan(kappa * L).
+ *
+ * Set use_pure_pursuit = false to use path curvature at each sample instead.
+ *
+ * Vanilla MPPI does not call feedback inside rollout kernels; bias the nominal control
+ * with applyFeedforwardToNominal() before each solve (see racer_dubins_stadium example).
+ */
+#pragma once
+
+#include <mppi/feedback_controllers/feedback.cuh>
+#include <mppi/path/path2d.hpp>
+#include <mppi/path/path_reference_generator.hpp>
+#include <mppi/utils/angle_utils.cuh>
+
+#include <array>
+#include <cmath>
+#include <vector>
+
+struct PathTrackerFeedbackParams
+{
+  /** If true, pure-pursuit lookahead steer; if false, atan(kappa * L) from path curvature at each
+   * sample. */
+  bool use_pure_pursuit = true;
+  /** Lookahead horizon as time x speed [m] (clamped by min/max distance). */
+  float lookahead_time = 0.4F;
+  float min_lookahead_distance = 0.5F;
+  float max_lookahead_distance = 8.0F;
+  /** Scales steer feedforward; use >1 if the nominal path still turns too little. */
+  float steer_feedforward_gain = 1.0F;
+  /** How many leading u_nom columns get steer replaced (rest keep MPPI warm start). */
+  int feedforward_horizon_steps = 1;
+};
+
+template <int NUM_TIMESTEPS>
+struct PathTrackerFeedbackState : GPUState
+{
+  float ref_kappa[NUM_TIMESTEPS] = {};
+  float goal_yaw[NUM_TIMESTEPS] = {};
+  float look_x[NUM_TIMESTEPS] = {};
+  float look_y[NUM_TIMESTEPS] = {};
+  float lookahead_dist[NUM_TIMESTEPS] = {};
+  float wheel_base = 0.3F;
+  float steer_angle_scale = 1.0F;
+  float steer_command_angle_scale = 1.0F;
+  float steer_feedforward_gain = 1.0F;
+  /** Max |steer command|; set from dynamics before GPU rollout. */
+  float steer_command_limit = 1.0F;
+  float dt = 0.01F;
+  int num_timesteps = NUM_TIMESTEPS;
+  int ref_kappa_valid = 0;
+  int goal_traj_valid = 0;
+  int use_pure_pursuit = 1;
+};
+
+namespace mppi
+{
+namespace feedback
+{
+namespace detail
+{
+
+template <class Params>
+struct HasBicyclePathSteer
+{
+private:
+  template <
+    class U, class = decltype(U::StateIndex::YAW), class = decltype(U::StateIndex::VEL_X),
+    class = decltype(U::ControlIndex::STEER_CMD), class = decltype(std::declval<U &>().wheel_base),
+    class = decltype(std::declval<U &>().steer_angle_scale),
+    class = decltype(std::declval<U &>().steer_command_angle_scale)>
+  static std::true_type test(int);
+  template <class U>
+  static std::false_type test(...);
+
+public:
+  static constexpr bool value = decltype(test<Params>(0))::value;
+};
+
+template <class Params>
+struct SteerCommandMagnitudeLimit
+{
+  template <class U, class = decltype(std::declval<const U &>().max_steer_angle)>
+  static __host__ __device__ float limit(const U & p)
+  {
+    return p.max_steer_angle;
+  }
+
+  static __host__ __device__ float limit(...) { return 1.0F; }
+};
+
+template <class Params>
+__host__ __device__ inline float steerCommandFromCurvature(
+  const Params & p, float kappa, float steer_gain = 1.0F, float steer_limit = 0.0F)
+{
+  const float steer_angle = atanf(kappa * p.wheel_base) * p.steer_angle_scale;
+  const float cmd = steer_gain * steer_angle / p.steer_command_angle_scale;
+  const float lim = steer_limit > 0.0F ? steer_limit : SteerCommandMagnitudeLimit<Params>::limit(p);
+  return fmaxf(-lim, fminf(lim, cmd));
+}
+
+__host__ __device__ inline float clampLookaheadDistance(
+  const float lookahead_dist, const float min_dist, const float max_dist)
+{
+  return fmaxf(min_dist, fminf(max_dist, lookahead_dist));
+}
+
+/** Pure-pursuit bicycle steer toward (look_x, look_y) with commanded lookahead distance L_d [m]. */
+template <class Params>
+__host__ __device__ inline float purePursuitSteerCommand(
+  const Params & p, const float veh_x, const float veh_y, const float veh_yaw, const float look_x,
+  const float look_y, const float lookahead_dist, const float steer_gain,
+  const float steer_limit = 0.0F)
+{
+  const float dx = look_x - veh_x;
+  const float dy = look_y - veh_y;
+#ifdef __CUDA_ARCH__
+  const float heading_to_point = atan2f(dy, dx);
+  const float eta = angle_utils::shortestAngularDistance(veh_yaw, heading_to_point);
+  const float sin_eta = sinf(eta);
+#else
+  const float heading_to_point = std::atan2(dy, dx);
+  const float eta = angle_utils::shortestAngularDistance(veh_yaw, heading_to_point);
+  const float sin_eta = std::sin(eta);
+#endif
+  const float Ld = fmaxf(lookahead_dist, 1.0E-3F);
+  const float kappa = 2.0F * sin_eta / Ld;
+  return steerCommandFromCurvature(p, kappa, steer_gain, steer_limit);
+}
+
+template <
+  class DYN_T, int NUM_TIMESTEPS,
+  bool Enabled = HasBicyclePathSteer<typename DYN_T::DYN_PARAMS_T>::value>
+struct PathTrackerSteerControl;
+
+template <class DYN_T, int NUM_TIMESTEPS>
+struct PathTrackerSteerControl<DYN_T, NUM_TIMESTEPS, true>
+{
+  using Params = typename DYN_T::DYN_PARAMS_T;
+  using control_array = typename DYN_T::control_array;
+  using state_trajectory = Eigen::Matrix<float, DYN_T::STATE_DIM, NUM_TIMESTEPS>;
+
+  static control_array computePurePursuit(
+    const Params & dyn_params, const state_trajectory & goal_traj,
+    const typename DYN_T::state_array & x_act, const int t, const float look_x, const float look_y,
+    const float lookahead_dist, const float steer_gain)
+  {
+    control_array u = control_array::Zero();
+    constexpr int kYaw = static_cast<int>(Params::StateIndex::YAW);
+    constexpr int kX = static_cast<int>(Params::StateIndex::POS_X);
+    constexpr int kY = static_cast<int>(Params::StateIndex::POS_Y);
+    constexpr int kSteer = static_cast<int>(Params::ControlIndex::STEER_CMD);
+
+    float veh_x = x_act(kX);
+    float veh_y = x_act(kY);
+    float veh_yaw = x_act(kYaw);
+    if (t > 0) {
+      veh_x = goal_traj(kX, t);
+      veh_y = goal_traj(kY, t);
+      veh_yaw = goal_traj(kYaw, t);
+    }
+
+    u(kSteer) = purePursuitSteerCommand(
+      dyn_params, veh_x, veh_y, veh_yaw, look_x, look_y, lookahead_dist, steer_gain);
+    return u;
+  }
+
+  static control_array computeCurvature(
+    DYN_T & dyn, const state_trajectory & goal_traj, const typename DYN_T::state_array & x_act,
+    const int t, const float dt, const float path_kappa, const bool path_kappa_valid,
+    const float steer_gain)
+  {
+    control_array u = control_array::Zero();
+    constexpr int kYaw = static_cast<int>(Params::StateIndex::YAW);
+    constexpr int kVel = static_cast<int>(Params::StateIndex::VEL_X);
+    constexpr int kSteer = static_cast<int>(Params::ControlIndex::STEER_CMD);
+
+    float kappa = path_kappa;
+    if (!path_kappa_valid) {
+      const int t_next = std::min(t + 1, NUM_TIMESTEPS - 1);
+      const float yaw0 = goal_traj(kYaw, t);
+      const float yaw1 = goal_traj(kYaw, t_next);
+      const float vel = std::max(std::fabs(x_act(kVel)), 0.1F);
+      const float ds = std::max(vel * dt * static_cast<float>(t_next - t), 1.0E-3F);
+      kappa = angle_utils::shortestAngularDistance(yaw0, yaw1) / ds;
+    }
+
+    u(kSteer) = steerCommandFromCurvature(dyn.getParams(), kappa, steer_gain);
+    return u;
+  }
+};
+
+template <class DYN_T, int NUM_TIMESTEPS>
+struct PathTrackerSteerControl<DYN_T, NUM_TIMESTEPS, false>
+{
+  using control_array = typename DYN_T::control_array;
+
+  static control_array compute(
+    const DYN_T &, const Eigen::Matrix<float, DYN_T::STATE_DIM, NUM_TIMESTEPS> &,
+    const typename DYN_T::state_array &, int, float, float, bool, float)
+  {
+    return control_array::Zero();
+  }
+};
+
+}  // namespace detail
+
+template <class DYN_T, int NUM_TIMESTEPS>
+Eigen::Matrix<float, DYN_T::STATE_DIM, NUM_TIMESTEPS> goalTrajectoryFromPathReference(
+  const std::vector<mppi::path::PathReferenceSample> & ref)
+{
+  using Params = typename DYN_T::DYN_PARAMS_T;
+  Eigen::Matrix<float, DYN_T::STATE_DIM, NUM_TIMESTEPS> goal_traj =
+    Eigen::Matrix<float, DYN_T::STATE_DIM, NUM_TIMESTEPS>::Zero();
+
+  constexpr int kVel = static_cast<int>(Params::StateIndex::VEL_X);
+  constexpr int kYaw = static_cast<int>(Params::StateIndex::YAW);
+  constexpr int kX = static_cast<int>(Params::StateIndex::POS_X);
+  constexpr int kY = static_cast<int>(Params::StateIndex::POS_Y);
+
+  for (int t = 0; t < NUM_TIMESTEPS; ++t) {
+    const mppi::path::PathReferenceSample & s =
+      ref[static_cast<size_t>(std::min(t, static_cast<int>(ref.size()) - 1))];
+    goal_traj(kVel, t) = s.v;
+    goal_traj(kYaw, t) = s.yaw;
+    goal_traj(kX, t) = s.x;
+    goal_traj(kY, t) = s.y;
+  }
+  return goal_traj;
+}
+
+template <int NUM_TIMESTEPS>
+std::array<float, NUM_TIMESTEPS> referenceCurvaturesFromPath(
+  const mppi::path::Path2D & path, const std::vector<mppi::path::PathReferenceSample> & ref)
+{
+  std::array<float, NUM_TIMESTEPS> kappa{};
+  for (int t = 0; t < NUM_TIMESTEPS; ++t) {
+    const mppi::path::PathReferenceSample & s =
+      ref[static_cast<size_t>(std::min(t, static_cast<int>(ref.size()) - 1))];
+    kappa[static_cast<size_t>(t)] = path.curvatureAt(s.arc_length_s);
+  }
+  return kappa;
+}
+
+template <int NUM_TIMESTEPS>
+inline int lookaheadReferenceIndex(
+  const std::vector<mppi::path::PathReferenceSample> & ref, const int start_idx,
+  const float lookahead_ds)
+{
+  if (ref.empty()) {
+    return 0;
+  }
+  const int n = static_cast<int>(ref.size());
+  const int i0 = std::max(0, std::min(start_idx, n - 1));
+  const float s_target = ref[static_cast<size_t>(i0)].arc_length_s + lookahead_ds;
+  for (int i = i0; i < n; ++i) {
+    if (ref[static_cast<size_t>(i)].arc_length_s >= s_target) {
+      return i;
+    }
+  }
+  return n - 1;
+}
+
+template <int NUM_TIMESTEPS>
+inline void fillPurePursuitLookaheadTargets(
+  const std::vector<mppi::path::PathReferenceSample> & ref,
+  const PathTrackerFeedbackParams & params, float * look_x, float * look_y, float * lookahead_dist)
+{
+  if (ref.empty()) {
+    return;
+  }
+  for (int t = 0; t < NUM_TIMESTEPS; ++t) {
+    const int ref_idx = std::min(t, static_cast<int>(ref.size()) - 1);
+    const mppi::path::PathReferenceSample & sample = ref[static_cast<size_t>(ref_idx)];
+    const float v = std::max(sample.v, 0.1F);
+    const float Ld = detail::clampLookaheadDistance(
+      params.lookahead_time * v, params.min_lookahead_distance, params.max_lookahead_distance);
+    const int look_idx = lookaheadReferenceIndex<NUM_TIMESTEPS>(ref, ref_idx, Ld);
+    const mppi::path::PathReferenceSample & look = ref[static_cast<size_t>(look_idx)];
+    look_x[t] = look.x;
+    look_y[t] = look.y;
+    lookahead_dist[t] = Ld;
+  }
+}
+
+}  // namespace feedback
+}  // namespace mppi
+
+template <class DYN_T, int NUM_TIMESTEPS>
+class PathTrackerFeedbackImpl
+: public GPUFeedbackController<
+    PathTrackerFeedbackImpl<DYN_T, NUM_TIMESTEPS>, DYN_T, PathTrackerFeedbackState<NUM_TIMESTEPS>>
+{
+public:
+  using FEEDBACK_STATE_T = PathTrackerFeedbackState<NUM_TIMESTEPS>;
+  using Params = typename DYN_T::DYN_PARAMS_T;
+
+  PathTrackerFeedbackImpl(cudaStream_t stream = 0)
+  : GPUFeedbackController<PathTrackerFeedbackImpl<DYN_T, NUM_TIMESTEPS>, DYN_T, FEEDBACK_STATE_T>(
+      stream)
+  {
+  }
+
+  __device__ void k(
+    const float * __restrict__ x_act, const float * __restrict__ x_goal, const int t,
+    float * __restrict__ theta, float * __restrict__ control_output)
+  {
+    (void)x_goal;
+    (void)theta;
+    for (int i = 0; i < DYN_T::CONTROL_DIM; ++i) {
+      control_output[i] = 0.0F;
+    }
+
+    const FEEDBACK_STATE_T & st = this->state_;
+    if (st.goal_traj_valid == 0) {
+      return;
+    }
+
+    constexpr int kX = static_cast<int>(Params::StateIndex::POS_X);
+    constexpr int kY = static_cast<int>(Params::StateIndex::POS_Y);
+    constexpr int kYaw = static_cast<int>(Params::StateIndex::YAW);
+    constexpr int kVel = static_cast<int>(Params::StateIndex::VEL_X);
+    constexpr int kSteer = static_cast<int>(Params::ControlIndex::STEER_CMD);
+
+    const int t_clamped = min(max(t, 0), st.num_timesteps - 1);
+
+    Params p;
+    p.wheel_base = st.wheel_base;
+    p.steer_angle_scale = st.steer_angle_scale;
+    p.steer_command_angle_scale = st.steer_command_angle_scale;
+
+    if (st.use_pure_pursuit != 0) {
+      control_output[kSteer] = mppi::feedback::detail::purePursuitSteerCommand(
+        p, x_act[kX], x_act[kY], x_act[kYaw], st.look_x[t_clamped], st.look_y[t_clamped],
+        st.lookahead_dist[t_clamped], st.steer_feedforward_gain, st.steer_command_limit);
+      return;
+    }
+
+    float kappa = 0.0F;
+    if (st.ref_kappa_valid != 0) {
+      kappa = st.ref_kappa[t_clamped];
+    } else {
+      const int t_next = min(t_clamped + 1, st.num_timesteps - 1);
+      const float vel = fmaxf(fabsf(x_act[kVel]), 0.1F);
+      const float ds = fmaxf(vel * st.dt * static_cast<float>(t_next - t_clamped), 1.0E-3F);
+      kappa =
+        angle_utils::shortestAngularDistance(st.goal_yaw[t_clamped], st.goal_yaw[t_next]) / ds;
+    }
+
+    control_output[kSteer] = mppi::feedback::detail::steerCommandFromCurvature(
+      p, kappa, st.steer_feedforward_gain, st.steer_command_limit);
+  }
+};
+
+template <class DYN_T, int NUM_TIMESTEPS>
+class PathTrackerFeedback
+: public FeedbackController<
+    PathTrackerFeedbackImpl<DYN_T, NUM_TIMESTEPS>, PathTrackerFeedbackParams, NUM_TIMESTEPS>
+{
+public:
+  using PARENT_CLASS = FeedbackController<
+    PathTrackerFeedbackImpl<DYN_T, NUM_TIMESTEPS>, PathTrackerFeedbackParams, NUM_TIMESTEPS>;
+  using control_array = typename PARENT_CLASS::control_array;
+  using control_trajectory = typename PARENT_CLASS::control_trajectory;
+  using state_array = typename PARENT_CLASS::state_array;
+  using state_trajectory = typename PARENT_CLASS::state_trajectory;
+  using TEMPLATED_FEEDBACK_STATE = typename PARENT_CLASS::TEMPLATED_FEEDBACK_STATE;
+  using FEEDBACK_STATE_T = PathTrackerFeedbackState<NUM_TIMESTEPS>;
+
+  PathTrackerFeedback(DYN_T * dyn = nullptr, float dt = 0.01F)
+  : PARENT_CLASS(dt, NUM_TIMESTEPS), dyn_(dyn)
+  {
+  }
+
+  void initTrackingController() override {}
+
+  void updateReference(
+    const mppi::path::Path2D & path, const std::vector<mppi::path::PathReferenceSample> & ref)
+  {
+    ref_samples_ = ref;
+    ref_kappa_ = mppi::feedback::referenceCurvaturesFromPath<NUM_TIMESTEPS>(path, ref);
+    ref_kappa_valid_ = true;
+    mppi::feedback::fillPurePursuitLookaheadTargets<NUM_TIMESTEPS>(
+      ref_samples_, this->params_, look_x_.data(), look_y_.data(), lookahead_dist_.data());
+  }
+
+  control_array k_(
+    const Eigen::Ref<const state_array> & x_act, const Eigen::Ref<const state_array> & x_goal,
+    int t, TEMPLATED_FEEDBACK_STATE & fb_state) override
+  {
+    (void)x_goal;
+    (void)fb_state;
+    if (dyn_ == nullptr || !goal_traj_valid_) {
+      return control_array::Zero();
+    }
+    const float steer_gain = this->params_.steer_feedforward_gain;
+    if (this->params_.use_pure_pursuit) {
+      return mppi::feedback::detail::PathTrackerSteerControl<DYN_T, NUM_TIMESTEPS>::
+        computePurePursuit(
+          dyn_->getParams(), goal_traj_, x_act, t, look_x_[static_cast<size_t>(t)],
+          look_y_[static_cast<size_t>(t)], lookahead_dist_[static_cast<size_t>(t)], steer_gain);
+    }
+    const float path_kappa = ref_kappa_valid_ ? ref_kappa_[static_cast<size_t>(t)] : 0.0F;
+    return mppi::feedback::detail::PathTrackerSteerControl<DYN_T, NUM_TIMESTEPS>::computeCurvature(
+      *dyn_, goal_traj_, x_act, t, this->getDt(), path_kappa, ref_kappa_valid_, steer_gain);
+  }
+
+  void computeFeedback(
+    const Eigen::Ref<const state_array> & init_state,
+    const Eigen::Ref<const state_trajectory> & goal_traj,
+    const Eigen::Ref<const control_trajectory> & control_traj) override
+  {
+    (void)init_state;
+    (void)control_traj;
+    goal_traj_ = goal_traj;
+    goal_traj_valid_ = true;
+    syncFeedbackStateToGpu();
+  }
+
+  /**
+   * Set nominal steer from pure-pursuit / path curvature (throttle entries unchanged).
+   * Replaces steer each step; do not accumulate on top of the previous MPPI solution.
+   */
+  void applyFeedforwardToNominal(
+    Eigen::Ref<control_trajectory> u_nom, const Eigen::Ref<const state_array> & x,
+    const Eigen::Ref<const state_trajectory> & goal_traj)
+  {
+    computeFeedback(x, goal_traj, u_nom);
+    using Params = typename DYN_T::DYN_PARAMS_T;
+    constexpr int kSteer = static_cast<int>(Params::ControlIndex::STEER_CMD);
+    const int n_ff = std::max(1, std::min(this->params_.feedforward_horizon_steps, NUM_TIMESTEPS));
+    TEMPLATED_FEEDBACK_STATE fb_state{};
+    for (int t = 0; t < n_ff; ++t) {
+      const control_array u_ff = k_(x, goal_traj.col(t), t, fb_state);
+      u_nom(kSteer, t) = u_ff(kSteer);
+    }
+  }
+
+private:
+  void syncFeedbackStateToGpu()
+  {
+    if (dyn_ == nullptr || !goal_traj_valid_) {
+      return;
+    }
+
+    FEEDBACK_STATE_T gpu_state{};
+    gpu_state.num_timesteps = NUM_TIMESTEPS;
+    gpu_state.dt = this->getDt();
+    gpu_state.goal_traj_valid = 1;
+    gpu_state.ref_kappa_valid = ref_kappa_valid_ ? 1 : 0;
+    gpu_state.use_pure_pursuit = this->params_.use_pure_pursuit ? 1 : 0;
+
+    using Params = typename DYN_T::DYN_PARAMS_T;
+    constexpr int kYaw = static_cast<int>(Params::StateIndex::YAW);
+    for (int t = 0; t < NUM_TIMESTEPS; ++t) {
+      gpu_state.goal_yaw[t] = goal_traj_(kYaw, t);
+      gpu_state.ref_kappa[t] = ref_kappa_valid_ ? ref_kappa_[static_cast<size_t>(t)] : 0.0F;
+      gpu_state.look_x[t] = look_x_[static_cast<size_t>(t)];
+      gpu_state.look_y[t] = look_y_[static_cast<size_t>(t)];
+      gpu_state.lookahead_dist[t] = lookahead_dist_[static_cast<size_t>(t)];
+    }
+
+    const auto & p = dyn_->getParams();
+    gpu_state.wheel_base = p.wheel_base;
+    gpu_state.steer_angle_scale = p.steer_angle_scale;
+    gpu_state.steer_command_angle_scale = p.steer_command_angle_scale;
+    gpu_state.steer_feedforward_gain = this->params_.steer_feedforward_gain;
+    gpu_state.steer_command_limit =
+      mppi::feedback::detail::SteerCommandMagnitudeLimit<Params>::limit(p);
+
+    this->getHostPointer()->setFeedbackState(gpu_state);
+  }
+
+  DYN_T * dyn_ = nullptr;
+  state_trajectory goal_traj_ = state_trajectory::Zero();
+  std::vector<mppi::path::PathReferenceSample> ref_samples_;
+  std::array<float, NUM_TIMESTEPS> ref_kappa_{};
+  std::array<float, NUM_TIMESTEPS> look_x_{};
+  std::array<float, NUM_TIMESTEPS> look_y_{};
+  std::array<float, NUM_TIMESTEPS> lookahead_dist_{};
+  bool goal_traj_valid_ = false;
+  bool ref_kappa_valid_ = false;
+};

--- a/planning/autoware_mppi_optimizer/include/mppi/feedback_controllers/zero_feedback.cuh
+++ b/planning/autoware_mppi_optimizer/include/mppi/feedback_controllers/zero_feedback.cuh
@@ -1,0 +1,68 @@
+/**
+ * No-op feedback controller (zero control correction).
+ */
+#pragma once
+
+#include <mppi/feedback_controllers/feedback.cuh>
+
+template <class DYN_T, int NUM_TIMESTEPS>
+class ZeroFeedbackImpl
+: public GPUFeedbackController<ZeroFeedbackImpl<DYN_T, NUM_TIMESTEPS>, DYN_T, GPUState>
+{
+public:
+  ZeroFeedbackImpl(cudaStream_t stream = 0)
+  : GPUFeedbackController<ZeroFeedbackImpl<DYN_T, NUM_TIMESTEPS>, DYN_T, GPUState>(stream)
+  {
+  }
+
+  __device__ void k(
+    const float * __restrict__ x_act, const float * __restrict__ x_goal, const int t,
+    float * __restrict__ theta, float * __restrict__ control_output)
+  {
+    (void)x_act;
+    (void)x_goal;
+    (void)t;
+    (void)theta;
+    (void)control_output;
+  }
+};
+
+template <class DYN_T, int NUM_TIMESTEPS>
+class ZeroFeedback
+: public FeedbackController<ZeroFeedbackImpl<DYN_T, NUM_TIMESTEPS>, int, NUM_TIMESTEPS>
+{
+public:
+  using PARENT_CLASS =
+    FeedbackController<ZeroFeedbackImpl<DYN_T, NUM_TIMESTEPS>, int, NUM_TIMESTEPS>;
+  using control_array = typename PARENT_CLASS::control_array;
+  using state_array = typename PARENT_CLASS::state_array;
+  using TEMPLATED_FEEDBACK_STATE = typename PARENT_CLASS::TEMPLATED_FEEDBACK_STATE;
+
+  ZeroFeedback(DYN_T * dyn = nullptr, float dt = 0.01F) : PARENT_CLASS(dt, NUM_TIMESTEPS)
+  {
+    (void)dyn;
+  }
+
+  void initTrackingController() override {}
+
+  control_array k_(
+    const Eigen::Ref<const state_array> & x_act, const Eigen::Ref<const state_array> & x_goal,
+    int t, TEMPLATED_FEEDBACK_STATE & fb_state) override
+  {
+    (void)x_act;
+    (void)x_goal;
+    (void)t;
+    (void)fb_state;
+    return control_array::Zero();
+  }
+
+  void computeFeedback(
+    const Eigen::Ref<const state_array> & init_state,
+    const Eigen::Ref<const typename PARENT_CLASS::state_trajectory> & goal_traj,
+    const Eigen::Ref<const typename PARENT_CLASS::control_trajectory> & control_traj) override
+  {
+    (void)init_state;
+    (void)goal_traj;
+    (void)control_traj;
+  }
+};

--- a/planning/autoware_mppi_optimizer/include/mppi/path/drivable_area.hpp
+++ b/planning/autoware_mppi_optimizer/include/mppi/path/drivable_area.hpp
@@ -1,0 +1,119 @@
+/**
+ * Closed polygons for drivable road surfaces and trajectory deviation corridors.
+ */
+#pragma once
+
+#include <mppi/cost_functions/moving_car_obstacles.hpp>
+#include <mppi/path/path2d.hpp>
+
+#include <algorithm>
+#include <cmath>
+#include <vector>
+
+namespace mppi
+{
+namespace path
+{
+
+/** Closed polygon in world coordinates (vertices in order). */
+struct Polygon2D
+{
+  std::vector<float> x;
+  std::vector<float> y;
+
+  bool empty() const { return x.size() < 3U || x.size() != y.size(); }
+
+  size_t size() const { return std::min(x.size(), y.size()); }
+};
+
+/** Corridor along a path: left boundary forward, right boundary backward. */
+inline Polygon2D pathCorridorPolygon(
+  const Path2D & path, const float left_half, const float right_half,
+  const float sample_spacing = 0.5F, const int max_vertices = 0)
+{
+  Polygon2D poly;
+  const float path_length = path.length();
+  if (path_length <= 0.0F || left_half <= 0.0F || right_half <= 0.0F) {
+    return poly;
+  }
+
+  float spacing = std::max(sample_spacing, path_length / 256.0F);
+  if (max_vertices >= 6) {
+    const float max_spacing = path_length / (static_cast<float>(max_vertices) * 0.5F - 2.0F);
+    spacing = std::max(spacing, max_spacing);
+  }
+
+  std::vector<float> left_x;
+  std::vector<float> left_y;
+  std::vector<float> right_x;
+  std::vector<float> right_y;
+  left_x.reserve(static_cast<size_t>(path_length / spacing) + 4U);
+  right_x.reserve(left_x.capacity());
+
+  for (float s = 0.0F; s <= path_length; s += spacing) {
+    const Pose2D p = path.poseAt(s);
+    float tx = 0.0F;
+    float ty = 0.0F;
+    path.tangentAt(s, tx, ty);
+    left_x.push_back(p.x - left_half * ty);
+    left_y.push_back(p.y + left_half * tx);
+    right_x.push_back(p.x + right_half * ty);
+    right_y.push_back(p.y - right_half * tx);
+  }
+
+  if (left_x.size() < 2U) {
+    return poly;
+  }
+
+  poly.x = left_x;
+  poly.y = left_y;
+  for (int i = static_cast<int>(right_x.size()) - 1; i >= 0; --i) {
+    poly.x.push_back(right_x[static_cast<size_t>(i)]);
+    poly.y.push_back(right_y[static_cast<size_t>(i)]);
+  }
+  return poly;
+}
+
+inline Polygon2D symmetricPathCorridorPolygon(
+  const Path2D & path, const float half_width, const float sample_spacing = 0.5F,
+  const int max_vertices = 0)
+{
+  return pathCorridorPolygon(path, half_width, half_width, sample_spacing, max_vertices);
+}
+
+/** Axis-aligned rectangle for a straight road segment. */
+inline Polygon2D straightCorridorPolygon(
+  const float x0, const float y0, const float x1, const float y1, const float half_width)
+{
+  Polygon2D poly;
+  const float dx = x1 - x0;
+  const float dy = y1 - y0;
+  const float len = std::sqrt(dx * dx + dy * dy);
+  if (len < 1.0E-6F || half_width <= 0.0F) {
+    return poly;
+  }
+
+  const float tx = dx / len;
+  const float ty = dy / len;
+  const float nx = -ty;
+  const float ny = tx;
+
+  poly.x = {x0 + nx * half_width, x1 + nx * half_width, x1 - nx * half_width, x0 - nx * half_width};
+  poly.y = {y0 + ny * half_width, y1 + ny * half_width, y1 - ny * half_width, y0 - ny * half_width};
+  return poly;
+}
+
+/** Both lanes of TwoLaneRoadLayout (+y forward). */
+inline Polygon2D twoLaneRoadPolygon()
+{
+  using L = mppi::cost::TwoLaneRoadLayout;
+  const float x_left = L::kLeftLaneX - L::kLaneHalfWidth;
+  const float x_right = L::kRightLaneX + L::kLaneHalfWidth;
+  Polygon2D poly;
+  poly.x = {x_left, x_right, x_right, x_left};
+  poly.y = {L::kRoadYStart, L::kRoadYStart, L::kRoadYEnd, L::kRoadYEnd};
+  return poly;
+}
+
+}  // namespace path
+}  // namespace mppi

--- a/planning/autoware_mppi_optimizer/include/mppi/path/drivable_area.hpp
+++ b/planning/autoware_mppi_optimizer/include/mppi/path/drivable_area.hpp
@@ -1,16 +1,16 @@
- // Copyright 2026 TIER IV, Inc.
- //
- // Licensed under the Apache License, Version 2.0 (the "License");
- // you may not use this file except in compliance with the License.
- // You may obtain a copy of the License at
- //
- //     http://www.apache.org/licenses/LICENSE-2.0
- //
- // Unless required by applicable law or agreed to in writing, software
- // distributed under the License is distributed on an "AS IS" BASIS,
- // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- // See the License for the specific language governing permissions and
- // limitations under the License.
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
 
 /**
  * Closed polygons for drivable road surfaces and trajectory deviation corridors.

--- a/planning/autoware_mppi_optimizer/include/mppi/path/drivable_area.hpp
+++ b/planning/autoware_mppi_optimizer/include/mppi/path/drivable_area.hpp
@@ -1,3 +1,17 @@
+ // Copyright 2026 TIER IV, Inc.
+ //
+ // Licensed under the Apache License, Version 2.0 (the "License");
+ // you may not use this file except in compliance with the License.
+ // You may obtain a copy of the License at
+ //
+ //     http://www.apache.org/licenses/LICENSE-2.0
+ //
+ // Unless required by applicable law or agreed to in writing, software
+ // distributed under the License is distributed on an "AS IS" BASIS,
+ // WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ // See the License for the specific language governing permissions and
+ // limitations under the License.
+
 /**
  * Closed polygons for drivable road surfaces and trajectory deviation corridors.
  */

--- a/planning/autoware_mppi_optimizer/include/mppi/path/path2d.hpp
+++ b/planning/autoware_mppi_optimizer/include/mppi/path/path2d.hpp
@@ -1,0 +1,528 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * Planar reference paths for Dubins / bicycle path tracking.
+ *
+ * Supports exact analytic primitives (circle, straight line) and polyline paths
+ * (stadium, Catmull–Rom). Analytic paths use true arc-length geometry for pose,
+ * tangent, curvature, and projection; polyline anchors are optional and only used
+ * for visualization export.
+ */
+#pragma once
+
+#include <mppi/utils/angle_utils.cuh>
+
+#include <algorithm>
+#include <cmath>
+#include <stdexcept>
+#include <utility>
+#include <vector>
+
+namespace mppi
+{
+namespace path
+{
+
+struct Pose2D
+{
+  float x = 0.0F;
+  float y = 0.0F;
+  float yaw = 0.0F;
+};
+
+/** Anchor on the path with cumulative arc length s [m] from the start. */
+struct PathAnchor : Pose2D
+{
+  float s = 0.0F;
+};
+
+enum class PathGeometryKind { Polyline, Circle, Line };
+
+struct CircleGeometry
+{
+  float center_x = 0.0F;
+  float center_y = 0.0F;
+  float radius = 1.0F;
+  /** Polar angle at s = 0; CCW motion, tangent yaw = theta + pi/2. */
+  float theta0 = 0.0F;
+};
+
+struct LineGeometry
+{
+  float x0 = 0.0F;
+  float y0 = 0.0F;
+  float x1 = 0.0F;
+  float y1 = 0.0F;
+  float yaw = 0.0F;
+  float length = 0.0F;
+};
+
+class Path2D
+{
+public:
+  PathGeometryKind geometryKind() const { return geometry_; }
+
+  bool isAnalyticCircle() const { return geometry_ == PathGeometryKind::Circle; }
+
+  bool isAnalyticLine() const { return geometry_ == PathGeometryKind::Line; }
+
+  const CircleGeometry & circleGeometry() const { return circle_; }
+
+  bool closed() const { return closed_; }
+
+  float length() const { return length_; }
+
+  /** Polyline samples for plotting only (analytic paths are densely sampled from exact geometry).
+   */
+  const std::vector<PathAnchor> & anchors() const { return anchors_; }
+
+  bool empty() const
+  {
+    if (geometry_ == PathGeometryKind::Circle) {
+      return circle_.radius < 1.0E-6F;
+    }
+    if (geometry_ == PathGeometryKind::Line) {
+      return line_.length < 1.0E-6F;
+    }
+    return anchors_.size() < 2U;
+  }
+
+  float wrapArcLength(float s) const;
+
+  Pose2D poseAt(float s) const;
+
+  void tangentAt(float s, float & tx, float & ty) const;
+
+  float curvatureAt(float s) const;
+
+  /** θ(s) for analytic circle; undefined for other geometries. */
+  float circleThetaAt(float s) const;
+
+  static Path2D straightLine(float x0, float y0, float x1, float y1, int plot_samples = 64);
+
+  /**
+   * Exact circle: CCW, yaw tangent = θ + π/2, s = 0 at θ = theta0, length = 2πR.
+   * @param plot_samples  Polyline density for CSV/plot export only (not used in tracking).
+   */
+  static Path2D circle(
+    float center_x, float center_y, float radius, float theta0 = 0.0F, int plot_samples = 256);
+
+  static Path2D stadium(float straight_length, float radius, int samples_per_arc = 48);
+
+  static Path2D catmullRom(
+    const std::vector<std::pair<float, float>> & control_xy, bool closed,
+    int samples_per_span = 16);
+
+private:
+  PathGeometryKind geometry_ = PathGeometryKind::Polyline;
+  bool closed_ = false;
+  float length_ = 0.0F;
+  CircleGeometry circle_{};
+  LineGeometry line_{};
+  std::vector<PathAnchor> anchors_;
+
+  void finalizeFromPoses(std::vector<Pose2D> poses, bool closed);
+  void buildPlotAnchorsFromGeometry(int num_samples);
+
+  int segmentIndexForS(float s_wrapped, float & local_u) const;
+
+  Pose2D poseOnCircle(float s) const;
+  Pose2D poseOnLine(float s) const;
+  void tangentOnCircle(float s, float & tx, float & ty) const;
+  void tangentOnLine(float s, float & tx, float & ty) const;
+};
+
+namespace detail
+{
+inline float positiveAngleFromTheta0(const float theta, const float theta0)
+{
+  float d = angle_utils::normalizeAngle(theta - theta0);
+  if (d < 0.0F) {
+    d += 2.0F * static_cast<float>(M_PI);
+  }
+  return d;
+}
+}  // namespace detail
+
+inline float Path2D::circleThetaAt(const float s) const
+{
+  return circle_.theta0 + s / circle_.radius;
+}
+
+inline Pose2D Path2D::poseOnCircle(const float s) const
+{
+  const float sw = wrapArcLength(s);
+  const float theta = circleThetaAt(sw);
+  Pose2D out;
+  out.x = circle_.center_x + circle_.radius * std::cos(theta);
+  out.y = circle_.center_y + circle_.radius * std::sin(theta);
+  out.yaw = angle_utils::normalizeAngle(theta + static_cast<float>(M_PI) * 0.5F);
+  return out;
+}
+
+inline Pose2D Path2D::poseOnLine(const float s) const
+{
+  const float sw = wrapArcLength(s);
+  const float u = sw / std::max(line_.length, 1.0E-9F);
+  Pose2D out;
+  out.x = line_.x0 + u * (line_.x1 - line_.x0);
+  out.y = line_.y0 + u * (line_.y1 - line_.y0);
+  out.yaw = line_.yaw;
+  return out;
+}
+
+inline void Path2D::tangentOnCircle(const float s, float & tx, float & ty) const
+{
+  const float theta = circleThetaAt(wrapArcLength(s));
+  tx = -std::sin(theta);
+  ty = std::cos(theta);
+}
+
+inline void Path2D::tangentOnLine(const float, float & tx, float & ty) const
+{
+  tx = std::cos(line_.yaw);
+  ty = std::sin(line_.yaw);
+}
+
+inline float Path2D::wrapArcLength(float s) const
+{
+  if (geometry_ == PathGeometryKind::Circle) {
+    if (circle_.radius < 1.0E-6F) {
+      return 0.0F;
+    }
+    const float two_pi_r = length_;
+    s = s - std::floor(s / two_pi_r) * two_pi_r;
+    if (s < 0.0F) {
+      s += two_pi_r;
+    }
+    return s;
+  }
+  if (geometry_ == PathGeometryKind::Line) {
+    return std::max(0.0F, std::min(s, length_));
+  }
+  if (anchors_.size() < 2U) {
+    return 0.0F;
+  }
+  if (closed_) {
+    if (length_ < 1.0E-6F) {
+      return 0.0F;
+    }
+    s = s - std::floor(s / length_) * length_;
+    if (s < 0.0F) {
+      s += length_;
+    }
+    return s;
+  }
+  return std::max(0.0F, std::min(s, length_));
+}
+
+inline int Path2D::segmentIndexForS(float s_wrapped, float & local_u) const
+{
+  const int n = static_cast<int>(anchors_.size());
+  if (n < 2) {
+    local_u = 0.0F;
+    return 0;
+  }
+  if (s_wrapped <= anchors_.front().s) {
+    local_u = 0.0F;
+    return 0;
+  }
+  for (int i = 0; i < n - 1; ++i) {
+    const float s1 = anchors_[i + 1].s;
+    if (s_wrapped <= s1) {
+      const float s0 = anchors_[i].s;
+      const float ds = std::max(s1 - s0, 1.0E-9F);
+      local_u = (s_wrapped - s0) / ds;
+      return i;
+    }
+  }
+  local_u = 1.0F;
+  return n - 2;
+}
+
+inline Pose2D Path2D::poseAt(float s) const
+{
+  if (geometry_ == PathGeometryKind::Circle) {
+    return poseOnCircle(s);
+  }
+  if (geometry_ == PathGeometryKind::Line) {
+    return poseOnLine(s);
+  }
+  if (anchors_.size() < 2U) {
+    return {};
+  }
+  const float sw = wrapArcLength(s);
+  float u = 0.0F;
+  const int seg = segmentIndexForS(sw, u);
+  const PathAnchor & a0 = anchors_[seg];
+  const PathAnchor & a1 = anchors_[seg + 1];
+  Pose2D out;
+  out.x = a0.x + u * (a1.x - a0.x);
+  out.y = a0.y + u * (a1.y - a0.y);
+  out.yaw = angle_utils::interpolateEulerAngleLinear(a0.yaw, a1.yaw, u);
+  return out;
+}
+
+inline void Path2D::tangentAt(float s, float & tx, float & ty) const
+{
+  if (geometry_ == PathGeometryKind::Circle) {
+    tangentOnCircle(s, tx, ty);
+    return;
+  }
+  if (geometry_ == PathGeometryKind::Line) {
+    tangentOnLine(s, tx, ty);
+    return;
+  }
+  constexpr float ds = 0.05F;
+  const float sw = wrapArcLength(s);
+  const Pose2D p_m = poseAt(sw - ds);
+  const Pose2D p_p = poseAt(sw + ds);
+  const float dx = p_p.x - p_m.x;
+  const float dy = p_p.y - p_m.y;
+  const float n = std::sqrt(dx * dx + dy * dy);
+  if (n < 1.0E-9F) {
+    const float c = std::cos(poseAt(sw).yaw);
+    const float sn = std::sin(poseAt(sw).yaw);
+    tx = c;
+    ty = sn;
+    return;
+  }
+  tx = dx / n;
+  ty = dy / n;
+}
+
+inline float Path2D::curvatureAt(float s) const
+{
+  if (geometry_ == PathGeometryKind::Circle) {
+    (void)s;
+    return 1.0F / circle_.radius;
+  }
+  if (geometry_ == PathGeometryKind::Line) {
+    (void)s;
+    return 0.0F;
+  }
+  constexpr float ds = 0.1F;
+  const float sw = wrapArcLength(s);
+  const float yaw_m = poseAt(sw - ds).yaw;
+  const float yaw_p = poseAt(sw + ds).yaw;
+  return angle_utils::shortestAngularDistance(yaw_m, yaw_p) / (2.0F * ds);
+}
+
+inline void Path2D::buildPlotAnchorsFromGeometry(const int num_samples)
+{
+  const int n = std::max(2, num_samples);
+  anchors_.clear();
+  anchors_.reserve(static_cast<size_t>(n));
+  for (int i = 0; i < n; ++i) {
+    const float s = length_ * static_cast<float>(i) / static_cast<float>(n - 1);
+    const Pose2D p = poseAt(s);
+    PathAnchor a;
+    a.x = p.x;
+    a.y = p.y;
+    a.yaw = p.yaw;
+    a.s = s;
+    anchors_.push_back(a);
+  }
+  if (geometry_ == PathGeometryKind::Circle && n >= 2) {
+    anchors_.back() = anchors_.front();
+    anchors_.back().s = length_;
+  }
+}
+
+inline void Path2D::finalizeFromPoses(std::vector<Pose2D> poses, const bool closed)
+{
+  geometry_ = PathGeometryKind::Polyline;
+  if (poses.size() < 2U) {
+    throw std::invalid_argument("Path2D: need at least two poses");
+  }
+  closed_ = closed;
+  anchors_.clear();
+  anchors_.reserve(poses.size());
+  float s_acc = 0.0F;
+  for (size_t i = 0; i < poses.size(); ++i) {
+    PathAnchor a;
+    a.x = poses[i].x;
+    a.y = poses[i].y;
+    a.yaw = poses[i].yaw;
+    a.s = s_acc;
+    anchors_.push_back(a);
+    if (i + 1U < poses.size()) {
+      const float dx = poses[i + 1].x - poses[i].x;
+      const float dy = poses[i + 1].y - poses[i].y;
+      s_acc += std::sqrt(dx * dx + dy * dy);
+    }
+  }
+  length_ = s_acc;
+  if (closed_ && poses.size() >= 2U) {
+    const float dx = poses.front().x - poses.back().x;
+    const float dy = poses.front().y - poses.back().y;
+    length_ = anchors_.back().s + std::sqrt(dx * dx + dy * dy);
+    PathAnchor close_pt = anchors_.front();
+    close_pt.s = length_;
+    anchors_.push_back(close_pt);
+  }
+}
+
+inline Path2D Path2D::straightLine(
+  const float x0, const float y0, const float x1, const float y1, const int plot_samples)
+{
+  Path2D path;
+  path.geometry_ = PathGeometryKind::Line;
+  path.closed_ = false;
+  path.line_.x0 = x0;
+  path.line_.y0 = y0;
+  path.line_.x1 = x1;
+  path.line_.y1 = y1;
+  const float dx = x1 - x0;
+  const float dy = y1 - y0;
+  path.line_.length = std::sqrt(dx * dx + dy * dy);
+  path.line_.yaw = std::atan2(dy, dx);
+  path.length_ = path.line_.length;
+  path.buildPlotAnchorsFromGeometry(plot_samples);
+  return path;
+}
+
+inline Path2D Path2D::circle(
+  const float center_x, const float center_y, const float radius, const float theta0,
+  const int plot_samples)
+{
+  if (radius < 1.0E-6F) {
+    throw std::invalid_argument("Path2D::circle: radius must be positive");
+  }
+  Path2D path;
+  path.geometry_ = PathGeometryKind::Circle;
+  path.closed_ = true;
+  path.circle_.center_x = center_x;
+  path.circle_.center_y = center_y;
+  path.circle_.radius = radius;
+  path.circle_.theta0 = theta0;
+  path.length_ = 2.0F * static_cast<float>(M_PI) * radius;
+  path.buildPlotAnchorsFromGeometry(plot_samples);
+  return path;
+}
+
+inline Path2D Path2D::stadium(
+  const float straight_length, const float radius, const int samples_per_arc)
+{
+  const int na = std::max(4, samples_per_arc);
+  const float hs = 0.5F * straight_length;
+  std::vector<Pose2D> poses;
+  poses.reserve(static_cast<size_t>(2 * na + 2));
+
+  auto append = [&poses](const float x, const float y, const float yaw) {
+    Pose2D pose;
+    pose.x = x;
+    pose.y = y;
+    pose.yaw = yaw;
+    poses.push_back(pose);
+  };
+
+  append(-hs, -radius, 0.0F);
+  append(hs, -radius, 0.0F);
+  for (int i = 1; i <= na; ++i) {
+    const float a = -static_cast<float>(M_PI) * 0.5F +
+                    static_cast<float>(M_PI) * static_cast<float>(i) / static_cast<float>(na);
+    append(hs + radius * std::cos(a), radius * std::sin(a), a + static_cast<float>(M_PI) * 0.5F);
+  }
+  append(hs, radius, static_cast<float>(M_PI));
+  append(-hs, radius, static_cast<float>(M_PI));
+  for (int i = 1; i <= na; ++i) {
+    const float a = static_cast<float>(M_PI) * 0.5F +
+                    static_cast<float>(M_PI) * static_cast<float>(i) / static_cast<float>(na);
+    append(-hs + radius * std::cos(a), radius * std::sin(a), a + static_cast<float>(M_PI) * 0.5F);
+  }
+
+  Path2D path;
+  path.finalizeFromPoses(std::move(poses), true);
+  return path;
+}
+
+namespace detail
+{
+inline void catmullRomPoint(
+  const float p0x, const float p0y, const float p1x, const float p1y, const float p2x,
+  const float p2y, const float p3x, const float p3y, const float u, float & x, float & y)
+{
+  const float u2 = u * u;
+  const float u3 = u2 * u;
+  x = 0.5F * ((2.0F * p1x) + (-p0x + p2x) * u + (2.0F * p0x - 5.0F * p1x + 4.0F * p2x - p3x) * u2 +
+              (-p0x + 3.0F * p1x - 3.0F * p2x + p3x) * u3);
+  y = 0.5F * ((2.0F * p1y) + (-p0y + p2y) * u + (2.0F * p0y - 5.0F * p1y + 4.0F * p2y - p3y) * u2 +
+              (-p0y + 3.0F * p1y - 3.0F * p2y + p3y) * u3);
+}
+}  // namespace detail
+
+inline Path2D Path2D::catmullRom(
+  const std::vector<std::pair<float, float>> & control_xy, const bool closed,
+  const int samples_per_span)
+{
+  const int m = static_cast<int>(control_xy.size());
+  if (m < 2) {
+    throw std::invalid_argument("Path2D::catmullRom: need >= 2 control points");
+  }
+  const int ns = std::max(2, samples_per_span);
+  std::vector<Pose2D> poses;
+  const int n_span = closed ? m : m - 1;
+  for (int span = 0; span < n_span; ++span) {
+    auto idx = [m, closed](int i) -> int {
+      if (closed) {
+        return (i % m + m) % m;
+      }
+      return std::max(0, std::min(i, m - 1));
+    };
+    const int i0 = idx(span - 1);
+    const int i1 = idx(span);
+    const int i2 = idx(span + 1);
+    const int i3 = idx(span + 2);
+    const int u_start = (span == 0) ? 0 : 1;
+    for (int k = u_start; k <= ns; ++k) {
+      const float u = static_cast<float>(k) / static_cast<float>(ns);
+      float x = 0.0F;
+      float y = 0.0F;
+      detail::catmullRomPoint(
+        control_xy[static_cast<size_t>(i0)].first, control_xy[static_cast<size_t>(i0)].second,
+        control_xy[static_cast<size_t>(i1)].first, control_xy[static_cast<size_t>(i1)].second,
+        control_xy[static_cast<size_t>(i2)].first, control_xy[static_cast<size_t>(i2)].second,
+        control_xy[static_cast<size_t>(i3)].first, control_xy[static_cast<size_t>(i3)].second, u, x,
+        y);
+      float yaw = 0.0F;
+      if (k < ns || span < n_span - 1) {
+        float xn = 0.0F;
+        float yn = 0.0F;
+        const float un = std::min(1.0F, u + 1.0F / static_cast<float>(ns));
+        detail::catmullRomPoint(
+          control_xy[static_cast<size_t>(i0)].first, control_xy[static_cast<size_t>(i0)].second,
+          control_xy[static_cast<size_t>(i1)].first, control_xy[static_cast<size_t>(i1)].second,
+          control_xy[static_cast<size_t>(i2)].first, control_xy[static_cast<size_t>(i2)].second,
+          control_xy[static_cast<size_t>(i3)].first, control_xy[static_cast<size_t>(i3)].second, un,
+          xn, yn);
+        yaw = std::atan2(yn - y, xn - x);
+      } else if (!poses.empty()) {
+        yaw = poses.back().yaw;
+      }
+      Pose2D pose;
+      pose.x = x;
+      pose.y = y;
+      pose.yaw = yaw;
+      poses.push_back(pose);
+    }
+  }
+  Path2D path;
+  path.finalizeFromPoses(std::move(poses), closed);
+  return path;
+}
+
+}  // namespace path
+}  // namespace mppi

--- a/planning/autoware_mppi_optimizer/include/mppi/path/path_projection.hpp
+++ b/planning/autoware_mppi_optimizer/include/mppi/path/path_projection.hpp
@@ -1,0 +1,263 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * Project a vehicle pose (x, y) onto a Path2D.
+ * Analytic circle/line use closed-form projection; polylines use segment search + Newton
+ * refinement.
+ */
+#pragma once
+
+#include <mppi/path/path2d.hpp>
+
+#include <algorithm>
+#include <cmath>
+#include <limits>
+
+namespace mppi
+{
+namespace path
+{
+
+struct PathProjection
+{
+  float arc_length_s = 0.0F;
+  float distance = 0.0F;
+  /** Signed lateral offset: positive = left of path tangent (inside for CCW circle). */
+  float signed_lateral_error = 0.0F;
+  Pose2D footpoint{};
+};
+
+namespace detail
+{
+
+inline float distSquaredPointToSegment(
+  const float px, const float py, const float ax, const float ay, const float bx, const float by,
+  float & t_clamped)
+{
+  const float abx = bx - ax;
+  const float aby = by - ay;
+  const float apx = px - ax;
+  const float apy = py - ay;
+  const float ab2 = abx * abx + aby * aby;
+  float t = 0.0F;
+  if (ab2 > 1.0E-12F) {
+    t = (apx * abx + apy * aby) / ab2;
+  }
+  t = std::max(0.0F, std::min(1.0F, t));
+  t_clamped = t;
+  const float cx = ax + t * abx;
+  const float cy = ay + t * aby;
+  const float dx = px - cx;
+  const float dy = py - cy;
+  return dx * dx + dy * dy;
+}
+
+inline float arcLengthOnSegment(const Path2D & path, const int seg, const float t)
+{
+  const auto & a = path.anchors();
+  const float s0 = a[static_cast<size_t>(seg)].s;
+  const float s1 = a[static_cast<size_t>(seg + 1)].s;
+  return s0 + t * (s1 - s0);
+}
+
+inline float newtonStep(const Path2D & path, const float px, const float py, const float s)
+{
+  const Pose2D p = path.poseAt(s);
+  float tx = 0.0F;
+  float ty = 0.0F;
+  path.tangentAt(s, tx, ty);
+  constexpr float ds = 0.05F;
+  float tx_p = 0.0F;
+  float ty_p = 0.0F;
+  path.tangentAt(s + ds, tx_p, ty_p);
+  const float ddx = (tx_p - tx) / ds;
+  const float ddy = (ty_p - ty) / ds;
+
+  const float ex = p.x - px;
+  const float ey = p.y - py;
+  const float fp = ex * tx + ey * ty;
+  const float fpp = tx * tx + ty * ty + ex * ddx + ey * ddy;
+  if (std::fabs(fpp) < 1.0E-8F) {
+    return s;
+  }
+  return s - fp / fpp;
+}
+
+inline float wrapArcLengthDelta(const float a, const float b, const float period)
+{
+  float d = a - b;
+  d = d - std::round(d / period) * period;
+  return d;
+}
+
+inline PathProjection projectOntoCircle(
+  const Path2D & path, const float px, const float py,
+  const float s_hint = std::numeric_limits<float>::quiet_NaN())
+{
+  PathProjection result;
+  const CircleGeometry & c = path.circleGeometry();
+  const float dx = px - c.center_x;
+  const float dy = py - c.center_y;
+  const float rho = std::sqrt(dx * dx + dy * dy);
+  const float theta = std::atan2(dy, dx);
+
+  const float ang = detail::positiveAngleFromTheta0(theta, c.theta0);
+  float s = c.radius * ang;
+
+  if (!std::isnan(s_hint)) {
+    const float period = path.length();
+    float best_s = s;
+    float best_cost = std::fabs(wrapArcLengthDelta(s, s_hint, period));
+    for (int k = -2; k <= 2; ++k) {
+      const float candidate = s + static_cast<float>(k) * period;
+      const float cost = std::fabs(wrapArcLengthDelta(candidate, s_hint, period));
+      if (cost < best_cost) {
+        best_cost = cost;
+        best_s = candidate;
+      }
+    }
+    s = path.wrapArcLength(best_s);
+  } else {
+    s = path.wrapArcLength(s);
+  }
+
+  result.arc_length_s = s;
+  result.footpoint = path.poseAt(s);
+  float tx = 0.0F;
+  float ty = 0.0F;
+  path.tangentAt(s, tx, ty);
+  const float ex = px - result.footpoint.x;
+  const float ey = py - result.footpoint.y;
+  result.distance = std::sqrt(ex * ex + ey * ey);
+  result.signed_lateral_error = c.radius - rho;
+  return result;
+}
+
+inline PathProjection projectOntoLine(const Path2D & path, const float px, const float py)
+{
+  PathProjection result;
+  const Pose2D p0 = path.poseAt(0.0F);
+  const Pose2D p1 = path.poseAt(path.length());
+  const float segx = p1.x - p0.x;
+  const float segy = p1.y - p0.y;
+  const float seg_len2 = segx * segx + segy * segy;
+  float t = 0.0F;
+  if (seg_len2 > 1.0E-12F) {
+    t = ((px - p0.x) * segx + (py - p0.y) * segy) / seg_len2;
+  }
+  t = std::max(0.0F, std::min(1.0F, t));
+  result.arc_length_s = t * path.length();
+  result.footpoint.x = p0.x + t * segx;
+  result.footpoint.y = p0.y + t * segy;
+  result.footpoint.yaw = p0.yaw;
+  float tx = 0.0F;
+  float ty = 0.0F;
+  path.tangentAt(result.arc_length_s, tx, ty);
+  const float ex = px - result.footpoint.x;
+  const float ey = py - result.footpoint.y;
+  result.distance = std::sqrt(ex * ex + ey * ey);
+  result.signed_lateral_error = -ex * ty + ey * tx;
+  return result;
+}
+
+inline PathProjection projectOntoPolyline(
+  const Path2D & path, const float px, const float py,
+  const float s_hint = std::numeric_limits<float>::quiet_NaN(), const int newton_iters = 6)
+{
+  PathProjection result;
+  const auto & anchors = path.anchors();
+  const int n_seg = static_cast<int>(anchors.size()) - 1;
+
+  float best_d2 = std::numeric_limits<float>::max();
+  float best_s = 0.0F;
+
+  auto consider_segment = [&](const int seg) {
+    float t = 0.0F;
+    const float ax = anchors[static_cast<size_t>(seg)].x;
+    const float ay = anchors[static_cast<size_t>(seg)].y;
+    const float bx = anchors[static_cast<size_t>(seg + 1)].x;
+    const float by = anchors[static_cast<size_t>(seg + 1)].y;
+    const float d2 = distSquaredPointToSegment(px, py, ax, ay, bx, by, t);
+    if (d2 < best_d2) {
+      best_d2 = d2;
+      best_s = arcLengthOnSegment(path, seg, t);
+    }
+  };
+
+  if (!std::isnan(s_hint)) {
+    const float window = std::max(5.0F, 0.15F * path.length());
+    const float s_lo = path.wrapArcLength(s_hint - window);
+    const float s_hi = path.wrapArcLength(s_hint + window);
+    for (int seg = 0; seg < n_seg; ++seg) {
+      const float s0 = anchors[static_cast<size_t>(seg)].s;
+      const float s1 = anchors[static_cast<size_t>(seg + 1)].s;
+      if (s1 >= s_lo && s0 <= s_hi) {
+        consider_segment(seg);
+      }
+    }
+  }
+
+  if (best_d2 >= std::numeric_limits<float>::max() * 0.5F) {
+    for (int seg = 0; seg < n_seg; ++seg) {
+      consider_segment(seg);
+    }
+  }
+
+  float s = best_s;
+  const float s_min = 0.0F;
+  const float s_max = path.length();
+  for (int k = 0; k < newton_iters; ++k) {
+    s = newtonStep(path, px, py, s);
+    if (path.closed()) {
+      s = path.wrapArcLength(s);
+    } else {
+      s = std::max(s_min, std::min(s, s_max));
+    }
+  }
+
+  result.arc_length_s = s;
+  result.footpoint = path.poseAt(s);
+  float tx = 0.0F;
+  float ty = 0.0F;
+  path.tangentAt(s, tx, ty);
+  const float dx = px - result.footpoint.x;
+  const float dy = py - result.footpoint.y;
+  result.distance = std::sqrt(dx * dx + dy * dy);
+  result.signed_lateral_error = -dx * ty + dy * tx;
+  return result;
+}
+
+}  // namespace detail
+
+inline PathProjection projectPoseOntoPath(
+  const Path2D & path, const float px, const float py,
+  const float s_hint = std::numeric_limits<float>::quiet_NaN(), const int newton_iters = 6)
+{
+  PathProjection result;
+  if (path.empty()) {
+    return result;
+  }
+
+  if (path.isAnalyticCircle()) {
+    return detail::projectOntoCircle(path, px, py, s_hint);
+  }
+  if (path.isAnalyticLine()) {
+    return detail::projectOntoLine(path, px, py);
+  }
+  return detail::projectOntoPolyline(path, px, py, s_hint, newton_iters);
+}
+
+}  // namespace path
+}  // namespace mppi

--- a/planning/autoware_mppi_optimizer/include/mppi/path/path_reference_generator.hpp
+++ b/planning/autoware_mppi_optimizer/include/mppi/path/path_reference_generator.hpp
@@ -1,0 +1,163 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * Time-stamped reference along a Path2D for MPPI tracking (samples every dt).
+ *
+ * Reference construction:
+ * 1. Start at the closest point on the path centerline (orthogonal projection of x, y).
+ * 2. March forward in arc length: s_{k+1} = s_k + v_ref(s_k) * dt, where v_ref is the path
+ *    reference speed (target speed, curvature-limited, end-of-path slowed).
+ *
+ * Vehicle speed is not used to seed or advance the reference.
+ */
+#pragma once
+
+#include <mppi/path/path2d.hpp>
+#include <mppi/path/path_projection.hpp>
+
+#include <algorithm>
+#include <cmath>
+#include <vector>
+
+namespace mppi
+{
+namespace path
+{
+
+struct PathReferenceSample
+{
+  float t = 0.0F;
+  float arc_length_s = 0.0F;
+  float x = 0.0F;
+  float y = 0.0F;
+  float yaw = 0.0F;
+  float v = 0.0F;
+};
+
+class PathReferenceGenerator
+{
+public:
+  PathReferenceGenerator() = default;
+
+  explicit PathReferenceGenerator(const float dt) : dt_(dt) {}
+
+  void setDt(const float dt) { dt_ = dt; }
+
+  float dt() const { return dt_; }
+
+  void setSpeedCap(const float v_max)
+  {
+    v_max_ = v_max;
+    if (target_speed_ > v_max_) {
+      target_speed_ = v_max_;
+    }
+  }
+
+  void setTargetSpeed(const float v_target) { target_speed_ = std::min(v_target, v_max_); }
+
+  float targetSpeed() const { return target_speed_; }
+
+  void setLateralAccelCap(const float a_lat_max) { a_lat_max_ = a_lat_max; }
+
+  /** Reference speed at arc length s (target speed, curvature-limited, end-of-path slowed). */
+  float referenceSpeedAt(const Path2D & path, const float s) const
+  {
+    const float kappa = std::fabs(path.curvatureAt(s));
+    const float kappa_eps = 1.0E-4F;
+    float v_ref = target_speed_;
+    if (kappa >= kappa_eps) {
+      v_ref = std::min(target_speed_, std::sqrt(a_lat_max_ / kappa));
+    }
+    if (!path.closed()) {
+      const float dist_to_end = path.length() - s;
+      if (dist_to_end < 5.0F) {
+        v_ref = std::min(v_ref, target_speed_ * std::max(0.0F, dist_to_end / 5.0F));
+      }
+      if (dist_to_end <= 0.0F) {
+        v_ref = 0.0F;
+      }
+    }
+    return std::min(v_ref, v_max_);
+  }
+
+  float speedAt(const Path2D & path, const float s) const { return referenceSpeedAt(path, s); }
+
+  /**
+   * Reference from arc length s0: sample at t = 0, dt, ... marching with v_ref(s) * dt.
+   */
+  std::vector<PathReferenceSample> generate(
+    const Path2D & path, const float start_s, const int count) const
+  {
+    std::vector<PathReferenceSample> out;
+    if (count <= 0 || path.empty()) {
+      return out;
+    }
+    out.resize(static_cast<size_t>(count));
+    float s = path.wrapArcLength(start_s);
+    for (int k = 0; k < count; ++k) {
+      PathReferenceSample & r = out[static_cast<size_t>(k)];
+      r.t = static_cast<float>(k) * dt_;
+      r.arc_length_s = s;
+      const Pose2D p = path.poseAt(s);
+      r.x = p.x;
+      r.y = p.y;
+      r.yaw = p.yaw;
+      r.v = referenceSpeedAt(path, s);
+      if (k + 1 < count) {
+        const float s_next = s + r.v * dt_;
+        if (path.closed()) {
+          s = path.wrapArcLength(s_next);
+        } else {
+          s = std::min(s_next, path.length());
+        }
+      }
+    }
+    return out;
+  }
+
+  /**
+   * Project (x, y) to the closest centerline point, then march forward at reference speed.
+   * @param s_hint  Optional arc-length hint for projection search (e.g. last step's s).
+   */
+  std::vector<PathReferenceSample> generate(
+    const Path2D & path, const int count, const float x, const float y,
+    const float s_hint = 0.0F) const
+  {
+    if (count <= 0 || path.empty()) {
+      return {};
+    }
+    const PathProjection proj = projectPoseOntoPath(path, x, y, path.wrapArcLength(s_hint));
+    return generate(path, proj.arc_length_s, count);
+  }
+
+  /** @deprecated Use generate(path, count, x, y, s_hint); yaw and v are ignored. */
+  std::vector<PathReferenceSample> generate(
+    const Path2D & path, const float start_s, const int count, const float x, const float y,
+    const float yaw, const float v) const
+  {
+    (void)yaw;
+    (void)v;
+    return generate(path, count, x, y, start_s);
+  }
+
+private:
+  float dt_ = 0.1F;
+  float v_max_ = 3.0F;
+  float target_speed_ = 3.0F;
+  float a_lat_max_ = 8.0F;
+};
+
+}  // namespace path
+}  // namespace mppi

--- a/planning/autoware_mppi_optimizer/include/mppi/sampling_distributions/diffusion/diffusion_distribution.cu
+++ b/planning/autoware_mppi_optimizer/include/mppi/sampling_distributions/diffusion/diffusion_distribution.cu
@@ -1,0 +1,204 @@
+#include <mppi/core/mppi_common.cuh>
+#include <mppi/sampling_distributions/diffusion/diffusion_distribution.cuh>
+
+#include <cstring>
+
+namespace mppi
+{
+namespace sampling_distributions
+{
+#define DIFFUSION_TEMPLATE \
+  template <class CLASS_T, template <int> class PARAMS_TEMPLATE, class DYN_PARAMS_T>
+#define DIFFUSION_CLASS DiffusionDistributionImpl<CLASS_T, PARAMS_TEMPLATE, DYN_PARAMS_T>
+
+DIFFUSION_TEMPLATE
+DIFFUSION_CLASS::DiffusionDistributionImpl(cudaStream_t stream) : PARENT_CLASS(stream)
+{
+}
+
+DIFFUSION_TEMPLATE
+DIFFUSION_CLASS::DiffusionDistributionImpl(const SAMPLING_PARAMS_T & params, cudaStream_t stream)
+: PARENT_CLASS(params, stream)
+{
+}
+
+DIFFUSION_TEMPLATE
+__host__ void DIFFUSION_CLASS::loadWeights(const std::string & path, bool synchronize)
+{
+  weights_ = diffusion::loadDiffusionModelWeights(path);
+  weights_loaded_ = true;
+  constexpr int kControlDim = static_cast<int>(DYN_PARAMS_T::ControlIndex::NUM_CONTROLS);
+  if (weights_.horizon != this->getNumTimesteps()) {
+    this->logger_->error(
+      "Diffusion weights horizon %d != sampler num_timesteps %d\n", weights_.horizon,
+      this->getNumTimesteps());
+    throw std::runtime_error("diffusion horizon mismatch");
+  }
+  if (weights_.control_dim != kControlDim) {
+    this->logger_->error(
+      "Diffusion weights control_dim %d != dynamics control_dim %d\n", weights_.control_dim,
+      kControlDim);
+    throw std::runtime_error("diffusion control_dim mismatch");
+  }
+  (void)synchronize;
+}
+
+DIFFUSION_TEMPLATE
+__host__ void DIFFUSION_CLASS::setObstacleContext(const float * context, const int context_dim)
+{
+  obstacle_context_.assign(static_cast<size_t>(context_dim), 0.0F);
+  if (context != nullptr && context_dim > 0) {
+    std::memcpy(
+      obstacle_context_.data(), context, sizeof(float) * static_cast<size_t>(context_dim));
+  }
+}
+
+DIFFUSION_TEMPLATE
+__host__ void DIFFUSION_CLASS::setObstacleContextFromMovingCars(
+  const float ego_x, const float ego_y, const float ego_yaw, const float ego_vel,
+  const float boundary_left, const float boundary_right,
+  const std::vector<mppi::cost::MovingCarObstacle> & cars, const float sim_time)
+{
+  obstacle_context_.assign(static_cast<size_t>(diffusion::kDiffusionContextDim), 0.0F);
+  diffusion::encodeDiffusionObstacleContextFromMovingCars(
+    ego_x, ego_y, ego_yaw, ego_vel, boundary_left, boundary_right, cars, sim_time,
+    obstacle_context_.data());
+}
+
+DIFFUSION_TEMPLATE
+__host__ void DIFFUSION_CLASS::setObstacleContextFromParkedCars(
+  const float ego_x, const float ego_y, const float ego_yaw, const float ego_vel,
+  const float boundary_left, const float boundary_right,
+  const std::vector<mppi::cost::ParkedCarObstacle> & cars)
+{
+  obstacle_context_.assign(static_cast<size_t>(diffusion::kDiffusionContextDim), 0.0F);
+  diffusion::encodeDiffusionObstacleContextFromParkedCars(
+    ego_x, ego_y, ego_yaw, ego_vel, boundary_left, boundary_right, cars, obstacle_context_.data());
+}
+
+DIFFUSION_TEMPLATE
+__host__ void DIFFUSION_CLASS::generateSamples(
+  const int & optimization_stride, const int & iteration_num, curandGenerator_t & gen,
+  bool synchronize)
+{
+  (void)gen;
+  (void)iteration_num;
+  if (!weights_loaded_ && !pending_weights_path_.empty()) {
+    loadWeights(pending_weights_path_, false);
+  }
+  if (!weights_loaded_) {
+    this->logger_->error("DiffusionDistribution: weights not loaded; call loadWeights() first.\n");
+    PARENT_CLASS::generateSamples(optimization_stride, iteration_num, gen, synchronize);
+    return;
+  }
+
+  if (
+    weights_.context_dim > 0 &&
+    static_cast<int>(obstacle_context_.size()) != weights_.context_dim) {
+    this->logger_->error(
+      "Diffusion context size %zu != weights context_dim %d\n", obstacle_context_.size(),
+      weights_.context_dim);
+    PARENT_CLASS::generateSamples(optimization_stride, iteration_num, gen, synchronize);
+    return;
+  }
+
+  const float * context_ptr =
+    weights_.context_dim > 0 && !obstacle_context_.empty() ? obstacle_context_.data() : nullptr;
+
+  const int num_rollouts = this->getNumRollouts();
+  const int num_timesteps = this->getNumTimesteps();
+  const int num_distributions = this->getNumDistributions();
+  const int traj_dim = weights_.traj_dim;
+
+  const int control_dim = weights_.control_dim;
+  std::vector<float> host_samples(
+    static_cast<size_t>(num_distributions) * static_cast<size_t>(num_rollouts) *
+    static_cast<size_t>(num_timesteps) * static_cast<size_t>(control_dim));
+  std::vector<float> u_nom(static_cast<size_t>(traj_dim));
+  std::vector<float> u_sample(static_cast<size_t>(traj_dim));
+
+  for (int d = 0; d < num_distributions; ++d) {
+    HANDLE_ERROR(cudaMemcpyAsync(
+      u_nom.data(), &(this->control_means_d_[d * num_timesteps * control_dim]),
+      sizeof(float) * static_cast<size_t>(traj_dim), cudaMemcpyDeviceToHost, this->stream_));
+    HANDLE_ERROR(cudaStreamSynchronize(this->stream_));
+
+    for (int r = 0; r < num_rollouts; ++r) {
+      float * dst = &host_samples
+                      [(static_cast<size_t>(d) * static_cast<size_t>(num_rollouts) *
+                        static_cast<size_t>(num_timesteps) * static_cast<size_t>(control_dim)) +
+                       (static_cast<size_t>(r) * static_cast<size_t>(num_timesteps) *
+                        static_cast<size_t>(control_dim))];
+      if (r == 0) {
+        std::memcpy(dst, u_nom.data(), sizeof(float) * static_cast<size_t>(traj_dim));
+        continue;
+      }
+
+      diffusion::diffusionSampleTrajectory(
+        weights_, u_nom.data(), context_ptr, u_sample.data(), rng_);
+      std::memcpy(dst, u_sample.data(), sizeof(float) * static_cast<size_t>(traj_dim));
+
+      for (int t = 0; t < std::min(optimization_stride, num_timesteps); ++t) {
+        std::memcpy(
+          &dst[t * control_dim], &u_nom[static_cast<size_t>(t * control_dim)],
+          sizeof(float) * static_cast<size_t>(control_dim));
+      }
+    }
+  }
+
+  HANDLE_ERROR(cudaMemcpyAsync(
+    this->control_samples_d_, host_samples.data(), host_samples.size() * sizeof(float),
+    cudaMemcpyHostToDevice, this->stream_));
+  if (synchronize) {
+    HANDLE_ERROR(cudaStreamSynchronize(this->stream_));
+  }
+}
+
+DIFFUSION_TEMPLATE
+__host__ __device__ float DIFFUSION_CLASS::computeLikelihoodRatioCost(
+  const float * __restrict__ u, float * __restrict__ theta_d, const int sample_index, const int t,
+  const int distribution_idx, const float lambda, const float alpha)
+{
+  (void)theta_d;
+  if (alpha >= 1.0F) {
+    return 0.0F;
+  }
+  const float std_dev = this->params_.likelihood_std_dev;
+  const float inv_var = 1.0F / (std_dev * std_dev);
+  const int distribution_i =
+    distribution_idx >= this->params_.num_distributions ? 0 : distribution_idx;
+  const float * mean =
+    &(this->control_means_d_[(this->params_.num_timesteps * distribution_i + t) * CONTROL_DIM]);
+  float cost = 0.0F;
+  for (int i = 0; i < CONTROL_DIM; ++i) {
+    const float m = mean[i];
+    cost += this->params_.control_cost_coeff[i] * m * (m - 2.0F * u[i]) * inv_var;
+  }
+  return 0.5F * lambda * (1.0F - alpha) * cost;
+}
+
+DIFFUSION_TEMPLATE
+__host__ float DIFFUSION_CLASS::computeLikelihoodRatioCost(
+  const Eigen::Ref<const control_array> & u, const int sample_index, const int t,
+  const int distribution_idx, const float lambda, const float alpha)
+{
+  if (alpha >= 1.0F) {
+    return 0.0F;
+  }
+  const float std_dev = this->params_.likelihood_std_dev;
+  const float inv_var = 1.0F / (std_dev * std_dev);
+  const int distribution_i =
+    distribution_idx >= this->params_.num_distributions ? 0 : distribution_idx;
+  const int mean_index = (distribution_i * this->getNumTimesteps() + t) * CONTROL_DIM;
+  float cost = 0.0F;
+  for (int i = 0; i < CONTROL_DIM; ++i) {
+    const float m = this->means_[static_cast<size_t>(mean_index + i)];
+    cost += this->params_.control_cost_coeff[i] * m * (m - 2.0F * u(i)) * inv_var;
+  }
+  return 0.5F * lambda * (1.0F - alpha) * cost;
+}
+
+#undef DIFFUSION_TEMPLATE
+#undef DIFFUSION_CLASS
+}  // namespace sampling_distributions
+}  // namespace mppi

--- a/planning/autoware_mppi_optimizer/include/mppi/sampling_distributions/diffusion/diffusion_distribution.cuh
+++ b/planning/autoware_mppi_optimizer/include/mppi/sampling_distributions/diffusion/diffusion_distribution.cuh
@@ -1,0 +1,102 @@
+#pragma once
+
+#include <mppi/sampling_distributions/diffusion/diffusion_model.hpp>
+#include <mppi/sampling_distributions/gaussian/gaussian.cuh>
+
+#include <random>
+#include <string>
+
+namespace mppi
+{
+namespace sampling_distributions
+{
+
+template <int C_DIM, int MAX_DISTRIBUTIONS_T = 2>
+struct DiffusionParamsImpl : public GaussianParamsImpl<C_DIM, MAX_DISTRIBUTIONS_T>
+{
+  /** Fallback std_dev for MPPI likelihood term when alpha < 1. */
+  float likelihood_std_dev = 0.35F;
+
+  DiffusionParamsImpl(int num_rollouts = 1, int num_timesteps = 1, int num_distributions = 1)
+  : GaussianParamsImpl<C_DIM, MAX_DISTRIBUTIONS_T>(num_rollouts, num_timesteps, num_distributions)
+  {
+  }
+};
+
+template <int C_DIM>
+using DiffusionParams = DiffusionParamsImpl<C_DIM, 2>;
+
+template <
+  class CLASS_T, template <int> class PARAMS_TEMPLATE = DiffusionParams,
+  class DYN_PARAMS_T = DynamicsParams>
+class DiffusionDistributionImpl
+: public GaussianDistributionImpl<CLASS_T, PARAMS_TEMPLATE, DYN_PARAMS_T>
+{
+public:
+  using PARENT_CLASS = GaussianDistributionImpl<CLASS_T, PARAMS_TEMPLATE, DYN_PARAMS_T>;
+  using SAMPLING_PARAMS_T = typename PARENT_CLASS::SAMPLING_PARAMS_T;
+  using control_array = typename PARENT_CLASS::control_array;
+  static const int CONTROL_DIM = PARENT_CLASS::CONTROL_DIM;
+
+  DiffusionDistributionImpl(cudaStream_t stream = 0);
+  DiffusionDistributionImpl(const SAMPLING_PARAMS_T & params, cudaStream_t stream = 0);
+
+  __host__ std::string getSamplingDistributionName() const override { return "Diffusion"; }
+
+  __host__ void loadWeights(const std::string & path, bool synchronize = true);
+
+  __host__ void setWeightsPath(const std::string & path) { pending_weights_path_ = path; }
+
+  /** Scene/obstacle context vector (length kDiffusionContextDim or weights_.context_dim). */
+  __host__ void setObstacleContext(const float * context, int context_dim);
+
+  __host__ void setObstacleContextFromMovingCars(
+    float ego_x, float ego_y, float ego_yaw, float ego_vel, float boundary_left,
+    float boundary_right, const std::vector<mppi::cost::MovingCarObstacle> & cars, float sim_time);
+
+  __host__ void setObstacleContextFromParkedCars(
+    float ego_x, float ego_y, float ego_yaw, float ego_vel, float boundary_left,
+    float boundary_right, const std::vector<mppi::cost::ParkedCarObstacle> & cars);
+
+  __host__ void generateSamples(
+    const int & optimization_stride, const int & iteration_num, curandGenerator_t & gen,
+    bool synchronize = true);
+
+  __host__ __device__ float computeLikelihoodRatioCost(
+    const float * __restrict__ u, float * __restrict__ theta_d, const int sample_index, const int t,
+    const int distribution_idx, const float lambda = 1.0, const float alpha = 0.0);
+
+  __host__ float computeLikelihoodRatioCost(
+    const Eigen::Ref<const control_array> & u, const int sample_index, const int t,
+    const int distribution_idx, const float lambda = 1.0, const float alpha = 0.0);
+
+protected:
+  diffusion::DiffusionModelWeights weights_;
+  bool weights_loaded_ = false;
+  std::string pending_weights_path_;
+  std::vector<float> obstacle_context_;
+  std::mt19937 rng_{std::random_device{}()};
+};
+
+template <class DYN_PARAMS_T>
+class DiffusionDistribution : public DiffusionDistributionImpl<
+                                DiffusionDistribution<DYN_PARAMS_T>, DiffusionParams, DYN_PARAMS_T>
+{
+public:
+  using PARENT_CLASS =
+    DiffusionDistributionImpl<DiffusionDistribution, DiffusionParams, DYN_PARAMS_T>;
+  using SAMPLING_PARAMS_T = typename PARENT_CLASS::SAMPLING_PARAMS_T;
+
+  DiffusionDistribution(cudaStream_t stream = 0) : PARENT_CLASS(stream) {}
+  DiffusionDistribution(const SAMPLING_PARAMS_T & params, cudaStream_t stream = 0)
+  : PARENT_CLASS(params, stream)
+  {
+  }
+};
+
+}  // namespace sampling_distributions
+}  // namespace mppi
+
+#if __CUDACC__
+#include "diffusion_distribution.cu"
+#endif

--- a/planning/autoware_mppi_optimizer/include/mppi/sampling_distributions/diffusion/diffusion_model.hpp
+++ b/planning/autoware_mppi_optimizer/include/mppi/sampling_distributions/diffusion/diffusion_model.hpp
@@ -1,0 +1,230 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#ifndef MPPI__SAMPLING_DISTRIBUTIONS__DIFFUSION__DIFFUSION_MODEL_HPP_
+#define MPPI__SAMPLING_DISTRIBUTIONS__DIFFUSION__DIFFUSION_MODEL_HPP_
+
+#include <mppi/sampling_distributions/diffusion/obstacle_context.hpp>
+
+#include <algorithm>
+#include <cmath>
+#include <cstdint>
+#include <cstring>
+#include <fstream>
+#include <random>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace mppi
+{
+namespace sampling_distributions
+{
+namespace diffusion
+{
+constexpr char kDiffusionMagic[8] = {'M', 'P', 'P', 'I', 'D', 'I', 'F', 'F'};
+constexpr int kDiffusionWeightVersion = 2;
+constexpr int kDiffusionTimeEmbDim = 16;
+
+struct DiffusionModelWeights
+{
+  int horizon = 0;
+  int control_dim = 0;
+  int hidden_dim = 0;
+  int context_dim = 0;
+  int train_timesteps = 0;
+  int inference_timesteps = 0;
+  int traj_dim = 0;
+  std::vector<float> W1;
+  std::vector<float> b1;
+  std::vector<float> W2;
+  std::vector<float> b2;
+  std::vector<float> W3;
+  std::vector<float> b3;
+  std::vector<float> betas;
+  std::vector<float> alpha_bar;
+};
+
+inline std::vector<float> readFloatArray(std::ifstream & in)
+{
+  std::uint32_t n = 0;
+  in.read(reinterpret_cast<char *>(&n), sizeof(n));
+  if (!in) {
+    throw std::runtime_error("truncated diffusion weight file");
+  }
+  std::vector<float> out(n);
+  in.read(reinterpret_cast<char *>(out.data()), sizeof(float) * n);
+  if (!in) {
+    throw std::runtime_error("truncated diffusion weight payload");
+  }
+  return out;
+}
+
+inline DiffusionModelWeights loadDiffusionModelWeights(const std::string & path)
+{
+  std::ifstream in(path, std::ios::binary);
+  if (!in) {
+    throw std::runtime_error("failed to open diffusion weights: " + path);
+  }
+  char magic[8];
+  in.read(magic, 8);
+  if (!in || std::string(magic, 8) != std::string(kDiffusionMagic, 8)) {
+    throw std::runtime_error("invalid diffusion weight magic in " + path);
+  }
+  std::uint32_t header[8];
+  in.read(reinterpret_cast<char *>(header), sizeof(header));
+  if (!in) {
+    throw std::runtime_error("truncated diffusion header");
+  }
+  const int version = static_cast<int>(header[0]);
+  if (version < 1 || version > kDiffusionWeightVersion) {
+    throw std::runtime_error("unsupported diffusion weight version");
+  }
+  DiffusionModelWeights w;
+  w.horizon = static_cast<int>(header[1]);
+  w.control_dim = static_cast<int>(header[2]);
+  w.hidden_dim = static_cast<int>(header[3]);
+  w.context_dim = version >= 2 ? static_cast<int>(header[4]) : 0;
+  w.train_timesteps = static_cast<int>(header[version >= 2 ? 5 : 4]);
+  w.inference_timesteps = static_cast<int>(header[version >= 2 ? 6 : 5]);
+  w.traj_dim = w.horizon * w.control_dim;
+  w.W1 = readFloatArray(in);
+  w.b1 = readFloatArray(in);
+  w.W2 = readFloatArray(in);
+  w.b2 = readFloatArray(in);
+  w.W3 = readFloatArray(in);
+  w.b3 = readFloatArray(in);
+  w.betas = readFloatArray(in);
+  w.alpha_bar = readFloatArray(in);
+  return w;
+}
+
+inline void sinusoidalTimeEmbedding(
+  const int t, const int train_timesteps, float * out, const int dim)
+{
+  const float tn = static_cast<float>(t) / static_cast<float>(std::max(train_timesteps - 1, 1));
+  const int half = dim / 2;
+  for (int i = 0; i < half; ++i) {
+    const float freq =
+      std::exp(-std::log(10000.0F) * static_cast<float>(i) / static_cast<float>(half));
+    const float arg = tn * freq;
+    out[i] = std::sin(arg);
+    out[i + half] = std::cos(arg);
+  }
+}
+
+inline void linearReluMatVec(
+  const std::vector<float> & W, const std::vector<float> & b, const float * x, float * y,
+  const int out_dim, const int in_dim)
+{
+  for (int o = 0; o < out_dim; ++o) {
+    float acc = b[static_cast<size_t>(o)];
+    const float * row = &W[static_cast<size_t>(o * in_dim)];
+    for (int i = 0; i < in_dim; ++i) {
+      acc += row[i] * x[i];
+    }
+    y[o] = acc > 0.0F ? acc : 0.0F;
+  }
+}
+
+inline void linearMatVec(
+  const std::vector<float> & W, const std::vector<float> & b, const float * x, float * y,
+  const int out_dim, const int in_dim)
+{
+  for (int o = 0; o < out_dim; ++o) {
+    float acc = b[static_cast<size_t>(o)];
+    const float * row = &W[static_cast<size_t>(o * in_dim)];
+    for (int i = 0; i < in_dim; ++i) {
+      acc += row[i] * x[i];
+    }
+    y[o] = acc;
+  }
+}
+
+inline void diffusionPredictEps(
+  const DiffusionModelWeights & w, const float * x_t, const float * u_nom, const float * context,
+  const int t, float * eps_out)
+{
+  const int h = w.hidden_dim;
+  const int traj = w.traj_dim;
+  const int ctx = w.context_dim;
+  const int in_dim = 2 * traj + ctx + kDiffusionTimeEmbDim;
+  std::vector<float> input(static_cast<size_t>(in_dim));
+  std::vector<float> h1(static_cast<size_t>(h));
+  std::vector<float> h2(static_cast<size_t>(h));
+  float t_emb[kDiffusionTimeEmbDim];
+  sinusoidalTimeEmbedding(t, w.train_timesteps, t_emb, kDiffusionTimeEmbDim);
+  for (int i = 0; i < traj; ++i) {
+    input[static_cast<size_t>(i)] = x_t[i];
+    input[static_cast<size_t>(traj + i)] = u_nom[i];
+  }
+  for (int i = 0; i < ctx; ++i) {
+    input[static_cast<size_t>(2 * traj + i)] = context != nullptr ? context[i] : 0.0F;
+  }
+  for (int i = 0; i < kDiffusionTimeEmbDim; ++i) {
+    input[static_cast<size_t>(2 * traj + ctx + i)] = t_emb[i];
+  }
+  linearReluMatVec(w.W1, w.b1, input.data(), h1.data(), h, in_dim);
+  linearReluMatVec(w.W2, w.b2, h1.data(), h2.data(), h, h);
+  linearMatVec(w.W3, w.b3, h2.data(), eps_out, traj, h);
+}
+
+inline void diffusionSampleTrajectory(
+  const DiffusionModelWeights & w, const float * u_nom, const float * context, float * u_out,
+  std::mt19937 & rng)
+{
+  const int traj = w.traj_dim;
+  std::vector<float> x(static_cast<size_t>(traj));
+  std::vector<float> eps(static_cast<size_t>(traj));
+  std::normal_distribution<float> normal(0.0F, 1.0F);
+  for (int i = 0; i < traj; ++i) {
+    x[static_cast<size_t>(i)] = normal(rng);
+  }
+
+  const int infer = std::max(1, w.inference_timesteps);
+  for (int step = 0; step < infer; ++step) {
+    const int t_val = static_cast<int>(std::lround(
+      static_cast<float>(w.train_timesteps - 1) *
+      (1.0F - static_cast<float>(step) / static_cast<float>(infer - 1))));
+    const int t = std::max(0, std::min(w.train_timesteps - 1, t_val));
+    diffusionPredictEps(w, x.data(), u_nom, context, t, eps.data());
+    const float alpha = 1.0F - w.betas[static_cast<size_t>(t)];
+    const float alpha_bar = w.alpha_bar[static_cast<size_t>(t)];
+    const float beta = w.betas[static_cast<size_t>(t)];
+    const float inv_sqrt_alpha = 1.0F / std::sqrt(std::max(alpha, 1.0E-8F));
+    const float coef2 = beta / std::sqrt(std::max(1.0F - alpha_bar, 1.0E-8F));
+    for (int i = 0; i < traj; ++i) {
+      x[static_cast<size_t>(i)] =
+        inv_sqrt_alpha * (x[static_cast<size_t>(i)] - coef2 * eps[static_cast<size_t>(i)]);
+    }
+    if (step + 1 < infer) {
+      const float noise_scale = std::sqrt(std::max(beta, 0.0F));
+      for (int i = 0; i < traj; ++i) {
+        x[static_cast<size_t>(i)] += noise_scale * normal(rng);
+      }
+    }
+  }
+
+  for (int i = 0; i < traj; ++i) {
+    u_out[i] = u_nom[i] + x[static_cast<size_t>(i)];
+  }
+}
+
+}  // namespace diffusion
+}  // namespace sampling_distributions
+}  // namespace mppi
+
+#endif  // MPPI__SAMPLING_DISTRIBUTIONS__DIFFUSION__DIFFUSION_MODEL_HPP_

--- a/planning/autoware_mppi_optimizer/include/mppi/sampling_distributions/diffusion/diffusion_model.hpp
+++ b/planning/autoware_mppi_optimizer/include/mppi/sampling_distributions/diffusion/diffusion_model.hpp
@@ -196,10 +196,15 @@ inline void diffusionSampleTrajectory(
 
   const int infer = std::max(1, w.inference_timesteps);
   for (int step = 0; step < infer; ++step) {
-    const int t_val = static_cast<int>(std::lround(
-      static_cast<float>(w.train_timesteps - 1) *
-      (1.0F - static_cast<float>(step) / static_cast<float>(infer - 1))));
-    const int t = std::max(0, std::min(w.train_timesteps - 1, t_val));
+    int t = 0;
+    if (infer == 1) {
+      t = std::max(0, w.train_timesteps - 1);
+    } else {
+      const int t_val = static_cast<int>(std::lround(
+        static_cast<float>(w.train_timesteps - 1) *
+        (1.0F - static_cast<float>(step) / static_cast<float>(infer - 1))));
+      t = std::max(0, std::min(w.train_timesteps - 1, t_val));
+    }
     diffusionPredictEps(w, x.data(), u_nom, context, t, eps.data());
     const float alpha = 1.0F - w.betas[static_cast<size_t>(t)];
     const float alpha_bar = w.alpha_bar[static_cast<size_t>(t)];

--- a/planning/autoware_mppi_optimizer/include/mppi/sampling_distributions/diffusion/obstacle_context.hpp
+++ b/planning/autoware_mppi_optimizer/include/mppi/sampling_distributions/diffusion/obstacle_context.hpp
@@ -1,0 +1,269 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * Fixed-size ego-relative obstacle encoding for diffusion sampler conditioning.
+ *
+ * Layout (kDiffusionContextDim = 35):
+ *   Per obstacle slot (up to 4): dx, dy, cos(d_yaw), sin(d_yaw), half_length, half_width, vx_ego,
+ * vy_ego Scene tail: boundary_left, boundary_right, ego_vel
+ *
+ * Positions/velocities are in the ego rear-axle frame at MPPI decision time. Unused obstacle slots
+ * are zero.
+ */
+#pragma once
+
+#ifndef MPPI__SAMPLING_DISTRIBUTIONS__DIFFUSION__OBSTACLE_CONTEXT_HPP_
+#define MPPI__SAMPLING_DISTRIBUTIONS__DIFFUSION__OBSTACLE_CONTEXT_HPP_
+
+#include <mppi/cost_functions/moving_car_obstacles.hpp>
+#include <mppi/cost_functions/parked_car_obstacles.hpp>
+
+#include <algorithm>
+#include <cmath>
+#include <cstring>
+#include <vector>
+
+namespace mppi
+{
+namespace sampling_distributions
+{
+namespace diffusion
+{
+
+constexpr int kMaxContextObstacles = 4;
+constexpr int kObstacleFeatureDim = 8;
+constexpr int kSceneContextDim = 3;
+constexpr int kDiffusionContextDim = kMaxContextObstacles * kObstacleFeatureDim + kSceneContextDim;
+
+inline void zeroDiffusionContext(float * out)
+{
+  std::memset(out, 0, sizeof(float) * static_cast<size_t>(kDiffusionContextDim));
+}
+
+inline void encodeObstacleSlot(
+  const float ego_x, const float ego_y, const float ego_cos, const float ego_sin, const float obs_x,
+  const float obs_y, const float obs_yaw, const float obs_half_length, const float obs_half_width,
+  const float obs_vx_world, const float obs_vy_world, float * slot_out)
+{
+  const float dx_world = obs_x - ego_x;
+  const float dy_world = obs_y - ego_y;
+  slot_out[0] = ego_cos * dx_world + ego_sin * dy_world;
+  slot_out[1] = -ego_sin * dx_world + ego_cos * dy_world;
+  const float d_yaw = obs_yaw - std::atan2(ego_sin, ego_cos);
+  slot_out[2] = std::cos(d_yaw);
+  slot_out[3] = std::sin(d_yaw);
+  slot_out[4] = obs_half_length;
+  slot_out[5] = obs_half_width;
+  slot_out[6] = ego_cos * obs_vx_world + ego_sin * obs_vy_world;
+  slot_out[7] = -ego_sin * obs_vx_world + ego_cos * obs_vy_world;
+}
+
+/** Encode nearest obstacles by squared distance (static or moving at decision time). */
+inline void encodeDiffusionObstacleContext(
+  const float ego_x, const float ego_y, const float ego_yaw, const float ego_vel,
+  const float boundary_left, const float boundary_right, const float * obs_x, const float * obs_y,
+  const float * obs_yaw, const float * obs_half_length, const float * obs_half_width,
+  const float * obs_vx_world, const float * obs_vy_world, const int num_obstacles, float * out)
+{
+  zeroDiffusionContext(out);
+  const float ego_cos = std::cos(ego_yaw);
+  const float ego_sin = std::sin(ego_yaw);
+
+  struct RankedObstacle
+  {
+    int index = 0;
+    float dist_sq = 0.0F;
+  };
+
+  RankedObstacle ranked[kMaxContextObstacles];
+  const int n = std::max(0, num_obstacles);
+  const int keep = std::min(n, kMaxContextObstacles);
+  for (int i = 0; i < keep; ++i) {
+    const float dx = obs_x[i] - ego_x;
+    const float dy = obs_y[i] - ego_y;
+    ranked[i].index = i;
+    ranked[i].dist_sq = dx * dx + dy * dy;
+  }
+  std::sort(ranked, ranked + keep, [](const RankedObstacle & a, const RankedObstacle & b) {
+    return a.dist_sq < b.dist_sq;
+  });
+
+  for (int slot = 0; slot < keep; ++slot) {
+    const int i = ranked[slot].index;
+    const float vx = obs_vx_world != nullptr ? obs_vx_world[i] : 0.0F;
+    const float vy = obs_vy_world != nullptr ? obs_vy_world[i] : 0.0F;
+    encodeObstacleSlot(
+      ego_x, ego_y, ego_cos, ego_sin, obs_x[i], obs_y[i], obs_yaw[i], obs_half_length[i],
+      obs_half_width[i], vx, vy, &out[slot * kObstacleFeatureDim]);
+  }
+
+  const int scene_base = kMaxContextObstacles * kObstacleFeatureDim;
+  out[scene_base + 0] = boundary_left;
+  out[scene_base + 1] = boundary_right;
+  out[scene_base + 2] = ego_vel;
+}
+
+namespace detail
+{
+
+inline void gatherActiveMovingCarObstacles(
+  const std::vector<mppi::cost::MovingCarObstacle> & cars, const float sim_time,
+  std::vector<float> & obs_x, std::vector<float> & obs_y, std::vector<float> & obs_yaw,
+  std::vector<float> & obs_half_length, std::vector<float> & obs_half_width,
+  std::vector<float> & obs_vx, std::vector<float> & obs_vy)
+{
+  obs_x.clear();
+  obs_y.clear();
+  obs_yaw.clear();
+  obs_half_length.clear();
+  obs_half_width.clear();
+  obs_vx.clear();
+  obs_vy.clear();
+  obs_x.reserve(cars.size());
+  obs_y.reserve(cars.size());
+  obs_yaw.reserve(cars.size());
+  obs_half_length.reserve(cars.size());
+  obs_half_width.reserve(cars.size());
+  obs_vx.reserve(cars.size());
+  obs_vy.reserve(cars.size());
+  for (const mppi::cost::MovingCarObstacle & car : cars) {
+    if (!car.isActiveAt(sim_time)) {
+      continue;
+    }
+    const mppi::cost::ParkedCarObstacle pose = car.poseAt(sim_time);
+    obs_x.push_back(pose.ox);
+    obs_y.push_back(pose.oy);
+    obs_yaw.push_back(pose.yaw);
+    obs_half_length.push_back(pose.length * 0.5F);
+    obs_half_width.push_back(pose.width * 0.5F);
+    obs_vx.push_back(car.vx);
+    obs_vy.push_back(car.vy);
+  }
+}
+
+inline void gatherParkedCarObstacles(
+  const std::vector<mppi::cost::ParkedCarObstacle> & cars, std::vector<float> & obs_x,
+  std::vector<float> & obs_y, std::vector<float> & obs_yaw, std::vector<float> & obs_half_length,
+  std::vector<float> & obs_half_width)
+{
+  obs_x.clear();
+  obs_y.clear();
+  obs_yaw.clear();
+  obs_half_length.clear();
+  obs_half_width.clear();
+  obs_x.reserve(cars.size());
+  obs_y.reserve(cars.size());
+  obs_yaw.reserve(cars.size());
+  obs_half_length.reserve(cars.size());
+  obs_half_width.reserve(cars.size());
+  for (const mppi::cost::ParkedCarObstacle & car : cars) {
+    obs_x.push_back(car.ox);
+    obs_y.push_back(car.oy);
+    obs_yaw.push_back(car.yaw);
+    obs_half_length.push_back(car.length * 0.5F);
+    obs_half_width.push_back(car.width * 0.5F);
+  }
+}
+
+}  // namespace detail
+
+/** Build the fixed-size diffusion context vector from active moving obstacles at sim_time. */
+inline std::vector<float> encodeDiffusionObstacleContextFromMovingCars(
+  const float ego_x, const float ego_y, const float ego_yaw, const float ego_vel,
+  const float boundary_left, const float boundary_right,
+  const std::vector<mppi::cost::MovingCarObstacle> & cars, const float sim_time)
+{
+  std::vector<float> obs_x;
+  std::vector<float> obs_y;
+  std::vector<float> obs_yaw;
+  std::vector<float> obs_half_length;
+  std::vector<float> obs_half_width;
+  std::vector<float> obs_vx;
+  std::vector<float> obs_vy;
+  detail::gatherActiveMovingCarObstacles(
+    cars, sim_time, obs_x, obs_y, obs_yaw, obs_half_length, obs_half_width, obs_vx, obs_vy);
+
+  std::vector<float> out(static_cast<size_t>(kDiffusionContextDim), 0.0F);
+  encodeDiffusionObstacleContext(
+    ego_x, ego_y, ego_yaw, ego_vel, boundary_left, boundary_right, obs_x.data(), obs_y.data(),
+    obs_yaw.data(), obs_half_length.data(), obs_half_width.data(), obs_vx.data(), obs_vy.data(),
+    static_cast<int>(obs_x.size()), out.data());
+  return out;
+}
+
+/** In-place variant for callers that reuse a pre-sized buffer (e.g. DiffusionDistribution). */
+inline void encodeDiffusionObstacleContextFromMovingCars(
+  const float ego_x, const float ego_y, const float ego_yaw, const float ego_vel,
+  const float boundary_left, const float boundary_right,
+  const std::vector<mppi::cost::MovingCarObstacle> & cars, const float sim_time, float * out)
+{
+  std::vector<float> obs_x;
+  std::vector<float> obs_y;
+  std::vector<float> obs_yaw;
+  std::vector<float> obs_half_length;
+  std::vector<float> obs_half_width;
+  std::vector<float> obs_vx;
+  std::vector<float> obs_vy;
+  detail::gatherActiveMovingCarObstacles(
+    cars, sim_time, obs_x, obs_y, obs_yaw, obs_half_length, obs_half_width, obs_vx, obs_vy);
+  encodeDiffusionObstacleContext(
+    ego_x, ego_y, ego_yaw, ego_vel, boundary_left, boundary_right, obs_x.data(), obs_y.data(),
+    obs_yaw.data(), obs_half_length.data(), obs_half_width.data(), obs_vx.data(), obs_vy.data(),
+    static_cast<int>(obs_x.size()), out);
+}
+
+/** Build the fixed-size diffusion context vector from static parked obstacles (zero velocity). */
+inline std::vector<float> encodeDiffusionObstacleContextFromParkedCars(
+  const float ego_x, const float ego_y, const float ego_yaw, const float ego_vel,
+  const float boundary_left, const float boundary_right,
+  const std::vector<mppi::cost::ParkedCarObstacle> & cars)
+{
+  std::vector<float> obs_x;
+  std::vector<float> obs_y;
+  std::vector<float> obs_yaw;
+  std::vector<float> obs_half_length;
+  std::vector<float> obs_half_width;
+  detail::gatherParkedCarObstacles(cars, obs_x, obs_y, obs_yaw, obs_half_length, obs_half_width);
+
+  std::vector<float> out(static_cast<size_t>(kDiffusionContextDim), 0.0F);
+  encodeDiffusionObstacleContext(
+    ego_x, ego_y, ego_yaw, ego_vel, boundary_left, boundary_right, obs_x.data(), obs_y.data(),
+    obs_yaw.data(), obs_half_length.data(), obs_half_width.data(), nullptr, nullptr,
+    static_cast<int>(obs_x.size()), out.data());
+  return out;
+}
+
+inline void encodeDiffusionObstacleContextFromParkedCars(
+  const float ego_x, const float ego_y, const float ego_yaw, const float ego_vel,
+  const float boundary_left, const float boundary_right,
+  const std::vector<mppi::cost::ParkedCarObstacle> & cars, float * out)
+{
+  std::vector<float> obs_x;
+  std::vector<float> obs_y;
+  std::vector<float> obs_yaw;
+  std::vector<float> obs_half_length;
+  std::vector<float> obs_half_width;
+  detail::gatherParkedCarObstacles(cars, obs_x, obs_y, obs_yaw, obs_half_length, obs_half_width);
+  encodeDiffusionObstacleContext(
+    ego_x, ego_y, ego_yaw, ego_vel, boundary_left, boundary_right, obs_x.data(), obs_y.data(),
+    obs_yaw.data(), obs_half_length.data(), obs_half_width.data(), nullptr, nullptr,
+    static_cast<int>(obs_x.size()), out);
+}
+
+}  // namespace diffusion
+}  // namespace sampling_distributions
+}  // namespace mppi
+
+#endif  // MPPI__SAMPLING_DISTRIBUTIONS__DIFFUSION__OBSTACLE_CONTEXT_HPP_

--- a/planning/autoware_mppi_optimizer/include/mppi/utils/data_manager.hpp
+++ b/planning/autoware_mppi_optimizer/include/mppi/utils/data_manager.hpp
@@ -1,0 +1,704 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * @file data_manager.hpp
+ * @brief Modular CSV / rollout snapshot dumping for MPPI examples and tools.
+ *
+ * Bundles closed-loop temporal logs, per-step rollout snapshots (top-N by weight),
+ * and single-iteration analysis dumps. Output schemas match:
+ *   scripts/mppi/plot_racer_dubins_temporal_mppi.py
+ *   scripts/mppi/plot_mppi_rollouts_at_step.py
+ *   scripts/mppi/plot_mppi_lambda_retune.py
+ *   scripts/mppi/plot_mppi_rollout_analysis.py
+ */
+#ifndef MPPI__UTILS__DATA_MANAGER_HPP_
+#define MPPI__UTILS__DATA_MANAGER_HPP_
+
+#include <mppi/utils/gpu_err_chk.cuh>
+#include <mppi/utils/rollout_csv.hpp>
+
+#include <cuda_runtime.h>
+#include <sys/stat.h>
+
+#include <algorithm>
+#include <atomic>
+#include <cmath>
+#include <condition_variable>
+#include <fstream>
+#include <iomanip>
+#include <iostream>
+#include <mutex>
+#include <numeric>
+#include <queue>
+#include <sstream>
+#include <string>
+#include <thread>
+#include <utility>
+#include <vector>
+
+namespace mppi
+{
+namespace data
+{
+constexpr int kDefaultTopRollouts = 400;
+
+enum class PathTrackingLogSchema {
+  kRefV,
+  kRefVPoseTarget,
+};
+
+struct PathTrackingStepLog
+{
+  float t = 0.0F;
+  float pos_x = 0.0F;
+  float pos_y = 0.0F;
+  float yaw = 0.0F;
+  float vel_x = 0.0F;
+  float steer_angle = 0.0F;
+  float brake_state = 0.0F;
+  float u_accel = 0.0F;
+  float u_steer = 0.0F;
+  float nom_u_accel = 0.0F;
+  float nom_u_steer = 0.0F;
+  float ref_x = 0.0F;
+  float ref_y = 0.0F;
+  float ref_yaw = 0.0F;
+  float ref_v = 0.0F;
+  float ref_v_pose = 0.0F;
+  float ref_v_target = 0.0F;
+  float arc_s = 0.0F;
+  float lat_err = 0.0F;
+  float baseline = 0.0F;
+};
+
+struct RolloutOutputIndices
+{
+  int x = 0;
+  int y = 1;
+  int yaw = 2;
+  int vel = 3;
+
+  RolloutOutputIndices() = default;
+  RolloutOutputIndices(int x_idx, int y_idx, int yaw_idx, int vel_idx)
+  : x(x_idx), y(y_idx), yaw(yaw_idx), vel(vel_idx)
+  {
+  }
+};
+
+struct RolloutWeightBundle
+{
+  std::vector<int> rollout_indices;
+  std::vector<float> raw_costs;
+  std::vector<float> unnormalized_importance;
+  std::vector<float> normalized_weights;
+  float baseline = 0.0F;
+  float normalizer = 0.0F;
+};
+
+inline std::string rolloutDirectoryFromLog(const std::string & log_csv_path)
+{
+  std::string stem = log_csv_path;
+  const size_t n = stem.size();
+  if (n > 4U && stem.compare(n - 4U, 4U, ".csv") == 0) {
+    stem.erase(n - 4U);
+  }
+  return stem + "_rollouts";
+}
+
+inline std::string stepDirectoryName(int step)
+{
+  std::ostringstream oss;
+  oss << "step_" << std::setw(6) << std::setfill('0') << step;
+  return oss.str();
+}
+
+inline bool ensureDirectory(const std::string & path)
+{
+  struct stat st;
+  if (stat(path.c_str(), &st) == 0) {
+    return S_ISDIR(st.st_mode);
+  }
+  return mkdir(path.c_str(), 0755) == 0;
+}
+
+template <class CTRL_T>
+inline void extractWeightsFromController(
+  const CTRL_T & controller, float lambda, RolloutWeightBundle & out)
+{
+  const auto & weights_eig = controller.getSampledCostSeq();
+  const float baseline = static_cast<float>(controller.getBaselineCost());
+  const float normalizer = static_cast<float>(controller.getNormalizerCost());
+  const int num_rollouts = static_cast<int>(weights_eig.size());
+
+  out.baseline = baseline;
+  out.normalizer = normalizer;
+  out.rollout_indices.resize(static_cast<size_t>(num_rollouts));
+  out.raw_costs.resize(static_cast<size_t>(num_rollouts));
+  out.unnormalized_importance.resize(static_cast<size_t>(num_rollouts));
+  out.normalized_weights.resize(static_cast<size_t>(num_rollouts));
+
+  for (int i = 0; i < num_rollouts; ++i) {
+    const float w = static_cast<float>(weights_eig(i));
+    out.rollout_indices[static_cast<size_t>(i)] = i;
+    out.unnormalized_importance[static_cast<size_t>(i)] = w;
+    out.normalized_weights[static_cast<size_t>(i)] = (normalizer > 0.0F) ? w / normalizer : 0.0F;
+    out.raw_costs[static_cast<size_t>(i)] =
+      (w > 0.0F) ? (baseline - lambda * std::log(w)) : (baseline + 1.0e30F);
+  }
+}
+
+inline void selectTopRolloutsByWeight(RolloutWeightBundle & bundle, int top_n)
+{
+  const int n = static_cast<int>(bundle.normalized_weights.size());
+  if (top_n <= 0 || top_n >= n) {
+    return;
+  }
+
+  std::vector<int> order(static_cast<size_t>(n));
+  std::iota(order.begin(), order.end(), 0);
+  std::partial_sort(order.begin(), order.begin() + top_n, order.end(), [&](int a, int b) {
+    return bundle.normalized_weights[static_cast<size_t>(a)] >
+           bundle.normalized_weights[static_cast<size_t>(b)];
+  });
+  order.resize(static_cast<size_t>(top_n));
+
+  RolloutWeightBundle top;
+  top.baseline = bundle.baseline;
+  top.normalizer = bundle.normalizer;
+  top.rollout_indices.resize(static_cast<size_t>(top_n));
+  top.raw_costs.resize(static_cast<size_t>(top_n));
+  top.unnormalized_importance.resize(static_cast<size_t>(top_n));
+  top.normalized_weights.resize(static_cast<size_t>(top_n));
+  for (int i = 0; i < top_n; ++i) {
+    const int src = order[static_cast<size_t>(i)];
+    top.rollout_indices[static_cast<size_t>(i)] = bundle.rollout_indices[static_cast<size_t>(src)];
+    top.raw_costs[static_cast<size_t>(i)] = bundle.raw_costs[static_cast<size_t>(src)];
+    top.unnormalized_importance[static_cast<size_t>(i)] =
+      bundle.unnormalized_importance[static_cast<size_t>(src)];
+    top.normalized_weights[static_cast<size_t>(i)] =
+      bundle.normalized_weights[static_cast<size_t>(src)];
+  }
+  bundle = std::move(top);
+}
+
+template <class DYN_T, class SAMPLER_T>
+void copySamplerControlsToHost(
+  SAMPLER_T & sampler, int horizon, int num_rollouts, std::vector<float> & host_controls)
+{
+  std::vector<int> all(static_cast<size_t>(num_rollouts));
+  std::iota(all.begin(), all.end(), 0);
+  copySamplerControlsToHost<DYN_T>(sampler, horizon, all, host_controls);
+}
+
+template <class DYN_T, class SAMPLER_T>
+void copySamplerControlsToHost(
+  SAMPLER_T & sampler, int horizon, const std::vector<int> & rollout_indices,
+  std::vector<float> & host_controls)
+{
+  const int k = static_cast<int>(rollout_indices.size());
+  const size_t rollout_stride =
+    static_cast<size_t>(horizon) * static_cast<size_t>(DYN_T::CONTROL_DIM) * sizeof(float);
+  host_controls.assign(
+    static_cast<size_t>(k) * static_cast<size_t>(horizon) * static_cast<size_t>(DYN_T::CONTROL_DIM),
+    0.0F);
+  for (int out_idx = 0; out_idx < k; ++out_idx) {
+    const int rollout = rollout_indices[static_cast<size_t>(out_idx)];
+    float * device_controls = sampler.getControlSample(rollout, 0, 0);
+    HANDLE_ERROR(cudaMemcpy(
+      host_controls.data() + static_cast<size_t>(out_idx) * static_cast<size_t>(horizon) *
+                               static_cast<size_t>(DYN_T::CONTROL_DIM),
+      device_controls, rollout_stride, cudaMemcpyDeviceToHost));
+  }
+}
+
+template <class DYN_T, class OutputTrajT>
+void hostReplayRolloutsFromControls(
+  DYN_T & model, const typename DYN_T::state_array & x0, int horizon, float dt,
+  const std::vector<int> & rollout_indices, const std::vector<float> & host_controls,
+  std::vector<OutputTrajT> & outputs)
+{
+  const int k = static_cast<int>(rollout_indices.size());
+  outputs.resize(static_cast<size_t>(k));
+  for (OutputTrajT & traj : outputs) {
+    traj.resize(DYN_T::OUTPUT_DIM, horizon);
+    traj.setZero();
+  }
+
+  typename DYN_T::state_array x_local;
+  typename DYN_T::state_array x_next = model.getZeroState();
+  typename DYN_T::state_array xdot = model.getZeroState();
+  typename DYN_T::output_array y_t = DYN_T::output_array::Zero();
+  typename DYN_T::control_array u_local = DYN_T::control_array::Zero();
+
+  for (int out_idx = 0; out_idx < k; ++out_idx) {
+    x_local = x0;
+    for (int t = 0; t < horizon; ++t) {
+      const float * src =
+        host_controls.data() +
+        (static_cast<size_t>(out_idx) * static_cast<size_t>(horizon) + static_cast<size_t>(t)) *
+          static_cast<size_t>(DYN_T::CONTROL_DIM);
+      for (int d = 0; d < DYN_T::CONTROL_DIM; ++d) {
+        u_local(d) = src[d];
+      }
+      model.enforceConstraints(x_local, u_local);
+      model.step(x_local, x_next, xdot, u_local, y_t, static_cast<float>(t), dt);
+      outputs[static_cast<size_t>(out_idx)].col(t) = y_t;
+      x_local = x_next;
+    }
+  }
+}
+
+template <class DYN_T, class SAMPLER_T, class OutputTrajT>
+void hostReplayRollouts(
+  DYN_T & model, SAMPLER_T & sampler, const typename DYN_T::state_array & x0, int horizon, float dt,
+  int num_rollouts, const std::vector<int> & rollout_indices, std::vector<OutputTrajT> & outputs,
+  std::vector<float> * host_controls_out = nullptr)
+{
+  std::vector<float> host_controls;
+  copySamplerControlsToHost<DYN_T>(sampler, horizon, rollout_indices, host_controls);
+  hostReplayRolloutsFromControls<DYN_T, OutputTrajT>(
+    model, x0, horizon, dt, rollout_indices, host_controls, outputs);
+  if (host_controls_out != nullptr) {
+    *host_controls_out = std::move(host_controls);
+  }
+}
+
+template <class DYN_T, class SAMPLER_T, class OutputTrajT>
+void hostReplayAllRollouts(
+  DYN_T & model, SAMPLER_T & sampler, const typename DYN_T::state_array & x0, int horizon, float dt,
+  int num_rollouts, std::vector<OutputTrajT> & outputs)
+{
+  std::vector<int> all(static_cast<size_t>(num_rollouts));
+  std::iota(all.begin(), all.end(), 0);
+  hostReplayRollouts<DYN_T, SAMPLER_T, OutputTrajT>(
+    model, sampler, x0, horizon, dt, num_rollouts, all, outputs);
+}
+
+/**
+ * Central dumping helper for MPPI examples.
+ *
+ * @tparam DYN_T Dynamics type (must expose POS_X/Y/YAW/VEL_X/STEER_ANGLE state indices).
+ */
+template <class DYN_T>
+class MppiDataManager
+{
+public:
+  using state_array = typename DYN_T::state_array;
+  using dyn_params_t = typename DYN_T::DYN_PARAMS_T;
+  using control_trajectory_t = Eigen::Matrix<float, DYN_T::CONTROL_DIM, Eigen::Dynamic>;
+  using output_trajectory_t = Eigen::Matrix<float, DYN_T::OUTPUT_DIM, Eigen::Dynamic>;
+
+  MppiDataManager() = default;
+
+  ~MppiDataManager() { close(); }
+
+  MppiDataManager(const MppiDataManager &) = delete;
+  MppiDataManager & operator=(const MppiDataManager &) = delete;
+
+  void setAsyncRolloutDumps(const bool enabled) { async_rollout_dumps_ = enabled; }
+
+  bool asyncRolloutDumps() const { return async_rollout_dumps_; }
+
+  bool beginRun(
+    const std::string & log_csv_path, const mppi::path::Path2D & path,
+    PathTrackingLogSchema schema = PathTrackingLogSchema::kRefVPoseTarget)
+  {
+    log_path_ = log_csv_path;
+    rollout_dir_ = rolloutDirectoryFromLog(log_csv_path);
+    schema_ = schema;
+
+    mppi::rollout_csv::writeCenterlineForLog(path, log_csv_path);
+    if (!ensureDirectory(rollout_dir_)) {
+      std::cerr << "Could not create rollout directory: " << rollout_dir_ << "\n";
+      return false;
+    }
+
+    rollout_index_path_ = rollout_dir_ + "/steps_index.csv";
+    {
+      std::ofstream idx(rollout_index_path_.c_str());
+      if (!idx) {
+        std::cerr << "Could not open rollout index: " << rollout_index_path_ << "\n";
+        return false;
+      }
+      idx << "step,sim_time,prefix\n";
+    }
+
+    temporal_log_.open(log_csv_path.c_str());
+    if (!temporal_log_) {
+      std::cerr << "Could not open temporal log: " << log_csv_path << "\n";
+      return false;
+    }
+    writeTemporalHeader();
+    temporal_log_ << std::scientific;
+
+    if (async_rollout_dumps_) {
+      startDumpWorker();
+    }
+    return true;
+  }
+
+  bool beginAnalysisRun(const std::string & prefix, const mppi::path::Path2D & path)
+  {
+    analysis_prefix_ = prefix;
+    mppi::rollout_csv::writeCenterline(path, prefix);
+    return true;
+  }
+
+  void setRoadBoundaryLimits(float left, float right)
+  {
+    boundary_left_ = left;
+    boundary_right_ = right;
+  }
+
+  void logPathTrackingStep(const PathTrackingStepLog & rec)
+  {
+    if (!temporal_log_) {
+      return;
+    }
+    temporal_log_ << rec.t << "," << rec.pos_x << "," << rec.pos_y << "," << rec.yaw << ","
+                  << rec.vel_x << "," << rec.steer_angle << "," << rec.brake_state << ","
+                  << rec.u_accel << "," << rec.u_steer << "," << rec.nom_u_accel << ","
+                  << rec.nom_u_steer << "," << rec.ref_x << "," << rec.ref_y << "," << rec.ref_yaw
+                  << ",";
+    if (schema_ == PathTrackingLogSchema::kRefV) {
+      temporal_log_ << rec.ref_v << ",";
+    } else {
+      temporal_log_ << rec.ref_v_pose << "," << rec.ref_v_target << ",";
+    }
+    temporal_log_ << rec.arc_s << "," << rec.lat_err << "," << rec.baseline << "\n";
+  }
+
+  template <class CTRL_T, class SAMPLER_T, class ControlTrajT>
+  void dumpRolloutSnapshot(
+    int step, float sim_time, const state_array & x, CTRL_T & controller, DYN_T & model,
+    SAMPLER_T & sampler, int horizon, float lambda, float dt, const ControlTrajT & u_opt,
+    const RolloutOutputIndices & out_idx, int top_n = kDefaultTopRollouts,
+    const std::vector<float> & obstacle_context = {})
+  {
+    RolloutSnapshotJob job = prepareRolloutSnapshot(
+      step, sim_time, x, controller, model, sampler, horizon, lambda, dt, u_opt, out_idx, top_n);
+    job.obstacle_context = obstacle_context;
+    if (job.valid) {
+      if (async_rollout_dumps_) {
+        enqueueRolloutSnapshot(std::move(job));
+      } else {
+        writeRolloutSnapshotJob(job);
+      }
+    }
+  }
+
+  /** Block until all queued rollout snapshot writes finish. */
+  void waitForRolloutDumps()
+  {
+    if (!dump_worker_running_) {
+      return;
+    }
+    std::unique_lock<std::mutex> lock(dump_mutex_);
+    dump_cv_.wait(lock, [this]() { return dump_queue_.empty() && dump_jobs_in_flight_ == 0; });
+  }
+
+  void close()
+  {
+    waitForRolloutDumps();
+    stopDumpWorker();
+    if (temporal_log_.is_open()) {
+      temporal_log_.close();
+    }
+  }
+
+  template <class CTRL_T, class SAMPLER_T, class ControlTrajT>
+  void dumpSingleIterationFromController(
+    const typename DYN_T::state_array & x, CTRL_T & controller, DYN_T & model, SAMPLER_T & sampler,
+    int horizon, float lambda, float dt, const ControlTrajT & u_opt,
+    const RolloutOutputIndices & out_idx, int top_n = kDefaultTopRollouts)
+  {
+    using OutputTrajT = typename CTRL_T::output_trajectory;
+    RolloutWeightBundle weights;
+    extractWeightsFromController(controller, lambda, weights);
+    const int num_rollouts = static_cast<int>(controller.getSampledCostSeq().size());
+
+    rollout_csv::writeMeta<DYN_T>(
+      analysis_prefix_ + "_meta.csv", x, dt, lambda, horizon, num_rollouts, num_rollouts,
+      weights.baseline, weights.normalizer, -1, -1.0F, boundary_left_, boundary_right_);
+    rollout_csv::writeCosts(
+      analysis_prefix_ + "_costs.csv", weights.raw_costs, weights.unnormalized_importance,
+      weights.normalized_weights);
+    rollout_csv::writeCombinedTrajectory<DYN_T>(
+      model, x, u_opt, analysis_prefix_ + "_combined.csv", dt);
+
+    RolloutWeightBundle top_weights = weights;
+    selectTopRolloutsByWeight(top_weights, top_n);
+    std::vector<OutputTrajT> top_outputs;
+    std::vector<float> host_controls;
+    hostReplayRollouts<DYN_T, SAMPLER_T, OutputTrajT>(
+      model, sampler, x, horizon, dt, num_rollouts, top_weights.rollout_indices, top_outputs,
+      &host_controls);
+    rollout_csv::writeRolloutTrajectories<DYN_T, OutputTrajT>(
+      analysis_prefix_ + "_rollouts_xy.csv", x, horizon, top_outputs, top_weights.rollout_indices,
+      out_idx.x, out_idx.y, out_idx.yaw, out_idx.vel);
+    rollout_csv::writeRolloutControls<DYN_T>(
+      analysis_prefix_ + "_rollouts_controls.csv", host_controls, horizon, num_rollouts,
+      top_weights.rollout_indices);
+  }
+
+  template <class SAMPLER_T, class OutputTrajT, class ControlTrajT>
+  void dumpSingleIterationHostReplay(
+    const typename DYN_T::state_array & x, DYN_T & model, SAMPLER_T & sampler, int horizon,
+    float lambda, float dt, int num_rollouts, const ControlTrajT & u_opt,
+    const std::vector<float> & raw_costs, float baseline, const RolloutOutputIndices & out_idx,
+    int top_n = kDefaultTopRollouts)
+  {
+    std::vector<float> unnormalized_importance(static_cast<size_t>(num_rollouts), 0.0F);
+    for (int i = 0; i < num_rollouts; ++i) {
+      unnormalized_importance[static_cast<size_t>(i)] =
+        std::exp(-(raw_costs[static_cast<size_t>(i)] - baseline) / lambda);
+    }
+    const float normalizer =
+      std::accumulate(unnormalized_importance.begin(), unnormalized_importance.end(), 0.0F);
+    std::vector<float> normalized_weights(static_cast<size_t>(num_rollouts), 0.0F);
+    for (int i = 0; i < num_rollouts; ++i) {
+      normalized_weights[static_cast<size_t>(i)] =
+        (normalizer > 0.0F) ? unnormalized_importance[static_cast<size_t>(i)] / normalizer : 0.0F;
+    }
+
+    rollout_csv::writeMeta<DYN_T>(
+      analysis_prefix_ + "_meta.csv", x, dt, lambda, horizon, num_rollouts, num_rollouts, baseline,
+      normalizer, -1, -1.0F, boundary_left_, boundary_right_);
+    rollout_csv::writeCosts(
+      analysis_prefix_ + "_costs.csv", raw_costs, unnormalized_importance, normalized_weights);
+    rollout_csv::writeCombinedTrajectory<DYN_T>(
+      model, x, u_opt, analysis_prefix_ + "_combined.csv", dt);
+
+    RolloutWeightBundle top;
+    top.baseline = baseline;
+    top.normalizer = normalizer;
+    top.rollout_indices.resize(static_cast<size_t>(num_rollouts));
+    top.raw_costs = raw_costs;
+    top.unnormalized_importance = unnormalized_importance;
+    top.normalized_weights = normalized_weights;
+    selectTopRolloutsByWeight(top, top_n);
+
+    std::vector<OutputTrajT> top_outputs;
+    std::vector<float> host_controls;
+    hostReplayRollouts<DYN_T, SAMPLER_T, OutputTrajT>(
+      model, sampler, x, horizon, dt, num_rollouts, top.rollout_indices, top_outputs,
+      &host_controls);
+    rollout_csv::writeRolloutTrajectories<DYN_T, OutputTrajT>(
+      analysis_prefix_ + "_rollouts_xy.csv", x, horizon, top_outputs, top.rollout_indices,
+      out_idx.x, out_idx.y, out_idx.yaw, out_idx.vel);
+    rollout_csv::writeRolloutControls<DYN_T>(
+      analysis_prefix_ + "_rollouts_controls.csv", host_controls, horizon, num_rollouts,
+      top.rollout_indices);
+  }
+
+  const std::string & rolloutDirectory() const { return rollout_dir_; }
+
+  size_t pendingRolloutDumpJobs() const
+  {
+    std::lock_guard<std::mutex> lock(dump_mutex_);
+    return dump_queue_.size() + static_cast<size_t>(dump_jobs_in_flight_);
+  }
+
+  const std::string & logPath() const { return log_path_; }
+
+private:
+  struct RolloutSnapshotJob
+  {
+    bool valid = false;
+    int step = 0;
+    float sim_time = 0.0F;
+    int horizon = 0;
+    float dt = 0.0F;
+    float lambda = 0.0F;
+    int num_rollouts = 0;
+    RolloutOutputIndices out_idx{};
+    state_array x = state_array::Zero();
+    dyn_params_t dyn_params{};
+    control_trajectory_t u_opt;
+    RolloutWeightBundle weights;
+    RolloutWeightBundle top_weights;
+    std::vector<float> host_controls;
+    std::vector<float> obstacle_context;
+    std::string step_dir;
+  };
+
+  template <class CTRL_T, class SAMPLER_T, class ControlTrajT>
+  RolloutSnapshotJob prepareRolloutSnapshot(
+    int step, float sim_time, const state_array & x, CTRL_T & controller, DYN_T & model,
+    SAMPLER_T & sampler, int horizon, float lambda, float dt, const ControlTrajT & u_opt,
+    const RolloutOutputIndices & out_idx, int top_n)
+  {
+    RolloutSnapshotJob job;
+    extractWeightsFromController(controller, lambda, job.weights);
+
+    job.step_dir = rollout_dir_ + "/" + stepDirectoryName(step);
+    if (!ensureDirectory(job.step_dir)) {
+      return job;
+    }
+
+    job.valid = true;
+    job.step = step;
+    job.sim_time = sim_time;
+    job.horizon = horizon;
+    job.dt = dt;
+    job.lambda = lambda;
+    job.num_rollouts = static_cast<int>(controller.getSampledCostSeq().size());
+    job.out_idx = out_idx;
+    job.x = x;
+    job.dyn_params = model.getParams();
+    job.u_opt = u_opt;
+
+    job.top_weights = job.weights;
+    selectTopRolloutsByWeight(job.top_weights, top_n);
+    copySamplerControlsToHost<DYN_T>(
+      sampler, horizon, job.top_weights.rollout_indices, job.host_controls);
+    return job;
+  }
+
+  void writeRolloutSnapshotJob(const RolloutSnapshotJob & job)
+  {
+    DYN_T model;
+    model.setParams(job.dyn_params);
+
+    rollout_csv::writeMeta<DYN_T>(
+      job.step_dir + "/meta.csv", job.x, job.dt, job.lambda, job.horizon, job.num_rollouts,
+      job.num_rollouts, job.weights.baseline, job.weights.normalizer, job.step, job.sim_time,
+      boundary_left_, boundary_right_);
+    rollout_csv::writeCosts(
+      job.step_dir + "/costs.csv", job.weights.raw_costs, job.weights.unnormalized_importance,
+      job.weights.normalized_weights);
+    rollout_csv::writeCombinedTrajectory<DYN_T>(
+      model, job.x, job.u_opt, job.step_dir + "/combined.csv", job.dt);
+    if (!job.obstacle_context.empty()) {
+      rollout_csv::writeContextVector(
+        job.step_dir + "/context.csv", job.obstacle_context.data(),
+        static_cast<int>(job.obstacle_context.size()));
+    }
+
+    std::vector<output_trajectory_t> top_outputs;
+    hostReplayRolloutsFromControls<DYN_T, output_trajectory_t>(
+      model, job.x, job.horizon, job.dt, job.top_weights.rollout_indices, job.host_controls,
+      top_outputs);
+    rollout_csv::writeRolloutTrajectories<DYN_T, output_trajectory_t>(
+      job.step_dir + "/rollouts_xy.csv", job.x, job.horizon, top_outputs,
+      job.top_weights.rollout_indices, job.out_idx.x, job.out_idx.y, job.out_idx.yaw,
+      job.out_idx.vel);
+    rollout_csv::writeRolloutControls<DYN_T>(
+      job.step_dir + "/rollouts_controls.csv", job.host_controls, job.horizon, job.num_rollouts,
+      job.top_weights.rollout_indices);
+
+    std::lock_guard<std::mutex> lock(dump_mutex_);
+    std::ofstream idx(rollout_index_path_.c_str(), std::ios::app);
+    if (idx) {
+      idx << job.step << "," << job.sim_time << "," << job.step_dir << "\n";
+    }
+  }
+
+  void enqueueRolloutSnapshot(RolloutSnapshotJob job)
+  {
+    {
+      std::lock_guard<std::mutex> lock(dump_mutex_);
+      dump_queue_.push(std::move(job));
+    }
+    dump_cv_.notify_one();
+  }
+
+  void startDumpWorker()
+  {
+    if (dump_worker_running_) {
+      return;
+    }
+    dump_shutdown_ = false;
+    dump_worker_running_ = true;
+    dump_thread_ = std::thread([this]() { dumpWorkerLoop(); });
+  }
+
+  void stopDumpWorker()
+  {
+    if (!dump_worker_running_) {
+      return;
+    }
+    {
+      std::lock_guard<std::mutex> lock(dump_mutex_);
+      dump_shutdown_ = true;
+    }
+    dump_cv_.notify_all();
+    if (dump_thread_.joinable()) {
+      dump_thread_.join();
+    }
+    dump_worker_running_ = false;
+  }
+
+  void dumpWorkerLoop()
+  {
+    while (true) {
+      RolloutSnapshotJob job;
+      {
+        std::unique_lock<std::mutex> lock(dump_mutex_);
+        dump_cv_.wait(lock, [this]() { return dump_shutdown_ || !dump_queue_.empty(); });
+        if (dump_shutdown_ && dump_queue_.empty()) {
+          break;
+        }
+        job = std::move(dump_queue_.front());
+        dump_queue_.pop();
+        ++dump_jobs_in_flight_;
+      }
+
+      writeRolloutSnapshotJob(job);
+
+      {
+        std::lock_guard<std::mutex> lock(dump_mutex_);
+        --dump_jobs_in_flight_;
+      }
+      dump_cv_.notify_all();
+    }
+  }
+
+  void writeTemporalHeader()
+  {
+    temporal_log_
+      << "t,pos_x,pos_y,yaw,vel_x,steer_angle,brake_state,u_accel,u_steer,nom_u_accel,nom_u_steer,"
+         "ref_x,ref_y,ref_yaw,";
+    if (schema_ == PathTrackingLogSchema::kRefV) {
+      temporal_log_ << "ref_v,";
+    } else {
+      temporal_log_ << "ref_v_pose,ref_v_target,";
+    }
+    temporal_log_ << "arc_s,lat_err,baseline\n";
+  }
+
+  std::string log_path_;
+  std::string rollout_dir_;
+  std::string rollout_index_path_;
+  std::string analysis_prefix_;
+  PathTrackingLogSchema schema_ = PathTrackingLogSchema::kRefVPoseTarget;
+  float boundary_left_ = -1.0F;
+  float boundary_right_ = -1.0F;
+  bool async_rollout_dumps_ = true;
+  std::ofstream temporal_log_;
+
+  std::thread dump_thread_;
+  mutable std::mutex dump_mutex_;
+  std::condition_variable dump_cv_;
+  std::queue<RolloutSnapshotJob> dump_queue_;
+  bool dump_shutdown_ = false;
+  bool dump_worker_running_ = false;
+  int dump_jobs_in_flight_ = 0;
+};
+
+}  // namespace data
+}  // namespace mppi
+
+#endif  // MPPI__UTILS__DATA_MANAGER_HPP_

--- a/planning/autoware_mppi_optimizer/include/mppi/utils/rollout_csv.hpp
+++ b/planning/autoware_mppi_optimizer/include/mppi/utils/rollout_csv.hpp
@@ -1,0 +1,290 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * Header-only CSV writers for MPPI rollout / iteration analysis.
+ *
+ * All writers are templated on the dynamics type so they can be reused across
+ * different examples. The dynamics type must expose `DYN_T::DYN_PARAMS_T` with
+ * `StateIndex`, `OutputIndex`, and `ControlIndex` enums.
+ *
+ * Schemas (in lock-step with `scripts/mppi/plot_mppi_rollout_analysis.py` and
+ * `scripts/mppi/plot_mppi_rollouts_at_step.py`):
+ *   <prefix>_centerline.csv : x_m,y_m
+ *   <prefix>_meta.csv       : key,value
+ *   <prefix>_costs.csv      : rollout_index,raw_cost,unnormalized_importance,normalized_weight
+ *   <prefix>_combined.csv   : step,t,x,y,yaw,vel_x,steer,u_accel,u_steer
+ *   <prefix>_rollouts_xy.csv: rollout_index,step,x,y,yaw,vel_x
+ *   <prefix>_rollouts_controls.csv: rollout_index,step,u_accel,u_steer
+ *   <prefix>_context.csv       : index,value  (diffusion obstacle context vector)
+ */
+#ifndef MPPI__UTILS__ROLLOUT_CSV_HPP_
+#define MPPI__UTILS__ROLLOUT_CSV_HPP_
+
+#include <Eigen/Dense>
+#include <mppi/path/path2d.hpp>
+
+#include <cmath>
+#include <fstream>
+#include <iostream>
+#include <string>
+#include <vector>
+
+namespace mppi
+{
+namespace rollout_csv
+{
+inline void writeCenterline(
+  const mppi::path::Path2D & path, const std::string & prefix, bool log_path = true)
+{
+  const std::string out = prefix + "_centerline.csv";
+  std::ofstream f(out.c_str());
+  if (!f) {
+    return;
+  }
+  f << "x_m,y_m\n";
+  for (const mppi::path::PathAnchor & a : path.anchors()) {
+    f << a.x << "," << a.y << "\n";
+  }
+  if (log_path) {
+    std::cout << "Wrote centerline: " << out << "\n";
+  }
+}
+
+/**
+ * Sister to `writeCenterline` for closed-loop tracking examples that pass
+ * a full log path like "foo.csv": writes "foo_centerline.csv".
+ */
+inline void writeCenterlineForLog(const mppi::path::Path2D & path, const std::string & log_csv_path)
+{
+  std::string out = log_csv_path;
+  const size_t n = out.size();
+  if (n > 4U && out.compare(n - 4U, 4U, ".csv") == 0) {
+    out.insert(n - 4U, "_centerline");
+  } else {
+    out += "_centerline.csv";
+  }
+  std::ofstream f(out.c_str());
+  if (!f) {
+    return;
+  }
+  f << "x_m,y_m\n";
+  for (const mppi::path::PathAnchor & a : path.anchors()) {
+    f << a.x << "," << a.y << "\n";
+  }
+  std::cout << "Wrote centerline for plot: " << out << "\n";
+}
+
+template <class DYN_T>
+void writeMeta(
+  const std::string & path, const typename DYN_T::state_array & x, float dt, float lambda,
+  int horizon, int num_rollouts, int num_logged_traj, float baseline, float normalizer,
+  int sim_step = -1, float sim_time = -1.0F, float boundary_left = -1.0F,
+  float boundary_right = -1.0F)
+{
+  using S = typename DYN_T::DYN_PARAMS_T::StateIndex;
+  std::ofstream f(path.c_str());
+  if (!f) {
+    return;
+  }
+  f << "key,value\n";
+  f << "dt," << dt << "\n";
+  f << "horizon," << horizon << "\n";
+  f << "num_rollouts," << num_rollouts << "\n";
+  f << "num_logged_trajectories," << num_logged_traj << "\n";
+  f << "lambda," << lambda << "\n";
+  f << "baseline," << baseline << "\n";
+  f << "normalizer," << normalizer << "\n";
+  if (sim_step >= 0) {
+    f << "sim_step," << sim_step << "\n";
+  }
+  if (sim_time >= 0.0F) {
+    f << "sim_time," << sim_time << "\n";
+  }
+  f << "init_pos_x," << x(static_cast<int>(S::POS_X)) << "\n";
+  f << "init_pos_y," << x(static_cast<int>(S::POS_Y)) << "\n";
+  f << "init_yaw," << x(static_cast<int>(S::YAW)) << "\n";
+  f << "init_vel_x," << x(static_cast<int>(S::VEL_X)) << "\n";
+  f << "init_steer," << x(static_cast<int>(S::STEER_ANGLE)) << "\n";
+  if (boundary_left >= 0.0F) {
+    f << "boundary_threshold_left," << boundary_left << "\n";
+  }
+  if (boundary_right >= 0.0F) {
+    f << "boundary_threshold_right," << boundary_right << "\n";
+  }
+  if (boundary_left >= 0.0F && boundary_right < 0.0F) {
+    f << "boundary_threshold," << boundary_left << "\n";
+  } else if (
+    boundary_left >= 0.0F && boundary_right >= 0.0F &&
+    std::abs(boundary_left - boundary_right) < 1.0E-6F) {
+    f << "boundary_threshold," << boundary_left << "\n";
+  }
+}
+
+inline void writeCosts(
+  const std::string & path, const std::vector<float> & raw_costs,
+  const std::vector<float> & unnormalized_importance, const std::vector<float> & normalized_weights)
+{
+  std::ofstream f(path.c_str());
+  if (!f) {
+    return;
+  }
+  f << "rollout_index,raw_cost,unnormalized_importance,normalized_weight\n";
+  const int n = static_cast<int>(raw_costs.size());
+  for (int i = 0; i < n; ++i) {
+    f << i << "," << raw_costs[i] << "," << unnormalized_importance[i] << ","
+      << normalized_weights[i] << "\n";
+  }
+}
+
+/**
+ * Same as writeCosts but only writes the selected rollout indices (preserving
+ * the original rollout_index column for cross-referencing).
+ */
+inline void writeCostsIndexed(
+  const std::string & path, const std::vector<int> & rollout_indices,
+  const std::vector<float> & raw_costs, const std::vector<float> & unnormalized_importance,
+  const std::vector<float> & normalized_weights)
+{
+  std::ofstream f(path.c_str());
+  if (!f) {
+    return;
+  }
+  f << "rollout_index,raw_cost,unnormalized_importance,normalized_weight\n";
+  const int n = static_cast<int>(rollout_indices.size());
+  for (int i = 0; i < n; ++i) {
+    f << rollout_indices[static_cast<size_t>(i)] << "," << raw_costs[static_cast<size_t>(i)] << ","
+      << unnormalized_importance[static_cast<size_t>(i)] << ","
+      << normalized_weights[static_cast<size_t>(i)] << "\n";
+  }
+}
+
+template <class DYN_T, class CONTROL_TRAJ_T>
+void writeCombinedTrajectory(
+  DYN_T & model, const typename DYN_T::state_array & x0, const CONTROL_TRAJ_T & u,
+  const std::string & path, float dt)
+{
+  using S = typename DYN_T::DYN_PARAMS_T::StateIndex;
+  std::ofstream f(path.c_str());
+  if (!f) {
+    return;
+  }
+  f << "step,t,x,y,yaw,vel_x,steer,u_accel,u_steer\n";
+  typename DYN_T::state_array x = x0;
+  typename DYN_T::state_array x_next = model.getZeroState();
+  typename DYN_T::state_array xdot = model.getZeroState();
+  typename DYN_T::output_array y = DYN_T::output_array::Zero();
+  typename DYN_T::control_array u_step = DYN_T::control_array::Zero();
+
+  f << "0,0," << x(static_cast<int>(S::POS_X)) << "," << x(static_cast<int>(S::POS_Y)) << ","
+    << x(static_cast<int>(S::YAW)) << "," << x(static_cast<int>(S::VEL_X)) << ","
+    << x(static_cast<int>(S::STEER_ANGLE)) << ",0,0\n";
+
+  const int steps = static_cast<int>(u.cols());
+  for (int k = 0; k < steps; ++k) {
+    u_step = u.col(k);
+    model.enforceConstraints(x, u_step);
+    model.step(x, x_next, xdot, u_step, y, static_cast<float>(k), dt);
+    const float t = static_cast<float>(k + 1) * dt;
+    f << (k + 1) << "," << t << "," << x_next(static_cast<int>(S::POS_X)) << ","
+      << x_next(static_cast<int>(S::POS_Y)) << "," << x_next(static_cast<int>(S::YAW)) << ","
+      << x_next(static_cast<int>(S::VEL_X)) << "," << x_next(static_cast<int>(S::STEER_ANGLE))
+      << "," << u_step(0) << "," << u_step(1) << "\n";
+    x = x_next;
+  }
+}
+
+template <class DYN_T, class TrajT>
+void writeRolloutTrajectories(
+  const std::string & path, const typename DYN_T::state_array & x0, int horizon,
+  const std::vector<TrajT> & outputs, const std::vector<int> & rollout_indices, int out_x_idx,
+  int out_y_idx, int out_yaw_idx, int out_vel_idx)
+{
+  using S = typename DYN_T::DYN_PARAMS_T::StateIndex;
+  std::ofstream f(path.c_str());
+  if (!f) {
+    return;
+  }
+  f << "rollout_index,step,x,y,yaw,vel_x\n";
+  const int n_out = static_cast<int>(outputs.size());
+
+  for (int r = 0; r < n_out; ++r) {
+    const int rollout_index = rollout_indices.empty() ? r : rollout_indices[static_cast<size_t>(r)];
+    f << rollout_index << ",0," << x0(static_cast<int>(S::POS_X)) << ","
+      << x0(static_cast<int>(S::POS_Y)) << "," << x0(static_cast<int>(S::YAW)) << ","
+      << x0(static_cast<int>(S::VEL_X)) << "\n";
+    const TrajT & traj = outputs[static_cast<size_t>(r)];
+    for (int c = 0; c < horizon; ++c) {
+      f << rollout_index << "," << (c + 1) << "," << traj(out_x_idx, c) << "," << traj(out_y_idx, c)
+        << "," << traj(out_yaw_idx, c) << "," << traj(out_vel_idx, c) << "\n";
+    }
+  }
+}
+
+template <class DYN_T, class TrajT>
+void writeRolloutTrajectories(
+  const std::string & path, const typename DYN_T::state_array & x0, int horizon,
+  const std::vector<TrajT> & outputs, const std::vector<int> & rollout_indices)
+{
+  using O = typename DYN_T::DYN_PARAMS_T::OutputIndex;
+  writeRolloutTrajectories<DYN_T, TrajT>(
+    path, x0, horizon, outputs, rollout_indices, static_cast<int>(O::POS_X),
+    static_cast<int>(O::POS_Y), static_cast<int>(O::YAW), static_cast<int>(O::VEL_X));
+}
+
+template <class DYN_T, class TrajT>
+void writeRolloutTrajectories(
+  const std::string & path, const typename DYN_T::state_array & x0, int horizon,
+  const std::vector<TrajT> & outputs)
+{
+  writeRolloutTrajectories<DYN_T, TrajT>(path, x0, horizon, outputs, {});
+}
+
+template <class DYN_T>
+void writeRolloutControls(
+  const std::string & path, const std::vector<float> & host_controls, int horizon, int num_rollouts,
+  const std::vector<int> & rollout_indices)
+{
+  std::ofstream f(path.c_str());
+  if (!f) {
+    return;
+  }
+  f << "rollout_index,step,u_accel,u_steer\n";
+  const size_t stride = static_cast<size_t>(horizon) * static_cast<size_t>(DYN_T::CONTROL_DIM);
+  for (size_t out_idx = 0; out_idx < rollout_indices.size(); ++out_idx) {
+    const int rollout_index = rollout_indices[out_idx];
+    for (int t = 0; t < horizon; ++t) {
+      const float * src =
+        host_controls.data() +
+        (out_idx * stride + static_cast<size_t>(t) * static_cast<size_t>(DYN_T::CONTROL_DIM));
+      f << rollout_index << "," << t << "," << src[0] << "," << src[1] << "\n";
+    }
+  }
+}
+
+inline void writeContextVector(const std::string & path, const float * context, int context_dim)
+{
+  std::ofstream f(path.c_str());
+  if (!f || context == nullptr || context_dim <= 0) {
+    return;
+  }
+  f << "index,value\n";
+  for (int i = 0; i < context_dim; ++i) {
+    f << i << "," << context[i] << "\n";
+  }
+}
+}  // namespace rollout_csv
+}  // namespace mppi
+
+#endif  // MPPI__UTILS__ROLLOUT_CSV_HPP_

--- a/planning/autoware_mppi_optimizer/include/mppi/utils/step_timing.hpp
+++ b/planning/autoware_mppi_optimizer/include/mppi/utils/step_timing.hpp
@@ -1,0 +1,183 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * Steady-clock timing helpers for simulation loops (min / max / mean / mode).
+ */
+#pragma once
+
+#include <algorithm>
+#include <chrono>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <iomanip>
+#include <iostream>
+#include <numeric>
+#include <unordered_map>
+#include <vector>
+
+namespace mppi
+{
+namespace timing
+{
+
+using SteadyClock = std::chrono::steady_clock;
+using TimePoint = SteadyClock::time_point;
+
+inline double elapsedMs(const TimePoint & t0, const TimePoint & t1)
+{
+  return std::chrono::duration<double, std::milli>(t1 - t0).count();
+}
+
+struct TimingStats
+{
+  size_t count = 0;
+  double min_ms = 0.0;
+  double max_ms = 0.0;
+  double mean_ms = 0.0;
+  double mode_ms = 0.0;
+};
+
+inline TimingStats summarizeTimingsMs(
+  const std::vector<double> & samples_ms, const double bin_width_ms = 0.1)
+{
+  TimingStats stats;
+  if (samples_ms.empty()) {
+    return stats;
+  }
+
+  stats.count = samples_ms.size();
+  stats.min_ms = *std::min_element(samples_ms.begin(), samples_ms.end());
+  stats.max_ms = *std::max_element(samples_ms.begin(), samples_ms.end());
+  stats.mean_ms =
+    std::accumulate(samples_ms.begin(), samples_ms.end(), 0.0) / static_cast<double>(stats.count);
+
+  std::unordered_map<long long, size_t> histogram;
+  histogram.reserve(samples_ms.size());
+  for (const double sample_ms : samples_ms) {
+    const long long bin = static_cast<long long>(std::llround(sample_ms / bin_width_ms));
+    ++histogram[bin];
+  }
+
+  long long mode_bin = 0;
+  size_t mode_count = 0;
+  for (const auto & entry : histogram) {
+    if (entry.second > mode_count) {
+      mode_count = entry.second;
+      mode_bin = entry.first;
+    }
+  }
+  stats.mode_ms = static_cast<double>(mode_bin) * bin_width_ms;
+  return stats;
+}
+
+inline void printTimingStats(const char * label, const TimingStats & stats)
+{
+  if (stats.count == 0) {
+    std::cout << label << ": no samples\n";
+    return;
+  }
+
+  std::cout << std::fixed << std::setprecision(3);
+  std::cout << label << " (n=" << stats.count << "): min=" << stats.min_ms
+            << " ms  max=" << stats.max_ms << " ms  mean=" << stats.mean_ms
+            << " ms  mode=" << stats.mode_ms << " ms";
+  if (stats.mean_ms > 0.0) {
+    std::cout << "  (~" << (1000.0 / stats.mean_ms) << " Hz)";
+  }
+  std::cout << "\n";
+}
+
+/** Records per-step MPPI / viz / post durations for a simulation loop. */
+class StepTimingCollector
+{
+public:
+  void reserve(const size_t num_steps)
+  {
+    total_ms_.reserve(num_steps);
+    mppi_ms_.reserve(num_steps);
+    dump_ms_.reserve(num_steps);
+    viz_ms_.reserve(num_steps);
+    post_ms_.reserve(num_steps);
+  }
+
+  void beginStep() { step_start_ = SteadyClock::now(); }
+
+  void endMppi() { mppi_end_ = SteadyClock::now(); }
+
+  void endDump() { dump_end_ = SteadyClock::now(); }
+
+  void endViz() { viz_end_ = SteadyClock::now(); }
+
+  /** Full step including integrate + log. */
+  void endStep()
+  {
+    const TimePoint step_end = SteadyClock::now();
+    mppi_ms_.push_back(elapsedMs(step_start_, mppi_end_));
+    dump_ms_.push_back(elapsedMs(mppi_end_, dump_end_));
+    viz_ms_.push_back(elapsedMs(dump_end_, viz_end_));
+    post_ms_.push_back(elapsedMs(viz_end_, step_end));
+    total_ms_.push_back(elapsedMs(step_start_, step_end));
+  }
+
+  /** Early loop exit (e.g. ESC): no post phase recorded. */
+  void endStepEarlyExit()
+  {
+    mppi_ms_.push_back(elapsedMs(step_start_, mppi_end_));
+    dump_ms_.push_back(elapsedMs(mppi_end_, dump_end_));
+    viz_ms_.push_back(elapsedMs(dump_end_, viz_end_));
+    post_ms_.push_back(0.0);
+    total_ms_.push_back(elapsedMs(step_start_, viz_end_));
+  }
+
+  void printReport(const char * title = "Simulation step timing") const
+  {
+    std::cout << "\n--- " << title << " ---\n";
+    printTimingStats("Total step", summarizeTimingsMs(total_ms_));
+    printTimingStats("  MPPI (ref + computeControl + sampled traj)", summarizeTimingsMs(mppi_ms_));
+    printTimingStats("  Rollout dump (prepare + enqueue)", summarizeTimingsMs(dump_ms_));
+    printTimingStats("  Viz (draw + video + imshow)", summarizeTimingsMs(viz_ms_));
+    printTimingStats("  Post (integrate + log)", summarizeTimingsMs(post_ms_));
+    std::cout << std::defaultfloat;
+  }
+
+private:
+  std::vector<double> total_ms_;
+  std::vector<double> mppi_ms_;
+  std::vector<double> dump_ms_;
+  std::vector<double> viz_ms_;
+  std::vector<double> post_ms_;
+  TimePoint step_start_{};
+  TimePoint mppi_end_{};
+  TimePoint dump_end_{};
+  TimePoint viz_end_{};
+};
+
+}  // namespace timing
+}  // namespace mppi

--- a/planning/autoware_mppi_optimizer/include/mppi/utils/step_timing.hpp
+++ b/planning/autoware_mppi_optimizer/include/mppi/utils/step_timing.hpp
@@ -12,20 +12,6 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Copyright 2026 TIER IV, Inc.
-//
-// Licensed under the Apache License, Version 2.0 (the "License");
-// you may not use this file except in compliance with the License.
-// You may obtain a copy of the License at
-//
-//     http://www.apache.org/licenses/LICENSE-2.0
-//
-// Unless required by applicable law or agreed to in writing, software
-// distributed under the License is distributed on an "AS IS" BASIS,
-// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// See the License for the specific language governing permissions and
-// limitations under the License.
-
 /**
  * Steady-clock timing helpers for simulation loops (min / max / mean / mode).
  */

--- a/planning/autoware_mppi_optimizer/include/mppi/viz/path_tracking_viz.hpp
+++ b/planning/autoware_mppi_optimizer/include/mppi/viz/path_tracking_viz.hpp
@@ -1,0 +1,558 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+/**
+ * OpenCV visualization helpers for 2D path-tracking simulations.
+ */
+#pragma once
+
+#include <mppi/path/path2d.hpp>
+#include <mppi/path/path_reference_generator.hpp>
+#include <opencv2/opencv.hpp>
+
+#include <algorithm>
+#include <cmath>
+#include <numeric>
+#include <vector>
+
+namespace mppi
+{
+namespace viz
+{
+
+inline cv::Mat makeWhiteFrame(const int img_w, const int img_h)
+{
+  return cv::Mat(img_h, img_w, CV_8UC3, cv::Scalar(255, 255, 255));
+}
+
+inline cv::Point2f worldToPixel(
+  const float x, const float y, const int img_w, const int img_h, const float scale = 15.0F)
+{
+  const float u = static_cast<float>(img_w) / 2.0F + x * scale;
+  const float v = static_cast<float>(img_h) / 2.0F - y * scale;
+  return cv::Point2f(u, v);
+}
+
+inline cv::Scalar lerpBgr(const cv::Scalar & a, const cv::Scalar & b, const float t)
+{
+  const float s = std::max(0.0F, std::min(1.0F, t));
+  return cv::Scalar(a[0] + s * (b[0] - a[0]), a[1] + s * (b[1] - a[1]), a[2] + s * (b[2] - a[2]));
+}
+
+inline cv::Scalar costGradientColor(const float cost, const float min_cost, const float max_cost)
+{
+  const cv::Scalar k_teal(128, 128, 0);
+  const cv::Scalar k_purple(128, 0, 128);
+  if (max_cost <= min_cost) {
+    return k_teal;
+  }
+  const float t = (cost - min_cost) / (max_cost - min_cost);
+  return lerpBgr(k_teal, k_purple, t);
+}
+
+inline void drawCenterline(cv::Mat & img, const path::Path2D & path, const float scale = 15.0F)
+{
+  cv::Mat overlay = img.clone();
+  const auto & anchors = path.anchors();
+  for (size_t i = 0; i + 1 < anchors.size(); ++i) {
+    cv::line(
+      overlay, worldToPixel(anchors[i].x, anchors[i].y, img.cols, img.rows, scale),
+      worldToPixel(anchors[i + 1].x, anchors[i + 1].y, img.cols, img.rows, scale),
+      cv::Scalar(200, 200, 200), 2);
+  }
+  cv::addWeighted(overlay, 0.85, img, 0.15, 0, img);
+}
+
+/** Draw left/right road edges offset from the path centerline (matches RacerCost
+ * boundary_threshold). */
+inline void drawRoadBoundaries(
+  cv::Mat & img, const path::Path2D & path, const float half_width = 0.8F,
+  const float scale = 15.0F, const bool fill_corridor = true)
+{
+  const float path_length = path.length();
+  if (path_length <= 0.0F || half_width <= 0.0F) {
+    return;
+  }
+
+  constexpr float kSampleSpacing = 0.5F;
+  std::vector<cv::Point> left_px;
+  std::vector<cv::Point> right_px;
+  left_px.reserve(static_cast<size_t>(path_length / kSampleSpacing) + 4U);
+  right_px.reserve(left_px.capacity());
+
+  for (float s = 0.0F; s <= path_length; s += kSampleSpacing) {
+    const path::Pose2D p = path.poseAt(s);
+    float tx = 0.0F;
+    float ty = 0.0F;
+    path.tangentAt(s, tx, ty);
+    const cv::Point2f left =
+      worldToPixel(p.x - half_width * ty, p.y + half_width * tx, img.cols, img.rows, scale);
+    const cv::Point2f right =
+      worldToPixel(p.x + half_width * ty, p.y - half_width * tx, img.cols, img.rows, scale);
+    left_px.emplace_back(static_cast<int>(left.x + 0.5F), static_cast<int>(left.y + 0.5F));
+    right_px.emplace_back(static_cast<int>(right.x + 0.5F), static_cast<int>(right.y + 0.5F));
+  }
+
+  if (left_px.size() < 2U) {
+    return;
+  }
+
+  if (fill_corridor) {
+    std::vector<cv::Point> corridor = left_px;
+    corridor.insert(corridor.end(), right_px.rbegin(), right_px.rend());
+    cv::Mat overlay = img.clone();
+    const cv::Point * pts = corridor.data();
+    const int n_pts = static_cast<int>(corridor.size());
+    cv::fillPoly(overlay, &pts, &n_pts, 1, cv::Scalar(235, 245, 235));
+    cv::addWeighted(overlay, 0.35, img, 0.65, 0, img);
+  }
+
+  cv::Mat overlay = img.clone();
+  const cv::Scalar edge_color(120, 120, 120);
+  for (size_t i = 0; i + 1 < left_px.size(); ++i) {
+    cv::line(overlay, left_px[i], left_px[i + 1], edge_color, 1, cv::LINE_AA);
+    cv::line(overlay, right_px[i], right_px[i + 1], edge_color, 1, cv::LINE_AA);
+  }
+  cv::addWeighted(overlay, 0.9, img, 0.1, 0, img);
+}
+
+/** Draw allowed corridor edges relative to path (positive left/right match FirstOrderDubins
+ * off-road limits). */
+inline void drawAsymmetricRoadBoundaries(
+  cv::Mat & img, const path::Path2D & path, const float left_half, const float right_half,
+  const float scale = 15.0F, const bool fill_corridor = true)
+{
+  const float path_length = path.length();
+  if (path_length <= 0.0F || left_half <= 0.0F || right_half <= 0.0F) {
+    return;
+  }
+
+  constexpr float kSampleSpacing = 0.5F;
+  std::vector<cv::Point> left_px;
+  std::vector<cv::Point> right_px;
+  left_px.reserve(static_cast<size_t>(path_length / kSampleSpacing) + 4U);
+  right_px.reserve(left_px.capacity());
+
+  for (float s = 0.0F; s <= path_length; s += kSampleSpacing) {
+    const path::Pose2D p = path.poseAt(s);
+    float tx = 0.0F;
+    float ty = 0.0F;
+    path.tangentAt(s, tx, ty);
+    const cv::Point2f left =
+      worldToPixel(p.x - left_half * ty, p.y + left_half * tx, img.cols, img.rows, scale);
+    const cv::Point2f right =
+      worldToPixel(p.x + right_half * ty, p.y - right_half * tx, img.cols, img.rows, scale);
+    left_px.emplace_back(static_cast<int>(left.x + 0.5F), static_cast<int>(left.y + 0.5F));
+    right_px.emplace_back(static_cast<int>(right.x + 0.5F), static_cast<int>(right.y + 0.5F));
+  }
+
+  if (left_px.size() < 2U) {
+    return;
+  }
+
+  if (fill_corridor) {
+    std::vector<cv::Point> corridor = left_px;
+    corridor.insert(corridor.end(), right_px.rbegin(), right_px.rend());
+    cv::Mat overlay = img.clone();
+    const cv::Point * pts = corridor.data();
+    const int n_pts = static_cast<int>(corridor.size());
+    cv::fillPoly(overlay, &pts, &n_pts, 1, cv::Scalar(245, 250, 255));
+    cv::addWeighted(overlay, 0.35, img, 0.65, 0, img);
+  }
+
+  cv::Mat overlay = img.clone();
+  const cv::Scalar edge_color(40, 90, 200);
+  for (size_t i = 0; i + 1 < left_px.size(); ++i) {
+    cv::line(overlay, left_px[i], left_px[i + 1], edge_color, 2, cv::LINE_AA);
+    cv::line(overlay, right_px[i], right_px[i + 1], edge_color, 2, cv::LINE_AA);
+  }
+  cv::addWeighted(overlay, 0.9, img, 0.1, 0, img);
+}
+
+inline void drawReferencePath(
+  cv::Mat & img, const std::vector<path::PathReferenceSample> & ref, const float scale = 15.0F)
+{
+  if (ref.size() < 2) {
+    return;
+  }
+
+  cv::Mat overlay = img.clone();
+  for (size_t i = 0; i + 1 < ref.size(); ++i) {
+    cv::line(
+      overlay, worldToPixel(ref[i].x, ref[i].y, img.cols, img.rows, scale),
+      worldToPixel(ref[i + 1].x, ref[i + 1].y, img.cols, img.rows, scale), cv::Scalar(0, 165, 255),
+      2);
+  }
+  cv::addWeighted(overlay, 0.7, img, 0.3, 0, img);
+}
+
+/** Oriented rectangle at box center (body x = forward, y = left). */
+inline void drawOrientedBox(
+  cv::Mat & img, const float cx, const float cy, const float yaw, const float length,
+  const float width, const cv::Scalar & fill, const cv::Scalar & outline, const float scale = 15.0F)
+{
+  const float c = std::cos(yaw);
+  const float s = std::sin(yaw);
+  const float hl = length * 0.5F;
+  const float hw = width * 0.5F;
+
+  const float corners[4][2] = {{hl, hw}, {hl, -hw}, {-hl, -hw}, {-hl, hw}};
+  std::vector<cv::Point> px(4);
+  for (int i = 0; i < 4; ++i) {
+    const float bx = corners[i][0];
+    const float by = corners[i][1];
+    const float wx = cx + c * bx - s * by;
+    const float wy = cy + s * bx + c * by;
+    const cv::Point2f p = worldToPixel(wx, wy, img.cols, img.rows, scale);
+    px[static_cast<size_t>(i)] =
+      cv::Point(static_cast<int>(p.x + 0.5F), static_cast<int>(p.y + 0.5F));
+  }
+
+  const cv::Point * poly = px.data();
+  const int n = 4;
+  cv::fillPoly(img, &poly, &n, 1, fill);
+  cv::polylines(img, px, true, outline, 1, cv::LINE_AA);
+}
+
+/** Oriented rectangle parked car (body x = forward, y = left). */
+inline void drawParkedCar(
+  cv::Mat & img, const float x, const float y, const float yaw, const float length,
+  const float width, const cv::Scalar & fill, const cv::Scalar & outline, const float scale = 15.0F)
+{
+  drawOrientedBox(img, x, y, yaw, length, width, fill, outline, scale);
+}
+
+/** Ego OBB from rear-axle pose (matches RacerCost egoIntersectsParkedCar footprint). */
+inline void drawEgoVehicleAtRearAxle(
+  cv::Mat & img, const float axle_x, const float axle_y, const float yaw, const float length,
+  const float width, const float axle_to_box_center,
+  const cv::Scalar & fill = cv::Scalar(0, 200, 0),
+  const cv::Scalar & outline = cv::Scalar(0, 120, 0), const float scale = 15.0F)
+{
+  const float c = std::cos(yaw);
+  const float s = std::sin(yaw);
+  const float cx = axle_x + axle_to_box_center * c;
+  const float cy = axle_y + axle_to_box_center * s;
+  drawOrientedBox(img, cx, cy, yaw, length, width, fill, outline, scale);
+}
+
+template <typename ParkedCarT>
+inline void drawParkedCars(
+  cv::Mat & img, const std::vector<ParkedCarT> & cars,
+  const cv::Scalar & fill = cv::Scalar(40, 40, 180),
+  const cv::Scalar & outline = cv::Scalar(20, 20, 100), const float scale = 15.0F)
+{
+  for (const ParkedCarT & car : cars) {
+    drawParkedCar(img, car.ox, car.oy, car.yaw, car.length, car.width, fill, outline, scale);
+  }
+}
+
+template <typename TrajectoryMatrix>
+inline void drawTrajectory(
+  cv::Mat & img, const TrajectoryMatrix & traj, const int x_idx, const int y_idx,
+  const cv::Scalar & color = cv::Scalar(255, 64, 0), const int thickness = 3,
+  const float overlay_alpha = 0.85F, const float scale = 15.0F)
+{
+  cv::Mat overlay = img.clone();
+  for (int i = 0; i + 1 < traj.cols(); ++i) {
+    cv::line(
+      overlay, worldToPixel(traj(x_idx, i), traj(y_idx, i), img.cols, img.rows, scale),
+      worldToPixel(traj(x_idx, i + 1), traj(y_idx, i + 1), img.cols, img.rows, scale), color,
+      thickness);
+  }
+  cv::addWeighted(overlay, overlay_alpha, img, 1.0F - overlay_alpha, 0, img);
+}
+
+/** Default cap on rollouts drawn live; full samples remain in MPPI / CSV dumps. */
+constexpr int kDefaultMaxDrawRollouts = 400;
+
+template <typename TrajectoryMatrix>
+inline void drawSampledTrajectories(
+  cv::Mat & img, const std::vector<TrajectoryMatrix> & sampled_trajectories, const int x_idx,
+  const int y_idx, const int num_timesteps, const std::vector<float> & rollout_costs,
+  const int thickness = 1, const float scale = 15.0F,
+  const int max_rollouts = kDefaultMaxDrawRollouts)
+{
+  if (
+    sampled_trajectories.empty() || num_timesteps <= 1 ||
+    rollout_costs.size() != sampled_trajectories.size()) {
+    return;
+  }
+
+  const int num_valid_cols = num_timesteps - 1;
+
+  std::vector<size_t> draw_order(sampled_trajectories.size());
+  std::iota(draw_order.begin(), draw_order.end(), 0U);
+  if (max_rollouts > 0 && static_cast<int>(draw_order.size()) > max_rollouts) {
+    std::partial_sort(
+      draw_order.begin(), draw_order.begin() + static_cast<size_t>(max_rollouts), draw_order.end(),
+      [&rollout_costs](const size_t a, const size_t b) {
+        return rollout_costs[a] < rollout_costs[b];
+      });
+    draw_order.resize(static_cast<size_t>(max_rollouts));
+  }
+
+  float min_cost = rollout_costs[draw_order.front()];
+  float max_cost = rollout_costs[draw_order.front()];
+  for (const size_t idx : draw_order) {
+    min_cost = std::min(min_cost, rollout_costs[idx]);
+    max_cost = std::max(max_cost, rollout_costs[idx]);
+  }
+
+  std::sort(draw_order.begin(), draw_order.end(), [&rollout_costs](const size_t a, const size_t b) {
+    return rollout_costs[a] > rollout_costs[b];
+  });
+
+  for (const size_t idx : draw_order) {
+    const TrajectoryMatrix & traj = sampled_trajectories[idx];
+    const cv::Scalar color = costGradientColor(rollout_costs[idx], min_cost, max_cost);
+    const int cols_to_draw = std::min(num_valid_cols, static_cast<int>(traj.cols()));
+    for (int i = 0; i + 1 < cols_to_draw; ++i) {
+      cv::line(
+        img, worldToPixel(traj(x_idx, i), traj(y_idx, i), img.cols, img.rows, scale),
+        worldToPixel(traj(x_idx, i + 1), traj(y_idx, i + 1), img.cols, img.rows, scale), color,
+        thickness);
+    }
+  }
+}
+
+/** Draw a straight cross-street segment (world coordinates). */
+inline void drawStraightCorridor(
+  cv::Mat & img, const float x0, const float y0, const float x1, const float y1,
+  const float half_width, const float scale = 15.0F)
+{
+  const float dx = x1 - x0;
+  const float dy = y1 - y0;
+  const float len = std::sqrt(dx * dx + dy * dy);
+  if (len < 1.0E-6F) {
+    return;
+  }
+  const float tx = dx / len;
+  const float ty = dy / len;
+  const float nx = -ty;
+  const float ny = tx;
+  const cv::Point2f c0 =
+    worldToPixel(x0 + nx * half_width, y0 + ny * half_width, img.cols, img.rows, scale);
+  const cv::Point2f c1 =
+    worldToPixel(x1 + nx * half_width, y1 + ny * half_width, img.cols, img.rows, scale);
+  const cv::Point2f c2 =
+    worldToPixel(x1 - nx * half_width, y1 - ny * half_width, img.cols, img.rows, scale);
+  const cv::Point2f c3 =
+    worldToPixel(x0 - nx * half_width, y0 - ny * half_width, img.cols, img.rows, scale);
+  std::vector<cv::Point> poly = {
+    cv::Point(static_cast<int>(c0.x), static_cast<int>(c0.y)),
+    cv::Point(static_cast<int>(c1.x), static_cast<int>(c1.y)),
+    cv::Point(static_cast<int>(c2.x), static_cast<int>(c2.y)),
+    cv::Point(static_cast<int>(c3.x), static_cast<int>(c3.y)),
+  };
+  cv::Mat overlay = img.clone();
+  const cv::Point * pts = poly.data();
+  const int n_pts = 4;
+  cv::fillPoly(overlay, &pts, &n_pts, 1, cv::Scalar(235, 245, 235));
+  cv::addWeighted(overlay, 0.35, img, 0.65, 0, img);
+  cv::line(img, poly[0], poly[1], cv::Scalar(120, 120, 120), 1, cv::LINE_AA);
+  cv::line(img, poly[2], poly[3], cv::Scalar(120, 120, 120), 1, cv::LINE_AA);
+}
+
+/** Layout for stacked time-series strips under the track view. */
+struct TimeSeriesPlotLayout
+{
+  int plot_strip_height = 200;
+  int plot_strip_count = 4;
+  int plot_margin_left = 76;
+  int plot_margin_right = 16;
+  int plot_margin_top = 26;
+  int plot_margin_bottom = 14;
+  float plot_font_scale = 0.58F;
+  int plot_line_thickness = 2;
+  /** Downscale composite for imshow so the window fits typical displays (video stays full size). */
+  int max_display_width = 1440;
+  int max_display_height = 960;
+};
+
+inline const TimeSeriesPlotLayout & defaultTimeSeriesPlotLayout()
+{
+  static const TimeSeriesPlotLayout layout{};
+  return layout;
+}
+
+inline cv::Size compositeFrameSize(
+  const int track_width, const int track_height, const TimeSeriesPlotLayout & layout)
+{
+  return cv::Size(track_width, track_height + layout.plot_strip_count * layout.plot_strip_height);
+}
+
+/** Downscale for on-screen display; returns input unchanged if already within limits. */
+inline cv::Mat fitFrameForDisplay(const cv::Mat & frame, const int max_width, const int max_height)
+{
+  if (frame.empty() || max_width <= 0 || max_height <= 0) {
+    return frame;
+  }
+  const double sx = static_cast<double>(max_width) / static_cast<double>(frame.cols);
+  const double sy = static_cast<double>(max_height) / static_cast<double>(frame.rows);
+  const double scale = std::min({sx, sy, 1.0});
+  if (scale >= 0.999) {
+    return frame;
+  }
+  cv::Mat display;
+  cv::resize(frame, display, cv::Size(), scale, scale, cv::INTER_AREA);
+  return display;
+}
+
+inline void showCompositeFrame(
+  const char * window_name, const cv::Mat & composite, const TimeSeriesPlotLayout & layout)
+{
+  const cv::Mat display =
+    fitFrameForDisplay(composite, layout.max_display_width, layout.max_display_height);
+  cv::imshow(window_name, display);
+  cv::resizeWindow(window_name, display.cols, display.rows);
+  cv::setWindowProperty(window_name, cv::WND_PROP_ASPECT_RATIO, cv::WINDOW_KEEPRATIO);
+}
+
+/** Rolling signals for strip-chart overlays on path-tracking videos. */
+struct RunningTimeSeries
+{
+  std::vector<float> t;
+  std::vector<float> vel;
+  std::vector<float> accel;
+  std::vector<float> steer_cmd;
+  std::vector<float> steer_state;
+
+  void push(
+    const float time, const float velocity, const float acceleration, const float steer_command,
+    const float steer_angle, const size_t max_points = 400)
+  {
+    t.push_back(time);
+    vel.push_back(velocity);
+    accel.push_back(acceleration);
+    steer_cmd.push_back(steer_command);
+    steer_state.push_back(steer_angle);
+    if (t.size() > max_points) {
+      const size_t drop = t.size() - max_points;
+      t.erase(t.begin(), t.begin() + static_cast<std::ptrdiff_t>(drop));
+      vel.erase(vel.begin(), vel.begin() + static_cast<std::ptrdiff_t>(drop));
+      accel.erase(accel.begin(), accel.begin() + static_cast<std::ptrdiff_t>(drop));
+      steer_cmd.erase(steer_cmd.begin(), steer_cmd.begin() + static_cast<std::ptrdiff_t>(drop));
+      steer_state.erase(
+        steer_state.begin(), steer_state.begin() + static_cast<std::ptrdiff_t>(drop));
+    }
+  }
+};
+
+inline void drawTimeSeriesStrip(
+  cv::Mat & strip, const std::vector<float> & t, const std::vector<float> & y, const float y_min,
+  const float y_max, const cv::Scalar & color, const char * label,
+  const TimeSeriesPlotLayout & layout, const float ref_line = NAN,
+  const cv::Scalar & ref_color = cv::Scalar(180, 180, 180))
+{
+  strip.setTo(cv::Scalar(252, 252, 252));
+  const int w = strip.cols;
+  const int h = strip.rows;
+  const int margin_l = layout.plot_margin_left;
+  const int margin_r = layout.plot_margin_right;
+  const int margin_t = layout.plot_margin_top;
+  const int margin_b = layout.plot_margin_bottom;
+  const int plot_w = std::max(1, w - margin_l - margin_r);
+  const int plot_h = std::max(1, h - margin_t - margin_b);
+  const int axis_thickness = std::max(1, layout.plot_line_thickness - 1);
+  const int data_thickness = layout.plot_line_thickness;
+
+  cv::line(
+    strip, cv::Point(margin_l, margin_t), cv::Point(margin_l, margin_t + plot_h),
+    cv::Scalar(200, 200, 200), axis_thickness);
+  cv::line(
+    strip, cv::Point(margin_l, margin_t + plot_h), cv::Point(margin_l + plot_w, margin_t + plot_h),
+    cv::Scalar(200, 200, 200), axis_thickness);
+  cv::putText(
+    strip, label, cv::Point(8, margin_t - 8), cv::FONT_HERSHEY_SIMPLEX, layout.plot_font_scale,
+    cv::Scalar(30, 30, 30), 1, cv::LINE_AA);
+
+  const float y_span = std::max(y_max - y_min, 1.0E-6F);
+  auto to_px = [&](const float tv, const float yv) {
+    const float t0 = t.front();
+    const float t1 = t.back();
+    const float t_span = std::max(t1 - t0, 1.0E-6F);
+    const float u = (tv - t0) / t_span;
+    const float v = (yv - y_min) / y_span;
+    const int px = margin_l + static_cast<int>(u * static_cast<float>(plot_w));
+    const int py = margin_t + plot_h - static_cast<int>(v * static_cast<float>(plot_h));
+    return cv::Point(px, py);
+  };
+
+  if (!std::isnan(ref_line) && ref_line >= y_min && ref_line <= y_max) {
+    const cv::Point p0 = to_px(t.front(), ref_line);
+    const cv::Point p1 = to_px(t.back(), ref_line);
+    cv::line(strip, p0, p1, ref_color, data_thickness, cv::LINE_AA);
+  }
+
+  if (t.size() >= 2) {
+    for (size_t i = 1; i < t.size(); ++i) {
+      cv::line(
+        strip, to_px(t[i - 1], y[i - 1]), to_px(t[i], y[i]), color, data_thickness, cv::LINE_AA);
+    }
+  }
+}
+
+/** Stack track view (top) and four signal strips below (full resolution for video). */
+inline cv::Mat composeFrameWithTimeSeriesPlots(
+  const cv::Mat & track_frame, const RunningTimeSeries & history, const float vel_ref,
+  const float vel_max, const float accel_min, const float accel_max, const float steer_max,
+  const TimeSeriesPlotLayout & layout = defaultTimeSeriesPlotLayout())
+{
+  const int strip_h = layout.plot_strip_height;
+  const int total_h = track_frame.rows + layout.plot_strip_count * strip_h;
+  cv::Mat out(total_h, track_frame.cols, CV_8UC3, cv::Scalar(255, 255, 255));
+  track_frame.copyTo(out(cv::Rect(0, 0, track_frame.cols, track_frame.rows)));
+
+  if (history.t.size() < 2) {
+    return out;
+  }
+
+  const cv::Scalar k_vel(200, 120, 0);
+  const cv::Scalar k_accel(180, 60, 60);
+  const cv::Scalar k_steer_cmd(60, 60, 200);
+  const cv::Scalar k_steer_state(60, 160, 60);
+
+  int y_off = track_frame.rows;
+  cv::Mat strip_vel(strip_h, track_frame.cols, CV_8UC3);
+  drawTimeSeriesStrip(
+    strip_vel, history.t, history.vel, 0.0F, vel_max, k_vel, "velocity [m/s]", layout, vel_ref);
+  strip_vel.copyTo(out(cv::Rect(0, y_off, track_frame.cols, strip_h)));
+  y_off += strip_h;
+
+  cv::Mat strip_accel(strip_h, track_frame.cols, CV_8UC3);
+  drawTimeSeriesStrip(
+    strip_accel, history.t, history.accel, accel_min, accel_max, k_accel, "accel cmd [m/s^2]",
+    layout);
+  strip_accel.copyTo(out(cv::Rect(0, y_off, track_frame.cols, strip_h)));
+  y_off += strip_h;
+
+  cv::Mat strip_steer_cmd(strip_h, track_frame.cols, CV_8UC3);
+  drawTimeSeriesStrip(
+    strip_steer_cmd, history.t, history.steer_cmd, -steer_max, steer_max, k_steer_cmd,
+    "steer cmd [rad]", layout);
+  strip_steer_cmd.copyTo(out(cv::Rect(0, y_off, track_frame.cols, strip_h)));
+  y_off += strip_h;
+
+  cv::Mat strip_steer_state(strip_h, track_frame.cols, CV_8UC3);
+  drawTimeSeriesStrip(
+    strip_steer_state, history.t, history.steer_state, -steer_max, steer_max, k_steer_state,
+    "steer state [rad]", layout);
+  strip_steer_state.copyTo(out(cv::Rect(0, y_off, track_frame.cols, strip_h)));
+
+  return out;
+}
+
+}  // namespace viz
+}  // namespace mppi

--- a/planning/autoware_mppi_optimizer/launch/mppi_optimizer.launch.xml
+++ b/planning/autoware_mppi_optimizer/launch/mppi_optimizer.launch.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<launch>
+  <arg name="mppi_optimizer_param_path" default="$(find-pkg-share autoware_mppi_optimizer)/config/mppi_optimizer.param.yaml"/>
+  <arg name="vehicle_model" default="sample_vehicle"/>
+  <arg name="vehicle_info_param_path" default="$(find-pkg-share $(var vehicle_model)_description)/config/vehicle_info.param.yaml"/>
+  <arg name="simulator_model_param_path" default="$(find-pkg-share $(var vehicle_model)_description)/config/simulator_model.param.yaml"/>
+
+  <arg name="input_trajectory" default="/planning/scenario_planning/lane_driving/behavior_planning/path"/>
+  <arg name="input_odometry" default="/localization/kinematic_state"/>
+  <arg name="input_steering_status" default="/vehicle/status/steering_status"/>
+  <arg name="output_trajectory" default="/planning/mppi_optimizer/trajectory"/>
+
+  <node pkg="autoware_mppi_optimizer" exec="autoware_mppi_optimizer_node" name="mppi_optimizer_node" output="screen">
+    <param from="$(var simulator_model_param_path)"/>
+    <param from="$(var mppi_optimizer_param_path)"/>
+    <param from="$(var vehicle_info_param_path)" allow_substs="true"/>
+    <remap from="~/input/trajectory" to="$(var input_trajectory)"/>
+    <remap from="~/input/odometry" to="$(var input_odometry)"/>
+    <remap from="~/input/steering_status" to="$(var input_steering_status)"/>
+    <remap from="~/output/trajectory" to="$(var output_trajectory)"/>
+  </node>
+</launch>

--- a/planning/autoware_mppi_optimizer/package.xml
+++ b/planning/autoware_mppi_optimizer/package.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>autoware_mppi_optimizer</name>
+  <version>0.51.0</version>
+  <description>The autoware_mppi_optimizer package for trajectory optimization using Model Predictive Path Integral (MPPI) control</description>
+  <maintainer email="daniel.sanchez@tier4.jp">Daniel Sanchez</maintainer>
+  <license>Apache License 2.0</license>
+
+  <buildtool_depend>ament_cmake_auto</buildtool_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
+
+  <build_depend>eigen3_cmake_module</build_depend>
+
+  <depend>MPPI-Generic</depend>
+  <depend>autoware_perception_msgs</depend>
+  <depend>autoware_planning_msgs</depend>
+  <depend>autoware_utils</depend>
+  <depend>autoware_vehicle_info_utils</depend>
+  <depend>autoware_vehicle_msgs</depend>
+  <depend>eigen</depend>
+  <depend>geometry_msgs</depend>
+  <depend>nav_msgs</depend>
+  <depend>rclcpp</depend>
+  <depend>rclcpp_components</depend>
+  <depend>tf2</depend>
+  <depend>tf2_geometry_msgs</depend>
+  <depend>visualization_msgs</depend>
+
+  <test_depend>ament_cmake_ros</test_depend>
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>autoware_lint_common</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/planning/autoware_mppi_optimizer/src/first_order_dubins/first_order_dubins_mppi_interface.cu
+++ b/planning/autoware_mppi_optimizer/src/first_order_dubins/first_order_dubins_mppi_interface.cu
@@ -1,0 +1,765 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/mppi_optimizer/first_order_dubins_mppi_cost_params.hpp"
+#include "autoware/mppi_optimizer/first_order_dubins_mppi_interface.hpp"
+#include "autoware/mppi_optimizer/tracked_objects_obstacles.hpp"
+
+#include <mppi/controllers/MPPI/mppi_controller.cuh>
+#include <mppi/cost_functions/dubins/first_order_dubins_bicycle_cost.cuh>
+#include <mppi/cost_functions/dubins/first_order_dubins_bicycle_cost_bridge.hpp>
+#include <mppi/cost_functions/moving_car_obstacles.hpp>
+#include <mppi/dynamics/dubins/first_order_dubins_bicycle.cuh>
+#include <mppi/feedback_controllers/zero_feedback.cuh>
+#include <mppi/path/path2d.hpp>
+#include <mppi/path/path_projection.hpp>
+#include <mppi/sampling_distributions/gaussian/gaussian.cuh>
+#include <mppi/utils/gpu_err_chk.cuh>
+#include <rclcpp/logging.hpp>
+
+#include <geometry_msgs/msg/accel_with_covariance_stamped.hpp>
+#include <tf2_geometry_msgs/tf2_geometry_msgs.hpp>
+
+#include <tf2/LinearMath/Quaternion.h>
+#include <tf2/utils.h>
+
+#include <algorithm>
+#include <array>
+#include <chrono>
+#include <cmath>
+#include <memory>
+#include <numeric>
+#include <optional>
+#include <stdexcept>
+#include <utility>
+#include <vector>
+
+namespace autoware::mppi_optimizer
+{
+namespace
+{
+constexpr int kMppiHorizon = 80;
+constexpr int kRefHorizon = kMppiHorizon;
+constexpr float kDt = 0.1F;
+constexpr int kNumRollouts = 32 * 1024;
+constexpr float kLambda = 1500.0F;
+constexpr float kInitArcLength = 1.5F;
+constexpr size_t kTrackingIndexResetThreshold = 15U;
+// constexpr int kMaxVizRollouts = 200;  // rollout viz disabled
+constexpr char kLoggerName[] = "first_order_dubins_mppi";
+
+rclcpp::Logger mppiLogger()
+{
+  return rclcpp::get_logger(kLoggerName);
+}
+
+using DYN = FirstOrderDubinsBicycle;
+using COST = FirstOrderDubinsBicycleCost<kRefHorizon>;
+using FB = ZeroFeedback<DYN, kMppiHorizon>;
+using SAMPLER = mppi::sampling_distributions::GaussianDistribution<DYN::DYN_PARAMS_T>;
+using Mppi = VanillaMPPIController<DYN, COST, FB, kMppiHorizon, kNumRollouts, SAMPLER>;
+
+void applyUserCostParams(
+  FirstOrderDubinsBicycleCostParams<kRefHorizon> & cost_params,
+  const FirstOrderDubinsMppiCostParams & user)
+{
+  cost_params.desired_speed = user.desired_speed;
+  cost_params.speed_coeff = user.speed_coeff;
+  cost_params.track_coeff = user.track_coeff;
+  cost_params.heading_coeff = user.heading_coeff;
+  cost_params.crash_coeff = user.crash_coeff;
+  cost_params.boundary_threshold = user.boundary_threshold;
+  cost_params.boundary_threshold_left = user.boundary_threshold_left;
+  cost_params.boundary_threshold_right = user.boundary_threshold_right;
+  cost_params.accel_cmd_coeff = user.accel_cmd_coeff;
+  cost_params.steer_cmd_coeff = user.steer_cmd_coeff;
+  cost_params.lateral_acceleration_coeff = user.lateral_acceleration_coeff;
+  cost_params.lateral_jerk_coeff = user.lateral_jerk_coeff;
+  cost_params.longitudinal_jerk_coeff = user.longitudinal_jerk_coeff;
+  cost_params.obstacle_collision_margin = user.obstacle_collision_margin;
+  cost_params.goal_pos_coeff = user.goal_pos_coeff;
+  cost_params.goal_speed_coeff = user.goal_speed_coeff;
+  cost_params.goal_yaw_coeff = user.goal_yaw_coeff;
+  cost_params.goal_terminal_scale = user.goal_terminal_scale;
+}
+
+FirstOrderDubinsMppiState toHostState(const DYN::state_array & x)
+{
+  FirstOrderDubinsMppiState state;
+  state.x = x(static_cast<int>(FirstOrderDubinsBicycleParams::StateIndex::POS_X));
+  state.y = x(static_cast<int>(FirstOrderDubinsBicycleParams::StateIndex::POS_Y));
+  state.yaw = x(static_cast<int>(FirstOrderDubinsBicycleParams::StateIndex::YAW));
+  state.vel_x = x(static_cast<int>(FirstOrderDubinsBicycleParams::StateIndex::VEL_X));
+  return state;
+}
+
+void fromHostState(DYN::state_array & x, const FirstOrderDubinsMppiState & state)
+{
+  x(static_cast<int>(FirstOrderDubinsBicycleParams::StateIndex::POS_X)) = state.x;
+  x(static_cast<int>(FirstOrderDubinsBicycleParams::StateIndex::POS_Y)) = state.y;
+  x(static_cast<int>(FirstOrderDubinsBicycleParams::StateIndex::YAW)) = state.yaw;
+  x(static_cast<int>(FirstOrderDubinsBicycleParams::StateIndex::VEL_X)) = state.vel_x;
+}
+
+mppi::path::Path2D trajectoryToPath2D(const Trajectory & trajectory)
+{
+  std::vector<std::pair<float, float>> control_xy;
+  control_xy.reserve(trajectory.points.size());
+  for (const auto & point : trajectory.points) {
+    control_xy.emplace_back(
+      static_cast<float>(point.pose.position.x), static_cast<float>(point.pose.position.y));
+  }
+  if (control_xy.size() < 2U) {
+    throw std::runtime_error("Trajectory must contain at least two points for MPPI tracking");
+  }
+  return mppi::path::Path2D::catmullRom(control_xy, false, 8);
+}
+
+float yawFromOdometry(const Odometry & odometry)
+{
+  return static_cast<float>(tf2::getYaw(odometry.pose.pose.orientation));
+}
+
+float longitudinalAccelerationMps2(
+  const std::optional<geometry_msgs::msg::AccelWithCovarianceStamped> & acceleration)
+{
+  if (!acceleration.has_value()) {
+    return 0.0F;
+  }
+  return static_cast<float>(acceleration->accel.accel.linear.x);
+}
+
+float steeringTireAngleRad(
+  const std::optional<autoware_vehicle_msgs::msg::SteeringReport> & steering_status)
+{
+  if (!steering_status.has_value()) {
+    return 0.0F;
+  }
+  return steering_status->steering_tire_angle;
+}
+
+geometry_msgs::msg::Quaternion quaternionFromYaw(const float yaw)
+{
+  tf2::Quaternion quaternion;
+  quaternion.setRPY(0.0, 0.0, yaw);
+  return tf2::toMsg(quaternion);
+}
+
+size_t findTrackingStartIndex(const Trajectory & trajectory, const Odometry & odometry)
+{
+  const float ego_x = static_cast<float>(odometry.pose.pose.position.x);
+  const float ego_y = static_cast<float>(odometry.pose.pose.position.y);
+
+  const auto dist_sq_to_ego = [&](const auto & point) {
+    const float dx = static_cast<float>(point.pose.position.x) - ego_x;
+    const float dy = static_cast<float>(point.pose.position.y) - ego_y;
+    return dx * dx + dy * dy;
+  };
+
+  const auto nearest = std::min_element(
+    trajectory.points.begin(), trajectory.points.end(),
+    [&](const auto & a, const auto & b) { return dist_sq_to_ego(a) < dist_sq_to_ego(b); });
+  return static_cast<size_t>(std::distance(trajectory.points.begin(), nearest));
+}
+
+std::vector<mppi::path::PathReferenceSample> buildDiffusionReferenceHorizon(
+  const Trajectory & trajectory, const size_t start_idx, const mppi::path::Path2D & path)
+{
+  std::vector<mppi::path::PathReferenceSample> ref(static_cast<size_t>(kRefHorizon));
+  float arc_hint = kInitArcLength;
+
+  size_t k = 0;
+  for (auto & sample : ref) {
+    const size_t idx = std::min(start_idx + k, trajectory.points.size() - 1U);
+    const auto & point = trajectory.points[idx];
+
+    sample.t = static_cast<float>(k) * kDt;
+    sample.x = static_cast<float>(point.pose.position.x);
+    sample.y = static_cast<float>(point.pose.position.y);
+    sample.yaw = static_cast<float>(tf2::getYaw(point.pose.orientation));
+    sample.v = point.longitudinal_velocity_mps;
+
+    const mppi::path::PathProjection proj =
+      mppi::path::projectPoseOntoPath(path, sample.x, sample.y, arc_hint);
+    sample.arc_length_s = proj.arc_length_s;
+    arc_hint = proj.arc_length_s;
+    ++k;
+  }
+
+  return ref;
+}
+
+#if 0  // rollout visualization disabled (~80ms CPU replay of top-K samples)
+void replayRolloutPoints(
+  DYN & model, const DYN::state_array & x0, const float * controls, const int horizon,
+  const float dt, std::vector<std::pair<float, float>> & points)
+{
+  const int pos_x_idx = static_cast<int>(FirstOrderDubinsBicycleParams::StateIndex::POS_X);
+  const int pos_y_idx = static_cast<int>(FirstOrderDubinsBicycleParams::StateIndex::POS_Y);
+
+  points.clear();
+  points.reserve(static_cast<size_t>(horizon) + 1U);
+  points.emplace_back(x0(pos_x_idx), x0(pos_y_idx));
+
+  DYN::state_array x = x0;
+  DYN::state_array x_next = model.getZeroState();
+  DYN::state_array xdot = model.getZeroState();
+  DYN::output_array y = DYN::output_array::Zero();
+  DYN::control_array u = DYN::control_array::Zero();
+
+  for (int t = 0; t < horizon; ++t) {
+    for (int d = 0; d < DYN::CONTROL_DIM; ++d) {
+      u(d) = controls
+        [(static_cast<size_t>(t) * static_cast<size_t>(DYN::CONTROL_DIM)) + static_cast<size_t>(d)];
+    }
+    model.enforceConstraints(x, u);
+    model.step(x, x_next, xdot, u, y, static_cast<float>(t), dt);
+    points.emplace_back(x_next(pos_x_idx), x_next(pos_y_idx));
+    x = x_next;
+  }
+}
+#endif
+
+void fillOptimalHorizonPoints(
+  const Mppi::state_trajectory & state_trajectory, std::vector<std::pair<float, float>> & points)
+{
+  const int pos_x_idx = static_cast<int>(FirstOrderDubinsBicycleParams::StateIndex::POS_X);
+  const int pos_y_idx = static_cast<int>(FirstOrderDubinsBicycleParams::StateIndex::POS_Y);
+  const int horizon = static_cast<int>(state_trajectory.cols());
+
+  points.clear();
+  points.reserve(static_cast<size_t>(horizon));
+  for (int col = 0; col < horizon; ++col) {
+    points.emplace_back(state_trajectory(pos_x_idx, col), state_trajectory(pos_y_idx, col));
+  }
+}
+
+#if 0  // rollout visualization disabled
+void copySamplerControlsToHost(
+  SAMPLER & sampler, const int horizon, const std::vector<int> & rollout_indices,
+  std::vector<float> & host_controls)
+{
+  const size_t rollout_stride =
+    static_cast<size_t>(horizon) * static_cast<size_t>(DYN::CONTROL_DIM) * sizeof(float);
+  host_controls.assign(
+    rollout_indices.size() * static_cast<size_t>(horizon) * static_cast<size_t>(DYN::CONTROL_DIM),
+    0.0F);
+
+  size_t out_idx = 0;
+  for (const int rollout : rollout_indices) {
+    float * device_controls = sampler.getControlSample(rollout, 0, 0);
+    HANDLE_ERROR(cudaMemcpy(
+      host_controls.data() +
+        out_idx * static_cast<size_t>(horizon) * static_cast<size_t>(DYN::CONTROL_DIM),
+      device_controls, rollout_stride, cudaMemcpyDeviceToHost));
+    ++out_idx;
+  }
+}
+
+void selectTopRolloutIndices(
+  const std::vector<float> & normalized_weights, const std::vector<float> & raw_costs,
+  const int top_n, std::vector<int> & rollout_indices, std::vector<float> & selected_costs)
+{
+  const int num_rollouts = static_cast<int>(normalized_weights.size());
+  rollout_indices.resize(static_cast<size_t>(num_rollouts));
+  selected_costs = raw_costs;
+  std::iota(rollout_indices.begin(), rollout_indices.end(), 0);
+
+  if (top_n <= 0 || top_n >= num_rollouts) {
+    return;
+  }
+
+  std::partial_sort(
+    rollout_indices.begin(), rollout_indices.begin() + top_n, rollout_indices.end(),
+    [&](const int a, const int b) {
+      return normalized_weights[static_cast<size_t>(a)] >
+             normalized_weights[static_cast<size_t>(b)];
+    });
+  rollout_indices.resize(static_cast<size_t>(top_n));
+  selected_costs.resize(static_cast<size_t>(top_n));
+  std::transform(
+    rollout_indices.begin(), rollout_indices.end(), selected_costs.begin(),
+    [&](const int rollout) { return raw_costs[static_cast<size_t>(rollout)]; });
+}
+
+void buildRolloutVisualization(
+  Mppi & controller, SAMPLER & sampler, DYN & model, const DYN::state_array & x_at_optimization,
+  FirstOrderDubinsMppiDebug & debug)
+{
+  const Mppi::state_trajectory state_trajectory = controller.getActualStateSeq();
+  fillOptimalHorizonPoints(state_trajectory, debug.optimal_horizon);
+  debug.baseline_cost = controller.getBaselineCost();
+
+  const auto & importance = controller.getSampledCostSeq();
+  const float baseline = controller.getBaselineCost();
+  const int num_rollouts = static_cast<int>(importance.size());
+
+  std::vector<float> raw_costs(static_cast<size_t>(num_rollouts));
+  std::vector<float> normalized_weights(static_cast<size_t>(num_rollouts));
+  const float normalizer = controller.getNormalizerCost();
+  for (size_t i = 0; i < normalized_weights.size(); ++i) {
+    const float w = static_cast<float>(importance(static_cast<int>(i)));
+    normalized_weights[i] = (normalizer > 0.0F) ? w / normalizer : 0.0F;
+    raw_costs[i] = (w > 0.0F) ? (baseline - kLambda * std::log(w)) : (baseline + 1.0e30F);
+  }
+
+  std::vector<int> rollout_indices;
+  std::vector<float> selected_costs;
+  selectTopRolloutIndices(
+    normalized_weights, raw_costs, kMaxVizRollouts, rollout_indices, selected_costs);
+
+  std::vector<float> host_controls;
+  copySamplerControlsToHost(sampler, kMppiHorizon, rollout_indices, host_controls);
+
+  debug.rollouts.clear();
+  debug.rollouts.reserve(rollout_indices.size());
+  size_t out_idx = 0;
+  for (const float cost : selected_costs) {
+    FirstOrderDubinsMppiRollout rollout;
+    rollout.cost = cost;
+    const float * controls = host_controls.data() + out_idx * static_cast<size_t>(kMppiHorizon) *
+                                                      static_cast<size_t>(DYN::CONTROL_DIM);
+    replayRolloutPoints(model, x_at_optimization, controls, kMppiHorizon, kDt, rollout.points);
+    debug.rollouts.push_back(std::move(rollout));
+    ++out_idx;
+  }
+}
+#endif
+
+}  // namespace
+
+struct FirstOrderDubinsMppiInterface::Impl
+{
+  Trajectory diffusion_reference;
+  TrackedObjects tracked_objects;
+  mppi::path::Path2D path;
+  std::vector<mppi::cost::MovingCarObstacle> obstacles;
+
+  DYN model;
+  FirstOrderDubinsBicycleParams dyn;
+  FirstOrderDubinsMppiVehicleParams vehicle_params{};
+  FirstOrderDubinsMppiCostParams user_cost_params_{};
+  COST cost;
+  FirstOrderDubinsBicycleCostParams<kRefHorizon> cost_params{};
+  SAMPLER sampler;
+  FB feedback;
+  std::unique_ptr<Mppi> controller;
+  Mppi::control_trajectory u_nom = Mppi::control_trajectory::Zero();
+  Mppi::control_trajectory u_opt = Mppi::control_trajectory::Zero();
+  DYN::state_array x = DYN::state_array::Zero();
+
+  std::vector<float> obs_traj_x;
+  std::vector<float> obs_traj_y;
+  std::vector<float> obs_traj_yaw;
+  std::vector<float> obs_half_length;
+  std::vector<float> obs_half_width;
+
+  bool initialized{false};
+  int step_count{0};
+  size_t tracking_start_idx{0U};
+  float arc_length{kInitArcLength};
+  float sim_time{0.0F};
+
+  Impl() : feedback(&model, kDt), sampler(SAMPLER::SAMPLING_PARAMS_T{}) {}
+
+  void setup()
+  {
+    dyn = FirstOrderDubinsBicycleParams{};
+    dyn.wheel_base = vehicle_params.wheel_base;
+    dyn.max_steer_angle = vehicle_params.max_steer_angle;
+    dyn.accel_time_constant = vehicle_params.acc_time_constant;
+    dyn.steer_time_constant = vehicle_params.steer_time_constant;
+    dyn.max_steer_rate = vehicle_params.steer_rate_lim;
+    dyn.min_accel = vehicle_params.min_accel();
+    dyn.max_accel = vehicle_params.max_accel();
+    model.setParams(dyn);
+
+    if (vehicle_params.acc_time_delay > 0.0F || vehicle_params.steer_time_delay > 0.0F) {
+      RCLCPP_WARN_ONCE(
+        mppiLogger(),
+        "MPPI FirstOrderDubinsBicycle ignores acc_time_delay=%.3f and steer_time_delay=%.3f "
+        "(no dead-time state in dynamics model)",
+        vehicle_params.acc_time_delay, vehicle_params.steer_time_delay);
+    }
+
+    cost.GPUSetup();
+
+    cost_params = FirstOrderDubinsBicycleCostParams<kRefHorizon>{};
+    applyUserCostParams(cost_params, user_cost_params_);
+    mppi::cost::fillFirstOrderDubinsBicycleCostGeometry<kRefHorizon>(cost_params, dyn);
+
+    cost_params.ego_length = vehicle_params.ego_length;
+    cost_params.ego_width = vehicle_params.ego_width;
+    cost_params.ego_axle_to_box_center = vehicle_params.ego_axle_to_box_center;
+    cost.setParams(cost_params);
+
+    const float kMaxSteer = dyn.max_steer_angle;
+    std::array<float2, DYN::CONTROL_DIM> u_rng{};
+    u_rng[static_cast<int>(FirstOrderDubinsBicycleParams::ControlIndex::ACCELERATION_CMD)] = {
+      dyn.min_accel, dyn.max_accel};
+    u_rng[static_cast<int>(FirstOrderDubinsBicycleParams::ControlIndex::STEER_CMD)] = {
+      -kMaxSteer, kMaxSteer};
+    model.setControlRanges(u_rng);
+
+    SAMPLER::SAMPLING_PARAMS_T sp{};
+    sp.std_dev[static_cast<int>(FirstOrderDubinsBicycleParams::ControlIndex::ACCELERATION_CMD)] =
+      0.35F;
+    // Steer exploration scales with wheelbase: larger vehicles need larger delta-steer to change
+    // yaw.
+    constexpr float kReferenceWheelBase = 0.32F;
+    constexpr float kReferenceSteerStd = 0.03F;
+    const float steer_std = std::clamp(
+      kReferenceSteerStd * (vehicle_params.wheel_base / kReferenceWheelBase), kReferenceSteerStd,
+      0.12F);
+
+    sp.std_dev[static_cast<int>(FirstOrderDubinsBicycleParams::ControlIndex::STEER_CMD)] =
+      steer_std;
+    sp.sum_strides = std::max(32, (kNumRollouts + 1023) / 1024);
+    sampler = SAMPLER(sp);
+
+    controller = std::make_unique<Mppi>(
+      &model, &cost, &feedback, &sampler, kDt, 1, kLambda, 0.0F, kMppiHorizon, u_nom);
+    auto cp = controller->getParams();
+    cp.dynamics_rollout_dim_ = dim3(32, 2, 1);
+    cp.cost_rollout_dim_ = dim3(32, 2, 1);
+    cp.seed_ = 1U;
+    controller->setParams(cp);
+    controller->setPercentageSampledControlTrajectories(128.0F / static_cast<float>(kNumRollouts));
+
+    model.GPUSetup();
+
+    initialized = true;
+    step_count = 0;
+    tracking_start_idx = 0U;
+    arc_length = kInitArcLength;
+    sim_time = 0.0F;
+
+    RCLCPP_INFO(
+      mppiLogger(),
+      "MPPI GPU initialized (horizon=%d, rollouts=%d, dt=%.2f, lambda=%.1f, "
+      "wheel_base=%.2f, max_steer=%.2f, steer_std=%.3f, acc_tau=%.2f, steer_tau=%.2f, "
+      "steer_rate_lim=%.2f, vel_rate_lim=%.2f, ego=%.2fx%.2f, axle_to_center=%.2f, "
+      "desired_speed=%.2f, boundary_threshold=%.2f, obs_margin=%.2f)",
+      kMppiHorizon, kNumRollouts, kDt, kLambda, vehicle_params.wheel_base,
+      vehicle_params.max_steer_angle, steer_std, vehicle_params.acc_time_constant,
+      vehicle_params.steer_time_constant, vehicle_params.steer_rate_lim,
+      vehicle_params.vel_rate_lim, vehicle_params.ego_length, vehicle_params.ego_width,
+      vehicle_params.ego_axle_to_box_center, cost_params.desired_speed,
+      cost_params.boundary_threshold, cost_params.obstacle_collision_margin);
+  }
+
+  void resetWarmStart()
+  {
+    step_count = 0;
+    u_nom.setZero();
+    u_opt.setZero();
+    arc_length = kInitArcLength;
+    sim_time = 0.0F;
+  }
+
+  void updateDiffusionReference(
+    const Trajectory & reference, const Odometry & odometry,
+    const std::optional<geometry_msgs::msg::AccelWithCovarianceStamped> & acceleration,
+    const std::optional<autoware_vehicle_msgs::msg::SteeringReport> & steering_status,
+    const TrackedObjects & tracked_objects_in)
+  {
+    if (!initialized) {
+      setup();
+    }
+
+    diffusion_reference = reference;
+    tracked_objects = tracked_objects_in;
+    path = trajectoryToPath2D(reference);
+    obstacles.clear();
+
+    const size_t new_start_idx = findTrackingStartIndex(reference, odometry);
+    const bool large_index_jump =
+      step_count > 0 && (new_start_idx > tracking_start_idx + kTrackingIndexResetThreshold ||
+                         tracking_start_idx > new_start_idx + kTrackingIndexResetThreshold);
+    if (step_count == 0 || large_index_jump) {
+      resetWarmStart();
+    }
+    tracking_start_idx = new_start_idx;
+
+    const float ego_yaw = yawFromOdometry(odometry);
+    const float ego_v = static_cast<float>(odometry.twist.twist.linear.x);
+
+    x = model.getZeroState();
+    x(static_cast<int>(FirstOrderDubinsBicycleParams::StateIndex::POS_X)) =
+      static_cast<float>(odometry.pose.pose.position.x);
+    x(static_cast<int>(FirstOrderDubinsBicycleParams::StateIndex::POS_Y)) =
+      static_cast<float>(odometry.pose.pose.position.y);
+    x(static_cast<int>(FirstOrderDubinsBicycleParams::StateIndex::YAW)) = ego_yaw;
+    x(static_cast<int>(FirstOrderDubinsBicycleParams::StateIndex::VEL_X)) = ego_v;
+    const float ego_accel = std::clamp(
+      longitudinalAccelerationMps2(acceleration), vehicle_params.min_accel(),
+      vehicle_params.max_accel());
+    x(static_cast<int>(FirstOrderDubinsBicycleParams::StateIndex::ACCELERATION)) = ego_accel;
+    const float ego_steer = std::clamp(
+      steeringTireAngleRad(steering_status), -vehicle_params.max_steer_angle,
+      vehicle_params.max_steer_angle);
+    x(static_cast<int>(FirstOrderDubinsBicycleParams::StateIndex::STEER_ANGLE)) = ego_steer;
+
+    const mppi::path::PathProjection proj = mppi::path::projectPoseOntoPath(
+      path, x(static_cast<int>(FirstOrderDubinsBicycleParams::StateIndex::POS_X)),
+      x(static_cast<int>(FirstOrderDubinsBicycleParams::StateIndex::POS_Y)), arc_length);
+    arc_length = proj.arc_length_s;
+  }
+
+  FirstOrderDubinsMppiControl runStep()
+  {
+    if (step_count > 0) {
+      u_nom.leftCols(kMppiHorizon - 1) = u_opt.rightCols(kMppiHorizon - 1);
+      u_nom.rightCols(1) = u_opt.rightCols(1);
+    }
+
+    const std::vector<mppi::path::PathReferenceSample> ref =
+      buildDiffusionReferenceHorizon(diffusion_reference, tracking_start_idx, path);
+    mppi::cost::fillFirstOrderDubinsBicycleCostFromPathReference<kRefHorizon>(cost, ref);
+
+    int obstacle_count = 0;
+    if (!tracked_objects.objects.empty()) {
+      buildObstacleTrajectoryBuffersFromTrackedObjects(
+        tracked_objects, kDt, kRefHorizon, obs_traj_x, obs_traj_y, obs_traj_yaw, obs_half_length,
+        obs_half_width);
+      obstacle_count = trackedObjectObstacleCount(tracked_objects);
+    } else if (!obstacles.empty()) {
+      mppi::cost::buildObstacleTrajectoryBuffers(
+        obstacles, sim_time, kDt, kRefHorizon, obs_traj_x, obs_traj_y, obs_traj_yaw,
+        obs_half_length, obs_half_width);
+      obstacle_count =
+        static_cast<int>(std::min(obstacles.size(), static_cast<size_t>(kMaxMppiObstacles)));
+    } else {
+      obs_traj_x.clear();
+      obs_traj_y.clear();
+      obs_traj_yaw.clear();
+      obs_half_length.clear();
+      obs_half_width.clear();
+    }
+    mppi::cost::fillFirstOrderDubinsBicycleCostObstacleTrajectories<kRefHorizon>(
+      cost, obstacle_count > 0 ? obs_traj_x.data() : nullptr,
+      obstacle_count > 0 ? obs_traj_y.data() : nullptr,
+      obstacle_count > 0 ? obs_traj_yaw.data() : nullptr,
+      obstacle_count > 0 ? obs_half_length.data() : nullptr,
+      obstacle_count > 0 ? obs_half_width.data() : nullptr, obstacle_count, kRefHorizon);
+
+    controller->updateImportanceSampler(u_nom);
+    controller->computeControl(x, 1);
+    cudaStreamSynchronize(controller->stream_);
+
+    const Mppi::control_trajectory u_opt_traj = controller->getControlSeq();
+    u_opt = u_opt_traj;
+
+    DYN::control_array u_apply = u_opt_traj.col(0);
+    model.enforceConstraints(x, u_apply);
+
+    DYN::state_array x_next = model.getZeroState();
+    DYN::state_array xdot = model.getZeroState();
+    DYN::output_array y = DYN::output_array::Zero();
+    model.step(x, x_next, xdot, u_apply, y, static_cast<float>(step_count), kDt);
+    x = x_next;
+
+    const mppi::path::PathProjection proj = mppi::path::projectPoseOntoPath(
+      path, x(static_cast<int>(FirstOrderDubinsBicycleParams::StateIndex::POS_X)),
+      x(static_cast<int>(FirstOrderDubinsBicycleParams::StateIndex::POS_Y)), arc_length);
+    arc_length = proj.arc_length_s;
+
+    ++step_count;
+    sim_time += kDt;
+
+    FirstOrderDubinsMppiControl control;
+    control.accel_cmd =
+      u_apply(static_cast<int>(FirstOrderDubinsBicycleParams::ControlIndex::ACCELERATION_CMD));
+    control.steer_cmd =
+      u_apply(static_cast<int>(FirstOrderDubinsBicycleParams::ControlIndex::STEER_CMD));
+
+    RCLCPP_DEBUG(
+      mppiLogger(),
+      "MPPI track step %d: start_idx=%zu arc_s=%.2f ref_v0=%.2f u_accel=%.3f u_steer=%.3f "
+      "ego_v=%.2f baseline_cost=%.2f",
+      step_count, tracking_start_idx, arc_length, ref.empty() ? 0.0F : ref.front().v,
+      control.accel_cmd, control.steer_cmd,
+      x(static_cast<int>(FirstOrderDubinsBicycleParams::StateIndex::VEL_X)),
+      controller->getBaselineCost());
+
+    return control;
+  }
+
+  void teardown()
+  {
+    if (initialized) {
+      cost.freeCudaMem();
+      initialized = false;
+    }
+  }
+};
+
+FirstOrderDubinsMppiInterface::FirstOrderDubinsMppiInterface() : impl_(std::make_unique<Impl>())
+{
+}
+
+FirstOrderDubinsMppiInterface::~FirstOrderDubinsMppiInterface()
+{
+  if (impl_) {
+    impl_->teardown();
+  }
+}
+
+FirstOrderDubinsMppiInterface::FirstOrderDubinsMppiInterface(
+  FirstOrderDubinsMppiInterface && other) noexcept = default;
+
+FirstOrderDubinsMppiInterface & FirstOrderDubinsMppiInterface::operator=(
+  FirstOrderDubinsMppiInterface && other) noexcept = default;
+
+void FirstOrderDubinsMppiInterface::initialize()
+{
+  if (!impl_) {
+    throw std::runtime_error("FirstOrderDubinsMppiInterface implementation is missing");
+  }
+  impl_->setup();
+}
+
+bool FirstOrderDubinsMppiInterface::isInitialized() const
+{
+  return impl_ && impl_->initialized;
+}
+
+void FirstOrderDubinsMppiInterface::setVehicleParams(
+  const FirstOrderDubinsMppiVehicleParams & params)
+{
+  if (!impl_) {
+    throw std::runtime_error("FirstOrderDubinsMppiInterface implementation is missing");
+  }
+  if (impl_->initialized) {
+    impl_->teardown();
+  }
+  impl_->vehicle_params = params;
+}
+
+void FirstOrderDubinsMppiInterface::setCostParams(const FirstOrderDubinsMppiCostParams & params)
+{
+  if (!impl_) {
+    throw std::runtime_error("FirstOrderDubinsMppiInterface implementation is missing");
+  }
+  if (impl_->initialized) {
+    impl_->teardown();
+  }
+  impl_->user_cost_params_ = params;
+}
+
+FirstOrderDubinsMppiControl FirstOrderDubinsMppiInterface::computeStep(
+  FirstOrderDubinsMppiState & state, float & arc_length, float sim_time)
+{
+  if (!impl_ || !impl_->initialized) {
+    throw std::runtime_error(
+      "FirstOrderDubinsMppiInterface must be initialized before computeStep");
+  }
+
+  fromHostState(impl_->x, state);
+  impl_->arc_length = arc_length;
+  impl_->sim_time = sim_time;
+  const FirstOrderDubinsMppiControl control = impl_->runStep();
+  state = toHostState(impl_->x);
+  arc_length = impl_->arc_length;
+  return control;
+}
+
+FirstOrderDubinsMppiOptimizationResult FirstOrderDubinsMppiInterface::optimizeTrajectory(
+  const Trajectory & input, const Odometry & odometry,
+  const std::optional<geometry_msgs::msg::AccelWithCovarianceStamped> & acceleration,
+  const std::optional<autoware_vehicle_msgs::msg::SteeringReport> & steering_status,
+  const TrackedObjects & tracked_objects)
+{
+  if (!impl_) {
+    throw std::runtime_error("FirstOrderDubinsMppiInterface implementation is missing");
+  }
+  FirstOrderDubinsMppiOptimizationResult result;
+  if (input.points.size() < 2U) {
+    RCLCPP_WARN(
+      mppiLogger(), "MPPI skipped: trajectory has %zu points (need >= 2)", input.points.size());
+    result.trajectory = input;
+    result.debug.reference_trajectory = input;
+    result.debug.optimized_trajectory = input;
+    return result;
+  }
+
+  const auto start_time = std::chrono::steady_clock::now();
+
+  impl_->updateDiffusionReference(input, odometry, acceleration, steering_status, tracked_objects);
+  const FirstOrderDubinsMppiControl control = impl_->runStep();
+
+  const auto state_trajectory = impl_->controller->getActualStateSeq();
+  Trajectory output = input;
+
+  const int pos_x_idx = static_cast<int>(FirstOrderDubinsBicycleParams::StateIndex::POS_X);
+  const int pos_y_idx = static_cast<int>(FirstOrderDubinsBicycleParams::StateIndex::POS_Y);
+  const int yaw_idx = static_cast<int>(FirstOrderDubinsBicycleParams::StateIndex::YAW);
+  const int vel_x_idx = static_cast<int>(FirstOrderDubinsBicycleParams::StateIndex::VEL_X);
+
+  const size_t num_points = std::min(output.points.size(), static_cast<size_t>(kMppiHorizon));
+
+  float max_pos_delta = 0.0F;
+  float max_vel_delta = 0.0F;
+  size_t i = 0;
+  for (auto & out_point : output.points) {
+    if (i >= num_points) {
+      break;
+    }
+    const auto & in_point = input.points[i];
+    const int col = static_cast<int>(i);
+    const float tracked_x = state_trajectory(pos_x_idx, col);
+    const float tracked_y = state_trajectory(pos_y_idx, col);
+    const float tracked_yaw = state_trajectory(yaw_idx, col);
+    const float tracked_v = state_trajectory(vel_x_idx, col);
+
+    const float ref_x = static_cast<float>(in_point.pose.position.x);
+    const float ref_y = static_cast<float>(in_point.pose.position.y);
+    const float ref_v = in_point.longitudinal_velocity_mps;
+
+    max_pos_delta = std::max(max_pos_delta, std::hypot(tracked_x - ref_x, tracked_y - ref_y));
+    max_vel_delta = std::max(max_vel_delta, std::abs(tracked_v - ref_v));
+
+    out_point.pose.position.x = tracked_x;
+    out_point.pose.position.y = tracked_y;
+    out_point.pose.position.z = in_point.pose.position.z;
+    out_point.pose.orientation = quaternionFromYaw(tracked_yaw);
+    out_point.longitudinal_velocity_mps = tracked_v;
+    ++i;
+  }
+
+  const auto elapsed_ms =
+    std::chrono::duration<double, std::milli>(std::chrono::steady_clock::now() - start_time)
+      .count();
+
+  result.trajectory = output;
+  result.debug.reference_trajectory = input;
+  result.debug.optimized_trajectory = output;
+  // Rollout visualization disabled (CPU replay of top-K samples was ~80ms).
+  fillOptimalHorizonPoints(impl_->controller->getActualStateSeq(), result.debug.optimal_horizon);
+  result.debug.baseline_cost = impl_->controller->getBaselineCost();
+
+  RCLCPP_INFO(
+    mppiLogger(),
+    "MPPI tracked diffusion ref in %.1f ms: start_idx=%zu steps=%d output points size=%zu "
+    "points=%zu rollouts=%zu "
+    "obstacles=%zu u_accel=%.3f u_steer=%.3f baseline_cost=%.2f max_pos_err=%.3f m "
+    "max_vel_err=%.3f m/s",
+    elapsed_ms, impl_->tracking_start_idx, impl_->step_count, output.points.size(), num_points,
+    result.debug.rollouts.size(), tracked_objects.objects.size(), control.accel_cmd,
+    control.steer_cmd, result.debug.baseline_cost, max_pos_delta, max_vel_delta);
+
+  return result;
+}
+
+}  // namespace autoware::mppi_optimizer

--- a/planning/autoware_mppi_optimizer/src/first_order_dubins_mppi_cost_params_ros.cpp
+++ b/planning/autoware_mppi_optimizer/src/first_order_dubins_mppi_cost_params_ros.cpp
@@ -1,0 +1,102 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/mppi_optimizer/first_order_dubins_mppi_cost_params_ros.hpp"
+
+#include <string>
+
+namespace autoware::mppi_optimizer
+{
+namespace
+{
+
+std::string param_name(const std::string & prefix, const std::string & name)
+{
+  return prefix.empty() ? name : prefix + name;
+}
+
+}  // namespace
+
+void declare_first_order_dubins_mppi_cost_params(rclcpp::Node & node, const std::string & prefix)
+{
+  const FirstOrderDubinsMppiCostParams defaults;
+  node.declare_parameter(param_name(prefix, "desired_speed"), defaults.desired_speed);
+  node.declare_parameter(param_name(prefix, "speed_coeff"), defaults.speed_coeff);
+  node.declare_parameter(param_name(prefix, "track_coeff"), defaults.track_coeff);
+  node.declare_parameter(param_name(prefix, "heading_coeff"), defaults.heading_coeff);
+  node.declare_parameter(param_name(prefix, "crash_coeff"), defaults.crash_coeff);
+  node.declare_parameter(param_name(prefix, "boundary_threshold"), defaults.boundary_threshold);
+  node.declare_parameter(
+    param_name(prefix, "boundary_threshold_left"), defaults.boundary_threshold_left);
+  node.declare_parameter(
+    param_name(prefix, "boundary_threshold_right"), defaults.boundary_threshold_right);
+  node.declare_parameter(param_name(prefix, "accel_cmd_coeff"), defaults.accel_cmd_coeff);
+  node.declare_parameter(param_name(prefix, "steer_cmd_coeff"), defaults.steer_cmd_coeff);
+  node.declare_parameter(
+    param_name(prefix, "lateral_acceleration_coeff"), defaults.lateral_acceleration_coeff);
+  node.declare_parameter(param_name(prefix, "lateral_jerk_coeff"), defaults.lateral_jerk_coeff);
+  node.declare_parameter(
+    param_name(prefix, "longitudinal_jerk_coeff"), defaults.longitudinal_jerk_coeff);
+  node.declare_parameter(
+    param_name(prefix, "obstacle_collision_margin"), defaults.obstacle_collision_margin);
+  node.declare_parameter(param_name(prefix, "goal_pos_coeff"), defaults.goal_pos_coeff);
+  node.declare_parameter(param_name(prefix, "goal_speed_coeff"), defaults.goal_speed_coeff);
+  node.declare_parameter(param_name(prefix, "goal_yaw_coeff"), defaults.goal_yaw_coeff);
+  node.declare_parameter(param_name(prefix, "goal_terminal_scale"), defaults.goal_terminal_scale);
+}
+
+FirstOrderDubinsMppiCostParams get_first_order_dubins_mppi_cost_params(
+  const rclcpp::Node & node, const std::string & prefix)
+{
+  FirstOrderDubinsMppiCostParams params;
+  params.desired_speed =
+    static_cast<float>(node.get_parameter(param_name(prefix, "desired_speed")).as_double());
+  params.speed_coeff =
+    static_cast<float>(node.get_parameter(param_name(prefix, "speed_coeff")).as_double());
+  params.track_coeff =
+    static_cast<float>(node.get_parameter(param_name(prefix, "track_coeff")).as_double());
+  params.heading_coeff =
+    static_cast<float>(node.get_parameter(param_name(prefix, "heading_coeff")).as_double());
+  params.crash_coeff =
+    static_cast<float>(node.get_parameter(param_name(prefix, "crash_coeff")).as_double());
+  params.boundary_threshold =
+    static_cast<float>(node.get_parameter(param_name(prefix, "boundary_threshold")).as_double());
+  params.boundary_threshold_left = static_cast<float>(
+    node.get_parameter(param_name(prefix, "boundary_threshold_left")).as_double());
+  params.boundary_threshold_right = static_cast<float>(
+    node.get_parameter(param_name(prefix, "boundary_threshold_right")).as_double());
+  params.accel_cmd_coeff =
+    static_cast<float>(node.get_parameter(param_name(prefix, "accel_cmd_coeff")).as_double());
+  params.steer_cmd_coeff =
+    static_cast<float>(node.get_parameter(param_name(prefix, "steer_cmd_coeff")).as_double());
+  params.lateral_acceleration_coeff = static_cast<float>(
+    node.get_parameter(param_name(prefix, "lateral_acceleration_coeff")).as_double());
+  params.lateral_jerk_coeff =
+    static_cast<float>(node.get_parameter(param_name(prefix, "lateral_jerk_coeff")).as_double());
+  params.longitudinal_jerk_coeff = static_cast<float>(
+    node.get_parameter(param_name(prefix, "longitudinal_jerk_coeff")).as_double());
+  params.obstacle_collision_margin = static_cast<float>(
+    node.get_parameter(param_name(prefix, "obstacle_collision_margin")).as_double());
+  params.goal_pos_coeff =
+    static_cast<float>(node.get_parameter(param_name(prefix, "goal_pos_coeff")).as_double());
+  params.goal_speed_coeff =
+    static_cast<float>(node.get_parameter(param_name(prefix, "goal_speed_coeff")).as_double());
+  params.goal_yaw_coeff =
+    static_cast<float>(node.get_parameter(param_name(prefix, "goal_yaw_coeff")).as_double());
+  params.goal_terminal_scale =
+    static_cast<float>(node.get_parameter(param_name(prefix, "goal_terminal_scale")).as_double());
+  return params;
+}
+
+}  // namespace autoware::mppi_optimizer

--- a/planning/autoware_mppi_optimizer/src/first_order_dubins_mppi_vehicle_params_ros.cpp
+++ b/planning/autoware_mppi_optimizer/src/first_order_dubins_mppi_vehicle_params_ros.cpp
@@ -1,0 +1,50 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/mppi_optimizer/first_order_dubins_mppi_vehicle_params_ros.hpp"
+
+#include "autoware/mppi_optimizer/first_order_dubins_mppi_vehicle_params_conversion.hpp"
+
+#include <autoware/vehicle_info_utils/vehicle_info_utils.hpp>
+
+namespace autoware::mppi_optimizer
+{
+
+void declare_first_order_dubins_mppi_vehicle_dynamics_params(rclcpp::Node & node)
+{
+  const FirstOrderDubinsMppiVehicleParams defaults;
+  node.declare_parameter("acc_time_constant", defaults.acc_time_constant);
+  node.declare_parameter("steer_time_constant", defaults.steer_time_constant);
+  node.declare_parameter("steer_rate_lim", defaults.steer_rate_lim);
+  node.declare_parameter("vel_rate_lim", defaults.vel_rate_lim);
+  node.declare_parameter("acc_time_delay", defaults.acc_time_delay);
+  node.declare_parameter("steer_time_delay", defaults.steer_time_delay);
+}
+
+FirstOrderDubinsMppiVehicleParams get_first_order_dubins_mppi_vehicle_params(rclcpp::Node & node)
+{
+  FirstOrderDubinsMppiVehicleParams params =
+    makeVehicleParams(autoware::vehicle_info_utils::VehicleInfoUtils(node).getVehicleInfo());
+  params.acc_time_constant =
+    static_cast<float>(node.get_parameter("acc_time_constant").as_double());
+  params.steer_time_constant =
+    static_cast<float>(node.get_parameter("steer_time_constant").as_double());
+  params.steer_rate_lim = static_cast<float>(node.get_parameter("steer_rate_lim").as_double());
+  params.vel_rate_lim = static_cast<float>(node.get_parameter("vel_rate_lim").as_double());
+  params.acc_time_delay = static_cast<float>(node.get_parameter("acc_time_delay").as_double());
+  params.steer_time_delay = static_cast<float>(node.get_parameter("steer_time_delay").as_double());
+  return params;
+}
+
+}  // namespace autoware::mppi_optimizer

--- a/planning/autoware_mppi_optimizer/src/mppi_optimizer.cpp
+++ b/planning/autoware_mppi_optimizer/src/mppi_optimizer.cpp
@@ -22,6 +22,9 @@
 
 #include <memory>
 #include <optional>
+#include <stdexcept>
+
+#include <rclcpp_components/register_node_macro.hpp>
 
 namespace autoware::mppi_optimizer
 {
@@ -61,7 +64,7 @@ void MppiOptimizer::on_trajectory(const Trajectory::ConstSharedPtr msg)
     Trajectory tracked = result.trajectory;
     tracked.header = msg->header;
     trajectory_pub_->publish(tracked);
-  } catch (const std::exception & e) {
+  } catch (const std::runtime_error & e) {
     RCLCPP_ERROR_STREAM(get_logger(), "MPPI tracking failed: " << e.what());
     trajectory_pub_->publish(*msg);
   }
@@ -69,5 +72,4 @@ void MppiOptimizer::on_trajectory(const Trajectory::ConstSharedPtr msg)
 
 }  // namespace autoware::mppi_optimizer
 
-#include <rclcpp_components/register_node_macro.hpp>
 RCLCPP_COMPONENTS_REGISTER_NODE(autoware::mppi_optimizer::MppiOptimizer)

--- a/planning/autoware_mppi_optimizer/src/mppi_optimizer.cpp
+++ b/planning/autoware_mppi_optimizer/src/mppi_optimizer.cpp
@@ -1,0 +1,73 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/mppi_optimizer/mppi_optimizer.hpp"
+
+#include "autoware/mppi_optimizer/first_order_dubins_mppi_cost_params_ros.hpp"
+#include "autoware/mppi_optimizer/first_order_dubins_mppi_interface.hpp"
+#include "autoware/mppi_optimizer/first_order_dubins_mppi_vehicle_params_ros.hpp"
+
+#include <autoware_perception_msgs/msg/tracked_objects.hpp>
+
+#include <memory>
+#include <optional>
+
+namespace autoware::mppi_optimizer
+{
+
+MppiOptimizer::MppiOptimizer(const rclcpp::NodeOptions & options) : Node("mppi_optimizer", options)
+{
+  trajectory_sub_ = create_subscription<Trajectory>(
+    "~/input/trajectory", 1, std::bind(&MppiOptimizer::on_trajectory, this, std::placeholders::_1));
+  trajectory_pub_ = create_publisher<Trajectory>("~/output/trajectory", 1);
+  mppi_interface_ = std::make_unique<FirstOrderDubinsMppiInterface>();
+  declare_first_order_dubins_mppi_cost_params(*this);
+  declare_first_order_dubins_mppi_vehicle_dynamics_params(*this);
+  mppi_interface_->setCostParams(get_first_order_dubins_mppi_cost_params(*this));
+  mppi_interface_->setVehicleParams(get_first_order_dubins_mppi_vehicle_params(*this));
+}
+
+void MppiOptimizer::on_trajectory(const Trajectory::ConstSharedPtr msg)
+{
+  if (!msg || msg->points.empty()) {
+    return;
+  }
+
+  const auto odometry = sub_odometry_.take_data();
+  if (!odometry) {
+    RCLCPP_WARN_THROTTLE(get_logger(), *get_clock(), 5000, "Waiting for odometry...");
+    return;
+  }
+
+  const auto steering_status = sub_steering_.take_data();
+  const std::optional<SteeringReport> ego_steering =
+    steering_status ? std::make_optional(*steering_status) : std::nullopt;
+
+  try {
+    const autoware_perception_msgs::msg::TrackedObjects empty_tracked_objects;
+    const auto result = mppi_interface_->optimizeTrajectory(
+      *msg, *odometry, std::nullopt, ego_steering, empty_tracked_objects);
+    Trajectory tracked = result.trajectory;
+    tracked.header = msg->header;
+    trajectory_pub_->publish(tracked);
+  } catch (const std::exception & e) {
+    RCLCPP_ERROR_STREAM(get_logger(), "MPPI tracking failed: " << e.what());
+    trajectory_pub_->publish(*msg);
+  }
+}
+
+}  // namespace autoware::mppi_optimizer
+
+#include <rclcpp_components/register_node_macro.hpp>
+RCLCPP_COMPONENTS_REGISTER_NODE(autoware::mppi_optimizer::MppiOptimizer)

--- a/planning/autoware_mppi_optimizer/src/mppi_optimizer.cpp
+++ b/planning/autoware_mppi_optimizer/src/mppi_optimizer.cpp
@@ -18,13 +18,13 @@
 #include "autoware/mppi_optimizer/first_order_dubins_mppi_interface.hpp"
 #include "autoware/mppi_optimizer/first_order_dubins_mppi_vehicle_params_ros.hpp"
 
+#include <rclcpp_components/register_node_macro.hpp>
+
 #include <autoware_perception_msgs/msg/tracked_objects.hpp>
 
 #include <memory>
 #include <optional>
 #include <stdexcept>
-
-#include <rclcpp_components/register_node_macro.hpp>
 
 namespace autoware::mppi_optimizer
 {

--- a/planning/autoware_trajectory_optimizer/CMakeLists.txt
+++ b/planning/autoware_trajectory_optimizer/CMakeLists.txt
@@ -142,7 +142,7 @@ install(PROGRAMS
   DESTINATION lib/${PROJECT_NAME}
 )
 
-ament_auto_package(
+autoware_ament_auto_package(
   USE_SCOPED_HEADER_INSTALL_DIR
   INSTALL_TO_SHARE
   config

--- a/planning/autoware_trajectory_optimizer/CMakeLists.txt
+++ b/planning/autoware_trajectory_optimizer/CMakeLists.txt
@@ -142,7 +142,7 @@ install(PROGRAMS
   DESTINATION lib/${PROJECT_NAME}
 )
 
-autoware_ament_auto_package(
+ament_auto_package(
   USE_SCOPED_HEADER_INSTALL_DIR
   INSTALL_TO_SHARE
   config

--- a/planning/autoware_trajectory_optimizer/config/trajectory_optimizer.param.yaml
+++ b/planning/autoware_trajectory_optimizer/config/trajectory_optimizer.param.yaml
@@ -2,16 +2,16 @@
   ros__parameters:
     # Plugin execution order - plugins will run in this order
     plugin_names:
-      - "autoware::trajectory_optimizer::plugin::TrajectoryTemporalMPTOptimizer"
+      # - "autoware::trajectory_optimizer::plugin::TrajectoryTemporalMPTOptimizer"
       - "autoware::trajectory_optimizer::plugin::TrajectoryPointFixer"
-      - "autoware::trajectory_optimizer::plugin::TrajectoryKinematicFeasibilityEnforcer"
-      - "autoware::trajectory_optimizer::plugin::TrajectoryQPSmoother"
-      - "autoware::trajectory_optimizer::plugin::TrajectoryKinematicFeasibilityEnforcer"
-      - "autoware::trajectory_optimizer::plugin::TrajectoryVelocityOptimizer"
-      - "autoware::trajectory_optimizer::plugin::TrajectoryEBSmootherOptimizer"
-      - "autoware::trajectory_optimizer::plugin::TrajectorySplineSmoother"
-      - "autoware::trajectory_optimizer::plugin::TrajectoryMPTOptimizer"
-      - "autoware::trajectory_optimizer::plugin::TrajectoryExtender"
+      # - "autoware::trajectory_optimizer::plugin::TrajectoryKinematicFeasibilityEnforcer"
+      # - "autoware::trajectory_optimizer::plugin::TrajectoryQPSmoother"
+      # - "autoware::trajectory_optimizer::plugin::TrajectoryKinematicFeasibilityEnforcer"
+      # - "autoware::trajectory_optimizer::plugin::TrajectoryVelocityOptimizer"
+      # - "autoware::trajectory_optimizer::plugin::TrajectoryEBSmootherOptimizer"
+      # - "autoware::trajectory_optimizer::plugin::TrajectorySplineSmoother"
+      # - "autoware::trajectory_optimizer::plugin::TrajectoryMPTOptimizer"
+      # - "autoware::trajectory_optimizer::plugin::TrajectoryExtender"
 
     # Plugin activation flags - control runtime enable/disable
     use_akima_spline_interpolation: true

--- a/planning/autoware_trajectory_optimizer/config/trajectory_optimizer.param.yaml
+++ b/planning/autoware_trajectory_optimizer/config/trajectory_optimizer.param.yaml
@@ -2,16 +2,16 @@
   ros__parameters:
     # Plugin execution order - plugins will run in this order
     plugin_names:
-      # - "autoware::trajectory_optimizer::plugin::TrajectoryTemporalMPTOptimizer"
+      - "autoware::trajectory_optimizer::plugin::TrajectoryTemporalMPTOptimizer"
       - "autoware::trajectory_optimizer::plugin::TrajectoryPointFixer"
-      # - "autoware::trajectory_optimizer::plugin::TrajectoryKinematicFeasibilityEnforcer"
-      # - "autoware::trajectory_optimizer::plugin::TrajectoryQPSmoother"
-      # - "autoware::trajectory_optimizer::plugin::TrajectoryKinematicFeasibilityEnforcer"
-      # - "autoware::trajectory_optimizer::plugin::TrajectoryVelocityOptimizer"
-      # - "autoware::trajectory_optimizer::plugin::TrajectoryEBSmootherOptimizer"
-      # - "autoware::trajectory_optimizer::plugin::TrajectorySplineSmoother"
-      # - "autoware::trajectory_optimizer::plugin::TrajectoryMPTOptimizer"
-      # - "autoware::trajectory_optimizer::plugin::TrajectoryExtender"
+      - "autoware::trajectory_optimizer::plugin::TrajectoryKinematicFeasibilityEnforcer"
+      - "autoware::trajectory_optimizer::plugin::TrajectoryQPSmoother"
+      - "autoware::trajectory_optimizer::plugin::TrajectoryKinematicFeasibilityEnforcer"
+      - "autoware::trajectory_optimizer::plugin::TrajectoryVelocityOptimizer"
+      - "autoware::trajectory_optimizer::plugin::TrajectoryEBSmootherOptimizer"
+      - "autoware::trajectory_optimizer::plugin::TrajectorySplineSmoother"
+      - "autoware::trajectory_optimizer::plugin::TrajectoryMPTOptimizer"
+      - "autoware::trajectory_optimizer::plugin::TrajectoryExtender"
 
     # Plugin activation flags - control runtime enable/disable
     use_akima_spline_interpolation: true


### PR DESCRIPTION
## Summary

Core implementation for **PDDP-249: MPPI trajectory refinement in the diffusion planner**.

### Related PRs
- Launch/config: [autoware_launch.x2 #2537](https://github.com/tier4/autoware_launch.x2/pull/2537)
- Meta-repo integration: [pilot-auto.x2 #4576](https://github.com/tier4/pilot-auto.x2/pull/4576)

### Changes
**New package: `autoware_mppi_optimizer`**
- CUDA MPPI wrapper around [mppi_generic_vendor](https://github.com/autowarefoundation/mppi_generic_vendor) (MPPI-Generic)
- First-order Dubins bicycle model; `optimizeTrajectory()` tracks a diffusion reference using ego odometry + tracked objects as obstacles

**`autoware_diffusion_planner` integration**
- New flag `use_mppi_optimizer` — after ONNX inference, MPPI refines the trajectory in-place
- Debug topics: `~/debug/mppi/reference_trajectory`, `optimized_trajectory`, `markers`
- Loads MPPI cost/vehicle params from `mppi_optimizer.param.yaml` on the same node

**Testing setup**
- Most `autoware_trajectory_optimizer` plugins commented out (only `TrajectoryPointFixer` active) — likely to isolate MPPI effects during integration testing

**Pipeline:** Diffusion inference → MPPI refinement → published trajectory. Requires CUDA + `mppi_generic_vendor` (added in pilot-auto #4576).