### PR TITLE
feat(trajectory_selector): anchor the concatenation on the main input

### DIFF
--- a/planning/autoware_trajectory_concatenator/include/autoware/trajectory_concatenator/trajectory_concatenator_wrapper.hpp
+++ b/planning/autoware_trajectory_concatenator/include/autoware/trajectory_concatenator/trajectory_concatenator_wrapper.hpp
@@ -78,6 +78,7 @@ public:
     const auto time_now = node_ptr_->get_clock()->now();
 
     std::lock_guard<std::mutex> lock(concatenator_mutex_);
+    RCLCPP_DEBUG(logger_, "get_concatenated()");
     return concatenator_ptr_->get_concatenated(time_now);
   };
 

--- a/planning/autoware_trajectory_concatenator/src/detail/trajectory_concatenator.cpp
+++ b/planning/autoware_trajectory_concatenator/src/detail/trajectory_concatenator.cpp
@@ -59,7 +59,6 @@ CandidateTrajectories TrajectoryConcatenator::get_concatenated(
   std::vector<autoware_internal_planning_msgs::msg::GeneratorInfo> generator_info;
 
   const double current_time_sec = to_seconds(current_time);
-
   // Prune expired entries individually
   for (auto it = buffer_.begin(); it != buffer_.end();) {
     auto & pre_combine = it->second;

--- a/planning/autoware_trajectory_selector/CMakeLists.txt
+++ b/planning/autoware_trajectory_selector/CMakeLists.txt
@@ -7,6 +7,9 @@ autoware_package()
 ament_auto_add_library(${PROJECT_NAME} SHARED
   src/trajectory_selector_node.cpp
 )
+generate_parameter_library(${PROJECT_NAME}_param
+  param/parameter_struct.yaml
+)
 
 # autoware_trajectory_validator defines rosidl messages, so ament_target_dependencies
 # enters "modern cmake" mode and silently ignores _INCLUDE_DIRS and _LIBRARIES for it.
@@ -16,6 +19,7 @@ target_include_directories(${PROJECT_NAME} SYSTEM PUBLIC
 )
 target_link_libraries(${PROJECT_NAME}
   ${autoware_trajectory_validator_LIBRARIES}
+  ${PROJECT_NAME}_param
 )
 
 target_compile_options(${PROJECT_NAME} PUBLIC
@@ -59,6 +63,7 @@ if(BUILD_TESTING)
 
   ament_target_dependencies(test_trajectory_selector_node
     autoware_test_utils
+    rosgraph_msgs
   )
 endif()
 

--- a/planning/autoware_trajectory_selector/README.md
+++ b/planning/autoware_trajectory_selector/README.md
@@ -6,11 +6,12 @@
 
 ## Algorithm Overview
 
-1. Candidate trajectories arrive on two separate input topics — `~/input/trajectories_generative` for generative planners and `~/input/trajectories_backup` for backup planners. Each received message is forwarded to the internal concatenator buffer.
-2. A 100 ms timer fires: the concatenator prunes stale entries (older than `duration_time`) and returns the merged trajectory set from all registered generators.
-3. If any mandatory sensor input (odometry, predicted objects, acceleration, or HD map) is unavailable, the timer returns early without publishing.
-4. The validator runs all loaded plugins against each trajectory. Trajectories rejected by any enforced plugin (listed in `filter_names`) are removed from the output set.
-5. The surviving trajectories are published to `~/output/trajectories`.
+1. Candidate trajectories arrive on two separate input topics. `~/input/trajectories_generative` acts as an **anchor**: receiving a message on this topic triggers an immediate concatenation and validation cycle. `~/input/trajectories_backup` messages are buffered and processed in the next cycle.
+2. A 100 ms timer also fires periodically to ensure output is published even if the anchor input is delayed or missing. The timer is reset whenever an anchor message is received.
+3. During each cycle (triggered by the anchor or the timer), the concatenator prunes stale entries (older than `duration_time`) and returns the merged trajectory set from all registered generators.
+4. If any mandatory sensor input (odometry, predicted objects, acceleration, or HD map) is unavailable, the cycle returns early without publishing.
+5. The validator runs all loaded plugins against each trajectory. Trajectories rejected by any enforced plugin (listed in `filter_names`) are removed from the output set.
+6. The surviving trajectories are published to `~/output/trajectories`.
 
 ## Interface
 
@@ -30,9 +31,9 @@
 
 ### Parameters
 
-This node does not declare parameters of its own. Configuration is provided through the sub-package parameter files loaded at launch:
+{{ json_to_markdown("planning/autoware_trajectory_selector/schema/trajectory_selector.schema.json") }}
+
+Other configuration is provided through the sub-package parameter files loaded at launch:
 
 - Concatenation parameters: see [`autoware_trajectory_concatenator`](../autoware_trajectory_concatenator/README.md#parameters)
 - Validation parameters: see [`autoware_trajectory_validator`](../autoware_trajectory_validator/README.md#parameters)
-
-{{ json_to_markdown("planning/autoware_trajectory_selector/schema/trajectory_selector.schema.json") }}

--- a/planning/autoware_trajectory_selector/include/autoware/trajectory_selector/trajectory_selector_node.hpp
+++ b/planning/autoware_trajectory_selector/include/autoware/trajectory_selector/trajectory_selector_node.hpp
@@ -17,6 +17,7 @@
 
 #include "autoware/trajectory_validator/detail/validator_context.hpp"
 #include "autoware/trajectory_validator/trajectory_validator_wrapper.hpp"
+#include "autoware_trajectory_selector/autoware_trajectory_selector_param.hpp"
 
 #include <autoware/lanelet2_utils/conversion.hpp>
 #include <autoware/trajectory_concatenator/trajectory_concatenator_wrapper.hpp>
@@ -70,17 +71,33 @@ private:
   void map_callback(const LaneletMapBin::ConstSharedPtr msg);
 
   /**
+   * @brief Forwards incoming candidate trajectories to the concatenator and trigger the
+   * concatenation.
+   * @param msg Incoming candidate trajectories message.
+   * @warning must be in the same callback group as the timer callback as they both call
+   * on_anchor_trajectories
+   */
+  void on_anchor_trajectories(const CandidateTrajectories::ConstSharedPtr msg);
+  /**
    * @brief Forwards incoming candidate trajectories to the concatenator.
    * @param msg Incoming candidate trajectories message.
    */
   void on_trajectories(const CandidateTrajectories::ConstSharedPtr msg);
 
-  /** @brief Concatenates buffered trajectories, validates them, and publishes the result. */
-  void on_timer();
+  /**
+   * @brief Concatenates buffered trajectories, validates them, and publishes the result.
+   */
+  void concatenate_and_validate();
 
   /** @brief Collects the latest sensor data needed for validation; returns an error string if any
    * mandatory input is unavailable. */
   tl::expected<trajectory_validator::FilterContext, std::string> take_validator_data();
+
+  /** @brief Update parameters */
+  void update_parameters();
+
+  /** @brief Update the fallback timer */
+  void update_fallback_timer();
 
   std::unique_ptr<trajectory_concatenator::TrajectoryConcatenatorWrapper> concatenator_ptr_;
   std::unique_ptr<trajectory_validator::TrajectoryValidatorWrapper> validator_ptr_;
@@ -111,6 +128,10 @@ private:
   rclcpp::Publisher<autoware_utils_debug::ProcessingTimeDetail>::SharedPtr
     pub_processing_time_detail_;
   std::shared_ptr<autoware_utils_debug::TimeKeeper> time_keeper_{nullptr};
+
+  // Parameter interfaces
+  selector::ParamListener selector_params_listener_{get_node_parameters_interface()};
+  selector::Params selector_params_;
 };
 
 }  // namespace autoware::trajectory_selector

--- a/planning/autoware_trajectory_selector/launch/trajectory_selector.launch.xml
+++ b/planning/autoware_trajectory_selector/launch/trajectory_selector.launch.xml
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <launch>
+  <arg name="trajectory_selector_param_path" default="$(find-pkg-share autoware_trajectory_selector)/config/selector.param.yaml"/>
   <arg name="trajectory_concatenator_param_path" default="$(find-pkg-share autoware_trajectory_concatenator)/config/concatenator.param.yaml"/>
   <arg name="trajectory_validator_param_path" default="$(find-pkg-share autoware_trajectory_validator)/config/trajectory_validator.param.yaml"/>
   <arg name="input_generative_trajectories" default="~/input/trajectories_generative"/>
@@ -16,6 +17,7 @@
   <arg name="enable_pseudo_emergency_stop" default="false"/>
 
   <node pkg="autoware_trajectory_selector" exec="autoware_trajectory_selector_node" name="trajectory_selector_node" output="screen">
+    <param from="$(var trajectory_selector_param_path)" allow_substs="true"/>
     <param from="$(var trajectory_concatenator_param_path)" allow_substs="true"/>
     <param from="$(var trajectory_validator_param_path)" allow_substs="true"/>
     <param name="pseudo_emergency_stop.enable" value="$(var enable_pseudo_emergency_stop)"/>

--- a/planning/autoware_trajectory_selector/package.xml
+++ b/planning/autoware_trajectory_selector/package.xml
@@ -40,6 +40,7 @@
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>autoware_lint_common</test_depend>
   <test_depend>autoware_test_utils</test_depend>
+  <test_depend>rosgraph_msgs</test_depend>
 
   <export>
     <build_type>ament_cmake</build_type>

--- a/planning/autoware_trajectory_selector/param/parameter_struct.yaml
+++ b/planning/autoware_trajectory_selector/param/parameter_struct.yaml
@@ -1,0 +1,6 @@
+selector:
+  fallback_period_ms:
+    type: int
+    default_value: 150
+    description: fallback timer period in milliseconds.
+    read_only: false

--- a/planning/autoware_trajectory_selector/schema/trajectory_selector.schema.json
+++ b/planning/autoware_trajectory_selector/schema/trajectory_selector.schema.json
@@ -5,7 +5,18 @@
   "definitions": {
     "trajectory_selector": {
       "type": "object",
-      "properties": {},
+      "properties": {
+        "fallback_period_ms": {
+          "type": "integer",
+          "default": 150,
+          "minimum": 1,
+          "description": "fallback timer period in milliseconds",
+          "validation": {
+            "gt_eq<>": 100
+          }
+        }
+      },
+      "required": ["fallback_period_ms"],
       "additionalProperties": false
     }
   },

--- a/planning/autoware_trajectory_selector/src/trajectory_selector_node.cpp
+++ b/planning/autoware_trajectory_selector/src/trajectory_selector_node.cpp
@@ -14,6 +14,8 @@
 
 #include "autoware/trajectory_selector/trajectory_selector_node.hpp"
 
+#include <rclcpp/node_interfaces/node_parameters_interface.hpp>
+
 #include <memory>
 #include <string>
 
@@ -32,10 +34,9 @@ TrajectorySelectorNode::TrajectorySelectorNode(const rclcpp::NodeOptions & node_
     *this, get_node_parameters_interface(),
     autoware::vehicle_info_utils::VehicleInfoUtils(*this).getVehicleInfo(), time_keeper_);
 
-  constexpr int64_t timer_period_ms = 100;
-  timer_ = rclcpp::create_timer(
-    this, get_clock(), std::chrono::milliseconds(timer_period_ms),
-    std::bind(&TrajectorySelectorNode::on_timer, this));
+  selector_params_ = selector_params_listener_.get_params();
+  selector_params_listener_.setUserCallback([&](const auto &) { update_parameters(); });
+  update_fallback_timer();
 }
 
 void TrajectorySelectorNode::subscribers()
@@ -46,7 +47,7 @@ void TrajectorySelectorNode::subscribers()
 
   sub_trajectories_generative_ = create_subscription<CandidateTrajectories>(
     "~/input/trajectories_generative", 1,
-    std::bind(&TrajectorySelectorNode::on_trajectories, this, std::placeholders::_1));
+    std::bind(&TrajectorySelectorNode::on_anchor_trajectories, this, std::placeholders::_1));
 
   sub_trajectories_backup_ = create_subscription<CandidateTrajectories>(
     "~/input/trajectories_backup", 1,
@@ -70,6 +71,12 @@ void TrajectorySelectorNode::map_callback(const LaneletMapBin::ConstSharedPtr ms
     autoware::experimental::lanelet2_utils::from_autoware_map_msgs(*msg));
 }
 
+void TrajectorySelectorNode::on_anchor_trajectories(const CandidateTrajectories::ConstSharedPtr msg)
+{
+  concatenator_ptr_->add_candidate(*msg);
+  concatenate_and_validate();
+  timer_->reset();
+}
 void TrajectorySelectorNode::on_trajectories(const CandidateTrajectories::ConstSharedPtr msg)
 {
   concatenator_ptr_->add_candidate(*msg);
@@ -111,7 +118,7 @@ TrajectorySelectorNode::take_validator_data()
   return context;
 }
 
-void TrajectorySelectorNode::on_timer()
+void TrajectorySelectorNode::concatenate_and_validate()
 {
   autoware_utils_debug::ScopedTimeTrack st(__func__, *time_keeper_);
 
@@ -135,6 +142,30 @@ void TrajectorySelectorNode::on_timer()
   pub_trajectories_->publish(validated_trajectories);
 }
 
+void TrajectorySelectorNode::update_parameters()
+{
+  if (selector_params_listener_.is_old(selector_params_)) {
+    const auto new_params = selector_params_listener_.get_params();
+    const auto is_new_fallback_timer_period =
+      new_params.fallback_period_ms != selector_params_.fallback_period_ms;
+    selector_params_ = new_params;
+    if (is_new_fallback_timer_period) update_fallback_timer();
+
+    RCLCPP_INFO(get_logger(), "Trajectory Selector parameters are updated.");
+  }
+}
+void TrajectorySelectorNode::update_fallback_timer()
+{
+  if (timer_) {
+    timer_->cancel();
+  }
+  RCLCPP_INFO(
+    get_logger(), "New concatenate_and_validate timer callback created with period %ld.",
+    selector_params_.fallback_period_ms);
+  timer_ = rclcpp::create_timer(
+    this, get_clock(), std::chrono::milliseconds(selector_params_.fallback_period_ms),
+    std::bind(&TrajectorySelectorNode::concatenate_and_validate, this));
+}
 }  // namespace autoware::trajectory_selector
 
 #include <rclcpp_components/register_node_macro.hpp>

