### PR TITLE
ci: remove build_and_test_packages_above

### DIFF
--- a/.github/workflows/build-test-tidy-pr.yaml
+++ b/.github/workflows/build-test-tidy-pr.yaml
@@ -62,27 +62,6 @@ jobs:
     secrets:
       codecov-token: ${{ secrets.CODECOV_TOKEN }}
 
-  build-and-test-packages-above-differential:
-    if: ${{ always() }}
-    needs:
-      - require-label
-    strategy:
-      fail-fast: false
-      matrix:
-        rosdistro: [humble, jazzy]
-        include:
-          - rosdistro: humble
-            container: ghcr.io/autowarefoundation/autoware:universe-dependencies-humble
-          - rosdistro: jazzy
-            container: ghcr.io/autowarefoundation/autoware:universe-dependencies-jazzy
-
-    uses: ./.github/workflows/build-and-test-packages-above-differential.yaml
-    with:
-      rosdistro: ${{ matrix.rosdistro }}
-      container: ${{ matrix.container }}
-      run-condition: ${{ needs.require-label.outputs.result == 'true' }}
-      runner: "['self-hosted', 'Linux', 'X64']"
-
   build-and-test-differential-cuda:
     if: ${{ always() }}
     needs: check-if-cuda-job-is-needed

--- a/build_depends_nightly.repos
+++ b/build_depends_nightly.repos
@@ -8,8 +8,8 @@ repositories:
     version: main
   core/autoware_core:
     type: git
-    url: https://github.com/autowarefoundation/autoware_core.git
-    version: main
+    url: https://github.com/tier4/autoware_core.git
+    version: beta/v0.68
   core/autoware_cmake:
     type: git
     url: https://github.com/autowarefoundation/autoware_cmake.git

--- a/packages_above.repos
+++ b/packages_above.repos
@@ -1,12 +1,8 @@
 repositories:
   tools/autoware_tools:
     type: git
-    url: https://github.com/autowarefoundation/autoware_tools.git
-    version: main
-  launcher/autoware_launch:
-    type: git
-    url: https://github.com/autowarefoundation/autoware_launch.git
-    version: main
+    url: https://github.com/tier4/autoware_tools.git
+    version: beta/v0.68
   universe/external/eagleye:
     type: git
     url: https://github.com/MapIV/eagleye.git


### PR DESCRIPTION
Unlike AWF upstream, this fork fails to find self-hosted CI runner for build_and_test_packages_above which is not essential.

Also, update build_depends.repos for beta.