### PR TITLE
fix(mpc_lateral_controller): guard distance resampling against invalid arc length

### DIFF
--- a/control/autoware_mpc_lateral_controller/src/mpc_utils.cpp
+++ b/control/autoware_mpc_lateral_controller/src/mpc_utils.cpp
@@ -188,7 +188,7 @@ std::pair<bool, MPCTrajectory> resampleMPCTrajectoryByDistance(
     output.relative_time = lerp_arc_length(input.relative_time);  // must be linear
   } catch (const std::exception & e) {
     const auto logger = rclcpp::get_logger("mpc_util");
-    const rclcpp::Clock clock{RCL_ROS_TIME};
+    static rclcpp::Clock clock{RCL_ROS_TIME};
     RCLCPP_ERROR_THROTTLE(
       logger, clock, 5000,
       "[resampleMPCTrajectoryByDistance] interpolation failed: %s (input_points=%zu, "

--- a/control/autoware_mpc_lateral_controller/src/mpc_utils.cpp
+++ b/control/autoware_mpc_lateral_controller/src/mpc_utils.cpp
@@ -14,6 +14,7 @@
 
 #include "autoware/mpc_lateral_controller/mpc_utils.hpp"
 
+#include "autoware/interpolation/interpolation_utils.hpp"
 #include "autoware/interpolation/linear_interpolation.hpp"
 #include "autoware/interpolation/spline_interpolation.hpp"
 #include "autoware/motion_utils/trajectory/trajectory.hpp"
@@ -26,6 +27,7 @@
 #include <algorithm>
 #include <iostream>
 #include <limits>
+#include <stdexcept>
 #include <string>
 #include <utility>
 #include <vector>
@@ -137,7 +139,11 @@ std::pair<bool, MPCTrajectory> resampleMPCTrajectoryByDistance(
   std::vector<double> input_arclength;
   calcMPCTrajectoryArcLength(input, input_arclength);
 
-  if (input_arclength.empty()) {
+  if (input_arclength.size() < 2) {
+    return {false, output};
+  }
+
+  if (!autoware::interpolation::isIncreasing(input_arclength)) {
     return {false, output};
   }
 
@@ -167,14 +173,30 @@ std::pair<bool, MPCTrajectory> resampleMPCTrajectoryByDistance(
     return autoware::interpolation::spline(input_arclength, input_value, output_arclength);
   };
 
-  output.x = spline_arc_length(input.x);
-  output.y = spline_arc_length(input.y);
-  output.z = spline_arc_length(input.z);
-  output.yaw = spline_arc_length(input_yaw);
-  output.vx = lerp_arc_length(input.vx);  // must be linear
-  output.k = spline_arc_length(input.k);
-  output.smooth_k = spline_arc_length(input.smooth_k);
-  output.relative_time = lerp_arc_length(input.relative_time);  // must be linear
+  if (output_arclength.empty()) {
+    return {false, output};
+  }
+
+  try {
+    output.x = spline_arc_length(input.x);
+    output.y = spline_arc_length(input.y);
+    output.z = spline_arc_length(input.z);
+    output.yaw = spline_arc_length(input_yaw);
+    output.vx = lerp_arc_length(input.vx);  // must be linear
+    output.k = spline_arc_length(input.k);
+    output.smooth_k = spline_arc_length(input.smooth_k);
+    output.relative_time = lerp_arc_length(input.relative_time);  // must be linear
+  } catch (const std::exception & e) {
+    const auto logger = rclcpp::get_logger("mpc_util");
+    const rclcpp::Clock clock{RCL_ROS_TIME};
+    RCLCPP_ERROR_THROTTLE(
+      logger, clock, 5000,
+      "[resampleMPCTrajectoryByDistance] interpolation failed: %s (input_points=%zu, "
+      "path_length=%.3f m, output_samples=%zu, nearest_seg_idx=%zu, resample_interval=%.3f m)",
+      e.what(), input.size(), input_arclength.back(), output_arclength.size(), nearest_seg_idx,
+      resample_interval_dist);
+    return {false, output};
+  }
 
   return {true, output};
 }


### PR DESCRIPTION
## Related links
- **Base PR:** [autowarefoundation/autoware_universe#12908](https://github.com/autowarefoundation/autoware_universe/pull/12908)
- **Test PR:** [tier4/autoware_universe#3127](https://github.com/tier4/autoware_universe/pull/3127) (`feat/v0.64/e2e`)

## Summary
- Guard `resampleMPCTrajectoryByDistance()` against invalid arc-length keys before spline/lerp interpolation (non-monotonic or undersampled geometry).
- Return `{false, {}}` instead of throwing, so `MPC::setReferenceTrajectory()` can skip the cycle without aborting the trajectory follower node.
- Log throttled `RCLCPP_ERROR` with exception message and trajectory context when interpolation fails.

## Test plan
- [x] Not run locally — awaiting CI
- [ ] Reproduce prior crash with degenerate spatial trajectory; expect throttled error and skipped control instead of `validateKeys` abort

## Notes for reviewers
Integration branch: `feat/v0.64/e2e` (pilot-auto `feat/v4.4/e2e` product line). Same change as [tier4#3125](https://github.com/tier4/autoware_universe/pull/3125) (`beta/v0.68`) and [tier4#3126](https://github.com/tier4/autoware_universe/pull/3126) (`beta/v0.64`).