--- a/planning/autoware_trajectory_selector/test/node/test_trajectory_selector_node.cpp
+++ b/planning/autoware_trajectory_selector/test/node/test_trajectory_selector_node.cpp
@@ -16,9 +16,13 @@
 
 #include <autoware_test_utils/autoware_test_utils.hpp>
 #include <autoware_utils_uuid/uuid_helper.hpp>
+#include <rclcpp/parameter_value.hpp>
+
+#include <rosgraph_msgs/msg/clock.hpp>
 
 #include <gtest/gtest.h>
 
+#include <chrono>
 #include <memory>
 #include <string>
 #include <utility>
@@ -36,7 +40,9 @@ protected:
     node_options_.append_parameter_override(
       "filter_names",
       std::vector<std::string>{"autoware::trajectory_validator::plugin::DummyFilter"});
-    node_options_.append_parameter_override("dummy.dummy_param", 0.0);
+    node_options_.append_parameter_override("duration_time", 1.0);
+    node_options_.append_parameter_override("fallback_period_ms", 150);
+    node_options_.append_parameter_override("use_sim_time", true);
 
     const auto vehicle_info_param_path = autoware::test_utils::get_absolute_path_to_config(
       "autoware_test_utils", "test_vehicle_info.param.yaml");
@@ -45,7 +51,13 @@ protected:
 
     node_under_test_ =
       std::make_shared<autoware::trajectory_selector::TrajectorySelectorNode>(node_options_);
