### PR TITLE
feat(dummy_traffic_light_publisher): add new node to publish traffic light message instead of Rviz (backport #12456)

### DIFF
--- a/simulator/autoware_dummy_traffic_light_publisher/CMakeLists.txt
+++ b/simulator/autoware_dummy_traffic_light_publisher/CMakeLists.txt
@@ -1,0 +1,37 @@
+cmake_minimum_required(VERSION 3.14)
+project(autoware_dummy_traffic_light_publisher)
+
+find_package(autoware_cmake REQUIRED)
+autoware_package()
+
+ament_auto_add_library(${PROJECT_NAME}_lib SHARED
+  src/traffic_light_cycle.cpp
+  src/dummy_traffic_light.cpp
+  src/dummy_traffic_light_publisher_node.cpp
+)
+
+ament_auto_add_executable(${PROJECT_NAME}_node
+  src/main.cpp
+)
+
+target_link_libraries(${PROJECT_NAME}_node ${PROJECT_NAME}_lib)
+
+if(BUILD_TESTING)
+  ament_add_ros_isolated_gtest(test_traffic_light_cycle
+    test/test_traffic_light_cycle.cpp
+  )
+  target_include_directories(test_traffic_light_cycle PRIVATE src)
+  target_link_libraries(test_traffic_light_cycle ${PROJECT_NAME}_lib)
+
+  ament_add_ros_isolated_gtest(test_dummy_traffic_light
+    test/test_dummy_traffic_light.cpp
+  )
+  target_include_directories(test_dummy_traffic_light PRIVATE src)
+  target_link_libraries(test_dummy_traffic_light ${PROJECT_NAME}_lib)
+endif()
+
+ament_auto_package(
+  INSTALL_TO_SHARE
+  launch
+  config
+)

--- a/simulator/autoware_dummy_traffic_light_publisher/README.md
+++ b/simulator/autoware_dummy_traffic_light_publisher/README.md
@@ -1,0 +1,95 @@
+# autoware_dummy_traffic_light_publisher
+
+## Purpose
+
+Publish dummy traffic light signals for simulation environments where a traffic light recognition module is not available.
+
+## Modes
+
+| Mode         | Description                                                                                    |
+| ------------ | ---------------------------------------------------------------------------------------------- |
+| `standalone` | Cycles through Green -> Yellow -> Red for all traffic lights found in the vector map.          |
+| `empty`      | Publishes an empty `TrafficLightGroupArray` (no traffic light groups).                         |
+| `fixed`      | Publishes a single fixed color (`fixed_color`) for all traffic lights found in the vector map. |
+
+To assign different signals per traffic light ID, use pass-through instead (see below); `fixed` mode intentionally applies one color to every light.
+
+## Pass-through
+
+When a message is received on the input topic (`~/input/traffic_signals`), the node relays it as-is instead of generating its own signals. If no new input arrives within `passthrough_timeout` seconds, the node falls back to its configured mode.
+
+## Interface
+
+### Subscriptions
+
+| Topic                     | Type                                                  | Description                                                   |
+| ------------------------- | ----------------------------------------------------- | ------------------------------------------------------------- |
+| `~/input/vector_map`      | `autoware_map_msgs/msg/LaneletMapBin`                 | Lanelet2 map to extract traffic light regulatory element IDs. |
+| `~/input/traffic_signals` | `autoware_perception_msgs/msg/TrafficLightGroupArray` | External traffic light signals for pass-through.              |
+
+### Publications
+
+| Topic                      | Type                                                  | Description                                 |
+| -------------------------- | ----------------------------------------------------- | ------------------------------------------- |
+| `~/output/traffic_signals` | `autoware_perception_msgs/msg/TrafficLightGroupArray` | Generated or relayed traffic light signals. |
+
+## Parameters
+
+| Parameter             | Type   | Default   | Description                                                           |
+| --------------------- | ------ | --------- | --------------------------------------------------------------------- |
+| `mode`                | string | `"empty"` | Operating mode: `"standalone"`, `"empty"` or `"fixed"`.               |
+| `publish_rate`        | double | `10.0`    | Publishing frequency [Hz].                                            |
+| `green_duration`      | double | `30.0`    | Duration of the green phase [s] (`standalone` mode).                  |
+| `yellow_duration`     | double | `3.0`     | Duration of the yellow phase [s] (`standalone` mode).                 |
+| `red_duration`        | double | `30.0`    | Duration of the red phase [s] (`standalone` mode).                    |
+| `passthrough_timeout` | double | `1.0`     | Time after last input before falling back to the configured mode [s]. |
+| `fixed_color`         | string | `"red"`   | Color published in `fixed` mode: `"green"`, `"yellow"` or `"red"`.    |
+
+## Usage
+
+### Launch
+
+```bash
+ros2 launch autoware_dummy_traffic_light_publisher dummy_traffic_light_publisher.launch.xml
+```
+
+To override the mode:
+
+```bash
+ros2 launch autoware_dummy_traffic_light_publisher dummy_traffic_light_publisher.launch.xml mode:=standalone
+```
+
+To publish a fixed color for all traffic lights:
+
+```bash
+ros2 launch autoware_dummy_traffic_light_publisher dummy_traffic_light_publisher.launch.xml mode:=fixed fixed_color:=green
+```
+
+## Design and extension tactics
+
+This package separates concerns into three layers:
+
+| Layer             | Class                            | Role                                                                                       |
+| ----------------- | -------------------------------- | ------------------------------------------------------------------------------------------ |
+| ROS I/O           | `DummyTrafficLightPublisherNode` | Subscriptions (`take()`), timer, publisher, vector map parsing.                            |
+| Message assembly  | `DummyTrafficLight`              | Pass-through judgment, traffic light ID management, `TrafficLightGroupArray` construction. |
+| Signal generation | `TrafficLightCycle`              | Phase computation (Green/Yellow/Red) from elapsed time and `TrafficLightElement` output.   |
+
+When extending, modify only the layer that owns the responsibility:
+
+- **Adding arrow shapes, flashing patterns, or new signal types** — change `TrafficLightCycle`. It owns `TrafficLightElement` construction. Node and `DummyTrafficLight` are unaffected.
+- **Per-intersection or per-ID signal control** — change `DummyTrafficLight`. It maps IDs to elements. `TrafficLightCycle` and Node are unaffected.
+- **Adding new input sources or output topics** — change `DummyTrafficLightPublisherNode`. Logic layers are unaffected.
+
+### Run node directly
+
+The parameters have no in-code defaults, so a parameter file must be provided (e.g. the packaged `config/dummy_traffic_light_publisher.param.yaml`):
+
+```bash
+ros2 run autoware_dummy_traffic_light_publisher autoware_dummy_traffic_light_publisher_node --ros-args \
+  --params-file $(ros2 pkg prefix --share autoware_dummy_traffic_light_publisher)/config/dummy_traffic_light_publisher.param.yaml \
+  -p mode:=standalone \
+  -r ~/input/vector_map:=/map/vector_map \
+  -r ~/input/traffic_signals:=/simulator/input/traffic_signals \
+  -r ~/output/traffic_signals:=/perception/traffic_light_recognition/traffic_signals
+```

--- a/simulator/autoware_dummy_traffic_light_publisher/config/dummy_traffic_light_publisher.param.yaml
+++ b/simulator/autoware_dummy_traffic_light_publisher/config/dummy_traffic_light_publisher.param.yaml
@@ -1,0 +1,9 @@
+/**:
+  ros__parameters:
+    mode: "empty"  # "standalone", "empty" or "fixed"
+    publish_rate: 10.0  # Hz
+    green_duration: 30.0  # seconds
+    yellow_duration: 3.0  # seconds
+    red_duration: 30.0  # seconds
+    passthrough_timeout: 1.0  # seconds
+    fixed_color: "red"  # used in "fixed" mode: "green", "yellow" or "red"

--- a/simulator/autoware_dummy_traffic_light_publisher/launch/dummy_traffic_light_publisher.launch.xml
+++ b/simulator/autoware_dummy_traffic_light_publisher/launch/dummy_traffic_light_publisher.launch.xml
@@ -1,0 +1,14 @@
+<launch>
+  <arg name="mode" default="empty"/>
+  <arg name="fixed_color" default="red"/>
+  <arg name="dummy_traffic_light_publisher_param_file" default="$(find-pkg-share autoware_dummy_traffic_light_publisher)/config/dummy_traffic_light_publisher.param.yaml"/>
+
+  <node pkg="autoware_dummy_traffic_light_publisher" exec="autoware_dummy_traffic_light_publisher_node" name="dummy_traffic_light_publisher" output="screen">
+    <param from="$(var dummy_traffic_light_publisher_param_file)"/>
+    <param name="mode" value="$(var mode)"/>
+    <param name="fixed_color" value="$(var fixed_color)"/>
+    <remap from="~/input/vector_map" to="/map/vector_map"/>
+    <remap from="~/input/traffic_signals" to="/simulator/input/traffic_signals"/>
+    <remap from="~/output/traffic_signals" to="/perception/traffic_light_recognition/traffic_signals"/>
+  </node>
+</launch>

--- a/simulator/autoware_dummy_traffic_light_publisher/package.xml
+++ b/simulator/autoware_dummy_traffic_light_publisher/package.xml
@@ -1,0 +1,27 @@
+<?xml version="1.0"?>
+<?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
+<package format="3">
+  <name>autoware_dummy_traffic_light_publisher</name>
+  <version>0.1.0</version>
+  <description>Traffic light simulator for planning simulation</description>
+  <maintainer email="junya.sasaki@tier4.jp">Junya SASAKI</maintainer>
+  <maintainer email="takayuki.akamine@tier4.jp">Takayuki AKAMINE</maintainer>
+  <license>Apache License 2.0</license>
+
+  <buildtool_depend>ament_cmake_auto</buildtool_depend>
+  <buildtool_depend>autoware_cmake</buildtool_depend>
+
+  <depend>autoware_lanelet2_extension</depend>
+  <depend>autoware_lanelet2_utils</depend>
+  <depend>autoware_map_msgs</depend>
+  <depend>autoware_perception_msgs</depend>
+  <depend>rclcpp</depend>
+
+  <test_depend>ament_cmake_ros</test_depend>
+  <test_depend>ament_lint_auto</test_depend>
+  <test_depend>autoware_lint_common</test_depend>
+
+  <export>
+    <build_type>ament_cmake</build_type>
+  </export>
+</package>

--- a/simulator/autoware_dummy_traffic_light_publisher/src/dummy_traffic_light.cpp
+++ b/simulator/autoware_dummy_traffic_light_publisher/src/dummy_traffic_light.cpp
@@ -1,0 +1,112 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "dummy_traffic_light.hpp"
+
+#include <memory>
+#include <utility>
+#include <vector>
+
+namespace autoware::dummy_traffic_light_publisher
+{
+
+DummyTrafficLight::DummyTrafficLight(
+  const Config & config, std::unique_ptr<TrafficLightCycle> cycle)
+: config_(config), cycle_(std::move(cycle))
+{
+}
+
+void DummyTrafficLight::set_traffic_light_ids(const std::vector<int64_t> & ids)
+{
+  traffic_light_ids_ = ids;
+}
+
+void DummyTrafficLight::update_input_signals(
+  const autoware_perception_msgs::msg::TrafficLightGroupArray & msg, const rclcpp::Time & now)
+{
+  last_input_signals_ = msg;
+  last_input_time_ = now;
+}
+
+autoware_perception_msgs::msg::TrafficLightGroupArray DummyTrafficLight::create_message(
+  const rclcpp::Time & now)
+{
+  if (last_input_signals_ && last_input_time_) {
+    const double elapsed = (now - *last_input_time_).seconds();
+    if (elapsed < config_.passthrough_timeout) {
+      return *last_input_signals_;
+    }
+    last_input_signals_.reset();
+    last_input_time_.reset();
+  }
+
+  if (config_.mode == Mode::Empty || traffic_light_ids_.empty()) {
+    return build_empty_message(now);
+  }
+
+  if (config_.mode == Mode::Fixed) {
+    return build_fixed_message(now);
+  }
+
+  return build_standalone_message(now);
+}
+
+size_t DummyTrafficLight::traffic_light_count() const
+{
+  return traffic_light_ids_.size();
+}
+
+autoware_perception_msgs::msg::TrafficLightGroupArray DummyTrafficLight::build_standalone_message(
+  const rclcpp::Time & now)
+{
+  return build_groups_message(now, cycle_->update(now));
+}
+
+autoware_perception_msgs::msg::TrafficLightGroupArray DummyTrafficLight::build_fixed_message(
+  const rclcpp::Time & now) const
+{
+  autoware_perception_msgs::msg::TrafficLightElement element;
+  element.color = config_.fixed_color;
+  element.shape = autoware_perception_msgs::msg::TrafficLightElement::CIRCLE;
+  element.status = autoware_perception_msgs::msg::TrafficLightElement::SOLID_ON;
+  element.confidence = 1.0;
+  return build_groups_message(now, element);
+}
+
+autoware_perception_msgs::msg::TrafficLightGroupArray DummyTrafficLight::build_empty_message(
+  const rclcpp::Time & now)
+{
+  autoware_perception_msgs::msg::TrafficLightGroupArray output;
+  output.stamp = now;
+  return output;
+}
+
+autoware_perception_msgs::msg::TrafficLightGroupArray DummyTrafficLight::build_groups_message(
+  const rclcpp::Time & now,
+  const autoware_perception_msgs::msg::TrafficLightElement & element) const
+{
+  autoware_perception_msgs::msg::TrafficLightGroupArray output;
+  output.stamp = now;
+
+  for (const auto id : traffic_light_ids_) {
+    autoware_perception_msgs::msg::TrafficLightGroup group;
+    group.traffic_light_group_id = id;
+    group.elements.push_back(element);
+    output.traffic_light_groups.push_back(group);
+  }
+
+  return output;
+}
+
+}  // namespace autoware::dummy_traffic_light_publisher

--- a/simulator/autoware_dummy_traffic_light_publisher/src/dummy_traffic_light.hpp
+++ b/simulator/autoware_dummy_traffic_light_publisher/src/dummy_traffic_light.hpp
@@ -1,0 +1,75 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef DUMMY_TRAFFIC_LIGHT_HPP_
+#define DUMMY_TRAFFIC_LIGHT_HPP_
+
+#include "traffic_light_cycle.hpp"
+
+#include <rclcpp/time.hpp>
+
+#include <autoware_perception_msgs/msg/traffic_light_element.hpp>
+#include <autoware_perception_msgs/msg/traffic_light_group_array.hpp>
+
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <vector>
+
+namespace autoware::dummy_traffic_light_publisher
+{
+
+enum class Mode { Standalone, Empty, Fixed };
+
+class DummyTrafficLight
+{
+public:
+  struct Config
+  {
+    Mode mode;
+    double passthrough_timeout;
+    // Color published in Fixed mode (a TrafficLightElement color constant). Unused in other modes.
+    uint8_t fixed_color = autoware_perception_msgs::msg::TrafficLightElement::UNKNOWN;
+  };
+
+  DummyTrafficLight(const Config & config, std::unique_ptr<TrafficLightCycle> cycle);
+
+  void set_traffic_light_ids(const std::vector<int64_t> & ids);
+  void update_input_signals(
+    const autoware_perception_msgs::msg::TrafficLightGroupArray & msg, const rclcpp::Time & now);
+  autoware_perception_msgs::msg::TrafficLightGroupArray create_message(const rclcpp::Time & now);
+
+  size_t traffic_light_count() const;
+
+private:
+  autoware_perception_msgs::msg::TrafficLightGroupArray build_standalone_message(
+    const rclcpp::Time & now);
+  autoware_perception_msgs::msg::TrafficLightGroupArray build_fixed_message(
+    const rclcpp::Time & now) const;
+  static autoware_perception_msgs::msg::TrafficLightGroupArray build_empty_message(
+    const rclcpp::Time & now);
+  autoware_perception_msgs::msg::TrafficLightGroupArray build_groups_message(
+    const rclcpp::Time & now,
+    const autoware_perception_msgs::msg::TrafficLightElement & element) const;
+
+  Config config_;
+  std::unique_ptr<TrafficLightCycle> cycle_;
+  std::vector<int64_t> traffic_light_ids_;
+  std::optional<autoware_perception_msgs::msg::TrafficLightGroupArray> last_input_signals_;
+  std::optional<rclcpp::Time> last_input_time_;
+};
+
+}  // namespace autoware::dummy_traffic_light_publisher
+
+#endif  // DUMMY_TRAFFIC_LIGHT_HPP_

--- a/simulator/autoware_dummy_traffic_light_publisher/src/dummy_traffic_light_publisher_node.cpp
+++ b/simulator/autoware_dummy_traffic_light_publisher/src/dummy_traffic_light_publisher_node.cpp
@@ -1,0 +1,162 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "dummy_traffic_light_publisher_node.hpp"
+
+#include <autoware/lanelet2_utils/conversion.hpp>
+#include <autoware_lanelet2_extension/regulatory_elements/autoware_traffic_light.hpp>
+#include <autoware_lanelet2_extension/utility/query.hpp>
+
+#include <autoware_perception_msgs/msg/traffic_light_element.hpp>
+
+#include <cstdint>
+#include <memory>
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace autoware::dummy_traffic_light_publisher
+{
+
+Mode parse_mode(const std::string & mode_str)
+{
+  if (mode_str == "standalone") {
+    return Mode::Standalone;
+  }
+  if (mode_str == "empty") {
+    return Mode::Empty;
+  }
+  if (mode_str == "fixed") {
+    return Mode::Fixed;
+  }
+  throw std::invalid_argument(
+    "mode must be 'standalone', 'empty' or 'fixed', got: '" + mode_str + "'");
+}
+
+uint8_t parse_color(const std::string & color_str)
+{
+  using Element = autoware_perception_msgs::msg::TrafficLightElement;
+  if (color_str == "green") {
+    return Element::GREEN;
+  }
+  if (color_str == "yellow") {
+    return Element::AMBER;
+  }
+  if (color_str == "red") {
+    return Element::RED;
+  }
+  throw std::invalid_argument(
+    "fixed_color must be 'green', 'yellow' or 'red', got: '" + color_str + "'");
+}
+
+void validate_positive(const std::string & name, double value)
+{
+  if (value <= 0.0) {
+    throw std::invalid_argument(name + " must be positive, got: " + std::to_string(value));
+  }
+}
+
+DummyTrafficLightPublisherNode::DummyTrafficLightPublisherNode(const rclcpp::NodeOptions & options)
+: Node("dummy_traffic_light_publisher", options)
+{
+  // Parameters
+  const auto mode = parse_mode(this->declare_parameter<std::string>("mode"));
+  const auto publish_rate = this->declare_parameter<double>("publish_rate");
+  validate_positive("publish_rate", publish_rate);
+  const auto green_duration = this->declare_parameter<double>("green_duration");
+  validate_positive("green_duration", green_duration);
+  const auto yellow_duration = this->declare_parameter<double>("yellow_duration");
+  validate_positive("yellow_duration", yellow_duration);
+  const auto red_duration = this->declare_parameter<double>("red_duration");
+  validate_positive("red_duration", red_duration);
+  const auto passthrough_timeout = this->declare_parameter<double>("passthrough_timeout");
+  validate_positive("passthrough_timeout", passthrough_timeout);
+  const auto fixed_color = parse_color(this->declare_parameter<std::string>("fixed_color"));
+
+  // Logic
+  dummy_traffic_light_ = std::make_unique<DummyTrafficLight>(
+    DummyTrafficLight::Config{mode, passthrough_timeout, fixed_color},
+    std::make_unique<TrafficLightCycle>(green_duration, yellow_duration, red_duration));
+
+  // Pub/Sub/Timer (subscriptions use take() in onTimer instead of callbacks)
+  pub_ = this->create_publisher<autoware_perception_msgs::msg::TrafficLightGroupArray>(
+    "~/output/traffic_signals", rclcpp::QoS(1));
+
+  // use the take method in onTimer, so create dummy subscriptions with empty callbacks to get the
+  // subscription objects.
+  manual_group_ = this->create_callback_group(rclcpp::CallbackGroupType::MutuallyExclusive, false);
+
+  rclcpp::SubscriptionOptions sub_options;
+  sub_options.callback_group = manual_group_;
+
+  sub_vector_map_ = this->create_subscription<autoware_map_msgs::msg::LaneletMapBin>(
+    "~/input/vector_map", rclcpp::QoS{1}.transient_local(),
+    [](autoware_map_msgs::msg::LaneletMapBin::ConstSharedPtr) {}, sub_options);
+
+  sub_input_ = this->create_subscription<autoware_perception_msgs::msg::TrafficLightGroupArray>(
+    "~/input/traffic_signals", rclcpp::QoS(1),
+    [](autoware_perception_msgs::msg::TrafficLightGroupArray::ConstSharedPtr) {}, sub_options);
+
+  const auto period = rclcpp::Rate(publish_rate).period();
+  timer_ = rclcpp::create_timer(
+    this, get_clock(), period, std::bind(&DummyTrafficLightPublisherNode::onTimer, this));
+}
+
+void DummyTrafficLightPublisherNode::onTimer()
+{
+  const auto now = this->now();
+
+  // update map if there is a new message
+  try_update_vector_map();
+
+  // update traffic light signals and publish
+  {
+    autoware_perception_msgs::msg::TrafficLightGroupArray msg;
+    rclcpp::MessageInfo info;
+    if (sub_input_->take(msg, info)) {
+      dummy_traffic_light_->update_input_signals(msg, now);
+    }
+  }
+  pub_->publish(dummy_traffic_light_->create_message(now));
+}
+
+void DummyTrafficLightPublisherNode::try_update_vector_map()
+{
+  autoware_map_msgs::msg::LaneletMapBin msg;
+  rclcpp::MessageInfo info;
+  if (sub_vector_map_->take(msg, info)) {
+    try {
+      lanelet::LaneletMapPtr lanelet_map = autoware::experimental::lanelet2_utils::remove_const(
+        autoware::experimental::lanelet2_utils::from_autoware_map_msgs(msg));
+      lanelet::ConstLanelets all_lanelets = lanelet::utils::query::laneletLayer(lanelet_map);
+      std::vector<lanelet::TrafficLightConstPtr> tl_reg_elems =
+        lanelet::utils::query::trafficLights(all_lanelets);
+
+      std::vector<int64_t> ids;
+      ids.reserve(tl_reg_elems.size());
+      for (const auto & tl_reg_elem : tl_reg_elems) {
+        ids.push_back(tl_reg_elem->id());
+      }
+      dummy_traffic_light_->set_traffic_light_ids(ids);
+
+      RCLCPP_INFO(
+        this->get_logger(), "Received vector map with %zu traffic lights",
+        dummy_traffic_light_->traffic_light_count());
+    } catch (const std::exception & e) {
+      RCLCPP_ERROR(this->get_logger(), "Failed to parse vector map: %s", e.what());
+    }
+  }
+}
+
+}  // namespace autoware::dummy_traffic_light_publisher

--- a/simulator/autoware_dummy_traffic_light_publisher/src/dummy_traffic_light_publisher_node.hpp
+++ b/simulator/autoware_dummy_traffic_light_publisher/src/dummy_traffic_light_publisher_node.hpp
@@ -1,0 +1,50 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef DUMMY_TRAFFIC_LIGHT_PUBLISHER_NODE_HPP_
+#define DUMMY_TRAFFIC_LIGHT_PUBLISHER_NODE_HPP_
+
+#include "dummy_traffic_light.hpp"
+
+#include <rclcpp/rclcpp.hpp>
+
+#include <autoware_map_msgs/msg/lanelet_map_bin.hpp>
+#include <autoware_perception_msgs/msg/traffic_light_group_array.hpp>
+
+#include <memory>
+
+namespace autoware::dummy_traffic_light_publisher
+{
+
+class DummyTrafficLightPublisherNode : public rclcpp::Node
+{
+public:
+  explicit DummyTrafficLightPublisherNode(const rclcpp::NodeOptions & options);
+
+private:
+  void onTimer();
+  void try_update_vector_map();
+
+  std::unique_ptr<DummyTrafficLight> dummy_traffic_light_;
+
+  rclcpp::Publisher<autoware_perception_msgs::msg::TrafficLightGroupArray>::SharedPtr pub_;
+  rclcpp::Subscription<autoware_map_msgs::msg::LaneletMapBin>::SharedPtr sub_vector_map_;
+  rclcpp::Subscription<autoware_perception_msgs::msg::TrafficLightGroupArray>::SharedPtr sub_input_;
+  rclcpp::TimerBase::SharedPtr timer_;
+  rclcpp::CallbackGroup::SharedPtr manual_group_;
+};
+
+}  // namespace autoware::dummy_traffic_light_publisher
+
+#endif  // DUMMY_TRAFFIC_LIGHT_PUBLISHER_NODE_HPP_

--- a/simulator/autoware_dummy_traffic_light_publisher/src/main.cpp
+++ b/simulator/autoware_dummy_traffic_light_publisher/src/main.cpp
@@ -1,0 +1,29 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "dummy_traffic_light_publisher_node.hpp"
+
+#include <rclcpp/rclcpp.hpp>
+
+#include <memory>
+
+int main(int argc, char ** argv)
+{
+  rclcpp::init(argc, argv);
+  rclcpp::spin(
+    std::make_shared<autoware::dummy_traffic_light_publisher::DummyTrafficLightPublisherNode>(
+      rclcpp::NodeOptions()));
+  rclcpp::shutdown();
+  return 0;
+}

--- a/simulator/autoware_dummy_traffic_light_publisher/src/traffic_light_cycle.cpp
+++ b/simulator/autoware_dummy_traffic_light_publisher/src/traffic_light_cycle.cpp
@@ -1,0 +1,64 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "traffic_light_cycle.hpp"
+
+#include <cmath>
+#include <stdexcept>
+
+namespace autoware::dummy_traffic_light_publisher
+{
+
+TrafficLightCycle::TrafficLightCycle(
+  double green_duration, double yellow_duration, double red_duration)
+: green_duration_(green_duration), yellow_duration_(yellow_duration), red_duration_(red_duration)
+{
+  if (green_duration_ <= 0.0 || yellow_duration_ <= 0.0 || red_duration_ <= 0.0) {
+    throw std::invalid_argument("TrafficLightCycle durations must be positive");
+  }
+}
+
+autoware_perception_msgs::msg::TrafficLightElement TrafficLightCycle::update(
+  const rclcpp::Time & now)
+{
+  using Element = autoware_perception_msgs::msg::TrafficLightElement;
+
+  if (!start_time_) {
+    start_time_ = now;
+  }
+
+  const double total = green_duration_ + yellow_duration_ + red_duration_;
+  double elapsed = std::fmod((now - *start_time_).seconds(), total);
+  if (elapsed < 0.0) {
+    elapsed += total;
+  }
+
+  uint8_t color;
+  if (elapsed < green_duration_) {
+    color = Element::GREEN;
+  } else if (elapsed < green_duration_ + yellow_duration_) {
+    color = Element::AMBER;
+  } else {
+    color = Element::RED;
+  }
+
+  Element element;
+  element.color = color;
+  element.shape = Element::CIRCLE;
+  element.status = Element::SOLID_ON;
+  element.confidence = 1.0;
+  return element;
+}
+
+}  // namespace autoware::dummy_traffic_light_publisher

--- a/simulator/autoware_dummy_traffic_light_publisher/src/traffic_light_cycle.hpp
+++ b/simulator/autoware_dummy_traffic_light_publisher/src/traffic_light_cycle.hpp
@@ -1,0 +1,43 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef TRAFFIC_LIGHT_CYCLE_HPP_
+#define TRAFFIC_LIGHT_CYCLE_HPP_
+
+#include <rclcpp/time.hpp>
+
+#include <autoware_perception_msgs/msg/traffic_light_element.hpp>
+
+#include <optional>
+
+namespace autoware::dummy_traffic_light_publisher
+{
+
+class TrafficLightCycle
+{
+public:
+  TrafficLightCycle(double green_duration, double yellow_duration, double red_duration);
+
+  autoware_perception_msgs::msg::TrafficLightElement update(const rclcpp::Time & now);
+
+private:
+  double green_duration_;
+  double yellow_duration_;
+  double red_duration_;
+  std::optional<rclcpp::Time> start_time_;
+};
+
+}  // namespace autoware::dummy_traffic_light_publisher
+
+#endif  // TRAFFIC_LIGHT_CYCLE_HPP_

--- a/simulator/autoware_dummy_traffic_light_publisher/test/test_dummy_traffic_light.cpp
+++ b/simulator/autoware_dummy_traffic_light_publisher/test/test_dummy_traffic_light.cpp
@@ -1,0 +1,324 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "dummy_traffic_light.hpp"
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <memory>
+
+using autoware::dummy_traffic_light_publisher::DummyTrafficLight;
+using autoware::dummy_traffic_light_publisher::Mode;
+using autoware::dummy_traffic_light_publisher::TrafficLightCycle;
+using autoware_perception_msgs::msg::TrafficLightElement;
+using autoware_perception_msgs::msg::TrafficLightGroupArray;
+
+class DummyTrafficLightTest : public ::testing::Test
+{
+protected:
+  static constexpr double kGreenDuration = 30.0;
+  static constexpr double kYellowDuration = 3.0;
+  static constexpr double kRedDuration = 30.0;
+  static constexpr double kPassthroughTimeout = 1.0;
+
+  std::unique_ptr<DummyTrafficLight> createStandalone()
+  {
+    return std::make_unique<DummyTrafficLight>(
+      DummyTrafficLight::Config{Mode::Standalone, kPassthroughTimeout},
+      std::make_unique<TrafficLightCycle>(kGreenDuration, kYellowDuration, kRedDuration));
+  }
+
+  std::unique_ptr<DummyTrafficLight> createEmpty()
+  {
+    return std::make_unique<DummyTrafficLight>(
+      DummyTrafficLight::Config{Mode::Empty, kPassthroughTimeout},
+      std::make_unique<TrafficLightCycle>(kGreenDuration, kYellowDuration, kRedDuration));
+  }
+
+  std::unique_ptr<DummyTrafficLight> createFixed(uint8_t color)
+  {
+    return std::make_unique<DummyTrafficLight>(
+      DummyTrafficLight::Config{Mode::Fixed, kPassthroughTimeout, color},
+      std::make_unique<TrafficLightCycle>(kGreenDuration, kYellowDuration, kRedDuration));
+  }
+
+  rclcpp::Time timeFromSec(double seconds) const
+  {
+    return rclcpp::Time(static_cast<int64_t>(seconds * 1e9));
+  }
+};
+
+TEST_F(DummyTrafficLightTest, EmptyModePublishesEmptyMessage)
+{
+  auto logic = createEmpty();
+  const auto msg = logic->create_message(timeFromSec(0.0));
+  EXPECT_TRUE(msg.traffic_light_groups.empty());
+}
+
+TEST_F(DummyTrafficLightTest, StandaloneWithoutIdsPublishesEmpty)
+{
+  auto logic = createStandalone();
+  const auto msg = logic->create_message(timeFromSec(0.0));
+  EXPECT_TRUE(msg.traffic_light_groups.empty());
+}
+
+TEST_F(DummyTrafficLightTest, StandaloneWithIdsPublishesGroups)
+{
+  auto logic = createStandalone();
+  logic->set_traffic_light_ids({100, 200, 300});
+
+  const auto msg = logic->create_message(timeFromSec(0.0));
+  ASSERT_EQ(msg.traffic_light_groups.size(), 3u);
+  EXPECT_EQ(msg.traffic_light_groups[0].traffic_light_group_id, 100);
+  EXPECT_EQ(msg.traffic_light_groups[1].traffic_light_group_id, 200);
+  EXPECT_EQ(msg.traffic_light_groups[2].traffic_light_group_id, 300);
+
+  // All groups should have the same element (initial = GREEN)
+  for (const auto & group : msg.traffic_light_groups) {
+    ASSERT_EQ(group.elements.size(), 1u);
+    EXPECT_EQ(group.elements[0].color, TrafficLightElement::GREEN);
+    EXPECT_EQ(group.elements[0].shape, TrafficLightElement::CIRCLE);
+    EXPECT_EQ(group.elements[0].status, TrafficLightElement::SOLID_ON);
+  }
+  EXPECT_EQ(logic->traffic_light_count(), 3u);
+}
+
+TEST_F(DummyTrafficLightTest, FixedModePublishesFixedColorForAllIds)
+{
+  auto logic = createFixed(TrafficLightElement::RED);
+  logic->set_traffic_light_ids({100, 200, 300});
+
+  const auto msg = logic->create_message(timeFromSec(0.0));
+  ASSERT_EQ(msg.traffic_light_groups.size(), 3u);
+  for (const auto & group : msg.traffic_light_groups) {
+    ASSERT_EQ(group.elements.size(), 1u);
+    EXPECT_EQ(group.elements[0].color, TrafficLightElement::RED);
+    EXPECT_EQ(group.elements[0].shape, TrafficLightElement::CIRCLE);
+    EXPECT_EQ(group.elements[0].status, TrafficLightElement::SOLID_ON);
+  }
+}
+
+TEST_F(DummyTrafficLightTest, FixedModeWithoutIdsPublishesEmpty)
+{
+  auto logic = createFixed(TrafficLightElement::GREEN);
+  const auto msg = logic->create_message(timeFromSec(0.0));
+  EXPECT_TRUE(msg.traffic_light_groups.empty());
+}
+
+TEST_F(DummyTrafficLightTest, FixedModeColorDoesNotChangeOverTime)
+{
+  auto logic = createFixed(TrafficLightElement::GREEN);
+  logic->set_traffic_light_ids({1});
+
+  // Times that would move a standalone cycle into other phases must not affect the fixed color.
+  const double times[] = {0.0, 31.0, 35.0, 100.0};
+  for (const double sec : times) {
+    const auto msg = logic->create_message(timeFromSec(sec));
+    ASSERT_EQ(msg.traffic_light_groups.size(), 1u);
+    EXPECT_EQ(msg.traffic_light_groups[0].elements[0].color, TrafficLightElement::GREEN);
+  }
+}
+
+TEST_F(DummyTrafficLightTest, PassthroughRelaysInput)
+{
+  auto logic = createStandalone();
+
+  TrafficLightGroupArray input;
+  input.stamp = timeFromSec(1.0);
+  autoware_perception_msgs::msg::TrafficLightGroup group;
+  group.traffic_light_group_id = 42;
+  TrafficLightElement element;
+  element.color = TrafficLightElement::RED;
+  element.shape = TrafficLightElement::CIRCLE;
+  element.status = TrafficLightElement::SOLID_ON;
+  element.confidence = 1.0;
+  group.elements.push_back(element);
+  input.traffic_light_groups.push_back(group);
+
+  logic->update_input_signals(input, timeFromSec(1.0));
+
+  const auto msg = logic->create_message(timeFromSec(1.5));
+  ASSERT_EQ(msg.traffic_light_groups.size(), 1u);
+  EXPECT_EQ(msg.traffic_light_groups[0].traffic_light_group_id, 42);
+  EXPECT_EQ(msg.traffic_light_groups[0].elements[0].color, TrafficLightElement::RED);
+  // Passthrough returns the original input stamp, not the requested time
+  EXPECT_EQ(msg.stamp, timeFromSec(1.0));
+}
+
+TEST_F(DummyTrafficLightTest, PassthroughRelaysInputMultipleCalls)
+{
+  auto logic = createStandalone();
+
+  TrafficLightGroupArray input;
+  input.stamp = timeFromSec(1.0);
+  autoware_perception_msgs::msg::TrafficLightGroup group;
+  group.traffic_light_group_id = 50;
+  input.traffic_light_groups.push_back(group);
+
+  logic->update_input_signals(input, timeFromSec(1.0));
+
+  // Both calls within timeout should return the same input
+  const auto msg1 = logic->create_message(timeFromSec(1.3));
+  const auto msg2 = logic->create_message(timeFromSec(1.6));
+  ASSERT_EQ(msg1.traffic_light_groups.size(), 1u);
+  ASSERT_EQ(msg2.traffic_light_groups.size(), 1u);
+  EXPECT_EQ(msg1.traffic_light_groups[0].traffic_light_group_id, 50);
+  EXPECT_EQ(msg2.traffic_light_groups[0].traffic_light_group_id, 50);
+}
+
+TEST_F(DummyTrafficLightTest, PassthroughTimeoutFallsBack)
+{
+  auto logic = createStandalone();
+
+  TrafficLightGroupArray input;
+  input.stamp = timeFromSec(1.0);
+  autoware_perception_msgs::msg::TrafficLightGroup group;
+  group.traffic_light_group_id = 99;
+  input.traffic_light_groups.push_back(group);
+
+  logic->update_input_signals(input, timeFromSec(1.0));
+
+  // Within timeout: passthrough
+  const auto msg_within = logic->create_message(timeFromSec(1.5));
+  ASSERT_EQ(msg_within.traffic_light_groups.size(), 1u);
+  EXPECT_EQ(msg_within.traffic_light_groups[0].traffic_light_group_id, 99);
+
+  // After timeout: falls back to standalone (no IDs = empty)
+  const auto msg_after = logic->create_message(timeFromSec(2.5));
+  EXPECT_TRUE(msg_after.traffic_light_groups.empty());
+}
+
+TEST_F(DummyTrafficLightTest, EmptyModeStillAllowsPassthrough)
+{
+  auto logic = createEmpty();
+
+  TrafficLightGroupArray input;
+  input.stamp = timeFromSec(1.0);
+  autoware_perception_msgs::msg::TrafficLightGroup group;
+  group.traffic_light_group_id = 10;
+  input.traffic_light_groups.push_back(group);
+
+  logic->update_input_signals(input, timeFromSec(1.0));
+
+  // Even in empty mode, passthrough takes priority within timeout
+  const auto msg_within = logic->create_message(timeFromSec(1.5));
+  ASSERT_EQ(msg_within.traffic_light_groups.size(), 1u);
+
+  // After timeout, empty mode returns empty
+  const auto msg_after = logic->create_message(timeFromSec(2.5));
+  EXPECT_TRUE(msg_after.traffic_light_groups.empty());
+}
+
+TEST_F(DummyTrafficLightTest, MessageStampMatchesRequestedTime)
+{
+  auto logic = createEmpty();
+  const auto now = timeFromSec(5.0);
+  const auto msg = logic->create_message(now);
+  EXPECT_EQ(msg.stamp, now);
+}
+
+TEST_F(DummyTrafficLightTest, SetIdsOverwritesPrevious)
+{
+  auto logic = createStandalone();
+  logic->set_traffic_light_ids({1, 2, 3});
+  logic->set_traffic_light_ids({10, 20});
+
+  const auto msg = logic->create_message(timeFromSec(0.0));
+  ASSERT_EQ(msg.traffic_light_groups.size(), 2u);
+  EXPECT_EQ(msg.traffic_light_groups[0].traffic_light_group_id, 10);
+  EXPECT_EQ(msg.traffic_light_groups[1].traffic_light_group_id, 20);
+}
+
+TEST_F(DummyTrafficLightTest, SetIdsToEmptyFallsBackToEmpty)
+{
+  auto logic = createStandalone();
+  logic->set_traffic_light_ids({1, 2});
+
+  const auto msg1 = logic->create_message(timeFromSec(0.0));
+  ASSERT_EQ(msg1.traffic_light_groups.size(), 2u);
+
+  logic->set_traffic_light_ids({});
+
+  const auto msg2 = logic->create_message(timeFromSec(1.0));
+  EXPECT_TRUE(msg2.traffic_light_groups.empty());
+}
+
+TEST_F(DummyTrafficLightTest, PassthroughInputOverwrittenByNewInput)
+{
+  auto logic = createStandalone();
+
+  TrafficLightGroupArray input1;
+  input1.stamp = timeFromSec(1.0);
+  autoware_perception_msgs::msg::TrafficLightGroup group1;
+  group1.traffic_light_group_id = 10;
+  input1.traffic_light_groups.push_back(group1);
+
+  logic->update_input_signals(input1, timeFromSec(1.0));
+
+  TrafficLightGroupArray input2;
+  input2.stamp = timeFromSec(1.5);
+  autoware_perception_msgs::msg::TrafficLightGroup group2;
+  group2.traffic_light_group_id = 20;
+  input2.traffic_light_groups.push_back(group2);
+
+  logic->update_input_signals(input2, timeFromSec(1.5));
+
+  // New input replaces old, and timeout resets from 1.5s
+  const auto msg = logic->create_message(timeFromSec(2.0));
+  ASSERT_EQ(msg.traffic_light_groups.size(), 1u);
+  EXPECT_EQ(msg.traffic_light_groups[0].traffic_light_group_id, 20);
+}
+
+TEST_F(DummyTrafficLightTest, StandaloneColorChangesOverTime)
+{
+  auto logic = createStandalone();
+  logic->set_traffic_light_ids({1});
+
+  const auto msg_green = logic->create_message(timeFromSec(0.0));
+  EXPECT_EQ(msg_green.traffic_light_groups[0].elements[0].color, TrafficLightElement::GREEN);
+
+  const auto msg_yellow = logic->create_message(timeFromSec(30.0));
+  EXPECT_EQ(msg_yellow.traffic_light_groups[0].elements[0].color, TrafficLightElement::AMBER);
+
+  const auto msg_red = logic->create_message(timeFromSec(33.0));
+  EXPECT_EQ(msg_red.traffic_light_groups[0].elements[0].color, TrafficLightElement::RED);
+}
+
+TEST_F(DummyTrafficLightTest, PassthroughExactTimeoutExpires)
+{
+  auto logic = createStandalone();
+
+  TrafficLightGroupArray input;
+  input.stamp = timeFromSec(1.0);
+  autoware_perception_msgs::msg::TrafficLightGroup group;
+  group.traffic_light_group_id = 5;
+  input.traffic_light_groups.push_back(group);
+
+  logic->update_input_signals(input, timeFromSec(1.0));
+
+  // elapsed == passthrough_timeout (1.0s): condition is '<', so this should timeout
+  const auto msg = logic->create_message(timeFromSec(2.0));
+  EXPECT_TRUE(msg.traffic_light_groups.empty());
+}
+
+TEST_F(DummyTrafficLightTest, StandaloneMessageStampMatchesNow)
+{
+  auto logic = createStandalone();
+  logic->set_traffic_light_ids({1});
+
+  const auto now = timeFromSec(5.0);
+  const auto msg = logic->create_message(now);
+  EXPECT_EQ(msg.stamp, now);
+}

--- a/simulator/autoware_dummy_traffic_light_publisher/test/test_traffic_light_cycle.cpp
+++ b/simulator/autoware_dummy_traffic_light_publisher/test/test_traffic_light_cycle.cpp
@@ -1,0 +1,160 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "traffic_light_cycle.hpp"
+
+#include <gtest/gtest.h>
+
+#include <stdexcept>
+
+using autoware::dummy_traffic_light_publisher::TrafficLightCycle;
+using autoware_perception_msgs::msg::TrafficLightElement;
+
+class TrafficLightCycleTest : public ::testing::Test
+{
+protected:
+  static constexpr double kGreenDuration = 30.0;
+  static constexpr double kYellowDuration = 3.0;
+  static constexpr double kRedDuration = 30.0;
+
+  TrafficLightCycle cycle{kGreenDuration, kYellowDuration, kRedDuration};
+
+  rclcpp::Time timeFromSec(double seconds) const
+  {
+    return rclcpp::Time(static_cast<int64_t>(seconds * 1e9));
+  }
+};
+
+TEST_F(TrafficLightCycleTest, InitialOutputIsGreen)
+{
+  const auto element = cycle.update(timeFromSec(0.0));
+  EXPECT_EQ(element.color, TrafficLightElement::GREEN);
+  EXPECT_EQ(element.shape, TrafficLightElement::CIRCLE);
+  EXPECT_EQ(element.status, TrafficLightElement::SOLID_ON);
+  EXPECT_DOUBLE_EQ(element.confidence, 1.0);
+}
+
+TEST_F(TrafficLightCycleTest, StaysGreenBeforeDuration)
+{
+  cycle.update(timeFromSec(0.0));
+  const auto element = cycle.update(timeFromSec(kGreenDuration - 0.1));
+  EXPECT_EQ(element.color, TrafficLightElement::GREEN);
+}
+
+TEST_F(TrafficLightCycleTest, TransitionsToYellow)
+{
+  cycle.update(timeFromSec(0.0));
+  const auto element = cycle.update(timeFromSec(kGreenDuration));
+  EXPECT_EQ(element.color, TrafficLightElement::AMBER);
+}
+
+TEST_F(TrafficLightCycleTest, TransitionsToRed)
+{
+  cycle.update(timeFromSec(0.0));
+  const auto element = cycle.update(timeFromSec(kGreenDuration + kYellowDuration));
+  EXPECT_EQ(element.color, TrafficLightElement::RED);
+}
+
+TEST_F(TrafficLightCycleTest, CyclesBackToGreen)
+{
+  cycle.update(timeFromSec(0.0));
+  const auto element = cycle.update(timeFromSec(kGreenDuration + kYellowDuration + kRedDuration));
+  EXPECT_EQ(element.color, TrafficLightElement::GREEN);
+}
+
+TEST_F(TrafficLightCycleTest, MidGreenStaysGreen)
+{
+  cycle.update(timeFromSec(0.0));
+  const auto element = cycle.update(timeFromSec(15.0));
+  EXPECT_EQ(element.color, TrafficLightElement::GREEN);
+}
+
+TEST_F(TrafficLightCycleTest, MidYellowStaysYellow)
+{
+  cycle.update(timeFromSec(0.0));
+  const auto element = cycle.update(timeFromSec(31.5));
+  EXPECT_EQ(element.color, TrafficLightElement::AMBER);
+}
+
+TEST_F(TrafficLightCycleTest, MidRedStaysRed)
+{
+  cycle.update(timeFromSec(0.0));
+  const auto element = cycle.update(timeFromSec(50.0));
+  EXPECT_EQ(element.color, TrafficLightElement::RED);
+}
+
+TEST_F(TrafficLightCycleTest, SecondCycleGreen)
+{
+  const double full_cycle = kGreenDuration + kYellowDuration + kRedDuration;
+  cycle.update(timeFromSec(0.0));
+  const auto element = cycle.update(timeFromSec(full_cycle + 1.0));
+  EXPECT_EQ(element.color, TrafficLightElement::GREEN);
+}
+
+TEST_F(TrafficLightCycleTest, SecondCycleYellow)
+{
+  const double full_cycle = kGreenDuration + kYellowDuration + kRedDuration;
+  cycle.update(timeFromSec(0.0));
+  const auto element = cycle.update(timeFromSec(full_cycle + kGreenDuration));
+  EXPECT_EQ(element.color, TrafficLightElement::AMBER);
+}
+
+TEST_F(TrafficLightCycleTest, SecondCycleRed)
+{
+  const double full_cycle = kGreenDuration + kYellowDuration + kRedDuration;
+  cycle.update(timeFromSec(0.0));
+  const auto element = cycle.update(timeFromSec(full_cycle + kGreenDuration + kYellowDuration));
+  EXPECT_EQ(element.color, TrafficLightElement::RED);
+}
+
+TEST_F(TrafficLightCycleTest, LargeTimeJump)
+{
+  cycle.update(timeFromSec(0.0));
+  // 1000s = 15 full cycles + 55s remainder (55 >= 33 → Red phase)
+  const auto element = cycle.update(timeFromSec(1000.0));
+  EXPECT_EQ(element.color, TrafficLightElement::RED);
+}
+
+TEST_F(TrafficLightCycleTest, TimeRewindWrapsAround)
+{
+  cycle.update(timeFromSec(10.0));
+  // Rewind: now < start_time_ → negative elapsed → corrected by adding total
+  const auto element = cycle.update(timeFromSec(5.0));
+  // (5 - 10) = -5, fmod(-5, 63) = -5, +63 = 58 → Red
+  EXPECT_EQ(element.color, TrafficLightElement::RED);
+}
+
+TEST_F(TrafficLightCycleTest, NonZeroStartTime)
+{
+  cycle.update(timeFromSec(100.0));
+  // 15s after start → still Green
+  EXPECT_EQ(cycle.update(timeFromSec(115.0)).color, TrafficLightElement::GREEN);
+  // 30s after start → Yellow
+  EXPECT_EQ(cycle.update(timeFromSec(130.0)).color, TrafficLightElement::AMBER);
+  // 33s after start → Red
+  EXPECT_EQ(cycle.update(timeFromSec(133.0)).color, TrafficLightElement::RED);
+}
+
+TEST(TrafficLightCycleConstruction, ThrowsOnNonPositiveDuration)
+{
+  // Non-positive durations make the cycle total zero/negative and would break fmod, so reject them.
+  EXPECT_THROW(TrafficLightCycle(0.0, 3.0, 30.0), std::invalid_argument);
+  EXPECT_THROW(TrafficLightCycle(30.0, -1.0, 30.0), std::invalid_argument);
+  EXPECT_THROW(TrafficLightCycle(30.0, 3.0, 0.0), std::invalid_argument);
+}
+
+TEST(TrafficLightCycleConstruction, AcceptsPositiveDurations)
+{
+  EXPECT_NO_THROW(TrafficLightCycle(30.0, 3.0, 30.0));
+}


### PR DESCRIPTION
## Purpose
Rvizの代わりに信号情報を配信する `dummy_traffic_light_publisher` ノードをバックポートします。あわせて、最新の `fixed`（カラー固定）モードの対応も内包しています。

## Changes
- `dummy_traffic_light_publisher` パッケージの追加
- `standalone` / `empty` / `fixed` モードの実装

## Related PR / Issues
- Launcher side PR: https://github.com/tier4/autoware_launch.x2/compare/feat/v4.4/e2e...feat/add-dummy-traffic-light-launch-args?expand=1
- Original PR: #12456

https://tier4.atlassian.net/browse/T4DEV-55815