### PR TITLE
feat(perception): apply autoware_agnocast_wrapper for CIE to traffic light nodes (cherry-pick #12712, #12713, #12714)

### DIFF
--- a/perception/autoware_crosswalk_traffic_light_estimator/CMakeLists.txt
+++ b/perception/autoware_crosswalk_traffic_light_estimator/CMakeLists.txt
@@ -16,9 +16,11 @@ ament_auto_add_library(autoware_crosswalk_traffic_light_estimator SHARED
   src/node.cpp
 )
 
-rclcpp_components_register_node(autoware_crosswalk_traffic_light_estimator
+autoware_agnocast_wrapper_register_node(autoware_crosswalk_traffic_light_estimator
   PLUGIN "autoware::crosswalk_traffic_light_estimator::CrosswalkTrafficLightEstimatorNode"
   EXECUTABLE crosswalk_traffic_light_estimator_node
+  AGNOCAST_EXECUTOR CallbackIsolatedAgnocastExecutor
+  ROS2_EXECUTOR SingleThreadedExecutor
 )
 
 if(BUILD_TESTING)

--- a/perception/autoware_crosswalk_traffic_light_estimator/package.xml
+++ b/perception/autoware_crosswalk_traffic_light_estimator/package.xml
@@ -15,6 +15,7 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
+  <depend>autoware_agnocast_wrapper</depend>
   <depend>autoware_internal_debug_msgs</depend>
   <depend>autoware_lanelet2_extension</depend>
   <depend>autoware_lanelet2_utils</depend>

--- a/perception/autoware_traffic_light_arbiter/CMakeLists.txt
+++ b/perception/autoware_traffic_light_arbiter/CMakeLists.txt
@@ -9,9 +9,11 @@ ament_auto_add_library(${PROJECT_NAME} SHARED
   src/signal_match_validator.cpp
 )
 
-rclcpp_components_register_node(${PROJECT_NAME}
+autoware_agnocast_wrapper_register_node(${PROJECT_NAME}
   PLUGIN "autoware::traffic_light::TrafficLightArbiter"
   EXECUTABLE traffic_light_arbiter_node
+  AGNOCAST_EXECUTOR CallbackIsolatedAgnocastExecutor
+  ROS2_EXECUTOR SingleThreadedExecutor
 )
 
 if(BUILD_TESTING)

--- a/perception/autoware_traffic_light_arbiter/package.xml
+++ b/perception/autoware_traffic_light_arbiter/package.xml
@@ -13,6 +13,7 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
+  <depend>autoware_agnocast_wrapper</depend>
   <depend>autoware_lanelet2_extension</depend>
   <depend>autoware_lanelet2_utils</depend>
   <depend>autoware_map_msgs</depend>

--- a/perception/autoware_traffic_light_multi_camera_fusion/CMakeLists.txt
+++ b/perception/autoware_traffic_light_multi_camera_fusion/CMakeLists.txt
@@ -15,9 +15,11 @@ ament_auto_add_library(${PROJECT_NAME} SHARED
   src/signal_validator.cpp
 )
 
-rclcpp_components_register_node(${PROJECT_NAME}
+autoware_agnocast_wrapper_register_node(${PROJECT_NAME}
   PLUGIN "autoware::traffic_light::MultiCameraFusionNode"
   EXECUTABLE traffic_light_multi_camera_fusion_node
+  AGNOCAST_EXECUTOR CallbackIsolatedAgnocastExecutor
+  ROS2_EXECUTOR SingleThreadedExecutor
 )
 
 if(BUILD_TESTING)

--- a/perception/autoware_traffic_light_multi_camera_fusion/package.xml
+++ b/perception/autoware_traffic_light_multi_camera_fusion/package.xml
@@ -16,6 +16,7 @@
   <build_depend>ament_cmake_gtest</build_depend>
   <build_depend>autoware_cmake</build_depend>
 
+  <depend>autoware_agnocast_wrapper</depend>
   <depend>autoware_lanelet2_extension</depend>
   <depend>autoware_lanelet2_utils</depend>
   <depend>autoware_map_msgs</depend>


### PR DESCRIPTION
## Description

Cherry-pick of the following three upstream PRs onto `beta/v0.68` (all clean, no conflicts):

- autowarefoundation/autoware_universe#12712 (cherry-picked from `539df791c34588a98d2c525e93d2c27386946045`)
- autowarefoundation/autoware_universe#12713 (cherry-picked from `4c92a09d375bfcdd99472f58c84945e31dd229e6`)
- autowarefoundation/autoware_universe#12714 (cherry-picked from `22a2904ec7a0f5ebd26da7c4d03a3d2f790726ce`)

Each PR applies `autoware_agnocast_wrapper` to one perception traffic-light node so it can run under the Callback-Isolated Executor (CIE):

- `autoware_traffic_light_multi_camera_fusion` (#12712)
- `autoware_traffic_light_arbiter` (#12713)
- `autoware_crosswalk_traffic_light_estimator` (#12714)

The change in each package is identical in shape: `rclcpp_components_register_node` is replaced with `autoware_agnocast_wrapper_register_node` (`AGNOCAST_EXECUTOR CallbackIsolatedAgnocastExecutor`, `ROS2_EXECUTOR SingleThreadedExecutor`) in `CMakeLists.txt`, and `autoware_agnocast_wrapper` is added as a dependency in `package.xml`. The three packages are independent, so the cherry-pick order does not matter; they were applied in upstream merge order (#12712, #12713, #12714).

## Related links

**Parent Issue:**

- autowarefoundation/autoware_universe#12712
- autowarefoundation/autoware_universe#12713
- autowarefoundation/autoware_universe#12714

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

## Effects on system behavior

When agnocast is disabled (default), there is no change in behavior. The node runs with the standard ROS 2 `SingleThreadedExecutor` exactly as before.

When agnocast is enabled, the node runs under the Callback-Isolated Executor (CIE), which gives each callback group its own executor so that callbacks become isolatable and can be placed on dedicated real-time threads by the thread_configurator.