-    test_node_ = std::make_shared<rclcpp::Node>("test_helper_node");
+
+    rclcpp::NodeOptions test_node_options;
+    test_node_options.append_parameter_override("use_sim_time", true);
+    test_node_ = std::make_shared<rclcpp::Node>("test_helper_node", test_node_options);
+
+    clock_pub_ =
+      test_node_->create_publisher<rosgraph_msgs::msg::Clock>("/clock", rclcpp::ClockQoS());
 
     map_pub_ = test_node_->create_publisher<autoware_map_msgs::msg::LaneletMapBin>(
       "/trajectory_selector_node/input/lanelet2_map", rclcpp::QoS{1}.transient_local());
@@ -61,6 +73,9 @@ protected:
     traj_pub_ =
       test_node_->create_publisher<autoware_internal_planning_msgs::msg::CandidateTrajectories>(
         "/trajectory_selector_node/input/trajectories_generative", 1);
+    backup_traj_pub_ =
+      test_node_->create_publisher<autoware_internal_planning_msgs::msg::CandidateTrajectories>(
+        "/trajectory_selector_node/input/trajectories_backup", 1);
 
     output_sub_ =
       test_node_->create_subscription<autoware_internal_planning_msgs::msg::CandidateTrajectories>(
@@ -69,43 +84,92 @@ protected:
           const autoware_internal_planning_msgs::msg::CandidateTrajectories::ConstSharedPtr msg) {
           last_output_ = msg;
         });
