### PR TITLE
fix(obstacle_stop): cherry-pick of awf #12862

### DIFF
--- a/planning/autoware_trajectory_modifier/package.xml
+++ b/planning/autoware_trajectory_modifier/package.xml
@@ -9,6 +9,7 @@
   <maintainer email="go.sakayori@tier4.jp">Go Sakayori</maintainer>
   <maintainer email="shintaro.sakoda@tier4.jp">Shintaro Sakoda</maintainer>
   <maintainer email="alqudah.mohammad@tier4.jp">Alqudah Mohammad</maintainer>
+  <maintainer email="maxime.clement@tier4.jp">Maxime Clement</maintainer>
 
   <license>Apache License 2.0</license>
 

--- a/planning/autoware_trajectory_modifier/src/trajectory_modifier_utils/obstacle_stop_utils.cpp
+++ b/planning/autoware_trajectory_modifier/src/trajectory_modifier_utils/obstacle_stop_utils.cpp
@@ -572,12 +572,11 @@ void ObstacleTracker::update_objects(
       it++;
   }
 
-  auto closest_object_uuid =
+  auto get_closest_object_uuid =
     [&](const PredictedObject & object) -> std::optional<boost::uuids::uuid> {
     std::optional<boost::uuids::uuid> closest_uuid = std::nullopt;
     if (persistent_objects_map_.empty()) return std::nullopt;
-    double min_distance = std::numeric_limits<double>::max();
-    double yaw_diff = std::numeric_limits<double>::max();
+    double min_distance = object_distance_th_ + std::numeric_limits<double>::epsilon();
     for (const auto & [uuid, existing_object] : persistent_objects_map_) {
       const auto existing_obj_label = existing_object.object.classification.empty()
                                         ? ObjectClassification::UNKNOWN
@@ -588,23 +587,24 @@ void ObstacleTracker::update_objects(
       const auto distance = autoware_utils::calc_distance2d(
         object.kinematics.initial_pose_with_covariance.pose.position,
         existing_object.object.kinematics.initial_pose_with_covariance.pose.position);
-      if (distance < min_distance) {
-        min_distance = distance;
-        closest_uuid = uuid;
-        yaw_diff = std::abs(
-          autoware_utils_geometry::calc_yaw_deviation(
-            object.kinematics.initial_pose_with_covariance.pose,
-            existing_object.object.kinematics.initial_pose_with_covariance.pose));
-      }
-    }
-    if (closest_uuid && (min_distance > object_distance_th_ || yaw_diff > object_yaw_th_)) {
-      closest_uuid = std::nullopt;
+      if (distance > min_distance) continue;
+      // ignore orientation difference for cylinder objects
+      const auto yaw_diff =
+        object.shape.type == autoware_perception_msgs::msg::Shape::CYLINDER
+          ? 0.0
+          : std::abs(
+              autoware_utils_geometry::calc_yaw_deviation(
+                object.kinematics.initial_pose_with_covariance.pose,
+                existing_object.object.kinematics.initial_pose_with_covariance.pose));
+      if (yaw_diff > object_yaw_th_) continue;
+      min_distance = distance;
+      closest_uuid = uuid;
     }
     return closest_uuid;
   };
 
   for (const auto & object : objects.objects) {
-    const auto closest_uuid = closest_object_uuid(object);
+    const auto closest_uuid = get_closest_object_uuid(object);
     if (!closest_uuid) {
       persistent_objects_map_.emplace(id_generator_(), PersistentObject(object, now));
       continue;
@@ -636,27 +636,23 @@ void ObstacleTracker::update_points(
       it++;
   }
 
-  auto closest_point_uuid =
+  auto get_closest_point_uuid =
     [&](const geometry_msgs::msg::Point & point) -> std::optional<boost::uuids::uuid> {
     std::optional<boost::uuids::uuid> closest_uuid = std::nullopt;
     if (persistent_point_map_.empty()) return std::nullopt;
-    double min_distance = std::numeric_limits<double>::max();
+    double min_distance = pcd_distance_th_ + std::numeric_limits<double>::epsilon();
     for (const auto & [uuid, existing_point] : persistent_point_map_) {
       const auto distance = autoware_utils::calc_distance2d(point, existing_point.position);
-      if (distance < min_distance) {
-        min_distance = distance;
-        closest_uuid = uuid;
-      }
-    }
-    if (closest_uuid && min_distance > pcd_distance_th_) {
-      closest_uuid = std::nullopt;
+      if (distance > min_distance) continue;
+      min_distance = distance;
+      closest_uuid = uuid;
     }
     return closest_uuid;
   };
 
   for (const auto & point : points->points) {
     auto point_msg = autoware_utils::create_point(point.x, point.y, point.z);
-    const auto closest_uuid = closest_point_uuid(point_msg);
+    const auto closest_uuid = get_closest_point_uuid(point_msg);
     if (!closest_uuid) {
       persistent_point_map_.emplace(id_generator_(), PersistentPoint(point_msg, now));
       continue;


### PR DESCRIPTION
This is a cherry-pick PR of https://github.com/autowarefoundation/autoware_universe/pull/12862 to fix obstacle tracking logic to ignore orientation difference for cylinder type objects (pedestrians)