### PR TITLE
feat: change preffered lane color

### DIFF
--- a/planning/autoware_mission_planner_universe/src/lanelet2_plugins/default_planner.cpp
+++ b/planning/autoware_mission_planner_universe/src/lanelet2_plugins/default_planner.cpp
@@ -153,7 +153,7 @@ PlannerPlugin::MarkerArray DefaultPlanner::visualize(
     autoware_utils::create_marker_color(1.0, 1.0, 1.0, 0.999);
   const std_msgs::msg::ColorRGBA cl_end = autoware_utils::create_marker_color(0.2, 0.2, 0.4, 0.05);
   const std_msgs::msg::ColorRGBA cl_goal =
-    autoware_utils::create_marker_color(1.0, 0.5, 0.0, goal_lanelet_transparency);
+    autoware_utils::create_marker_color(0.2, 0.4, 0.4, goal_lanelet_transparency);
 
   visualization_msgs::msg::MarkerArray route_marker_array;
   insert_marker_array(


### PR DESCRIPTION
Preffered Laneの可視化時に黄色だと見づらいという意見があったため薄い水色のような色に変更しました

こちらのPRの修正をアップデートするPRです
https://github.com/tier4/autoware_universe/pull/3097

MOTでの表示は下記のようになります
<img width="1044" height="823" alt="image" src="https://github.com/user-attachments/assets/3f0cfa1c-16bb-4d87-951f-c8956aab9b30" />