+
+    // Seed the simulated clock at t = 1 s to avoid zero-time edge cases.
+    // Publishing immediately triggers the initial (warm-up) timer fire because the node's
+    // timer was created when the clock was still at 0, so its first deadline (0 + 150 ms)
+    // is already past. After the initial spins the next deadline is t = 1.0 s + 150 ms.
+    sim_time_ = rclcpp::Time(0, 0, RCL_ROS_TIME) + rclcpp::Duration(std::chrono::seconds(1));
+    publish_clock();
+    for (int i = 0; i < 10; ++i) {
+      rclcpp::spin_some(node_under_test_);
+      rclcpp::spin_some(test_node_);
+    }
   }
 
   void TearDown() override { rclcpp::shutdown(); }
 
-  bool spin_until(
-    std::function<bool()> && condition,
-    std::chrono::milliseconds timeout = std::chrono::milliseconds(1000))
+  /** Publish the current sim_time_ on /clock. */
+  void publish_clock()
   {
-    const auto start = std::chrono::steady_clock::now();
-    while (rclcpp::ok() && (std::chrono::steady_clock::now() - start) < timeout) {
-      if (condition()) return true;
+    rosgraph_msgs::msg::Clock msg;
+    msg.clock = sim_time_;
+    clock_pub_->publish(msg);
+  }
+
+  /**
+   * Spin both nodes a fixed number of times without advancing simulated time.
+   * Use this to let published messages propagate before starting a timed window.
+   */
+  void spin_for_messages(int iterations = 10)
+  {
+    for (int i = 0; i < iterations; ++i) {
       rclcpp::spin_some(node_under_test_);
       rclcpp::spin_some(test_node_);
-      std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    }
+  }
+
+  /**
+   * Advance the simulated clock in `step` increments, spinning after each
+   * advance, until `condition` returns true or `timeout` of simulated time
+   * has elapsed.
+   *
+   * No wall-clock sleeping is performed; all timing is driven by /clock
+   * messages published to the nodes.
+   *
+   * Two spin_some() calls are made for node_under_test_ after each clock
+   * advance: the first delivers the /clock update (which may mark a timer
+   * as ready), the second executes any newly-ready timer callback.
+   */
+  bool spin_until(
+    const std::function<bool()> & condition,
+    const rclcpp::Duration & timeout = rclcpp::Duration(std::chrono::seconds(1)),
+    const rclcpp::Duration & step = rclcpp::Duration(std::chrono::milliseconds(10)))
+  {
+    const rclcpp::Time deadline = sim_time_ + timeout;
+    while (rclcpp::ok()) {
+      rclcpp::spin_some(node_under_test_);
+      rclcpp::spin_some(test_node_);
+      if (condition()) return true;
+      if (sim_time_ >= deadline) break;
+      sim_time_ = sim_time_ + step;
+      publish_clock();
+      // First spin: delivers the clock update and may mark the timer as ready.
+      rclcpp::spin_some(node_under_test_);
+      // Second spin: executes any timer callback that became ready above.
+      rclcpp::spin_some(node_under_test_);
+      rclcpp::spin_some(test_node_);
     }
     return false;
   }
 
   void publish_context()
   {
-    const auto now = node_under_test_->now();
-
     auto map_msg = autoware::test_utils::makeMapBinMsg("autoware_test_utils", "lanelet2_map.osm");
     map_pub_->publish(map_msg);
 
     nav_msgs::msg::Odometry odom;
-    odom.header.stamp = now;
+    odom.header.stamp = sim_time_;
     odom.header.frame_id = "map";
     odom_pub_->publish(odom);
 
     geometry_msgs::msg::AccelWithCovarianceStamped accel;
-    accel.header.stamp = now;
+    accel.header.stamp = sim_time_;
     accel.header.frame_id = "map";
     accel_pub_->publish(accel);
 
     autoware_perception_msgs::msg::PredictedObjects objects;
-    objects.header.stamp = now;
+    objects.header.stamp = sim_time_;
     objects.header.frame_id = "map";
     obj_pub_->publish(objects);
 
@@ -138,6 +202,9 @@ protected:
   rclcpp::Node::SharedPtr test_node_;
   std::shared_ptr<trajectory_selector::TrajectorySelectorNode> node_under_test_;
 
+  rclcpp::Publisher<rosgraph_msgs::msg::Clock>::SharedPtr clock_pub_;
+  rclcpp::Time sim_time_{0, 0, RCL_ROS_TIME};
+
   rclcpp::Publisher<autoware_map_msgs::msg::LaneletMapBin>::SharedPtr map_pub_;
   rclcpp::Publisher<nav_msgs::msg::Odometry>::SharedPtr odom_pub_;
   rclcpp::Publisher<geometry_msgs::msg::AccelWithCovarianceStamped>::SharedPtr accel_pub_;
@@ -145,6 +212,8 @@ protected:
   rclcpp::Publisher<autoware_perception_msgs::msg::TrafficLightGroupArray>::SharedPtr tl_pub_;
   rclcpp::Publisher<autoware_internal_planning_msgs::msg::CandidateTrajectories>::SharedPtr
     traj_pub_;
+  rclcpp::Publisher<autoware_internal_planning_msgs::msg::CandidateTrajectories>::SharedPtr
+    backup_traj_pub_;
 
   rclcpp::Subscription<autoware_internal_planning_msgs::msg::CandidateTrajectories>::SharedPtr
     output_sub_;
@@ -154,9 +223,9 @@ protected:
 TEST_F(TrajectorySelectorNodeTest, FiltersTrajectoriesViaPlugin)
 {
   publish_context();
-  spin_until([] { return false; }, std::chrono::milliseconds(100));
+  spin_for_messages();
 
-  const auto now = node_under_test_->now();
+  const auto now = sim_time_;
   autoware_internal_planning_msgs::msg::CandidateTrajectories msg;
 
   add_trajectory(msg, "SafePlanner", 10.0, now);
@@ -166,19 +235,81 @@ TEST_F(TrajectorySelectorNodeTest, FiltersTrajectoriesViaPlugin)
 
   ASSERT_TRUE(spin_until(
     [this] { return last_output_ != nullptr && !last_output_->candidate_trajectories.empty(); },
-    std::chrono::milliseconds(1000)));
+    rclcpp::Duration(std::chrono::seconds(1))));
 
   EXPECT_EQ(last_output_->candidate_trajectories.size(), 1u);
   ASSERT_EQ(last_output_->generator_info.size(), 1u);
   EXPECT_EQ(last_output_->generator_info.front().generator_name.data, "SafePlanner");
 }
 
+TEST_F(TrajectorySelectorNodeTest, ImmediateOutputOnGenerativeInput)
+{
+  publish_context();
+  spin_for_messages();
+
+  const auto now = sim_time_;
+  autoware_internal_planning_msgs::msg::CandidateTrajectories msg;
+  add_trajectory(msg, "GenerativePlanner", 10.0, now);
+
+  last_output_ = nullptr;
+  traj_pub_->publish(msg);
+
+  // Should publish immediately (timer is 150 ms sim, so 50 ms sim is "immediate" enough)
+  const bool received = spin_until(
+    [this] { return last_output_ != nullptr; }, rclcpp::Duration(std::chrono::milliseconds(50)));
+  EXPECT_TRUE(received) << "Node should publish immediately on generative input";
+}
+
+TEST_F(TrajectorySelectorNodeTest, NoImmediateOutputOnBackupInput)
+{
+  publish_context();
+  spin_for_messages();
+
+  const auto now = sim_time_;
+  autoware_internal_planning_msgs::msg::CandidateTrajectories msg;
+  add_trajectory(msg, "BackupPlanner", 10.0, now);
+  bool received = spin_until(
+    [this] { return last_output_ != nullptr; }, rclcpp::Duration(std::chrono::milliseconds(50)));
+  EXPECT_FALSE(received) << "Node should NOT publish without any input";
+
+  last_output_ = nullptr;
+  backup_traj_pub_->publish(msg);
+
+  // Should NOT publish immediately
+  received = spin_until(
+    [this] { return last_output_ != nullptr; }, rclcpp::Duration(std::chrono::milliseconds(50)));
+  EXPECT_FALSE(received) << "Node should NOT publish immediately on backup input";
+
+  // Should publish eventually via timer (timer is 150 ms sim)
+  received = spin_until(
+    [this] { return last_output_ != nullptr; }, rclcpp::Duration(std::chrono::milliseconds(200)));
+  EXPECT_TRUE(received) << "Node should eventually publish on backup input via timer";
+}
+
+TEST_F(TrajectorySelectorNodeTest, TimerOutputWithoutGenerativeInput)
+{
+  publish_context();
+  spin_for_messages();
+
+  const auto now = sim_time_;
+  autoware_internal_planning_msgs::msg::CandidateTrajectories msg;
+  add_trajectory(msg, "SomePlanner", 10.0, now);
+
+  // Publish only to backup, generative is never published
+  last_output_ = nullptr;
+  backup_traj_pub_->publish(msg);
+
+  const bool received = spin_until(
+    [this] { return last_output_ != nullptr; }, rclcpp::Duration(std::chrono::milliseconds(200)));
+  EXPECT_TRUE(received) << "Node should publish via timer even if generative input is missing";
+}
+
 TEST_F(TrajectorySelectorNodeTest, HandlesPluginRejection)
 {
   publish_context();
-  spin_until([] { return false; }, std::chrono::milliseconds(100));
+  spin_for_messages();
 
-  const auto now = node_under_test_->now();
+  const auto now = sim_time_;
   autoware_internal_planning_msgs::msg::CandidateTrajectories msg;
   add_trajectory(msg, "FailingPlanner", -999.0, now);
 
@@ -190,7 +321,7 @@ TEST_F(TrajectorySelectorNodeTest, HandlesPluginRejection)
 
 TEST_F(TrajectorySelectorNodeTest, NoPublishWhenOdometryMissing)
 {
-  const auto now = node_under_test_->now();
+  const auto now = sim_time_;
 
   auto map_msg = autoware::test_utils::makeMapBinMsg("autoware_test_utils", "lanelet2_map.osm");
   map_pub_->publish(map_msg);
@@ -207,14 +338,14 @@ TEST_F(TrajectorySelectorNodeTest, NoPublishWhenOdometryMissing)
   add_trajectory(msg, "AnyPlanner", 10.0, now);
   traj_pub_->publish(msg);
 
-  const bool received =
-    spin_until([this] { return last_output_ != nullptr; }, std::chrono::milliseconds(500));
+  const bool received = spin_until(
+    [this] { return last_output_ != nullptr; }, rclcpp::Duration(std::chrono::milliseconds(500)));
   EXPECT_FALSE(received) << "Node must not publish when odometry is unavailable";
 }
 
 TEST_F(TrajectorySelectorNodeTest, NoPublishWhenAccelerationMissing)
 {
-  const auto now = node_under_test_->now();
+  const auto now = sim_time_;
 
   auto map_msg = autoware::test_utils::makeMapBinMsg("autoware_test_utils", "lanelet2_map.osm");
   map_pub_->publish(map_msg);
@@ -231,14 +362,14 @@ TEST_F(TrajectorySelectorNodeTest, NoPublishWhenAccelerationMissing)
   add_trajectory(msg, "AnyPlanner", 10.0, now);
   traj_pub_->publish(msg);
 
-  const bool received =
-    spin_until([this] { return last_output_ != nullptr; }, std::chrono::milliseconds(500));
+  const bool received = spin_until(
+    [this] { return last_output_ != nullptr; }, rclcpp::Duration(std::chrono::milliseconds(500)));
   EXPECT_FALSE(received) << "Node must not publish when acceleration is unavailable";
 }
 
 TEST_F(TrajectorySelectorNodeTest, NoPublishWhenObjectsMissing)
 {
-  const auto now = node_under_test_->now();
+  const auto now = sim_time_;
 
   auto map_msg = autoware::test_utils::makeMapBinMsg("autoware_test_utils", "lanelet2_map.osm");
   map_pub_->publish(map_msg);
@@ -255,9 +386,75 @@ TEST_F(TrajectorySelectorNodeTest, NoPublishWhenObjectsMissing)
   add_trajectory(msg, "AnyPlanner", 10.0, now);
   traj_pub_->publish(msg);
 
-  const bool received =
-    spin_until([this] { return last_output_ != nullptr; }, std::chrono::milliseconds(500));
+  const bool received = spin_until(
+    [this] { return last_output_ != nullptr; }, rclcpp::Duration(std::chrono::milliseconds(500)));
   EXPECT_FALSE(received) << "Node must not publish when predicted objects are unavailable";
+}
+
+TEST_F(TrajectorySelectorNodeTest, CustomFallbackPeriod)
+{
+  publish_context();
+  node_under_test_->set_parameters(
+    {rclcpp::Parameter("fallback_period_ms", 500), rclcpp::Parameter("duration_time", 1.0)});
+  spin_for_messages();
+
+  const auto now = sim_time_;
+  autoware_internal_planning_msgs::msg::CandidateTrajectories msg;
+  add_trajectory(msg, "SomePlanner", 10.0, now);
+
+  // Publish only to backup, generative is never published
+  last_output_ = nullptr;
+  backup_traj_pub_->publish(msg);
+
+  // Should NOT publish within 400ms because fallback_period_ms is 500ms
+  bool received = spin_until(
+    [this] { return last_output_ != nullptr; }, rclcpp::Duration(std::chrono::milliseconds(400)));
+  EXPECT_FALSE(received) << "Node should NOT publish within 400ms when fallback_period_ms is 500ms";
+
+  // Should publish eventually via timer (timer is 500ms, so 600ms total should be enough)
+  received = spin_until(
+    [this] { return last_output_ != nullptr; }, rclcpp::Duration(std::chrono::milliseconds(200)));
+  EXPECT_TRUE(received) << "Node should eventually publish on backup input via custom timer";
+}
+
+TEST_F(TrajectorySelectorNodeTest, ResetFallbackPeriod)
+{
+  publish_context();
+  node_under_test_->set_parameters(
+    {rclcpp::Parameter("fallback_period_ms", 500), rclcpp::Parameter("duration_time", 1.0)});
+  spin_for_messages();
+
+  const auto now = sim_time_;
+  autoware_internal_planning_msgs::msg::CandidateTrajectories msg;
+  add_trajectory(msg, "SomePlanner", 10.0, now);
+
+  // Publish only to backup, generative is never published
+  last_output_ = nullptr;
+  backup_traj_pub_->publish(msg);
+
+  bool received = spin_until(
+    [this] { return last_output_ != nullptr; }, rclcpp::Duration(std::chrono::milliseconds(400)));
+  EXPECT_FALSE(received) << "Node should NOT publish within 400ms when fallback_period_ms is 500ms";
+
+  // Set new fallback period which resets the fallback timer.
+  // update_fallback_timer() is called synchronously inside set_parameters, so the new
+  // timer deadline is anchored to the current sim_time_ at the moment of the call.
+  node_under_test_->set_parameters({
+    rclcpp::Parameter("fallback_period_ms", 400),
+  });
+
+  received = spin_until(
+    [this] { return last_output_ != nullptr; }, rclcpp::Duration(std::chrono::milliseconds(200)));
+  EXPECT_FALSE(received) << "Node should NOT publish because timer was reset";
+
+  node_under_test_->set_parameters({rclcpp::Parameter("fallback_period_ms", 200)});
+
+  received = spin_until(
+    [this] { return last_output_ != nullptr; }, rclcpp::Duration(std::chrono::milliseconds(100)));
+  EXPECT_FALSE(received) << "Node should NOT publish because timer was reset";
+  received = spin_until(
+    [this] { return last_output_ != nullptr; }, rclcpp::Duration(std::chrono::milliseconds(200)));
+  EXPECT_TRUE(received) << "Node should publish within 300ms when fallback_period_ms is 200ms";
 }
 
 }  // namespace autoware::trajectory_selector


### PR DESCRIPTION
## Description
This PR introduces an "anchor" mechanism to the trajectory_selector node to reduce processing latency.

Previously, the node processed buffered trajectories strictly on a fixed 100ms timer. This could introduce up to 100ms of latency if a generative planner finished its computation just after a timer cycle. 

With this change, the `~/input/trajectories_generative` topic acts as an anchor: receiving a message on this topic now triggers an immediate concatenation and validation cycle and resets the internal timer.
Backup trajectories (`~/input/trajectories_backup`) continue to be buffered and processed in the next available cycle (either triggered by a new anchor message or the periodic timer).

## Related links

https://tier4.atlassian.net/browse/PDDP-220
Required launch PR: https://github.com/tier4/autoware_launch.x2/pull/2564
AWF PR: https://github.com/autowarefoundation/autoware_universe/pull/12722

## How was this PR tested?

Evaluator:
- https://evaluation.ci.tier4.jp/evaluation/reports/98cf0319-3b0a-5725-8abf-b3c7e4c976df?project_id=x2_dev
- https://evaluation.ci.tier4.jp/evaluation/reports/c15732a6-36dc-5112-88cb-d48c1fac7253?project_id=x2_dev
Unit tests
Psim

## Notes for reviewers

None.

## Interface changes

None.

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

## Effects on system behavior

Reduces delay of the planning component.


https://github.com/autowarefoundation/autoware_universe/pull/12722