### PR TITLE
chore(perception): sync autoware_tensorrt_plugins to autowarefoundation main

### DIFF
--- a/perception/autoware_tensorrt_plugins/CHANGELOG.rst
+++ b/perception/autoware_tensorrt_plugins/CHANGELOG.rst
@@ -2,6 +2,24 @@
 Changelog for package autoware_tensorrt_plugins
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.51.0 (2026-05-01)
+-------------------
+* Merge remote-tracking branch 'origin/main' into tmp/bot/bump_version_base
+* fix(autoware_tensorrt_plugins): avoid tv::zeros and tv::empty (`#12378 <https://github.com/mitsudome-r/autoware_universe/issues/12378>`_)
+  Co-authored-by: Amadeusz Szymko <amadeusz.szymko.2@tier4.jp>
+* perf(perception): use emplace_back and emplace to avoid temporary object creation (`#12201 <https://github.com/mitsudome-r/autoware_universe/issues/12201>`_)
+  * perf(perception): use emplace_back to avoid temporary object creation
+  * style(pre-commit): autofix
+  * perf(perception): use emplace/emplace_back for most containers
+  * style(pre-commit): autofix
+  ---------
+  Co-authored-by: pre-commit-ci-lite[bot] <117423508+pre-commit-ci-lite[bot]@users.noreply.github.com>
+  Co-authored-by: Taekjin LEE <taekjin.lee@tier4.jp>
+* feat(autoware_tensorrt_plugins): restore Turing arch compatibility (`#12211 <https://github.com/mitsudome-r/autoware_universe/issues/12211>`_)
+* feat(autoware_tensorrt_plugins): cuda 12.0 build compatibility (`#12191 <https://github.com/mitsudome-r/autoware_universe/issues/12191>`_)
+  feat(autoware_tensorrt_plugins): CUDA 12.0+ build compatibility
+* Contributors: Amadeusz Szymko, Ryuta Kambe, github-actions, nishikawa-masaki
+
 0.50.0 (2026-02-14)
 -------------------
 * Merge remote-tracking branch 'origin/main' into humble

--- a/perception/autoware_tensorrt_plugins/CHANGELOG.rst
+++ b/perception/autoware_tensorrt_plugins/CHANGELOG.rst
@@ -2,6 +2,100 @@
 Changelog for package autoware_tensorrt_plugins
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
+0.52.0 (2026-06-30)
+-------------------
+* Merge remote-tracking branch 'origin/main' into tmp/bot/bump_version_base
+* perf(autoware_tensorrt_plugins): keep SegmentCSR allocation-free (`#12555 <https://github.com/autowarefoundation/autoware_universe/issues/12555>`_)
+  Initialize the SegmentCSR output buffer directly instead of allocating, filling, copying, and freeing a scratch base buffer on every launch.
+  Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
+* feat(autoware_tensorrt_plugins): support fused bias/activation in ImplicitGemmPlugin (`#12658 <https://github.com/autowarefoundation/autoware_universe/issues/12658>`_)
+  * feat(autoware_tensorrt_plugins): add fused activation and optional bias support to ImplicitGemmPlugin
+  - Add act_type field to ImplicitGemmParameters for fused activation
+  (kNone/kReLU/kSigmoid/kLeakyReLU)
+  - Support optional 6th input for per-channel fused bias (BN-folded);
+  the plugin now accepts 5 (no bias) or 6 (with bias) inputs
+  - Pass act_alpha, act_beta, act_type, and bias tensor to
+  ConvGemmOps::implicit_gemm instead of hardcoded kNone/empty
+  - Track num_plugin_inputs\_ across clone/configurePlugin/onShapeChange
+  - Extend parse_fields lambda to accept act_type as optional 7th ONNX
+  attribute (backward-compatible with 6-field ONNX graphs)
+  * chore: fix naming
+  * chore: fix implicit gemm
+  * chore: clean code
+  * chore: fix naming
+  ---------
+* refactor(autoware_tensorrt_plugins): remove SegmentCSR nD indptr path (`#12739 <https://github.com/autowarefoundation/autoware_universe/issues/12739>`_)
+  Remove the unused n-dimensional indptr launcher path and offset helper now that the plugin contract is explicitly 1D.
+  Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
+* fix(autoware_tensorrt_plugins): fix implicitgemm build and runtime error (`#12734 <https://github.com/autowarefoundation/autoware_universe/issues/12734>`_)
+  * fix(autoware_tensorrt_plugins): fix kBUILD/kRUNTIME deserialization and type issues
+  * refactor(autoware_tensorrt_plugins): extract field parsing into lambda in createPlugin
+  * chore: fix cspell
+  ---------
+* refactor(autoware_tensorrt_plugins): clarify SegmentCSR contract (`#12741 <https://github.com/autowarefoundation/autoware_universe/issues/12741>`_)
+  * refactor(autoware_tensorrt_plugins): clarify SegmentCSR contract
+  Document the plugin's existing 2D source and 1D indptr contract, and replace the SegmentCSR launcher's output tuple with named output pointers.
+  Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
+  * fix: fix memory leak in kernel error path
+  Co-authored-by: Copilot Autofix powered by AI <175728472+Copilot@users.noreply.github.com>
+  ---------
+  Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
+  Co-authored-by: Copilot Autofix powered by AI <175728472+Copilot@users.noreply.github.com>
+* chore(autoware_tensorrt_plugins): add manato, mojomex as maintainers (`#12755 <https://github.com/autowarefoundation/autoware_universe/issues/12755>`_)
+* test(autoware_tensorrt_plugins): add SegmentCSR kernel tests (`#12740 <https://github.com/autowarefoundation/autoware_universe/issues/12740>`_)
+  * test(autoware_tensorrt_plugins): add SegmentCSR kernel tests
+  Add parameterized reference-kernel coverage for SegmentCSR mean and max reductions, including empty segments, no-output cases, empty source input, and zero-column output. Guard the existing launcher against zero-output work so these edge cases complete without zero-size kernel launches or reduction-axis division by zero.
+  Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
+  * style(pre-commit): autofix
+  ---------
+  Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
+  Co-authored-by: pre-commit-ci-lite[bot] <117423508+pre-commit-ci-lite[bot]@users.noreply.github.com>
+* perf(autoware_tensorrt_plugins): remove Thrust from sort kernels (`#12554 <https://github.com/autowarefoundation/autoware_universe/issues/12554>`_)
+  * perf(autoware_tensorrt_plugins): remove Thrust from sort kernels
+  * docs(autoware_tensorrt_plugins): clarify unique workspace flow
+  * Clarify unique offset sentinel workspace
+  * Document unique workspace layout fields
+  * perf(autoware_tensorrt_plugins): avoid plugin stream syncs
+  * style(pre-commit): autofix
+  * refactor(autoware_tensorrt_plugins): share kernel helpers
+  * docs(autoware_tensorrt_plugins): explain inverse index offset
+  * style(autoware_tensorrt_plugins): clarify unique count branch
+  * style(autoware_tensorrt_plugins): mark workspace size maybe unused
+  * style(autoware_tensorrt_plugins): use byte workspace arithmetic
+  * style(pre-commit): autofix
+  * perf(autoware_tensorrt_plugins): use run length encode for unique counts
+  * style(pre-commit): autofix
+  ---------
+  Co-authored-by: pre-commit-ci-lite[bot] <117423508+pre-commit-ci-lite[bot]@users.noreply.github.com>
+* feat(autoware_tensorrt_plugins): add do sort attribute in GetIndicePairsImplicitGemmPlugin for faster inference (`#12631 <https://github.com/autowarefoundation/autoware_universe/issues/12631>`_)
+  * feat: add do sort attribute for faster inference
+  * style(pre-commit): autofix
+  * chore: clean up code and add better warning msg
+  ---------
+  Co-authored-by: pre-commit-ci-lite[bot] <117423508+pre-commit-ci-lite[bot]@users.noreply.github.com>
+* test(autoware_tensorrt_plugins): add reference kernel tests (`#12561 <https://github.com/autowarefoundation/autoware_universe/issues/12561>`_)
+  * test(autoware_tensorrt_plugins): add reference kernel tests
+  * style(pre-commit): autofix
+  * refactor(autoware_tensorrt_plugins): split tests into logical units
+  Co-authored-by: Copilot <copilot@github.com>
+  * chore: add include guard
+  Co-authored-by: Copilot <copilot@github.com>
+  * style(pre-commit): autofix
+  * chore: remove unused includes
+  * test: hopefully made tests GPU-less CI friendly
+  Co-authored-by: Copilot <copilot@github.com>
+  ---------
+  Co-authored-by: pre-commit-ci-lite[bot] <117423508+pre-commit-ci-lite[bot]@users.noreply.github.com>
+  Co-authored-by: Copilot <copilot@github.com>
+* fix(autoware_tensorrt_plugins): correct CustomUnique count offset (`#12502 <https://github.com/autowarefoundation/autoware_universe/issues/12502>`_)
+  * fix(autoware_tensorrt_plugins): correct CustomUnique count offset
+  Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
+  * style(pre-commit): autofix
+  ---------
+  Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>
+  Co-authored-by: pre-commit-ci-lite[bot] <117423508+pre-commit-ci-lite[bot]@users.noreply.github.com>
+* Contributors: Max Schmeller, Yi-Hsiang Fang (Vivid), github-actions
+
 0.51.0 (2026-05-01)
 -------------------
 * Merge remote-tracking branch 'origin/main' into tmp/bot/bump_version_base

--- a/perception/autoware_tensorrt_plugins/CMakeLists.txt
+++ b/perception/autoware_tensorrt_plugins/CMakeLists.txt
@@ -152,6 +152,7 @@ if(TRT_AVAIL AND CUDA_AVAIL AND SPCONV_AVAIL)
 
     ament_add_gtest(reference_kernels_test
       test/argsort_kernel_test.cpp
+      test/segment_csr_kernel_test.cpp
       test/unique_kernel_test.cpp
     )
     if(TARGET reference_kernels_test)

--- a/perception/autoware_tensorrt_plugins/CMakeLists.txt
+++ b/perception/autoware_tensorrt_plugins/CMakeLists.txt
@@ -147,6 +147,28 @@ if(TRT_AVAIL AND CUDA_AVAIL AND SPCONV_AVAIL)
       spconv::spconv
   )
 
+  if(BUILD_TESTING)
+    find_package(ament_cmake_gtest REQUIRED)
+
+    ament_add_gtest(reference_kernels_test
+      test/argsort_kernel_test.cpp
+      test/unique_kernel_test.cpp
+    )
+    if(TARGET reference_kernels_test)
+      target_link_libraries(reference_kernels_test
+        CUDA::cudart
+        cuda_ops
+      )
+      target_include_directories(reference_kernels_test PRIVATE
+        include
+        test
+        ${autoware_cuda_utils_INCLUDE_DIRS}
+        ${CUDA_INCLUDE_DIRS}
+      )
+      target_compile_definitions(reference_kernels_test PRIVATE _GLIBCXX_USE_CXX11_ABI=1)
+    endif()
+  endif()
+
   install(
     TARGETS ${PROJECT_NAME}
     DESTINATION share/${PROJECT_NAME}/plugins

--- a/perception/autoware_tensorrt_plugins/README.md
+++ b/perception/autoware_tensorrt_plugins/README.md
@@ -25,6 +25,16 @@ We provide a wrapper for the `bev_pool` operation presented in [BEVFusion](https
 
 We provide a wrapper for the `segment_csr` operation presented in [torch_scatter](https://github.com/rusty1s/pytorch_scatter/tree/master). Please refer to the original code for specific details.
 
+The `SegmentCSR` TensorRT plugin supports a 2D source tensor and a 1D CSR row pointer:
+
+- `src`: row-major tensor with shape `[num_rows, num_cols]`
+- `indptr`: int64 tensor with shape `[num_segments + 1]`
+- `output`: tensor with shape `[num_segments, num_cols]`
+
+Each output row reduces the contiguous source rows `src[indptr[s] : indptr[s + 1]]` independently
+for every column. Higher-rank/batched CSR inputs are not part of this plugin contract; callers
+should flatten or reshape inputs before invoking the plugin.
+
 ### Unique
 
 While ONNX supports the unique operation, TensorRT does not provide an implementation. For this reason we implement `Unique` as `CustomUnique` to avoid name classes.

--- a/perception/autoware_tensorrt_plugins/include/autoware/scatter_ops/segment_csr.h
+++ b/perception/autoware_tensorrt_plugins/include/autoware/scatter_ops/segment_csr.h
@@ -25,19 +25,19 @@
 
 #include <cuda_runtime.h>
 
-#include <tuple>
+#include <cstdint>
 #include <vector>
 
 template <typename scalar_t, ReductionType REDUCE>
 int32_t segment_csr_launch(
-  const scalar_t * src, const std::vector<int32_t> & src_size, const int64_t * indptr,
-  const std::vector<int32_t> & indptr_size, const scalar_t * base,
-  std::tuple<scalar_t *, int64_t *> out, cudaStream_t stream);
+  const scalar_t * src_in, const std::vector<int32_t> & src_size_in, const int64_t * indptr_in,
+  const std::vector<int32_t> & indptr_size_in, const scalar_t * base_values_in,
+  scalar_t * reduced_values_out, int64_t * arg_indices_out, cudaStream_t stream_in);
 
 template <typename scalar_t, ReductionType REDUCE>
 int32_t segment_csr_launch(
-  const scalar_t * src, const std::vector<int32_t> & src_size, const int64_t * indptr,
-  const std::vector<int32_t> & indptr_size, std::tuple<scalar_t *, int64_t *> out,
-  cudaStream_t stream);
+  const scalar_t * src_in, const std::vector<int32_t> & src_size_in, const int64_t * indptr_in,
+  const std::vector<int32_t> & indptr_size_in, scalar_t * reduced_values_out,
+  int64_t * arg_indices_out, cudaStream_t stream_in);
 
 #endif  // AUTOWARE__SCATTER_OPS__SEGMENT_CSR_H_

--- a/perception/autoware_tensorrt_plugins/include/autoware/scatter_ops/segment_csr.h
+++ b/perception/autoware_tensorrt_plugins/include/autoware/scatter_ops/segment_csr.h
@@ -26,18 +26,37 @@
 #include <cuda_runtime.h>
 
 #include <cstdint>
-#include <vector>
 
+/// Reduces a row-major `src` matrix along contiguous CSR segments on `stream_in`.
+///
+/// Each output segment `s` is the `REDUCE` of the rows
+/// `src_in[indptr_in[s] : indptr_in[s + 1]]`, applied per column.
+///
+/// Input contract:
+/// - `src_in` points to `num_rows_in * num_cols_in` `scalar_t` values, row-major.
+/// - `num_rows_in`, `num_cols_in`, and `indptr_size_in` must be non-negative.
+/// - `indptr_in` points to `indptr_size_in` int64 CSR row pointers in non-decreasing order
+///   with `0 <= indptr_in[i] <= num_rows_in`. The segment count is
+///   `num_segments = max(indptr_size_in - 1, 0)`; when `indptr_size_in == 0`, `indptr_in` is not
+///   read and no output segments are produced.
+/// - `reduced_values_out` points to `num_segments * num_cols_in` `scalar_t` values.
+/// - `arg_indices_out` is only used for `REDUCE == MIN` or `REDUCE == MAX`. When non-null for those
+///   reductions it points to `num_segments * num_cols_in` int64 values. Pass `nullptr` for SUM,
+///   MEAN, MUL, and DIV, or when argmin/argmax indices are not needed.
+/// - All pointers are device pointers.
+///
+/// Output contract:
+/// - Returns `0` if all work was enqueued successfully, or `-1` if any size argument is negative.
+/// - `reduced_values_out[s * num_cols_in + c]` contains the reduction of column `c` of
+///   `src_in[indptr_in[s] : indptr_in[s + 1]]`. Empty segments produce the reducer's empty value:
+///   `0` for SUM, MEAN, MIN, and MAX, and `1` for MUL and DIV.
+/// - When written, `arg_indices_out[s * num_cols_in + c]` contains the source row index that
+///   produced the min/max for that output cell. Cells corresponding to empty segments are left at
+///   the sentinel value `num_rows_in` (an out-of-range index).
 template <typename scalar_t, ReductionType REDUCE>
 int32_t segment_csr_launch(
-  const scalar_t * src_in, const std::vector<int32_t> & src_size_in, const int64_t * indptr_in,
-  const std::vector<int32_t> & indptr_size_in, const scalar_t * base_values_in,
-  scalar_t * reduced_values_out, int64_t * arg_indices_out, cudaStream_t stream_in);
-
-template <typename scalar_t, ReductionType REDUCE>
-int32_t segment_csr_launch(
-  const scalar_t * src_in, const std::vector<int32_t> & src_size_in, const int64_t * indptr_in,
-  const std::vector<int32_t> & indptr_size_in, scalar_t * reduced_values_out,
-  int64_t * arg_indices_out, cudaStream_t stream_in);
+  const scalar_t * src_in, int32_t num_rows_in, int32_t num_cols_in, const int64_t * indptr_in,
+  int32_t indptr_size_in, scalar_t * reduced_values_out, int64_t * arg_indices_out,
+  cudaStream_t stream_in);
 
 #endif  // AUTOWARE__SCATTER_OPS__SEGMENT_CSR_H_

--- a/perception/autoware_tensorrt_plugins/include/autoware/scatter_ops/utils.cuh
+++ b/perception/autoware_tensorrt_plugins/include/autoware/scatter_ops/utils.cuh
@@ -56,18 +56,4 @@ __global__ void div_kernel(
   src[thread_idx] /= divisor[thread_idx];
 }
 
-// cSpell:ignore indptr
-inline __host__ __device__ int indptr_to_offset(
-  const int64_t * indptr_size, int32_t indptr_dim, int32_t idx)
-{
-  int offset = idx % (indptr_size[indptr_dim - 1] - 1), stride = 1;
-  idx /= indptr_size[indptr_dim - 1] - 1;
-  for (int i = indptr_dim - 2; i >= 0; --i) {
-    stride *= indptr_size[i + 1];
-    offset += (idx % indptr_size[i]) * stride;
-    idx /= indptr_size[i];
-  }
-  return offset;
-}
-
 #endif  // AUTOWARE__SCATTER_OPS_UTILS_CUH

--- a/perception/autoware_tensorrt_plugins/include/autoware/tensorrt_plugins/get_indices_pairs_implicit_gemm_plugin.hpp
+++ b/perception/autoware_tensorrt_plugins/include/autoware/tensorrt_plugins/get_indices_pairs_implicit_gemm_plugin.hpp
@@ -125,6 +125,10 @@ private:
   // upper bound of number of output indices. needed to bound memory usage.
   static constexpr int out_indices_num_limit_{256000};
 
+  // Pre-allocated workspace size for thrust temporary buffer used by spconv sort operations.
+  // 8 MiB is generous enough for CUB radix sort of up to out_indices_num_limit_ elements.
+  static constexpr std::size_t kThrustTempBytes{8U * 1024U * 1024U};
+
   std::string layer_name_;
   GetIndicesPairsImplicitGemmParameters params_;
   std::vector<nvinfer1::PluginField> data_to_serialize_;

--- a/perception/autoware_tensorrt_plugins/include/autoware/tensorrt_plugins/get_indices_pairs_implicit_gemm_plugin.hpp
+++ b/perception/autoware_tensorrt_plugins/include/autoware/tensorrt_plugins/get_indices_pairs_implicit_gemm_plugin.hpp
@@ -45,6 +45,12 @@ struct GetIndicesPairsImplicitGemmParameters
   std::vector<std::int32_t> stride;
   std::int32_t subm;  // cSpell:ignore subm
   std::int32_t transpose;
+  // do_sort: 1 = run pair-mask argsort (default).
+  //          0 = skip argsort for faster inference. spconv documents this mainly for INT8
+  //          (https://github.com/traveller59/spconv/blob/master/docs/INT8_GUIDE.md#performance-guide);
+  //          our FP16 benchmarks also show a large sparse-encoder latency reduction with skipping
+  //          argsort.
+  std::int32_t do_sort{1};
 
   nvinfer1::Dims dilation_dims;
   nvinfer1::Dims ksize_dims;

--- a/perception/autoware_tensorrt_plugins/include/autoware/tensorrt_plugins/implicit_gemm_plugin.hpp
+++ b/perception/autoware_tensorrt_plugins/include/autoware/tensorrt_plugins/implicit_gemm_plugin.hpp
@@ -128,6 +128,9 @@ private:
 
   std::unique_ptr<ConvTunerSimple> tuner_fp32_ptr_{};
   std::unique_ptr<ConvTunerSimple> tuner_fp16_ptr_{};
+
+  // Pre-allocated CPU mask tensor to avoid heap allocation during CUDA graph capture.
+  tv::Tensor mask_tensor_;
 };
 
 }  // namespace nvinfer1::plugin

--- a/perception/autoware_tensorrt_plugins/include/autoware/tensorrt_plugins/implicit_gemm_plugin.hpp
+++ b/perception/autoware_tensorrt_plugins/include/autoware/tensorrt_plugins/implicit_gemm_plugin.hpp
@@ -37,12 +37,12 @@ namespace nvinfer1::plugin
 
 struct ImplicitGemmParameters
 {
-  float act_alpha;
-  float act_beta;
-  std::int64_t is_subm;  // cSpell:ignore subm
-  std::int64_t is_train;
-  float output_add_scale;
-  float output_scale;
+  float act_alpha{0.0F};
+  float act_beta{0.0F};
+  std::int32_t is_subm{0};  // cSpell:ignore subm
+  std::int32_t is_train{0};
+  float output_add_scale{1.0F};
+  float output_scale{1.0F};
 };
 
 class ImplicitGemmPlugin : public IPluginV3,

--- a/perception/autoware_tensorrt_plugins/include/autoware/tensorrt_plugins/implicit_gemm_plugin.hpp
+++ b/perception/autoware_tensorrt_plugins/include/autoware/tensorrt_plugins/implicit_gemm_plugin.hpp
@@ -43,6 +43,10 @@ struct ImplicitGemmParameters
   std::int32_t is_train{0};
   float output_add_scale{1.0F};
   float output_scale{1.0F};
+
+  /// tv::gemm::Activation as integer:
+  /// kNone=0, kReLU=1, kSigmoid=2, kLeakyReLU=3.
+  std::int32_t act_type{static_cast<std::int32_t>(tv::gemm::Activation::kNone)};
 };
 
 class ImplicitGemmPlugin : public IPluginV3,
@@ -116,12 +120,17 @@ private:
   static constexpr std::int32_t INOUT_PAIR_FWD_INDEX{2};
   static constexpr std::int32_t INOUT_PAIR_MASK_FWD_SPLITS_INDEX{3};
   static constexpr std::int32_t INOUT_MASK_ARGSORT_FWD_SPLITS_INDEX{4};
-  static constexpr std::int32_t INOUT_OUT_FEATURES_INDEX{5};
+  static constexpr std::int32_t INOUT_OPTIONAL_BIAS_INDEX{5};
+
+  static constexpr std::int32_t NUM_PLUGIN_INPUTS_NO_BIAS{5};
+  static constexpr std::int32_t NUM_PLUGIN_INPUTS_BIAS{6};
 
   void initFieldsToSerialize();
 
   std::string layer_name_;
   ImplicitGemmParameters params_;
+  /// Set in ``configurePlugin`` / ``onShapeChange``.
+  std::int32_t num_plugin_inputs_{NUM_PLUGIN_INPUTS_NO_BIAS};
   std::tuple<int, int> arch_;
   std::vector<nvinfer1::PluginField> data_to_serialize_;
   nvinfer1::PluginFieldCollection fc_to_serialize_;

--- a/perception/autoware_tensorrt_plugins/include/autoware/tensorrt_plugins/kernel_utils.hpp
+++ b/perception/autoware_tensorrt_plugins/include/autoware/tensorrt_plugins/kernel_utils.hpp
@@ -1,0 +1,41 @@
+// Copyright 2025 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef AUTOWARE__TENSORRT_PLUGINS__KERNEL_UTILS_HPP_
+#define AUTOWARE__TENSORRT_PLUGINS__KERNEL_UTILS_HPP_
+
+#include <cstddef>
+#include <cstdint>
+
+namespace autoware::tensorrt_plugins
+{
+
+inline std::size_t align_up(const std::size_t size, const std::size_t alignment)
+{
+  return ((size + alignment - 1U) / alignment) * alignment;
+}
+
+static __global__ void fill_iota(std::int64_t * output_out, const std::size_t num_elements_in)
+{
+  const auto index = static_cast<std::size_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  if (index >= num_elements_in) {
+    return;
+  }
+
+  output_out[index] = static_cast<std::int64_t>(index);
+}
+
+}  // namespace autoware::tensorrt_plugins
+
+#endif  // AUTOWARE__TENSORRT_PLUGINS__KERNEL_UTILS_HPP_

--- a/perception/autoware_tensorrt_plugins/include/autoware/tensorrt_plugins/plugin_utils.hpp
+++ b/perception/autoware_tensorrt_plugins/include/autoware/tensorrt_plugins/plugin_utils.hpp
@@ -24,6 +24,8 @@ void caughtError(std::exception const & e);
 
 void logDebug(char const * msg);
 
+void logWarning(char const * msg);
+
 #define PLUGIN_ASSERT(val) reportAssertion((val), #val, __FILE__, __LINE__)
 void reportAssertion(bool success, char const * msg, char const * file, std::int32_t line);
 

--- a/perception/autoware_tensorrt_plugins/include/autoware/tensorrt_plugins/plugin_utils.hpp
+++ b/perception/autoware_tensorrt_plugins/include/autoware/tensorrt_plugins/plugin_utils.hpp
@@ -35,7 +35,16 @@ cudaError_t reportCudaStatus(
 #define PLUGIN_ASSERT(val) reportAssertion((val), #val, __FILE__, __LINE__)
 void reportAssertion(bool success, char const * msg, char const * file, std::int32_t line);
 
+#define PLUGIN_ASSERT_MSG(val, detail) reportAssertionMsg((val), #val, (detail), __FILE__, __LINE__)
+void reportAssertionMsg(
+  bool success, char const * msg, char const * detail, char const * file, std::int32_t line);
+
 #define PLUGIN_VALIDATE(val) reportValidation((val), #val, __FILE__, __LINE__)
 void reportValidation(bool success, char const * msg, char const * file, std::int32_t line);
+
+#define PLUGIN_VALIDATE_MSG(val, detail) \
+  reportValidationMsg((val), #val, (detail), __FILE__, __LINE__)
+void reportValidationMsg(
+  bool success, char const * msg, char const * detail, char const * file, std::int32_t line);
 
 #endif  // AUTOWARE__TENSORRT_PLUGINS__PLUGIN_UTILS_HPP_

--- a/perception/autoware_tensorrt_plugins/include/autoware/tensorrt_plugins/plugin_utils.hpp
+++ b/perception/autoware_tensorrt_plugins/include/autoware/tensorrt_plugins/plugin_utils.hpp
@@ -16,6 +16,7 @@
 #define AUTOWARE__TENSORRT_PLUGINS__PLUGIN_UTILS_HPP_
 
 #include <NvInferRuntime.h>
+#include <cuda_runtime_api.h>
 
 #include <cstdint>
 #include <exception>
@@ -25,6 +26,11 @@ void caughtError(std::exception const & e);
 void logDebug(char const * msg);
 
 void logWarning(char const * msg);
+
+cudaError_t reportCudaStatus(
+  cudaError_t status, char const * msg, char const * file, std::int32_t line);
+
+#define PLUGIN_CUDA_CHECK(val) reportCudaStatus((val), #val, __FILE__, __LINE__)
 
 #define PLUGIN_ASSERT(val) reportAssertion((val), #val, __FILE__, __LINE__)
 void reportAssertion(bool success, char const * msg, char const * file, std::int32_t line);

--- a/perception/autoware_tensorrt_plugins/include/autoware/unique_ops/unique.hpp
+++ b/perception/autoware_tensorrt_plugins/include/autoware/unique_ops/unique.hpp
@@ -17,13 +17,45 @@
 
 #include <cuda_runtime_api.h>
 
+#include <cstddef>
 #include <cstdint>
 
-std::int64_t unique(
-  const std::int64_t * input, std::int64_t * unique, std::int64_t * inverse_indices,
-  std::int64_t * unique_counts, void * workspace, std::size_t num_input_elements,
-  std::size_t workspace_size, cudaStream_t stream);
+/// Computes sorted unique int64 values, inverse indices, counts, and the number of uniques on
+/// `stream_in`.
+///
+/// Input contract:
+/// - `input_in` points to `num_input_elements_in` int64 values.
+/// - `unique_values_out`, `inverse_indices_out`, and `unique_counts_out` each point to at least
+///   `num_input_elements_in` int64 values. The true `unique_counts_out` length is written to
+///   `num_unique_elements_out`, but the buffer must allow the worst case where every input is
+///   unique.
+/// - `num_unique_elements_out` points to one int64 device scalar.
+/// - `workspace_inout` points to at least `workspace_size_in` bytes.
+/// - `workspace_size_in` must be no smaller than
+///   `get_unique_workspace_size(num_input_elements_in)`.
+/// - All pointers are device pointers.
+///
+/// Output contract:
+/// - Returns `cudaSuccess` if all work was enqueued successfully; otherwise returns the first CUDA
+///   error encountered.
+/// - `unique_values_out[0:*num_unique_elements_out]` contains the input values in ascending order,
+///   with duplicates removed.
+/// - `inverse_indices_out[0:num_input_elements_in]` maps each original input element to its
+///   `unique_values_out` index.
+/// - `unique_counts_out[0:*num_unique_elements_out]` contains the occurrence count for each unique
+///   value.
+/// - `*num_unique_elements_out` contains the number of unique values found.
+cudaError_t unique(
+  const std::int64_t * input_in, std::int64_t * unique_values_out,
+  std::int64_t * inverse_indices_out, std::int64_t * unique_counts_out,
+  std::int64_t * num_unique_elements_out, void * workspace_inout, std::size_t num_input_elements_in,
+  std::size_t workspace_size_in, cudaStream_t stream_in);
 
-std::size_t get_unique_workspace_size(std::size_t num_elements);
+/// Bytes of CUB temporary storage required by the largest CUB primitive used by `unique`.
+std::size_t get_unique_temp_storage_size(std::size_t num_elements_in);
+
+/// Total TensorRT workspace bytes required by `unique`, including CUB temporary storage and
+/// all variant-local scratch arrays.
+std::size_t get_unique_workspace_size(std::size_t num_elements_in);
 
 #endif  // AUTOWARE__UNIQUE_OPS__UNIQUE_HPP_

--- a/perception/autoware_tensorrt_plugins/package.xml
+++ b/perception/autoware_tensorrt_plugins/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_tensorrt_plugins</name>
-  <version>0.50.0</version>
+  <version>0.51.0</version>
   <description>The autoware_tensorrt_plugins package</description>
   <maintainer email="kenzo.lobos@tier4.jp">Kenzo Lobos-Tsunekawa</maintainer>
   <maintainer email="amadeusz.szymko.2@tier4.jp">Amadeusz Szymko</maintainer>

--- a/perception/autoware_tensorrt_plugins/package.xml
+++ b/perception/autoware_tensorrt_plugins/package.xml
@@ -20,6 +20,7 @@
   <depend>autoware_cuda_dependency_meta</depend>
   <depend>autoware_cuda_utils</depend>
 
+  <test_depend>ament_cmake_gtest</test_depend>
   <test_depend>ament_cmake_ros</test_depend>
   <test_depend>ament_lint_auto</test_depend>
   <test_depend>autoware_lint_common</test_depend>

--- a/perception/autoware_tensorrt_plugins/package.xml
+++ b/perception/autoware_tensorrt_plugins/package.xml
@@ -8,6 +8,8 @@
   <maintainer email="amadeusz.szymko.2@tier4.jp">Amadeusz Szymko</maintainer>
   <maintainer email="kotaro.uetake@tier4.jp">Kotaro Uetake</maintainer>
   <maintainer email="masato.saeki@tier4.jp">Masato Saeki</maintainer>
+  <maintainer email="manato.hirabayashi@tier4.jp">Manato Hirabayashi</maintainer>
+  <maintainer email="max.schmeller@tier4.jp">Max Schmeller</maintainer>
 
   <license>Apache License 2.0</license>
 

--- a/perception/autoware_tensorrt_plugins/package.xml
+++ b/perception/autoware_tensorrt_plugins/package.xml
@@ -2,7 +2,7 @@
 <?xml-model href="http://download.ros.org/schema/package_format3.xsd" schematypens="http://www.w3.org/2001/XMLSchema"?>
 <package format="3">
   <name>autoware_tensorrt_plugins</name>
-  <version>0.51.0</version>
+  <version>0.52.0</version>
   <description>The autoware_tensorrt_plugins package</description>
   <maintainer email="kenzo.lobos@tier4.jp">Kenzo Lobos-Tsunekawa</maintainer>
   <maintainer email="amadeusz.szymko.2@tier4.jp">Amadeusz Szymko</maintainer>

--- a/perception/autoware_tensorrt_plugins/src/argsort_ops/argsort.cu
+++ b/perception/autoware_tensorrt_plugins/src/argsort_ops/argsort.cu
@@ -13,28 +13,44 @@
 // limitations under the License.
 
 #include "autoware/argsort_ops/argsort.hpp"
+#include "autoware/tensorrt_plugins/kernel_utils.hpp"
 
 #include <cub/cub.cuh>
 
-#include <thrust/device_ptr.h>
-#include <thrust/execution_policy.h>
-#include <thrust/sequence.h>
+#include <cstddef>
+
+namespace
+{
+
+constexpr int kThreadsPerBlock = 256;
+
+}  // namespace
 
 cudaError_t argsort(
   const std::int64_t * input_d, std::int64_t * output_d, void * workspace, std::size_t num_elements,
   std::size_t argsort_workspace_size, cudaStream_t stream)
 {
-  int workspace_offset = (argsort_workspace_size + sizeof(std::int64_t) - 1) / sizeof(std::int64_t);
-  thrust::device_ptr<std::int64_t> idx_ptr(
-    &reinterpret_cast<std::int64_t *>(workspace)[workspace_offset]);
+  if (num_elements == 0U) {
+    return cudaSuccess;
+  }
 
-  thrust::sequence(thrust::cuda::par.on(stream), idx_ptr, idx_ptr + num_elements, 0);
+  const auto scratch_offset =
+    autoware::tensorrt_plugins::align_up(argsort_workspace_size, alignof(std::int64_t));
+  auto * input_idx_d =
+    reinterpret_cast<std::int64_t *>(reinterpret_cast<std::byte *>(workspace) + scratch_offset);
+  auto * input_sorted_d = input_idx_d + num_elements;
 
-  std::int64_t * input_sorted_d = thrust::raw_pointer_cast(idx_ptr) + num_elements;
+  const auto num_blocks =
+    static_cast<unsigned int>((num_elements + kThreadsPerBlock - 1U) / kThreadsPerBlock);
+  autoware::tensorrt_plugins::fill_iota<<<num_blocks, kThreadsPerBlock, 0, stream>>>(
+    input_idx_d, num_elements);
+  if (const auto status = cudaPeekAtLastError(); status != cudaSuccess) {
+    return status;
+  }
 
   return cub::DeviceRadixSort::SortPairs(
-    workspace, argsort_workspace_size, input_d, input_sorted_d, thrust::raw_pointer_cast(idx_ptr),
-    output_d, num_elements, 0, 64, stream);
+    workspace, argsort_workspace_size, input_d, input_sorted_d, input_idx_d, output_d, num_elements,
+    0, 64, stream);
 }
 
 std::size_t get_argsort_workspace_size(std::size_t num_elements)

--- a/perception/autoware_tensorrt_plugins/src/argsort_plugin.cpp
+++ b/perception/autoware_tensorrt_plugins/src/argsort_plugin.cpp
@@ -149,14 +149,17 @@ std::int32_t ArgsortPlugin::enqueue(
   cudaStream_t stream) noexcept
 {
   auto num_elements = static_cast<std::size_t>(input_desc[0].dims.d[0]);
-  if (max_num_elements_ < num_elements) {
-    max_num_elements_ = num_elements;
-    argsort_workspace_size_ = get_argsort_workspace_size(max_num_elements_);
+  const auto workspace_size = get_argsort_workspace_size(num_elements);
+
+  if (const auto status = PLUGIN_CUDA_CHECK(argsort(
+        reinterpret_cast<std::int64_t const *>(inputs[0]),
+        reinterpret_cast<std::int64_t *>(outputs[0]), workspace, num_elements, workspace_size,
+        stream));
+      status != cudaSuccess) {
+    return -1;
   }
 
-  return argsort(
-    reinterpret_cast<std::int64_t const *>(inputs[0]), reinterpret_cast<std::int64_t *>(outputs[0]),
-    workspace, num_elements, argsort_workspace_size_, stream);
+  return 0;
 }
 
 std::int32_t ArgsortPlugin::onShapeChange(
@@ -183,8 +186,10 @@ std::size_t ArgsortPlugin::getWorkspaceSize(
   [[maybe_unused]] std::int32_t num_outputs) const noexcept
 {
   std::int64_t max_num_elements = inputs[0].max.d[0];
-  return get_argsort_workspace_size(max_num_elements) +
-         sizeof(std::int64_t) * 2 * (max_num_elements + 1);
+  const auto temp_size = get_argsort_workspace_size(max_num_elements);
+  const auto scratch_offset =
+    ((temp_size + alignof(std::int64_t) - 1U) / alignof(std::int64_t)) * alignof(std::int64_t);
+  return scratch_offset + sizeof(std::int64_t) * 2 * max_num_elements;
 }
 
 }  // namespace nvinfer1::plugin

--- a/perception/autoware_tensorrt_plugins/src/get_indices_pairs_implicit_gemm_plugin.cpp
+++ b/perception/autoware_tensorrt_plugins/src/get_indices_pairs_implicit_gemm_plugin.cpp
@@ -242,6 +242,48 @@ std::int32_t GetIndicesPairsImplicitGemmPlugin::getOutputShapes(
   return 0;
 }
 
+// =========================================================================
+// enqueue() pre-allocation memory layout
+//
+// All tensors are carved out of TensorRT-managed buffers (workspace and
+// output blobs) so that no cudaMalloc is issued during CUDA graph capture.
+//
+// Abbreviations:
+//   KV = kernel_volume
+//   N  = out_indices_num_limit_  (static upper bound)
+//   A  = input_desc[0].dims.d[0] (actual num_act_in at runtime)
+//   P  = is_subm ? A : N         (pair_fwd_size_padded)
+//   MC = mask_count              (1 or 2, depending on split-mask algo)
+//
+// ── workspace (single contiguous buffer from TensorRT) ──────────────────
+//
+//  ┌─────────────────────────────────────────────────┐  offset 0
+//  │  spconv internal workspace                      │
+//  │  (hash tables, temp indices, etc.)              │
+//  │  size: spconv_ws_size                           │
+//  ├─────────────────────────────────────────────────┤
+//  │  indices_kernel_num       [KV]                  │  int32
+//  ├─────────────────────────────────────────────────┤
+//  │  (non-subm only)                                │
+//  │  pair_bwd_padded          [KV x N]              │  int32
+//  │  pair_mask_bwd_padded     [MC x N]              │  int32
+//  │  mask_argsort_bwd_padded  [MC x N]              │  int32
+//  ├─────────────────────────────────────────────────┤
+//  │  thrust_tmp               [kThrustTempBytes]    │  uint8
+//  └─────────────────────────────────────────────────┘
+//
+// ── output blobs (each provided by TensorRT as a separate buffer) ───────
+//
+//  outputs[0]  out_indices           [P x 4]       int32
+//  outputs[1]  pair_fwd_padded       [KV x P]      int32
+//  outputs[2]  pair_mask_fwd_padded  [MC x P]      int32
+//  outputs[3]  mask_argsort_fwd      [MC x P]      int32
+//  outputs[4]  num_act_out           scalar        int32
+//
+// For subm convolutions P = A (sized to the actual input), while for
+// regular (non-subm) convolutions P = N (the static upper bound).
+// =========================================================================
+
 std::int32_t GetIndicesPairsImplicitGemmPlugin::enqueue(
   PluginTensorDesc const * input_desc, [[maybe_unused]] PluginTensorDesc const * output_desc,
   void const * const * inputs, void * const * outputs, [[maybe_unused]] void * workspace,
@@ -294,9 +336,39 @@ std::int32_t GetIndicesPairsImplicitGemmPlugin::enqueue(
     tv::from_blob(outputs[3], {mask_count, pair_fwd_size_padded}, tv::int32, 0);
   tv::Tensor out_indices = tv::from_blob(
     outputs[0], {is_subm ? input_desc[0].dims.d[0] : out_indices_num_limit_, 4}, tv::int32, 0);
-  tv::Tensor indices_kernel_num = tv::zeros({kernel_volume}, tv::int32, 0);
+
+  int spconv_ws_size = SpconvOps::get_indice_gen_workspace_size(
+    kernel_volume, out_indices_num_limit_, out_indices_num_limit_, out_indices_num_limit_, is_subm,
+    use_int64_hash_k, use_direct_table);
+  void * indices_kernel_num_ptr = static_cast<std::uint8_t *>(workspace) + spconv_ws_size;
+
+  tv::Tensor indices_kernel_num =
+    tv::from_blob(indices_kernel_num_ptr, {kernel_volume}, tv::int32, 0);
+
+  {
+    cudaError_t status = cudaMemsetAsync(
+      indices_kernel_num_ptr, 0, kernel_volume * tv::detail::sizeof_dtype(tv::int32), stream);
+    if (status != cudaSuccess) {
+      return status;
+    }
+  }
 
   tv::Tensor input_indices = tv::from_blob(inputs[0], {input_desc[0].dims.d[0], 4}, tv::int32, 0);
+
+  std::size_t thrust_tmp_offset =
+    static_cast<std::size_t>(spconv_ws_size) + kernel_volume * tv::detail::sizeof_dtype(tv::int32);
+  if (!is_subm) {
+    thrust_tmp_offset += static_cast<std::size_t>(kernel_volume) * static_num_act_in *
+                         tv::detail::sizeof_dtype(tv::int32);
+    thrust_tmp_offset += static_cast<std::size_t>(mask_count) * static_num_act_in *
+                         tv::detail::sizeof_dtype(tv::int32);
+    thrust_tmp_offset += static_cast<std::size_t>(mask_count) * static_num_act_in *
+                         tv::detail::sizeof_dtype(tv::int32);
+  }
+
+  tv::Tensor thrust_tmp = tv::from_blob(
+    static_cast<std::uint8_t *>(workspace) + thrust_tmp_offset,
+    {static_cast<std::int64_t>(kThrustTempBytes)}, tv::uint8, 0);
 
   std::tuple<tv::Tensor, int> pair_res;
 
@@ -313,6 +385,7 @@ std::int32_t GetIndicesPairsImplicitGemmPlugin::enqueue(
     ws_tensors.emplace(
       SPCONV_ALLOC_INDICE_NUM_PER_LOC, indices_kernel_num);  // cSpell:ignore INDICE
     StaticAllocator alloc(ws_tensors);
+    alloc.thrust_tmp_tensor_ = thrust_tmp;
 
     // cSpell:ignore indice
     pair_res = SpconvOps::get_indice_pairs_implicit_gemm(
@@ -322,9 +395,21 @@ std::int32_t GetIndicesPairsImplicitGemmPlugin::enqueue(
       use_direct_table);
 
   } else {
-    tv::Tensor pair_bwd_padded = tv::empty({kernel_volume, static_num_act_in}, tv::int32, 0);
-    tv::Tensor pair_mask_bwd_padded = tv::empty({mask_count, static_num_act_in}, tv::int32, 0);
-    tv::Tensor mask_argsort_bwd_padded = tv::empty({mask_count, static_num_act_in}, tv::int32, 0);
+    // Allocate bwd tensors from the workspace instead of tv::empty to avoid cudaMalloc during
+    // CUDA graph capture. They are placed after indices_kernel_num in the workspace.
+    std::uint8_t * extra_ptr = static_cast<std::uint8_t *>(indices_kernel_num_ptr) +
+                               kernel_volume * tv::detail::sizeof_dtype(tv::int32);
+
+    tv::Tensor pair_bwd_padded =
+      tv::from_blob(extra_ptr, {kernel_volume, static_num_act_in}, tv::int32, 0);
+    extra_ptr += kernel_volume * static_num_act_in * tv::detail::sizeof_dtype(tv::int32);
+
+    tv::Tensor pair_mask_bwd_padded =
+      tv::from_blob(extra_ptr, {mask_count, static_num_act_in}, tv::int32, 0);
+    extra_ptr += mask_count * static_num_act_in * tv::detail::sizeof_dtype(tv::int32);
+
+    tv::Tensor mask_argsort_bwd_padded =
+      tv::from_blob(extra_ptr, {mask_count, static_num_act_in}, tv::int32, 0);
 
     ws_tensors.emplace(SPCONV_ALLOC_PAIR_FWD, pair_fwd_padded);
     ws_tensors.emplace(SPCONV_ALLOC_PAIR_BWD, pair_bwd_padded);
@@ -340,6 +425,7 @@ std::int32_t GetIndicesPairsImplicitGemmPlugin::enqueue(
       SPCONV_ALLOC_INDICE_NUM_PER_LOC, indices_kernel_num);  // cSpell:ignore INDICE
 
     StaticAllocator alloc(ws_tensors);
+    alloc.thrust_tmp_tensor_ = thrust_tmp;
 
     // cSpell:ignore indice
     pair_res = SpconvOps::get_indice_pairs_implicit_gemm(
@@ -404,12 +490,30 @@ std::size_t GetIndicesPairsImplicitGemmPlugin::getWorkspaceSize(
   int kernel_volume =
     std::accumulate(params_.ksize.begin(), params_.ksize.end(), 1, std::multiplies<int>());
 
-  // query workspace size.
-  int workspace_size = SpconvOps::get_indice_gen_workspace_size(
-    kernel_volume, out_indices_num_limit_, out_indices_num_limit_, out_indices_num_limit_, is_subm,
-    use_int64_hash_k, use_direct_table);
+  size_t workspace_size = 0;
 
-  return static_cast<std::size_t>(workspace_size);
+  workspace_size += static_cast<size_t>(SpconvOps::get_indice_gen_workspace_size(
+    kernel_volume, out_indices_num_limit_, out_indices_num_limit_, out_indices_num_limit_, is_subm,
+    use_int64_hash_k, use_direct_table));
+
+  workspace_size += static_cast<std::size_t>(kernel_volume) * tv::detail::sizeof_dtype(tv::int32);
+
+  if (!is_subm) {
+    bool is_split_mask =
+      params_.algo == static_cast<std::int64_t>(tv::gemm::SparseConvAlgo::kMaskSplitImplicitGemm);
+    int mask_count = is_split_mask ? 2 : 1;
+
+    workspace_size += static_cast<std::size_t>(kernel_volume) * out_indices_num_limit_ *
+                      tv::detail::sizeof_dtype(tv::int32);
+    workspace_size += static_cast<std::size_t>(mask_count) * out_indices_num_limit_ *
+                      tv::detail::sizeof_dtype(tv::int32);
+    workspace_size += static_cast<std::size_t>(mask_count) * out_indices_num_limit_ *
+                      tv::detail::sizeof_dtype(tv::int32);
+  }
+
+  workspace_size += kThrustTempBytes;
+
+  return workspace_size;
 }
 
 }  // namespace nvinfer1::plugin

--- a/perception/autoware_tensorrt_plugins/src/get_indices_pairs_implicit_gemm_plugin.cpp
+++ b/perception/autoware_tensorrt_plugins/src/get_indices_pairs_implicit_gemm_plugin.cpp
@@ -63,6 +63,7 @@ void GetIndicesPairsImplicitGemmPlugin::initFieldsToSerialize()
   data_to_serialize_.emplace_back(
     "subm", &params_.subm, PluginFieldType::kINT32, 1);  // cSpell:ignore subm
   data_to_serialize_.emplace_back("transpose", &params_.transpose, PluginFieldType::kINT32, 1);
+  data_to_serialize_.emplace_back("do_sort", &params_.do_sort, PluginFieldType::kINT32, 1);
 
   fc_to_serialize_.nbFields = data_to_serialize_.size();
   fc_to_serialize_.fields = data_to_serialize_.data();
@@ -392,7 +393,7 @@ std::int32_t GetIndicesPairsImplicitGemmPlugin::enqueue(
       alloc, input_indices, params_.batch_size, input_dims, static_cast<int>(params_.algo), ksize,
       stride, padding, dilation, {0, 0, 0}, params_.subm, params_.transpose, false /*is_train*/,
       reinterpret_cast<std::uintptr_t>(stream), out_indices_num_limit_, tv::CUDAKernelTimer(false),
-      use_direct_table);
+      use_direct_table, static_cast<bool>(params_.do_sort));
 
   } else {
     // Allocate bwd tensors from the workspace instead of tv::empty to avoid cudaMalloc during
@@ -432,7 +433,7 @@ std::int32_t GetIndicesPairsImplicitGemmPlugin::enqueue(
       alloc, input_indices, params_.batch_size, input_dims, static_cast<int>(params_.algo), ksize,
       stride, padding, dilation, {0, 0, 0}, params_.subm, params_.transpose, false /*is_train*/,
       reinterpret_cast<std::uintptr_t>(stream), out_indices_num_limit_, tv::CUDAKernelTimer(false),
-      use_direct_table);
+      use_direct_table, static_cast<bool>(params_.do_sort));
   }
 
   std::int32_t num_act_out_real = std::get<1>(pair_res);

--- a/perception/autoware_tensorrt_plugins/src/get_indices_pairs_implicit_gemm_plugin_creator.cpp
+++ b/perception/autoware_tensorrt_plugins/src/get_indices_pairs_implicit_gemm_plugin_creator.cpp
@@ -47,6 +47,7 @@ GetIndicesPairsImplicitGemmPluginCreator::GetIndicesPairsImplicitGemmPluginCreat
   plugin_attributes_.emplace_back(
     "subm", nullptr, PluginFieldType::kINT32, 1);  // cSpell:ignore subm
   plugin_attributes_.emplace_back("transpose", nullptr, PluginFieldType::kINT32, 1);
+  plugin_attributes_.emplace_back("do_sort", nullptr, PluginFieldType::kINT32, 1);
 
   fc_.nbFields = plugin_attributes_.size();
   fc_.fields = plugin_attributes_.data();
@@ -69,7 +70,16 @@ IPluginV3 * GetIndicesPairsImplicitGemmPluginCreator::createPlugin(
       nvinfer1::PluginField const * fields{fc->fields};
       std::int32_t num_fields{fc->nbFields};
 
-      PLUGIN_VALIDATE(num_fields == 11);
+      // Accept 11 (legacy ONNX without do_sort) or 12 (with do_sort attribute).
+      PLUGIN_VALIDATE(num_fields == 11 || num_fields == 12);
+
+      if (num_fields == 11) {
+        std::ostringstream ss;
+        ss << name << ": legacy ONNX (11 plugin fields, missing do_sort). "
+           << "Re-export ONNX with explicit do_sort; 11-field support will be removed later. "
+           << "Using default do_sort=1.";
+        logWarning(ss.str().c_str());
+      }
 
       GetIndicesPairsImplicitGemmParameters parameters;
 
@@ -199,6 +209,10 @@ IPluginV3 * GetIndicesPairsImplicitGemmPluginCreator::createPlugin(
         if (attr_name == "transpose") {
           PLUGIN_VALIDATE(type == nvinfer1::PluginFieldType::kINT32);
           parameters.transpose = static_cast<std::int32_t const *>(fields[i].data)[0];
+        }
+        if (attr_name == "do_sort") {
+          PLUGIN_VALIDATE(type == nvinfer1::PluginFieldType::kINT32);
+          parameters.do_sort = static_cast<std::int32_t const *>(fields[i].data)[0];
         }
       }
 

--- a/perception/autoware_tensorrt_plugins/src/implicit_gemm_plugin.cpp
+++ b/perception/autoware_tensorrt_plugins/src/implicit_gemm_plugin.cpp
@@ -50,6 +50,10 @@ ImplicitGemmPlugin::ImplicitGemmPlugin(
   tuner_fp16_ptr_ =
     std::make_unique<ConvTunerSimple>(ConvMain::get_all_conv_algo_desp());  // cSpell:ignore desp
   tuner_fp32_ptr_ = std::make_unique<ConvTunerSimple>(ConvMain::get_all_conv_algo_desp());
+
+  // Pre-allocate CPU mask tensor to avoid heap allocation during CUDA graph capture.
+  mask_tensor_ = tv::zeros({1}, tv::uint32, -1);
+  mask_tensor_.data_ptr<uint32_t>()[0] = 0xffffffff;
 }
 
 void ImplicitGemmPlugin::initFieldsToSerialize()
@@ -268,11 +272,6 @@ std::int32_t ImplicitGemmPlugin::enqueue(
 
   tv::Tensor out_features = tv::from_blob(outputs[0], {num_act_out, num_out_features}, dtype, 0);
 
-  tv::Tensor mask_tensor = tv::zeros({1}, tv::uint32, -1);
-
-  auto mask_tensor_ptr = mask_tensor.data_ptr<uint32_t>();
-  mask_tensor_ptr[0] = 0xffffffff;
-
   std::vector<tv::Tensor> pair_mask_splits;
   std::vector<tv::Tensor> mask_argsort_splits;
 
@@ -289,7 +288,7 @@ std::int32_t ImplicitGemmPlugin::enqueue(
 
   auto conv_run_status = ConvGemmOps::implicit_gemm(
     alloc2, *tuner_ptr, input_features, weights, pair_fwd, pair_mask_splits, mask_argsort_splits,
-    num_act_out, mask_tensor, arch_, false, params_.is_subm,
+    num_act_out, mask_tensor_, arch_, false, params_.is_subm,
     reinterpret_cast<std::uintptr_t>(stream), tv::CUDAKernelTimer(false), true, false, tv::Tensor(),
     0.0, 0.0, tv::gemm::Activation::kNone, false, 1.0, tv::Tensor(), tv::Tensor(), 0.0, -1);
 

--- a/perception/autoware_tensorrt_plugins/src/implicit_gemm_plugin.cpp
+++ b/perception/autoware_tensorrt_plugins/src/implicit_gemm_plugin.cpp
@@ -59,17 +59,8 @@ ImplicitGemmPlugin::ImplicitGemmPlugin(
 void ImplicitGemmPlugin::initFieldsToSerialize()
 {
   data_to_serialize_.clear();
-  data_to_serialize_.emplace_back("act_alpha", &params_.act_alpha, PluginFieldType::kFLOAT32, 1);
-  data_to_serialize_.emplace_back("act_alpha", &params_.act_beta, PluginFieldType::kFLOAT32, 1);
-
   data_to_serialize_.emplace_back(
-    "is_subm", &params_.is_subm, PluginFieldType::kINT32, 1);  // cSpell:ignore subm
-  data_to_serialize_.emplace_back("is_train", &params_.is_train, PluginFieldType::kINT32, 1);
-
-  data_to_serialize_.emplace_back(
-    "output_add_scale", &params_.output_add_scale, PluginFieldType::kFLOAT32, 1);
-  data_to_serialize_.emplace_back(
-    "output_scale", &params_.output_scale, PluginFieldType::kFLOAT32, 1);
+    "parameters", &params_, PluginFieldType::kUNKNOWN, sizeof(ImplicitGemmParameters));
 
   fc_to_serialize_.nbFields = data_to_serialize_.size();
   fc_to_serialize_.fields = data_to_serialize_.data();
@@ -128,6 +119,8 @@ std::int32_t ImplicitGemmPlugin::configurePlugin(
   std::int32_t num_outputs) noexcept
 {
   // Validate input arguments.
+  PLUGIN_ASSERT(in != nullptr);
+  PLUGIN_ASSERT(out != nullptr);
   PLUGIN_ASSERT(num_inputs == 5);
   PLUGIN_ASSERT(num_outputs == 1);
   PLUGIN_ASSERT(in[INOUT_IN_FEATURES_INDEX].desc.dims.nbDims == 2);
@@ -158,21 +151,32 @@ bool ImplicitGemmPlugin::supportsFormatCombination(
   std::int32_t pos, DynamicPluginTensorDesc const * in_out, std::int32_t num_inputs,
   std::int32_t num_outputs) noexcept
 {
+  PLUGIN_ASSERT(in_out != nullptr);
   PLUGIN_ASSERT(num_inputs == 5);
   PLUGIN_ASSERT(num_outputs == 1);
+  PLUGIN_ASSERT(pos >= 0 && pos < num_inputs + num_outputs);
 
+  // spconv only supports contiguous (LINEAR) layout for all tensors.
   bool supported = in_out[pos].desc.format == nvinfer1::TensorFormat::kLINEAR;
 
+  // Output features must match the input features dtype.
+  if (pos == INOUT_OUT_FEATURES_INDEX) {
+    supported &= in_out[pos].desc.type == in_out[INOUT_IN_FEATURES_INDEX].desc.type;
+    return supported;
+  }
+
   switch (pos) {
+    // Input features: fp32 or fp16 (spconv supports both precisions).
     case INOUT_IN_FEATURES_INDEX:
       supported &=
         (in_out[pos].desc.type == nvinfer1::DataType::kFLOAT ||
          in_out[pos].desc.type == nvinfer1::DataType::kHALF);
       break;
+    // Filter weights must match input features dtype for mixed-precision-free GEMM.
     case INOUT_FILTERS_INDEX:
-    case INOUT_OUT_FEATURES_INDEX:
       supported &= in_out[pos].desc.type == in_out[INOUT_IN_FEATURES_INDEX].desc.type;
       break;
+    // Index / mask tensors are always int32 regardless of activation dtype.
     case INOUT_PAIR_FWD_INDEX:
     case INOUT_PAIR_MASK_FWD_SPLITS_INDEX:
     case INOUT_MASK_ARGSORT_FWD_SPLITS_INDEX:
@@ -190,6 +194,8 @@ std::int32_t ImplicitGemmPlugin::getOutputDataTypes(
   DataType * output_types, std::int32_t num_outputs, DataType const * input_types,
   std::int32_t num_inputs) const noexcept
 {
+  PLUGIN_ASSERT(output_types != nullptr);
+  PLUGIN_ASSERT(input_types != nullptr);
   PLUGIN_ASSERT(num_inputs == 5);
   PLUGIN_ASSERT(num_outputs == 1);
 
@@ -204,6 +210,8 @@ std::int32_t ImplicitGemmPlugin::getOutputShapes(
   DimsExprs * outputs, std::int32_t num_outputs,
   [[maybe_unused]] IExprBuilder & expr_builder) noexcept
 {
+  PLUGIN_ASSERT(inputs != nullptr);
+  PLUGIN_ASSERT(outputs != nullptr);
   PLUGIN_ASSERT(num_inputs == 5);
   PLUGIN_ASSERT(num_outputs == 1);
   PLUGIN_ASSERT(inputs[0].nbDims == 2);
@@ -216,7 +224,7 @@ std::int32_t ImplicitGemmPlugin::getOutputShapes(
 }
 
 std::int32_t ImplicitGemmPlugin::enqueue(
-  PluginTensorDesc const * input_desc, [[maybe_unused]] PluginTensorDesc const * output_desc,
+  PluginTensorDesc const * input_desc, PluginTensorDesc const * output_desc,
   void const * const * inputs, void * const * outputs, [[maybe_unused]] void * workspace,
   cudaStream_t stream) noexcept
 {
@@ -231,10 +239,10 @@ std::int32_t ImplicitGemmPlugin::enqueue(
 
   auto in_features_type = input_desc[INOUT_IN_FEATURES_INDEX].type;
   [[maybe_unused]] auto filters_type = input_desc[INOUT_FILTERS_INDEX].type;
-  [[maybe_unused]] auto out_features_type = input_desc[INOUT_OUT_FEATURES_INDEX].type;
+  [[maybe_unused]] auto out_features_type = output_desc[0].type;
 
-  assert(in_features_type == filters_type);
-  assert(in_features_type == out_features_type);
+  PLUGIN_ASSERT(in_features_type == filters_type);
+  PLUGIN_ASSERT(in_features_type == out_features_type);
 
   auto dtype = in_features_type == DataType::kFLOAT ? tv::float32 : tv::float16;
 
@@ -286,9 +294,9 @@ std::int32_t ImplicitGemmPlugin::enqueue(
 
   auto & tuner_ptr = dtype == tv::float32 ? tuner_fp32_ptr_ : tuner_fp16_ptr_;
 
-  auto conv_run_status = ConvGemmOps::implicit_gemm(
+  [[maybe_unused]] auto const conv_run_status = ConvGemmOps::implicit_gemm(
     alloc2, *tuner_ptr, input_features, weights, pair_fwd, pair_mask_splits, mask_argsort_splits,
-    num_act_out, mask_tensor_, arch_, false, params_.is_subm,
+    num_act_out, mask_tensor_, arch_, false, params_.is_subm,  // cSpell:ignore subm
     reinterpret_cast<std::uintptr_t>(stream), tv::CUDAKernelTimer(false), true, false, tv::Tensor(),
     0.0, 0.0, tv::gemm::Activation::kNone, false, 1.0, tv::Tensor(), tv::Tensor(), 0.0, -1);
 

--- a/perception/autoware_tensorrt_plugins/src/implicit_gemm_plugin.cpp
+++ b/perception/autoware_tensorrt_plugins/src/implicit_gemm_plugin.cpp
@@ -34,6 +34,36 @@
 #include <unordered_map>
 #include <vector>
 
+namespace
+{
+
+/** Validate the bias inputs, then wrap the bias device pointer into a tv::Tensor of the
+ * activation dtype (no copy).
+ *
+ * Spconv's fused bias-add needs the bias dtype to match the activation dtype; the ONNX export
+ * already emits it that way, so we only assert the match and wrap the pointer. */
+void validate_and_wrap_bias_tensor(
+  void const * bias_in, std::int64_t c_bias, tv::DType activation_dtype,
+  nvinfer1::DataType bias_trt_type, int device, tv::Tensor * bias_out) noexcept
+{
+  PLUGIN_ASSERT(bias_out != nullptr);
+  PLUGIN_ASSERT(bias_in != nullptr);
+  PLUGIN_ASSERT(activation_dtype == tv::float16 || activation_dtype == tv::float32);
+  PLUGIN_ASSERT(
+    bias_trt_type ==
+    (activation_dtype == tv::float16 ? nvinfer1::DataType::kHALF : nvinfer1::DataType::kFLOAT));
+  *bias_out = tv::from_blob(const_cast<void *>(bias_in), {c_bias}, activation_dtype, device);
+}
+
+tv::gemm::Activation activation_from_int(std::int32_t const v) noexcept
+{
+  PLUGIN_ASSERT(
+    v >= static_cast<std::int32_t>(tv::gemm::Activation::kNone) &&
+    v <= static_cast<std::int32_t>(tv::gemm::Activation::kLeakyReLU));
+  return static_cast<tv::gemm::Activation>(v);
+}
+}  // namespace
+
 namespace nvinfer1::plugin
 {
 
@@ -86,7 +116,8 @@ IPluginCapability * ImplicitGemmPlugin::getCapabilityInterface(PluginCapabilityT
 IPluginV3 * ImplicitGemmPlugin::clone() noexcept
 {
   try {
-    IPluginV3 * const plugin{new ImplicitGemmPlugin{layer_name_, params_}};
+    ImplicitGemmPlugin * const plugin{new ImplicitGemmPlugin{layer_name_, params_}};
+    plugin->num_plugin_inputs_ = num_plugin_inputs_;
     return plugin;
   } catch (std::exception const & e) {
     caughtError(e);
@@ -119,10 +150,17 @@ std::int32_t ImplicitGemmPlugin::configurePlugin(
   std::int32_t num_outputs) noexcept
 {
   // Validate input arguments.
+  // 5 inputs: standard implicit GEMM path without fused bias.
+  // 6 inputs: implicit GEMM path with optional per-channel bias.
+  // TODO(vividf): should use PLUGIN_VALIDATE_AND_RETURN instead of PLUGIN_ASSERT for input
+  // arguments
   PLUGIN_ASSERT(in != nullptr);
   PLUGIN_ASSERT(out != nullptr);
-  PLUGIN_ASSERT(num_inputs == 5);
+  PLUGIN_ASSERT(num_inputs == NUM_PLUGIN_INPUTS_NO_BIAS || num_inputs == NUM_PLUGIN_INPUTS_BIAS);
   PLUGIN_ASSERT(num_outputs == 1);
+
+  num_plugin_inputs_ = num_inputs;
+
   PLUGIN_ASSERT(in[INOUT_IN_FEATURES_INDEX].desc.dims.nbDims == 2);
   PLUGIN_ASSERT(in[INOUT_FILTERS_INDEX].desc.dims.nbDims == 5);
   PLUGIN_ASSERT(in[INOUT_PAIR_FWD_INDEX].desc.dims.nbDims == 2);
@@ -144,6 +182,17 @@ std::int32_t ImplicitGemmPlugin::configurePlugin(
   PLUGIN_ASSERT(
     in[INOUT_PAIR_FWD_INDEX].desc.type == in[INOUT_MASK_ARGSORT_FWD_SPLITS_INDEX].desc.type);
 
+  if (num_inputs == NUM_PLUGIN_INPUTS_BIAS) {
+    PLUGIN_ASSERT(in[INOUT_OPTIONAL_BIAS_INDEX].desc.dims.nbDims == 1);
+    PLUGIN_ASSERT(
+      in[INOUT_OPTIONAL_BIAS_INDEX].desc.dims.d[0] == in[INOUT_FILTERS_INDEX].desc.dims.d[0]);
+    DataType const bias_t = in[INOUT_OPTIONAL_BIAS_INDEX].desc.type;
+    PLUGIN_ASSERT(bias_t == in[INOUT_IN_FEATURES_INDEX].desc.type);
+  }
+  PLUGIN_ASSERT(
+    params_.act_type >= static_cast<std::int32_t>(tv::gemm::Activation::kNone) &&
+    params_.act_type <= static_cast<std::int32_t>(tv::gemm::Activation::kLeakyReLU));
+
   return 0;
 }
 
@@ -152,15 +201,19 @@ bool ImplicitGemmPlugin::supportsFormatCombination(
   std::int32_t num_outputs) noexcept
 {
   PLUGIN_ASSERT(in_out != nullptr);
-  PLUGIN_ASSERT(num_inputs == 5);
+  PLUGIN_ASSERT(num_inputs == NUM_PLUGIN_INPUTS_NO_BIAS || num_inputs == NUM_PLUGIN_INPUTS_BIAS);
   PLUGIN_ASSERT(num_outputs == 1);
-  PLUGIN_ASSERT(pos >= 0 && pos < num_inputs + num_outputs);
+  // in_out is the combined [inputs..., outputs...] tensor array; n_slots = num_inputs +
+  // num_outputs.
+  std::int32_t const n_slots = num_inputs + num_outputs;
+  PLUGIN_ASSERT(pos >= 0 && pos < n_slots);
 
   // spconv only supports contiguous (LINEAR) layout for all tensors.
   bool supported = in_out[pos].desc.format == nvinfer1::TensorFormat::kLINEAR;
 
   // Output features must match the input features dtype.
-  if (pos == INOUT_OUT_FEATURES_INDEX) {
+  std::int32_t const out_pos = num_inputs;
+  if (pos == out_pos) {
     supported &= in_out[pos].desc.type == in_out[INOUT_IN_FEATURES_INDEX].desc.type;
     return supported;
   }
@@ -182,6 +235,14 @@ bool ImplicitGemmPlugin::supportsFormatCombination(
     case INOUT_MASK_ARGSORT_FWD_SPLITS_INDEX:
       supported &= in_out[pos].desc.type == nvinfer1::DataType::kINT32;
       break;
+    // Optional fused bias must match input features dtype; rejected when there are only 5 inputs.
+    case INOUT_OPTIONAL_BIAS_INDEX:
+      if (num_inputs == NUM_PLUGIN_INPUTS_BIAS) {
+        supported &= in_out[pos].desc.type == in_out[INOUT_IN_FEATURES_INDEX].desc.type;
+      } else {
+        supported = false;
+      }
+      break;
     default:
       supported = false;
       break;
@@ -196,7 +257,7 @@ std::int32_t ImplicitGemmPlugin::getOutputDataTypes(
 {
   PLUGIN_ASSERT(output_types != nullptr);
   PLUGIN_ASSERT(input_types != nullptr);
-  PLUGIN_ASSERT(num_inputs == 5);
+  PLUGIN_ASSERT(num_inputs == NUM_PLUGIN_INPUTS_NO_BIAS || num_inputs == NUM_PLUGIN_INPUTS_BIAS);
   PLUGIN_ASSERT(num_outputs == 1);
 
   output_types[0] = input_types[INOUT_IN_FEATURES_INDEX];
@@ -212,7 +273,7 @@ std::int32_t ImplicitGemmPlugin::getOutputShapes(
 {
   PLUGIN_ASSERT(inputs != nullptr);
   PLUGIN_ASSERT(outputs != nullptr);
-  PLUGIN_ASSERT(num_inputs == 5);
+  PLUGIN_ASSERT(num_inputs == NUM_PLUGIN_INPUTS_NO_BIAS || num_inputs == NUM_PLUGIN_INPUTS_BIAS);
   PLUGIN_ASSERT(num_outputs == 1);
   PLUGIN_ASSERT(inputs[0].nbDims == 2);
 
@@ -224,12 +285,16 @@ std::int32_t ImplicitGemmPlugin::getOutputShapes(
 }
 
 std::int32_t ImplicitGemmPlugin::enqueue(
-  PluginTensorDesc const * input_desc, PluginTensorDesc const * output_desc,
+  PluginTensorDesc const * input_desc, [[maybe_unused]] PluginTensorDesc const * output_desc,
   void const * const * inputs, void * const * outputs, [[maybe_unused]] void * workspace,
   cudaStream_t stream) noexcept
 {
   using StaticAllocator = spconvlib::spconv::csrc::sparse::alloc::StaticAllocator;
   using ConvGemmOps = spconvlib::spconv::csrc::sparse::convops::spops::ConvGemmOps;
+
+  PLUGIN_ASSERT(
+    num_plugin_inputs_ == NUM_PLUGIN_INPUTS_NO_BIAS ||
+    num_plugin_inputs_ == NUM_PLUGIN_INPUTS_BIAS);
 
   std::int64_t num_act_in = input_desc[INOUT_IN_FEATURES_INDEX].dims.d[0];
   std::int64_t num_in_features = input_desc[INOUT_IN_FEATURES_INDEX].dims.d[1];
@@ -280,6 +345,19 @@ std::int32_t ImplicitGemmPlugin::enqueue(
 
   tv::Tensor out_features = tv::from_blob(outputs[0], {num_act_out, num_out_features}, dtype, 0);
 
+  // Wrap the optional per-channel bias (BN-folded, 6th ONNX input) into a tv::Tensor.
+  // When present, spconv fuses it inside the GEMM kernel instead of a separate bias_add kernel.
+  // bias_tv stays empty (default-constructed) when there are only 5 inputs (no bias), in which
+  // case implicit_gemm runs without a bias term.
+  tv::Tensor bias_tv{};
+  if (num_plugin_inputs_ == NUM_PLUGIN_INPUTS_BIAS) {
+    auto const bias_type = input_desc[INOUT_OPTIONAL_BIAS_INDEX].type;
+    std::int64_t const c_bias = input_desc[INOUT_OPTIONAL_BIAS_INDEX].dims.d[0];
+    validate_and_wrap_bias_tensor(
+      inputs[INOUT_OPTIONAL_BIAS_INDEX], c_bias, dtype, bias_type, input_features.device(),
+      &bias_tv);
+  }
+
   std::vector<tv::Tensor> pair_mask_splits;
   std::vector<tv::Tensor> mask_argsort_splits;
 
@@ -297,16 +375,19 @@ std::int32_t ImplicitGemmPlugin::enqueue(
   [[maybe_unused]] auto const conv_run_status = ConvGemmOps::implicit_gemm(
     alloc2, *tuner_ptr, input_features, weights, pair_fwd, pair_mask_splits, mask_argsort_splits,
     num_act_out, mask_tensor_, arch_, false, params_.is_subm,  // cSpell:ignore subm
-    reinterpret_cast<std::uintptr_t>(stream), tv::CUDAKernelTimer(false), true, false, tv::Tensor(),
-    0.0, 0.0, tv::gemm::Activation::kNone, false, 1.0, tv::Tensor(), tv::Tensor(), 0.0, -1);
+    reinterpret_cast<std::uintptr_t>(stream), tv::CUDAKernelTimer(false), true, false, bias_tv,
+    params_.act_alpha, params_.act_beta, activation_from_int(params_.act_type), false, 1.0,
+    tv::Tensor(), tv::Tensor(), 0.0, -1);
 
   return 0;
 }
 
 std::int32_t ImplicitGemmPlugin::onShapeChange(
-  [[maybe_unused]] PluginTensorDesc const * in, [[maybe_unused]] std::int32_t num_inputs,
+  [[maybe_unused]] PluginTensorDesc const * in, std::int32_t num_inputs,
   [[maybe_unused]] PluginTensorDesc const * out, [[maybe_unused]] std::int32_t num_outputs) noexcept
 {
+  PLUGIN_ASSERT(num_inputs == NUM_PLUGIN_INPUTS_NO_BIAS || num_inputs == NUM_PLUGIN_INPUTS_BIAS);
+  num_plugin_inputs_ = num_inputs;
   return 0;
 }
 

--- a/perception/autoware_tensorrt_plugins/src/implicit_gemm_plugin_creator.cpp
+++ b/perception/autoware_tensorrt_plugins/src/implicit_gemm_plugin_creator.cpp
@@ -55,79 +55,53 @@ nvinfer1::PluginFieldCollection const * ImplicitGemmPluginCreator::getFieldNames
 IPluginV3 * ImplicitGemmPluginCreator::createPlugin(
   char const * name, PluginFieldCollection const * fc, TensorRTPhase phase) noexcept
 {
+  auto parse_fields = [](
+                        nvinfer1::PluginField const * fields, std::int32_t num_fields,
+                        ImplicitGemmParameters & parameters) {
+    PLUGIN_VALIDATE(num_fields == 6);
+    for (std::int32_t i{0}; i < num_fields; ++i) {
+      const std::string attr_name = fields[i].name;
+      const nvinfer1::PluginFieldType type = fields[i].type;
+
+      if (attr_name == "act_alpha") {
+        PLUGIN_VALIDATE(type == nvinfer1::PluginFieldType::kFLOAT32);
+        parameters.act_alpha = static_cast<float const *>(fields[i].data)[0];
+      } else if (attr_name == "act_beta") {
+        PLUGIN_VALIDATE(type == nvinfer1::PluginFieldType::kFLOAT32);
+        parameters.act_beta = static_cast<float const *>(fields[i].data)[0];
+      } else if (attr_name == "is_subm") {
+        PLUGIN_VALIDATE(type == nvinfer1::PluginFieldType::kINT32);
+        parameters.is_subm = static_cast<std::int32_t const *>(fields[i].data)[0];
+      } else if (attr_name == "is_train") {
+        PLUGIN_VALIDATE(type == nvinfer1::PluginFieldType::kINT32);
+        parameters.is_train = static_cast<std::int32_t const *>(fields[i].data)[0];
+      } else if (attr_name == "output_add_scale") {
+        PLUGIN_VALIDATE(type == nvinfer1::PluginFieldType::kFLOAT32);
+        parameters.output_add_scale = static_cast<float const *>(fields[i].data)[0];
+      } else if (attr_name == "output_scale") {
+        PLUGIN_VALIDATE(type == nvinfer1::PluginFieldType::kFLOAT32);
+        parameters.output_scale = static_cast<float const *>(fields[i].data)[0];
+      }
+    }
+  };
+
   // The build phase and the deserialization phase are handled differently.
-  if (phase == TensorRTPhase::kBUILD || phase == TensorRTPhase::kRUNTIME) {
+  if (phase == TensorRTPhase::kBUILD) {
     // The attributes from the ONNX node will be parsed and passed via fc.
     try {
       nvinfer1::PluginField const * fields{fc->fields};
       std::int32_t num_fields{fc->nbFields};
 
-      PLUGIN_VALIDATE(num_fields == 6);
-
-      ImplicitGemmParameters parameters;
-
-      for (std::int32_t i{0}; i < num_fields; ++i) {
-        const std::string attr_name = fields[i].name;
-        const nvinfer1::PluginFieldType type = fields[i].type;
-
-        if (attr_name == "act_alpha") {
-          PLUGIN_VALIDATE(type == nvinfer1::PluginFieldType::kFLOAT32);
-          parameters.act_alpha = static_cast<float const *>(fields[i].data)[0];
-        }
-
-        if (attr_name == "act_beta") {
-          PLUGIN_VALIDATE(type == nvinfer1::PluginFieldType::kFLOAT32);
-          parameters.act_beta = static_cast<float const *>(fields[i].data)[0];
-        }
-
-        if (attr_name == "is_subm") {
-          PLUGIN_VALIDATE(type == nvinfer1::PluginFieldType::kINT32);
-          parameters.is_subm = static_cast<std::int32_t const *>(fields[i].data)[0];
-        }
-
-        if (attr_name == "is_train") {
-          PLUGIN_VALIDATE(type == nvinfer1::PluginFieldType::kINT32);
-          parameters.is_train = static_cast<std::int32_t const *>(fields[i].data)[0];
-        }
-
-        if (attr_name == "output_add_scale") {
-          PLUGIN_VALIDATE(type == nvinfer1::PluginFieldType::kFLOAT32);
-          parameters.output_add_scale = static_cast<float const *>(fields[i].data)[0];
-        }
-
-        if (attr_name == "output_scale") {
-          PLUGIN_VALIDATE(type == nvinfer1::PluginFieldType::kFLOAT32);
-          parameters.output_scale = static_cast<float const *>(fields[i].data)[0];
-        }
-      }
+      ImplicitGemmParameters parameters{};
+      parse_fields(fields, num_fields, parameters);
 
       // Log the attributes parsed from ONNX node.
       std::stringstream ss;
-      ss << name << " plugin Attributes:";
-      logDebug(ss.str().c_str());
-
-      ss.str("");
-      ss << "act_alpha: " << parameters.act_alpha;
-      logDebug(ss.str().c_str());
-
-      ss.str("");
-      ss << "act_beta: " << parameters.act_beta;
-      logDebug(ss.str().c_str());
-
-      ss.str("");
-      ss << "is_subm: " << parameters.is_subm;
-      logDebug(ss.str().c_str());
-
-      ss.str("");
-      ss << "is_train: " << parameters.is_train;
-      logDebug(ss.str().c_str());
-
-      ss.str("");
-      ss << "output_add_scale: " << parameters.output_add_scale;
-      logDebug(ss.str().c_str());
-
-      ss.str("");
-      ss << "output_scale: " << parameters.output_scale;
+      ss << name << " plugin Attributes:"
+         << " act_alpha=" << parameters.act_alpha << " act_beta=" << parameters.act_beta
+         << " is_subm=" << parameters.is_subm << " is_train=" << parameters.is_train
+         << " output_add_scale=" << parameters.output_add_scale
+         << " output_scale=" << parameters.output_scale;
       logDebug(ss.str().c_str());
 
       ImplicitGemmPlugin * const plugin{new ImplicitGemmPlugin{std::string(name), parameters}};
@@ -141,14 +115,16 @@ IPluginV3 * ImplicitGemmPluginCreator::createPlugin(
     try {
       nvinfer1::PluginField const * fields{fc->fields};
       std::int32_t num_fields{fc->nbFields};
-      PLUGIN_VALIDATE(num_fields == 1);
-
-      char const * attr_name = fields[0].name;
-      PLUGIN_VALIDATE(!strcmp(attr_name, "parameters"));
+      PLUGIN_ASSERT_MSG(
+        num_fields == 1,
+        "Unsupported serialized plugin format. The plugin I/O contract has changed. "
+        "Please rebuild the TensorRT engine.");
+      PLUGIN_VALIDATE(fields[0].name != nullptr);
+      PLUGIN_VALIDATE(!strcmp(fields[0].name, "parameters"));
       PLUGIN_VALIDATE(fields[0].type == nvinfer1::PluginFieldType::kUNKNOWN);
       PLUGIN_VALIDATE(fields[0].length == sizeof(ImplicitGemmParameters));
-      ImplicitGemmParameters params{*(static_cast<ImplicitGemmParameters const *>(fields[0].data))};
-
+      PLUGIN_VALIDATE(fields[0].data != nullptr);
+      auto params = *(static_cast<ImplicitGemmParameters const *>(fields[0].data));
       ImplicitGemmPlugin * const plugin{new ImplicitGemmPlugin{std::string(name), params}};
       return plugin;
     } catch (std::exception const & e) {

--- a/perception/autoware_tensorrt_plugins/src/implicit_gemm_plugin_creator.cpp
+++ b/perception/autoware_tensorrt_plugins/src/implicit_gemm_plugin_creator.cpp
@@ -41,6 +41,7 @@ ImplicitGemmPluginCreator::ImplicitGemmPluginCreator()
   plugin_attributes_.emplace_back("is_train", nullptr, PluginFieldType::kINT32, 1);
   plugin_attributes_.emplace_back("output_add_scale", nullptr, PluginFieldType::kFLOAT32, 1);
   plugin_attributes_.emplace_back("output_scale", nullptr, PluginFieldType::kFLOAT32, 1);
+  plugin_attributes_.emplace_back("act_type", nullptr, PluginFieldType::kINT32, 1);
 
   fc_.nbFields = plugin_attributes_.size();
   fc_.fields = plugin_attributes_.data();
@@ -58,7 +59,8 @@ IPluginV3 * ImplicitGemmPluginCreator::createPlugin(
   auto parse_fields = [](
                         nvinfer1::PluginField const * fields, std::int32_t num_fields,
                         ImplicitGemmParameters & parameters) {
-    PLUGIN_VALIDATE(num_fields == 6);
+    // Accept 6 (legacy without act_type) or 7 (with act_type).
+    PLUGIN_VALIDATE(num_fields == 6 || num_fields == 7);
     for (std::int32_t i{0}; i < num_fields; ++i) {
       const std::string attr_name = fields[i].name;
       const nvinfer1::PluginFieldType type = fields[i].type;
@@ -81,6 +83,10 @@ IPluginV3 * ImplicitGemmPluginCreator::createPlugin(
       } else if (attr_name == "output_scale") {
         PLUGIN_VALIDATE(type == nvinfer1::PluginFieldType::kFLOAT32);
         parameters.output_scale = static_cast<float const *>(fields[i].data)[0];
+      } else if (attr_name == "act_type") {
+        PLUGIN_VALIDATE(type == nvinfer1::PluginFieldType::kINT32);
+        parameters.act_type = static_cast<std::int32_t const *>(fields[i].data)[0];
+        PLUGIN_VALIDATE(parameters.act_type >= 0 && parameters.act_type <= 3);
       }
     }
   };
@@ -101,7 +107,7 @@ IPluginV3 * ImplicitGemmPluginCreator::createPlugin(
          << " act_alpha=" << parameters.act_alpha << " act_beta=" << parameters.act_beta
          << " is_subm=" << parameters.is_subm << " is_train=" << parameters.is_train
          << " output_add_scale=" << parameters.output_add_scale
-         << " output_scale=" << parameters.output_scale;
+         << " output_scale=" << parameters.output_scale << " act_type=" << parameters.act_type;
       logDebug(ss.str().c_str());
 
       ImplicitGemmPlugin * const plugin{new ImplicitGemmPlugin{std::string(name), parameters}};

--- a/perception/autoware_tensorrt_plugins/src/plugin_utils.cpp
+++ b/perception/autoware_tensorrt_plugins/src/plugin_utils.cpp
@@ -20,6 +20,33 @@
 #include <cstring>
 #include <sstream>
 
+namespace
+{
+void logAssertionFailure(
+  char const * msg, char const * detail, char const * file, std::int32_t line)
+{
+  std::ostringstream stream;
+  stream << "Assertion failed: " << msg << '\n';
+  if (detail != nullptr && std::strlen(detail) > 0) {
+    stream << detail << '\n';
+  }
+  stream << file << ':' << line << '\n' << "Aborting..." << '\n';
+  getLogger()->log(nvinfer1::ILogger::Severity::kINTERNAL_ERROR, stream.str().c_str());
+}
+
+void logValidationFailure(
+  char const * msg, char const * detail, char const * file, std::int32_t line)
+{
+  std::ostringstream stream;
+  stream << "Validation failed: " << msg << '\n';
+  if (detail != nullptr && std::strlen(detail) > 0) {
+    stream << detail << '\n';
+  }
+  stream << file << ':' << line << '\n';
+  getLogger()->log(nvinfer1::ILogger::Severity::kINTERNAL_ERROR, stream.str().c_str());
+}
+}  // namespace
+
 void caughtError(std::exception const & e)
 {
   getLogger()->log(nvinfer1::ILogger::Severity::kINTERNAL_ERROR, e.what());
@@ -51,11 +78,16 @@ cudaError_t reportCudaStatus(
 void reportAssertion(bool success, char const * msg, char const * file, std::int32_t line)
 {
   if (!success) {
-    std::ostringstream stream;
-    stream << "Assertion failed: " << msg << std::endl
-           << file << ':' << line << std::endl
-           << "Aborting..." << std::endl;
-    getLogger()->log(nvinfer1::ILogger::Severity::kINTERNAL_ERROR, stream.str().c_str());
+    logAssertionFailure(msg, nullptr, file, line);
+    std::abort();
+  }
+}
+
+void reportAssertionMsg(
+  bool success, char const * msg, char const * detail, char const * file, std::int32_t line)
+{
+  if (!success) {
+    logAssertionFailure(msg, detail, file, line);
     std::abort();
   }
 }
@@ -63,8 +95,14 @@ void reportAssertion(bool success, char const * msg, char const * file, std::int
 void reportValidation(bool success, char const * msg, char const * file, std::int32_t line)
 {
   if (!success) {
-    std::ostringstream stream;
-    stream << "Validation failed: " << msg << std::endl << file << ':' << line << std::endl;
-    getLogger()->log(nvinfer1::ILogger::Severity::kINTERNAL_ERROR, stream.str().c_str());
+    logValidationFailure(msg, nullptr, file, line);
+  }
+}
+
+void reportValidationMsg(
+  bool success, char const * msg, char const * detail, char const * file, std::int32_t line)
+{
+  if (!success) {
+    logValidationFailure(msg, detail, file, line);
   }
 }

--- a/perception/autoware_tensorrt_plugins/src/plugin_utils.cpp
+++ b/perception/autoware_tensorrt_plugins/src/plugin_utils.cpp
@@ -30,6 +30,11 @@ void logDebug(char const * msg)
   getLogger()->log(nvinfer1::ILogger::Severity::kVERBOSE, msg);
 }
 
+void logWarning(char const * msg)
+{
+  getLogger()->log(nvinfer1::ILogger::Severity::kWARNING, msg);
+}
+
 void reportAssertion(bool success, char const * msg, char const * file, std::int32_t line)
 {
   if (!success) {

--- a/perception/autoware_tensorrt_plugins/src/plugin_utils.cpp
+++ b/perception/autoware_tensorrt_plugins/src/plugin_utils.cpp
@@ -35,6 +35,19 @@ void logWarning(char const * msg)
   getLogger()->log(nvinfer1::ILogger::Severity::kWARNING, msg);
 }
 
+cudaError_t reportCudaStatus(
+  cudaError_t status, char const * msg, char const * file, std::int32_t line)
+{
+  if (status != cudaSuccess) {
+    std::ostringstream stream;
+    stream << "CUDA call failed: " << msg << std::endl
+           << file << ':' << line << std::endl
+           << cudaGetErrorName(status) << ": " << cudaGetErrorString(status) << std::endl;
+    getLogger()->log(nvinfer1::ILogger::Severity::kERROR, stream.str().c_str());
+  }
+  return status;
+}
+
 void reportAssertion(bool success, char const * msg, char const * file, std::int32_t line)
 {
   if (!success) {

--- a/perception/autoware_tensorrt_plugins/src/scatter_ops/segment_csr.cu
+++ b/perception/autoware_tensorrt_plugins/src/scatter_ops/segment_csr.cu
@@ -26,21 +26,20 @@
 #include <algorithm>
 #include <numeric>
 #include <string>
-#include <tuple>
 #include <vector>
 
 #define THREADS 256
 #define BLOCKS(TB, N) (TB * N + THREADS - 1) / THREADS
 #define FULL_MASK 0xffffffff
-#define SEGMENT_CSR_LAUNCH_INSTANTIATION_TR(T, R)                                             \
-  template int32_t segment_csr_launch<T, R>(                                                  \
-    const T * src, const std::vector<int32_t> & src_size, const int64_t * indptr,             \
-    const std::vector<int32_t> & indptr_size, std::tuple<T *, int64_t *> out,                 \
-    cudaStream_t stream);                                                                     \
-  template int32_t segment_csr_launch<T, R>(                                                  \
-    const T * src, const std::vector<int32_t> & src_size, const int64_t * indptr,             \
-    const std::vector<int32_t> & indptr_size, const T * base, std::tuple<T *, int64_t *> out, \
-    cudaStream_t stream);
+#define SEGMENT_CSR_LAUNCH_INSTANTIATION_TR(T, R)                                                  \
+  template int32_t segment_csr_launch<T, R>(                                                       \
+    const T * src_in, const std::vector<int32_t> & src_size_in, const int64_t * indptr_in,         \
+    const std::vector<int32_t> & indptr_size_in, T * reduced_values_out,                           \
+    int64_t * arg_indices_out, cudaStream_t stream_in);                                            \
+  template int32_t segment_csr_launch<T, R>(                                                       \
+    const T * src_in, const std::vector<int32_t> & src_size_in, const int64_t * indptr_in,         \
+    const std::vector<int32_t> & indptr_size_in, const T * base_values_in, T * reduced_values_out, \
+    int64_t * arg_indices_out, cudaStream_t stream_in);
 #define SEGMENT_CSR_LAUNCH_INSTANTIATION(T)                   \
   SEGMENT_CSR_LAUNCH_INSTANTIATION_TR(T, ReductionType::SUM)  \
   SEGMENT_CSR_LAUNCH_INSTANTIATION_TR(T, ReductionType::MEAN) \
@@ -138,76 +137,83 @@ __global__ void segment_csr_broadcast_kernel(
 //! \todo expand index
 template <typename scalar_t, ReductionType REDUCE>
 int32_t segment_csr_launch(
-  const scalar_t * src, const std::vector<int32_t> & src_size, const int64_t * indptr,
-  const std::vector<int32_t> & indptr_size, const scalar_t * base,
-  std::tuple<scalar_t *, int64_t *> out, cudaStream_t stream)
+  const scalar_t * src_in, const std::vector<int32_t> & src_size_in, const int64_t * indptr_in,
+  const std::vector<int32_t> & indptr_size_in, const scalar_t * base_values_in,
+  scalar_t * reduced_values_out, int64_t * arg_indices_out, cudaStream_t stream_in)
 {
-  if (indptr_size.empty() || src_size.size() < indptr_size.size()) return -1;
+  if (indptr_size_in.empty() || src_size_in.size() < indptr_size_in.size()) return -1;
 
-  if (!std::equal(indptr_size.begin(), indptr_size.end() - 1, src_size.begin())) return -1;
+  if (!std::equal(indptr_size_in.begin(), indptr_size_in.end() - 1, src_size_in.begin())) return -1;
 
-  auto dim = indptr_size.size() - 1;
+  auto dim = indptr_size_in.size() - 1;
 
   auto _mul = [](int a, int b) { return a * b; };
-  auto src_numel = std::accumulate(src_size.begin(), src_size.end(), 1, _mul);
-  auto indptr_numel = std::accumulate(indptr_size.begin(), indptr_size.end(), 1, _mul);
-  auto out_numel = get_output_numel(src_size, indptr_size, dim);
+  auto src_numel = std::accumulate(src_size_in.begin(), src_size_in.end(), 1, _mul);
+  auto indptr_numel = std::accumulate(indptr_size_in.begin(), indptr_size_in.end(), 1, _mul);
+  auto out_numel = get_output_numel(src_size_in, indptr_size_in, dim);
 
   if (out_numel == 0) return 0;
 
   cudaMemcpyAsync(
-    std::get<0>(out), base, sizeof(scalar_t) * out_numel, cudaMemcpyDeviceToDevice, stream);
+    reduced_values_out, base_values_in, sizeof(scalar_t) * out_numel, cudaMemcpyDeviceToDevice,
+    stream_in);
 
-  if ((REDUCE == ReductionType::MIN || REDUCE == ReductionType::MAX) && std::get<1>(out) != nullptr)
-    fill_kernel<int64_t>
-      <<<BLOCKS(1, out_numel), THREADS, 0, stream>>>(std::get<1>(out), out_numel, src_size[dim]);
+  if ((REDUCE == ReductionType::MIN || REDUCE == ReductionType::MAX) && arg_indices_out != nullptr)
+    fill_kernel<int64_t><<<BLOCKS(1, out_numel), THREADS, 0, stream_in>>>(
+      arg_indices_out, out_numel, src_size_in[dim]);
 
   if (src_numel == 0) return 0;
 
-  auto N = max(indptr_size[dim] - 1, 0) * (indptr_numel / indptr_size[dim]);
+  auto N = max(indptr_size_in[dim] - 1, 0) * (indptr_numel / indptr_size_in[dim]);
   auto K = out_numel / N;
-  auto E = src_size[dim];
+  auto E = src_size_in[dim];
   int64_t * indptr_size_dev;
-  cudaMallocAsync(&indptr_size_dev, sizeof(int64_t) * indptr_size.size(), stream);
+  cudaMallocAsync(&indptr_size_dev, sizeof(int64_t) * indptr_size_in.size(), stream_in);
   cudaMemcpyAsync(
-    indptr_size_dev, indptr_size.data(), sizeof(int64_t) * indptr_size.size(),
-    cudaMemcpyHostToDevice, stream);
+    indptr_size_dev, indptr_size_in.data(), sizeof(int64_t) * indptr_size_in.size(),
+    cudaMemcpyHostToDevice, stream_in);
 
   if (K == 1)
-    segment_csr_kernel<scalar_t, REDUCE, 1><<<BLOCKS(32, N), THREADS, 0, stream>>>(
-      src, indptr, indptr_size_dev, indptr_size.size(), std::get<0>(out), std::get<1>(out), N, E);
+    segment_csr_kernel<scalar_t, REDUCE, 1><<<BLOCKS(32, N), THREADS, 0, stream_in>>>(
+      src_in, indptr_in, indptr_size_dev, indptr_size_in.size(), reduced_values_out,
+      arg_indices_out, N, E);
   else
-    segment_csr_broadcast_kernel<scalar_t, REDUCE><<<BLOCKS(1, N * K), THREADS, 0, stream>>>(
-      src, indptr, indptr_size_dev, indptr_size.size(), std::get<0>(out), std::get<1>(out), N, K,
-      E);
+    segment_csr_broadcast_kernel<scalar_t, REDUCE><<<BLOCKS(1, N * K), THREADS, 0, stream_in>>>(
+      src_in, indptr_in, indptr_size_dev, indptr_size_in.size(), reduced_values_out,
+      arg_indices_out, N, K, E);
 
-  cudaFreeAsync(indptr_size_dev, stream);
+  cudaFreeAsync(indptr_size_dev, stream_in);
   return 0;
 }
 
 template <typename scalar_t, ReductionType REDUCE>
 int32_t segment_csr_launch(
-  const scalar_t * src, const std::vector<int32_t> & src_size, const int64_t * indptr,
-  const std::vector<int32_t> & indptr_size, std::tuple<scalar_t *, int64_t *> out,
-  cudaStream_t stream)
+  const scalar_t * src_in, const std::vector<int32_t> & src_size_in, const int64_t * indptr_in,
+  const std::vector<int32_t> & indptr_size_in, scalar_t * reduced_values_out,
+  int64_t * arg_indices_out, cudaStream_t stream_in)
 {
-  if (indptr_size.empty() || src_size.size() < indptr_size.size()) return -1;
+  if (indptr_size_in.empty() || src_size_in.size() < indptr_size_in.size()) return -1;
 
-  if (!std::equal(indptr_size.begin(), indptr_size.end() - 1, src_size.begin())) return -1;
+  if (!std::equal(indptr_size_in.begin(), indptr_size_in.end() - 1, src_size_in.begin())) return -1;
 
-  auto dim = indptr_size.size() - 1;
-  auto out_numel = get_output_numel(src_size, indptr_size, dim);
+  auto dim = indptr_size_in.size() - 1;
+  auto out_numel = get_output_numel(src_size_in, indptr_size_in, dim);
   if (out_numel == 0) return 0;
 
-  scalar_t * base;
-  cudaMallocAsync(&base, sizeof(scalar_t) * out_numel, stream);
-  fill_kernel<scalar_t><<<BLOCKS(1, out_numel), THREADS, 0, stream>>>(base, out_numel, (scalar_t)0);
+  scalar_t * base_values;
+  cudaMallocAsync(&base_values, sizeof(scalar_t) * out_numel, stream_in);
+  fill_kernel<scalar_t><<<BLOCKS(1, out_numel), THREADS, 0, stream_in>>>(
+    base_values, out_numel, static_cast<scalar_t>(0));
 
-  auto status =
-    segment_csr_launch<scalar_t, REDUCE>(src, src_size, indptr, indptr_size, base, out, stream);
-  if (status != 0) return status;
+  auto status = segment_csr_launch<scalar_t, REDUCE>(
+    src_in, src_size_in, indptr_in, indptr_size_in, base_values, reduced_values_out,
+    arg_indices_out, stream_in);
+  if (status != 0) {
+    cudaFreeAsync(base_values, stream_in);
+    return status;
+  }
 
-  cudaFreeAsync(base, stream);
+  cudaFreeAsync(base_values, stream_in);
   return 0;
 }
 

--- a/perception/autoware_tensorrt_plugins/src/scatter_ops/segment_csr.cu
+++ b/perception/autoware_tensorrt_plugins/src/scatter_ops/segment_csr.cu
@@ -23,6 +23,7 @@
 #include "autoware/scatter_ops/segment_csr.h"
 #include "autoware/scatter_ops/utils.cuh"
 
+#include <algorithm>
 #include <numeric>
 #include <string>
 #include <tuple>
@@ -47,6 +48,19 @@
   SEGMENT_CSR_LAUNCH_INSTANTIATION_TR(T, ReductionType::DIV)  \
   SEGMENT_CSR_LAUNCH_INSTANTIATION_TR(T, ReductionType::MIN)  \
   SEGMENT_CSR_LAUNCH_INSTANTIATION_TR(T, ReductionType::MAX)
+
+namespace
+{
+size_t get_output_numel(
+  const std::vector<int32_t> & src_size, const std::vector<int32_t> & indptr_size, size_t dim)
+{
+  size_t out_numel = static_cast<size_t>(std::max<int32_t>(indptr_size[dim] - 1, 0));
+  for (size_t i = 0; i < src_size.size(); ++i) {
+    if (i != dim) out_numel *= static_cast<size_t>(src_size[i]);
+  }
+  return out_numel;
+}
+}  // namespace
 
 template <typename scalar_t, ReductionType REDUCE, int TB>
 __global__ void segment_csr_kernel(
@@ -128,7 +142,7 @@ int32_t segment_csr_launch(
   const std::vector<int32_t> & indptr_size, const scalar_t * base,
   std::tuple<scalar_t *, int64_t *> out, cudaStream_t stream)
 {
-  if (src_size.size() < indptr_size.size()) return -1;
+  if (indptr_size.empty() || src_size.size() < indptr_size.size()) return -1;
 
   if (!std::equal(indptr_size.begin(), indptr_size.end() - 1, src_size.begin())) return -1;
 
@@ -137,7 +151,9 @@ int32_t segment_csr_launch(
   auto _mul = [](int a, int b) { return a * b; };
   auto src_numel = std::accumulate(src_size.begin(), src_size.end(), 1, _mul);
   auto indptr_numel = std::accumulate(indptr_size.begin(), indptr_size.end(), 1, _mul);
-  auto out_numel = src_numel / src_size[dim] * std::max<int32_t>(indptr_size[dim] - 1, 0);
+  auto out_numel = get_output_numel(src_size, indptr_size, dim);
+
+  if (out_numel == 0) return 0;
 
   cudaMemcpyAsync(
     std::get<0>(out), base, sizeof(scalar_t) * out_numel, cudaMemcpyDeviceToDevice, stream);
@@ -175,10 +191,13 @@ int32_t segment_csr_launch(
   const std::vector<int32_t> & indptr_size, std::tuple<scalar_t *, int64_t *> out,
   cudaStream_t stream)
 {
+  if (indptr_size.empty() || src_size.size() < indptr_size.size()) return -1;
+
+  if (!std::equal(indptr_size.begin(), indptr_size.end() - 1, src_size.begin())) return -1;
+
   auto dim = indptr_size.size() - 1;
-  auto src_numel =
-    std::accumulate(src_size.begin(), src_size.end(), 1, [](int a, int b) { return a * b; });
-  auto out_numel = src_numel / src_size[dim] * std::max<int32_t>(indptr_size[dim] - 1, 0);
+  auto out_numel = get_output_numel(src_size, indptr_size, dim);
+  if (out_numel == 0) return 0;
 
   scalar_t * base;
   cudaMallocAsync(&base, sizeof(scalar_t) * out_numel, stream);

--- a/perception/autoware_tensorrt_plugins/src/scatter_ops/segment_csr.cu
+++ b/perception/autoware_tensorrt_plugins/src/scatter_ops/segment_csr.cu
@@ -130,13 +130,8 @@ int32_t segment_csr_launch(
     fill_kernel<int64_t>
       <<<BLOCKS(1, out_numel), THREADS, 0, stream_in>>>(arg_indices_out, out_numel, num_rows_in);
 
-  scalar_t * base_values{nullptr};
-  cudaMallocAsync(&base_values, sizeof(scalar_t) * out_numel, stream_in);
   fill_kernel<scalar_t><<<BLOCKS(1, out_numel), THREADS, 0, stream_in>>>(
-    base_values, out_numel, static_cast<scalar_t>(0));
-  cudaMemcpyAsync(
-    reduced_values_out, base_values, sizeof(scalar_t) * out_numel, cudaMemcpyDeviceToDevice,
-    stream_in);
+    reduced_values_out, out_numel, static_cast<scalar_t>(0));
 
   if (num_cols_in == 1)
     segment_csr_kernel<scalar_t, REDUCE, 1><<<BLOCKS(32, num_segments), THREADS, 0, stream_in>>>(
@@ -145,8 +140,6 @@ int32_t segment_csr_launch(
     segment_csr_broadcast_kernel<scalar_t, REDUCE>
       <<<BLOCKS(1, num_segments * num_cols_in), THREADS, 0, stream_in>>>(
         src_in, indptr_in, reduced_values_out, arg_indices_out, num_segments, num_cols_in);
-
-  cudaFreeAsync(base_values, stream_in);
   return 0;
 }
 

--- a/perception/autoware_tensorrt_plugins/src/scatter_ops/segment_csr.cu
+++ b/perception/autoware_tensorrt_plugins/src/scatter_ops/segment_csr.cu
@@ -24,22 +24,16 @@
 #include "autoware/scatter_ops/utils.cuh"
 
 #include <algorithm>
-#include <numeric>
 #include <string>
-#include <vector>
 
 #define THREADS 256
 #define BLOCKS(TB, N) (TB * N + THREADS - 1) / THREADS
 #define FULL_MASK 0xffffffff
-#define SEGMENT_CSR_LAUNCH_INSTANTIATION_TR(T, R)                                                  \
-  template int32_t segment_csr_launch<T, R>(                                                       \
-    const T * src_in, const std::vector<int32_t> & src_size_in, const int64_t * indptr_in,         \
-    const std::vector<int32_t> & indptr_size_in, T * reduced_values_out,                           \
-    int64_t * arg_indices_out, cudaStream_t stream_in);                                            \
-  template int32_t segment_csr_launch<T, R>(                                                       \
-    const T * src_in, const std::vector<int32_t> & src_size_in, const int64_t * indptr_in,         \
-    const std::vector<int32_t> & indptr_size_in, const T * base_values_in, T * reduced_values_out, \
-    int64_t * arg_indices_out, cudaStream_t stream_in);
+#define SEGMENT_CSR_LAUNCH_INSTANTIATION_TR(T, R)                                          \
+  template int32_t segment_csr_launch<T, R>(                                               \
+    const T * src_in, int32_t num_rows_in, int32_t num_cols_in, const int64_t * indptr_in, \
+    int32_t indptr_size_in, T * reduced_values_out, int64_t * arg_indices_out,             \
+    cudaStream_t stream_in);
 #define SEGMENT_CSR_LAUNCH_INSTANTIATION(T)                   \
   SEGMENT_CSR_LAUNCH_INSTANTIATION_TR(T, ReductionType::SUM)  \
   SEGMENT_CSR_LAUNCH_INSTANTIATION_TR(T, ReductionType::MEAN) \
@@ -48,23 +42,10 @@
   SEGMENT_CSR_LAUNCH_INSTANTIATION_TR(T, ReductionType::MIN)  \
   SEGMENT_CSR_LAUNCH_INSTANTIATION_TR(T, ReductionType::MAX)
 
-namespace
-{
-size_t get_output_numel(
-  const std::vector<int32_t> & src_size, const std::vector<int32_t> & indptr_size, size_t dim)
-{
-  size_t out_numel = static_cast<size_t>(std::max<int32_t>(indptr_size[dim] - 1, 0));
-  for (size_t i = 0; i < src_size.size(); ++i) {
-    if (i != dim) out_numel *= static_cast<size_t>(src_size[i]);
-  }
-  return out_numel;
-}
-}  // namespace
-
 template <typename scalar_t, ReductionType REDUCE, int TB>
 __global__ void segment_csr_kernel(
-  const scalar_t * src, const int64_t * indptr, const int64_t * indptr_size, int32_t indptr_dim,
-  scalar_t * out, int64_t * arg_out, size_t N, size_t E)
+  const scalar_t * src_in, const int64_t * indptr_in, scalar_t * reduced_values_out,
+  int64_t * arg_indices_out, size_t num_segments_in)
 {
   // Each warp processes exactly `32/TB` rows and aggregates all row values
   // via a parallel reduction.
@@ -72,18 +53,16 @@ __global__ void segment_csr_kernel(
   int thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
   int row_idx = thread_idx / TB;
   int lane_idx = thread_idx & (TB - 1);
-  if (row_idx >= N) return;
+  if (row_idx >= num_segments_in) return;
 
-  int offset = indptr_to_offset(indptr_size, indptr_dim, row_idx);
-  int64_t row_start = __ldg(indptr + offset);
-  int64_t row_end = __ldg(indptr + offset + 1);
+  int64_t row_start = __ldg(indptr_in + row_idx);
+  int64_t row_end = __ldg(indptr_in + row_idx + 1);
 
   scalar_t val = Reducer<scalar_t, REDUCE>::init();
-  int64_t arg, arg_tmp;
+  int64_t arg{0}, arg_tmp{0};
 
-  offset = (row_idx / (indptr_size[indptr_dim - 1] - 1)) * E;
   for (int64_t src_idx = row_start + lane_idx; src_idx < row_end; src_idx += TB)
-    Reducer<scalar_t, REDUCE>::update(&val, src[offset + src_idx], &arg, src_idx);
+    Reducer<scalar_t, REDUCE>::update(&val, src_in[src_idx], &arg, src_idx);
 
 #pragma unroll
   for (int i = TB / 2; i > 0; i /= 2) {
@@ -94,124 +73,78 @@ __global__ void segment_csr_kernel(
   }
 
   if (lane_idx == 0)
-    if (arg_out != nullptr)
+    if (arg_indices_out != nullptr)
       Reducer<scalar_t, REDUCE>::write(
-        out + row_idx, val, arg_out + row_idx, arg, row_end - row_start);
+        reduced_values_out + row_idx, val, arg_indices_out + row_idx, arg, row_end - row_start);
     else
-      Reducer<scalar_t, REDUCE>::write(out + row_idx, val, row_end - row_start);
+      Reducer<scalar_t, REDUCE>::write(reduced_values_out + row_idx, val, row_end - row_start);
 }
 
 template <typename scalar_t, ReductionType REDUCE>
 __global__ void segment_csr_broadcast_kernel(
-  const scalar_t * src, const int64_t * indptr, const int64_t * indptr_size, int32_t indptr_dim,
-  scalar_t * out, int64_t * arg_out, size_t N, size_t K, size_t E)
+  const scalar_t * src_in, const int64_t * indptr_in, scalar_t * reduced_values_out,
+  int64_t * arg_indices_out, size_t num_segments_in, size_t num_cols_in)
 {
   // Each thread processes exactly one row. It turned out that is more
   // efficient than using shared memory due to avoiding synchronization
   // barriers.
 
   int thread_idx = blockIdx.x * blockDim.x + threadIdx.x;
-  int row_idx = thread_idx / K;
-  int lane_idx = thread_idx % K;
-  if (thread_idx >= N * K) return;
+  int row_idx = thread_idx / num_cols_in;
+  int lane_idx = thread_idx % num_cols_in;
+  if (thread_idx >= num_segments_in * num_cols_in) return;
 
-  int offset = indptr_to_offset(indptr_size, indptr_dim, row_idx);
-  int64_t row_start = __ldg(indptr + offset);
-  int64_t row_end = __ldg(indptr + offset + 1);
+  int64_t row_start = __ldg(indptr_in + row_idx);
+  int64_t row_end = __ldg(indptr_in + row_idx + 1);
 
   scalar_t val = Reducer<scalar_t, REDUCE>::init();
-  int64_t arg;
+  int64_t arg{0};
 
-  offset = (row_idx / (indptr_size[indptr_dim - 1] - 1)) * E * K;
   for (int64_t src_idx = row_start; src_idx < row_end; src_idx++)
-    Reducer<scalar_t, REDUCE>::update(&val, src[offset + K * src_idx + lane_idx], &arg, src_idx);
+    Reducer<scalar_t, REDUCE>::update(
+      &val, src_in[num_cols_in * src_idx + lane_idx], &arg, src_idx);
 
-  if (arg_out != nullptr)
+  if (arg_indices_out != nullptr)
     Reducer<scalar_t, REDUCE>::write(
-      out + thread_idx, val, arg_out + thread_idx, arg, row_end - row_start);
+      reduced_values_out + thread_idx, val, arg_indices_out + thread_idx, arg, row_end - row_start);
   else
-    Reducer<scalar_t, REDUCE>::write(out + thread_idx, val, row_end - row_start);
+    Reducer<scalar_t, REDUCE>::write(reduced_values_out + thread_idx, val, row_end - row_start);
 }
 
 //! \todo test different devices (cudaSetDevice(src.get_device());)
 //! \todo expand index
 template <typename scalar_t, ReductionType REDUCE>
 int32_t segment_csr_launch(
-  const scalar_t * src_in, const std::vector<int32_t> & src_size_in, const int64_t * indptr_in,
-  const std::vector<int32_t> & indptr_size_in, const scalar_t * base_values_in,
-  scalar_t * reduced_values_out, int64_t * arg_indices_out, cudaStream_t stream_in)
+  const scalar_t * src_in, int32_t num_rows_in, int32_t num_cols_in, const int64_t * indptr_in,
+  int32_t indptr_size_in, scalar_t * reduced_values_out, int64_t * arg_indices_out,
+  cudaStream_t stream_in)
 {
-  if (indptr_size_in.empty() || src_size_in.size() < indptr_size_in.size()) return -1;
+  if (num_rows_in < 0 || num_cols_in < 0 || indptr_size_in < 0) return -1;
 
-  if (!std::equal(indptr_size_in.begin(), indptr_size_in.end() - 1, src_size_in.begin())) return -1;
-
-  auto dim = indptr_size_in.size() - 1;
-
-  auto _mul = [](int a, int b) { return a * b; };
-  auto src_numel = std::accumulate(src_size_in.begin(), src_size_in.end(), 1, _mul);
-  auto indptr_numel = std::accumulate(indptr_size_in.begin(), indptr_size_in.end(), 1, _mul);
-  auto out_numel = get_output_numel(src_size_in, indptr_size_in, dim);
+  auto num_segments = std::max<int32_t>(indptr_size_in - 1, 0);
+  auto out_numel = static_cast<size_t>(num_segments) * static_cast<size_t>(num_cols_in);
 
   if (out_numel == 0) return 0;
-
-  cudaMemcpyAsync(
-    reduced_values_out, base_values_in, sizeof(scalar_t) * out_numel, cudaMemcpyDeviceToDevice,
-    stream_in);
 
   if ((REDUCE == ReductionType::MIN || REDUCE == ReductionType::MAX) && arg_indices_out != nullptr)
-    fill_kernel<int64_t><<<BLOCKS(1, out_numel), THREADS, 0, stream_in>>>(
-      arg_indices_out, out_numel, src_size_in[dim]);
+    fill_kernel<int64_t>
+      <<<BLOCKS(1, out_numel), THREADS, 0, stream_in>>>(arg_indices_out, out_numel, num_rows_in);
 
-  if (src_numel == 0) return 0;
-
-  auto N = max(indptr_size_in[dim] - 1, 0) * (indptr_numel / indptr_size_in[dim]);
-  auto K = out_numel / N;
-  auto E = src_size_in[dim];
-  int64_t * indptr_size_dev;
-  cudaMallocAsync(&indptr_size_dev, sizeof(int64_t) * indptr_size_in.size(), stream_in);
-  cudaMemcpyAsync(
-    indptr_size_dev, indptr_size_in.data(), sizeof(int64_t) * indptr_size_in.size(),
-    cudaMemcpyHostToDevice, stream_in);
-
-  if (K == 1)
-    segment_csr_kernel<scalar_t, REDUCE, 1><<<BLOCKS(32, N), THREADS, 0, stream_in>>>(
-      src_in, indptr_in, indptr_size_dev, indptr_size_in.size(), reduced_values_out,
-      arg_indices_out, N, E);
-  else
-    segment_csr_broadcast_kernel<scalar_t, REDUCE><<<BLOCKS(1, N * K), THREADS, 0, stream_in>>>(
-      src_in, indptr_in, indptr_size_dev, indptr_size_in.size(), reduced_values_out,
-      arg_indices_out, N, K, E);
-
-  cudaFreeAsync(indptr_size_dev, stream_in);
-  return 0;
-}
-
-template <typename scalar_t, ReductionType REDUCE>
-int32_t segment_csr_launch(
-  const scalar_t * src_in, const std::vector<int32_t> & src_size_in, const int64_t * indptr_in,
-  const std::vector<int32_t> & indptr_size_in, scalar_t * reduced_values_out,
-  int64_t * arg_indices_out, cudaStream_t stream_in)
-{
-  if (indptr_size_in.empty() || src_size_in.size() < indptr_size_in.size()) return -1;
-
-  if (!std::equal(indptr_size_in.begin(), indptr_size_in.end() - 1, src_size_in.begin())) return -1;
-
-  auto dim = indptr_size_in.size() - 1;
-  auto out_numel = get_output_numel(src_size_in, indptr_size_in, dim);
-  if (out_numel == 0) return 0;
-
-  scalar_t * base_values;
+  scalar_t * base_values{nullptr};
   cudaMallocAsync(&base_values, sizeof(scalar_t) * out_numel, stream_in);
   fill_kernel<scalar_t><<<BLOCKS(1, out_numel), THREADS, 0, stream_in>>>(
     base_values, out_numel, static_cast<scalar_t>(0));
+  cudaMemcpyAsync(
+    reduced_values_out, base_values, sizeof(scalar_t) * out_numel, cudaMemcpyDeviceToDevice,
+    stream_in);
 
-  auto status = segment_csr_launch<scalar_t, REDUCE>(
-    src_in, src_size_in, indptr_in, indptr_size_in, base_values, reduced_values_out,
-    arg_indices_out, stream_in);
-  if (status != 0) {
-    cudaFreeAsync(base_values, stream_in);
-    return status;
-  }
+  if (num_cols_in == 1)
+    segment_csr_kernel<scalar_t, REDUCE, 1><<<BLOCKS(32, num_segments), THREADS, 0, stream_in>>>(
+      src_in, indptr_in, reduced_values_out, arg_indices_out, num_segments);
+  else
+    segment_csr_broadcast_kernel<scalar_t, REDUCE>
+      <<<BLOCKS(1, num_segments * num_cols_in), THREADS, 0, stream_in>>>(
+        src_in, indptr_in, reduced_values_out, arg_indices_out, num_segments, num_cols_in);
 
   cudaFreeAsync(base_values, stream_in);
   return 0;

--- a/perception/autoware_tensorrt_plugins/src/segment_csr_plugin.cpp
+++ b/perception/autoware_tensorrt_plugins/src/segment_csr_plugin.cpp
@@ -26,7 +26,6 @@
 #include <cstdint>
 #include <exception>
 #include <string>
-#include <tuple>
 #include <vector>
 namespace nvinfer1::plugin
 {
@@ -187,24 +186,20 @@ std::int32_t SegmentCSRPlugin::enqueue(
   if (input_desc[0].type == nvinfer1::DataType::kFLOAT) {
     const float * src_ptr = reinterpret_cast<const float *>(inputs[0]);
     const std::int64_t * indptr_ptr = reinterpret_cast<const std::int64_t *>(inputs[1]);
-
-    std::tuple<float *, std::int64_t *> out =
-      std::make_tuple(static_cast<float *>(outputs[0]), nullptr);
+    float * out_ptr = static_cast<float *>(outputs[0]);
 
     AT_DISPATCH_REDUCTION_TYPES(reduce_, [&] {
-      result =
-        segment_csr_launch<float, REDUCE>(src_ptr, src_size, indptr_ptr, indptr_size, out, stream);
+      result = segment_csr_launch<float, REDUCE>(
+        src_ptr, src_size, indptr_ptr, indptr_size, out_ptr, nullptr, stream);
     });
   } else if (input_desc[0].type == nvinfer1::DataType::kHALF) {
     const half * src_ptr = reinterpret_cast<const half *>(inputs[0]);
     const std::int64_t * indptr_ptr = reinterpret_cast<const std::int64_t *>(inputs[1]);
-
-    std::tuple<half *, std::int64_t *> out =
-      std::make_tuple(static_cast<half *>(outputs[0]), nullptr);
+    half * out_ptr = static_cast<half *>(outputs[0]);
 
     AT_DISPATCH_REDUCTION_TYPES(reduce_, [&] {
-      result =
-        segment_csr_launch<half, REDUCE>(src_ptr, src_size, indptr_ptr, indptr_size, out, stream);
+      result = segment_csr_launch<half, REDUCE>(
+        src_ptr, src_size, indptr_ptr, indptr_size, out_ptr, nullptr, stream);
     });
   }
 

--- a/perception/autoware_tensorrt_plugins/src/segment_csr_plugin.cpp
+++ b/perception/autoware_tensorrt_plugins/src/segment_csr_plugin.cpp
@@ -26,7 +26,6 @@
 #include <cstdint>
 #include <exception>
 #include <string>
-#include <vector>
 namespace nvinfer1::plugin
 {
 
@@ -177,9 +176,9 @@ std::int32_t SegmentCSRPlugin::enqueue(
   void const * const * inputs, void * const * outputs, [[maybe_unused]] void * workspace,
   cudaStream_t stream) noexcept
 {
-  std::vector<int32_t> src_size{
-    static_cast<int32_t>(input_desc[0].dims.d[0]), static_cast<int32_t>(input_desc[0].dims.d[1])};
-  std::vector<int32_t> indptr_size{static_cast<int32_t>(input_desc[1].dims.d[0])};
+  const auto num_rows = static_cast<int32_t>(input_desc[0].dims.d[0]);
+  const auto num_cols = static_cast<int32_t>(input_desc[0].dims.d[1]);
+  const auto indptr_size = static_cast<int32_t>(input_desc[1].dims.d[0]);
 
   std::int32_t result = 0;
 
@@ -190,7 +189,7 @@ std::int32_t SegmentCSRPlugin::enqueue(
 
     AT_DISPATCH_REDUCTION_TYPES(reduce_, [&] {
       result = segment_csr_launch<float, REDUCE>(
-        src_ptr, src_size, indptr_ptr, indptr_size, out_ptr, nullptr, stream);
+        src_ptr, num_rows, num_cols, indptr_ptr, indptr_size, out_ptr, nullptr, stream);
     });
   } else if (input_desc[0].type == nvinfer1::DataType::kHALF) {
     const half * src_ptr = reinterpret_cast<const half *>(inputs[0]);
@@ -199,7 +198,7 @@ std::int32_t SegmentCSRPlugin::enqueue(
 
     AT_DISPATCH_REDUCTION_TYPES(reduce_, [&] {
       result = segment_csr_launch<half, REDUCE>(
-        src_ptr, src_size, indptr_ptr, indptr_size, out_ptr, nullptr, stream);
+        src_ptr, num_rows, num_cols, indptr_ptr, indptr_size, out_ptr, nullptr, stream);
     });
   }
 

--- a/perception/autoware_tensorrt_plugins/src/unique_ops/unique.cu
+++ b/perception/autoware_tensorrt_plugins/src/unique_ops/unique.cu
@@ -157,8 +157,7 @@ std::int64_t unique(
     sorted_input;
 
   cudaMemcpyAsync(
-    range_ptr + num_out * sizeof(int64_t), &num_input_elements, sizeof(std::int64_t),
-    cudaMemcpyHostToDevice, stream);
+    range_ptr + num_out, &num_input_elements, sizeof(std::int64_t), cudaMemcpyHostToDevice, stream);
 
   thrust::adjacent_difference(policy, range_ptr + 1, range_ptr + num_out + 1, unique_counts);
 

--- a/perception/autoware_tensorrt_plugins/src/unique_ops/unique.cu
+++ b/perception/autoware_tensorrt_plugins/src/unique_ops/unique.cu
@@ -97,81 +97,209 @@
 // ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE
 // POSSIBILITY OF SUCH DAMAGE.
 
+#include "autoware/tensorrt_plugins/kernel_utils.hpp"
 #include "autoware/unique_ops/unique.hpp"
 
 #include <cub/cub.cuh>
 
-#include <thrust/adjacent_difference.h>
-#include <thrust/device_ptr.h>
-#include <thrust/execution_policy.h>
-#include <thrust/scan.h>
-#include <thrust/scatter.h>
-#include <thrust/sequence.h>
-#include <thrust/sort.h>
-#include <thrust/unique.h>
+#include <algorithm>
+#include <cassert>
+#include <cstddef>
+#include <cstdint>
 
-std::int64_t unique(
-  const std::int64_t * input, std::int64_t * unique, std::int64_t * inverse_indices,
-  std::int64_t * unique_counts, void * workspace, std::size_t num_input_elements,
-  std::size_t unique_workspace_size, cudaStream_t stream)
+namespace
 {
-  auto policy = thrust::cuda::par.on(stream);
 
-  thrust::device_ptr<std::int64_t> idx_ptr(reinterpret_cast<std::int64_t *>(workspace));
+constexpr int kThreadsPerBlock = 256;
 
-  thrust::sequence(policy, idx_ptr, idx_ptr + num_input_elements + 1, 0);
+struct UniqueWorkspaceLayout
+{
+  /// Scratch storage reused by the largest CUB primitive in this implementation.
+  void * cub_temp_storage;
 
-  std::int64_t * sorted_input = unique;
-  std::int64_t * sorted_idx = thrust::raw_pointer_cast(idx_ptr) + 2 * num_input_elements + 1;
-  std::int64_t * inv_loc_ptr = thrust::raw_pointer_cast(idx_ptr) + 3 * num_input_elements + 1;
+  /// Number of bytes reserved for `cub_temp_storage`.
+  std::size_t cub_temp_storage_size;
 
-  void * sort_workspace_ptr =
-    reinterpret_cast<void *>(thrust::raw_pointer_cast(idx_ptr) + 4 * num_input_elements + 1);
+  // One int64 scratch block, then one int32 scratch block:
+  //
+  // workspace
+  // +-----------------------------+ 0
+  // | CUB temp storage            | cub_temp_storage_size bytes
+  // +-----------------------------+ align_up(cub_temp_storage_size, alignof(int64))
+  // | input_positions             | num_input_elements int64
+  // | sorted_input                | num_input_elements int64
+  // | sorted_input_positions      | num_input_elements int64
+  // | num_unique                  | 1 int32
+  // | run_ids                     | num_input_elements int32
+  // +-----------------------------+
 
-  auto sort_workspace_size =
-    unique_workspace_size - (4 * num_input_elements + 1) * sizeof(std::int64_t);
+  /// Original input positions used as values for the initial value/index sort.
+  std::int64_t * input_positions;
+
+  /// Sorted copy of the input values.
+  std::int64_t * sorted_input;
+
+  /// Original input positions ordered by `sorted_input`.
+  std::int64_t * sorted_input_positions;
+
+  /// Device scalar storing the number of unique sorted runs found by CUB.
+  std::int32_t * num_unique;
+
+  /// Per-sorted-element inclusive run ids used to scatter inverse indices.
+  std::int32_t * run_ids;
+};
+
+std::size_t query_unique_temp_storage_size(const std::size_t num_elements_in)
+{
+  std::size_t sort_temp_size = 0;
+  std::size_t scan_temp_size = 0;
+  std::size_t rle_temp_size = 0;
+
+  std::int64_t * int64_nullptr = nullptr;
+  std::int32_t * int32_nullptr = nullptr;
 
   cub::DeviceRadixSort::SortPairs(
-    sort_workspace_ptr, sort_workspace_size, input, sorted_input, thrust::raw_pointer_cast(idx_ptr),
-    sorted_idx, num_input_elements, 0, 64, stream);
+    nullptr, sort_temp_size, int64_nullptr, int64_nullptr, int64_nullptr, int64_nullptr,
+    num_elements_in, 0, 64, nullptr);
+  cub::DeviceScan::InclusiveSum(
+    nullptr, scan_temp_size, int32_nullptr, int32_nullptr, num_elements_in, nullptr);
+  cub::DeviceRunLengthEncode::Encode(
+    nullptr, rle_temp_size, int64_nullptr, int64_nullptr, int64_nullptr, int32_nullptr,
+    static_cast<int>(num_elements_in), nullptr);
 
-  auto equal = [] __device__(const std::int64_t a, const std::int64_t b) { return a == b; };
-
-  auto not_equal = [] __device__(const std::int64_t a, const std::int64_t b) { return a != b; };
-
-  thrust::adjacent_difference(
-    policy, sorted_input, sorted_input + num_input_elements, inv_loc_ptr, not_equal);
-
-  cudaMemsetAsync(inv_loc_ptr, 0, sizeof(int64_t), stream);
-
-  thrust::inclusive_scan(policy, inv_loc_ptr, inv_loc_ptr + num_input_elements, inv_loc_ptr);
-  thrust::scatter(
-    policy, inv_loc_ptr, inv_loc_ptr + num_input_elements, sorted_idx, inverse_indices);
-
-  std::int64_t num_out;
-
-  std::int64_t * range_ptr = idx_ptr.get();
-  num_out =
-    thrust::unique_by_key(policy, sorted_input, sorted_input + num_input_elements, range_ptr, equal)
-      .first -
-    sorted_input;
-
-  cudaMemcpyAsync(
-    range_ptr + num_out, &num_input_elements, sizeof(std::int64_t), cudaMemcpyHostToDevice, stream);
-
-  thrust::adjacent_difference(policy, range_ptr + 1, range_ptr + num_out + 1, unique_counts);
-
-  return num_out;
+  return std::max(sort_temp_size, std::max(scan_temp_size, rle_temp_size));
 }
 
-std::size_t get_unique_workspace_size(std::size_t num_elements)
+UniqueWorkspaceLayout make_unique_workspace_layout(
+  void * workspace_inout, const std::size_t num_input_elements_in,
+  const std::size_t cub_temp_storage_size_in)
 {
-  std::size_t temp_size = 0;
-  std::int64_t * int64_nullptr = nullptr;
+  const auto scratch_offset =
+    autoware::tensorrt_plugins::align_up(cub_temp_storage_size_in, alignof(std::int64_t));
+  auto * scratch = reinterpret_cast<char *>(workspace_inout) + scratch_offset;
 
-  cub::DeviceRadixSort::SortPairs(
-    nullptr, temp_size, int64_nullptr, int64_nullptr, int64_nullptr, int64_nullptr, num_elements, 0,
-    64, nullptr);
+  auto * input_positions = reinterpret_cast<std::int64_t *>(scratch);
+  auto * sorted_input = input_positions + num_input_elements_in;
+  auto * sorted_input_positions = sorted_input + num_input_elements_in;
+  auto * num_unique =
+    reinterpret_cast<std::int32_t *>(sorted_input_positions + num_input_elements_in);
+  auto * run_ids = reinterpret_cast<std::int32_t *>(num_unique + 1U);
 
-  return temp_size + (4 * num_elements + 1) * sizeof(std::int64_t);
+  return UniqueWorkspaceLayout{workspace_inout, cub_temp_storage_size_in, input_positions,
+                               sorted_input,    sorted_input_positions,   num_unique,
+                               run_ids};
+}
+
+__global__ void mark_run_starts(
+  const std::int64_t * sorted_input_in, std::int32_t * run_ids_out,
+  const std::size_t num_input_elements_in)
+{
+  const auto index = static_cast<std::size_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  if (index >= num_input_elements_in) {
+    return;
+  }
+
+  run_ids_out[index] =
+    (index == 0U || sorted_input_in[index] != sorted_input_in[index - 1U]) ? 1 : 0;
+}
+
+__global__ void scatter_inverse_indices(
+  const std::int64_t * sorted_idx_in, const std::int32_t * run_ids_in,
+  std::int64_t * inverse_indices_out, const std::size_t num_input_elements_in)
+{
+  const auto index = static_cast<std::size_t>(blockIdx.x) * blockDim.x + threadIdx.x;
+  if (index >= num_input_elements_in) {
+    return;
+  }
+
+  // Inclusive scan produces 1-based run ids; inverse indices use 0-based unique-value indices.
+  inverse_indices_out[sorted_idx_in[index]] = static_cast<std::int64_t>(run_ids_in[index] - 1);
+}
+
+__global__ void write_num_unique_elements(
+  const std::int32_t * num_unique_in, std::int64_t * num_unique_elements_out)
+{
+  *num_unique_elements_out = static_cast<std::int64_t>(*num_unique_in);
+}
+
+}  // namespace
+
+cudaError_t unique(
+  const std::int64_t * input_in, std::int64_t * unique_values_out,
+  std::int64_t * inverse_indices_out, std::int64_t * unique_counts_out,
+  std::int64_t * num_unique_elements_out, void * workspace_inout, std::size_t num_input_elements_in,
+  [[maybe_unused]] std::size_t workspace_size_in, cudaStream_t stream_in)
+{
+  if (num_input_elements_in == 0U) {
+    return cudaMemsetAsync(num_unique_elements_out, 0, sizeof(std::int64_t), stream_in);
+  }
+
+  assert(workspace_size_in >= get_unique_workspace_size(num_input_elements_in));
+
+  const auto cub_temp_storage_size = get_unique_temp_storage_size(num_input_elements_in);
+  auto layout =
+    make_unique_workspace_layout(workspace_inout, num_input_elements_in, cub_temp_storage_size);
+
+  const auto num_blocks =
+    static_cast<unsigned int>((num_input_elements_in + kThreadsPerBlock - 1U) / kThreadsPerBlock);
+
+  // 1. Sort values while carrying their original input positions.
+  autoware::tensorrt_plugins::fill_iota<<<num_blocks, kThreadsPerBlock, 0, stream_in>>>(
+    layout.input_positions, num_input_elements_in);
+  if (const auto status = cudaPeekAtLastError(); status != cudaSuccess) {
+    return status;
+  }
+  if (const auto status = cub::DeviceRadixSort::SortPairs(
+        layout.cub_temp_storage, layout.cub_temp_storage_size, input_in, layout.sorted_input,
+        layout.input_positions, layout.sorted_input_positions, num_input_elements_in, 0, 64,
+        stream_in);
+      status != cudaSuccess) {
+    return status;
+  }
+
+  // 2. Convert sorted run starts into sorted-position -> unique-index ids.
+  mark_run_starts<<<num_blocks, kThreadsPerBlock, 0, stream_in>>>(
+    layout.sorted_input, layout.run_ids, num_input_elements_in);
+  if (const auto status = cudaPeekAtLastError(); status != cudaSuccess) {
+    return status;
+  }
+  if (const auto status = cub::DeviceScan::InclusiveSum(
+        layout.cub_temp_storage, layout.cub_temp_storage_size, layout.run_ids, layout.run_ids,
+        num_input_elements_in, stream_in);
+      status != cudaSuccess) {
+    return status;
+  }
+
+  // 3. Scatter unique ids back to original input order.
+  scatter_inverse_indices<<<num_blocks, kThreadsPerBlock, 0, stream_in>>>(
+    layout.sorted_input_positions, layout.run_ids, inverse_indices_out, num_input_elements_in);
+  if (const auto status = cudaPeekAtLastError(); status != cudaSuccess) {
+    return status;
+  }
+
+  // 4. Compact sorted runs into unique values and occurrence counts.
+  if (const auto status = cub::DeviceRunLengthEncode::Encode(
+        layout.cub_temp_storage, layout.cub_temp_storage_size, layout.sorted_input,
+        unique_values_out, unique_counts_out, layout.num_unique,
+        static_cast<int>(num_input_elements_in), stream_in);
+      status != cudaSuccess) {
+    return status;
+  }
+
+  write_num_unique_elements<<<1, 1, 0, stream_in>>>(layout.num_unique, num_unique_elements_out);
+  return cudaPeekAtLastError();
+}
+
+std::size_t get_unique_temp_storage_size(std::size_t num_elements_in)
+{
+  return query_unique_temp_storage_size(num_elements_in);
+}
+
+std::size_t get_unique_workspace_size(std::size_t num_elements_in)
+{
+  const auto temp_size = query_unique_temp_storage_size(num_elements_in);
+  const auto scratch_offset =
+    autoware::tensorrt_plugins::align_up(temp_size, alignof(std::int64_t));
+  return scratch_offset + (3 * num_elements_in) * sizeof(std::int64_t) +
+         (num_elements_in + 1U) * sizeof(std::int32_t);
 }

--- a/perception/autoware_tensorrt_plugins/src/unique_plugin.cpp
+++ b/perception/autoware_tensorrt_plugins/src/unique_plugin.cpp
@@ -164,17 +164,16 @@ std::int32_t UniquePlugin::enqueue(
   cudaStream_t stream) noexcept
 {
   std::int64_t num_elements = input_desc[0].dims.d[0];
+  const auto workspace_size = get_unique_workspace_size(static_cast<std::size_t>(num_elements));
 
-  std::int64_t num_unique_elements = unique(
-    reinterpret_cast<const std::int64_t *>(inputs[0]), reinterpret_cast<std::int64_t *>(outputs[0]),
-    reinterpret_cast<std::int64_t *>(outputs[1]), reinterpret_cast<std::int64_t *>(outputs[2]),
-    workspace, num_elements, workspace_size_, stream);
-
-  cudaMemcpyAsync(
-    reinterpret_cast<std::int64_t *>(outputs[3]), &num_unique_elements, sizeof(std::int64_t),
-    cudaMemcpyHostToDevice, stream);
-
-  cudaStreamSynchronize(stream);
+  if (const auto status = PLUGIN_CUDA_CHECK(unique(
+        reinterpret_cast<const std::int64_t *>(inputs[0]),
+        reinterpret_cast<std::int64_t *>(outputs[0]), reinterpret_cast<std::int64_t *>(outputs[1]),
+        reinterpret_cast<std::int64_t *>(outputs[2]), reinterpret_cast<std::int64_t *>(outputs[3]),
+        workspace, num_elements, workspace_size, stream));
+      status != cudaSuccess) {
+    return -1;
+  }
 
   return 0;
 }

--- a/perception/autoware_tensorrt_plugins/test/argsort_kernel_test.cpp
+++ b/perception/autoware_tensorrt_plugins/test/argsort_kernel_test.cpp
@@ -1,0 +1,82 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/argsort_ops/argsort.hpp"
+#include "test_utils.hpp"
+
+#include <autoware/cuda_utils/cuda_gtest_utils.hpp>
+
+#include <cuda_runtime_api.h>
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <vector>
+
+namespace
+{
+
+using autoware::tensorrt_plugins::test::copy_to_device;
+using autoware::tensorrt_plugins::test::copy_to_host;
+using autoware::tensorrt_plugins::test::CudaStreamGuard;
+using autoware::tensorrt_plugins::test::DeviceBuffer;
+
+std::size_t get_argsort_total_workspace_size(const std::size_t num_elements)
+{
+  const auto temp_size = get_argsort_workspace_size(num_elements);
+  const auto scratch_offset =
+    ((temp_size + alignof(std::int64_t) - 1U) / alignof(std::int64_t)) * alignof(std::int64_t);
+  return scratch_offset + sizeof(std::int64_t) * 2U * num_elements;
+}
+
+std::vector<std::int64_t> make_argsort_reference(const std::vector<std::int64_t> & input)
+{
+  std::vector<std::int64_t> indices(input.size());
+  for (std::size_t index = 0; index < input.size(); ++index) {
+    indices[index] = static_cast<std::int64_t>(index);
+  }
+
+  std::stable_sort(
+    indices.begin(), indices.end(),
+    [&input](const std::int64_t lhs, const std::int64_t rhs) { return input[lhs] < input[rhs]; });
+
+  return indices;
+}
+
+TEST(ReferenceKernelsTest, ArgsortMatchesCpuReference)
+{
+  SKIP_TEST_IF_CUDA_UNAVAILABLE();
+
+  const std::vector<std::int64_t> input{7, 3, 7, 5, 3, 3, 9, 5, 11, 7};
+  const auto reference = make_argsort_reference(input);
+
+  CudaStreamGuard stream;
+  DeviceBuffer<std::int64_t> input_d(input.size());
+  DeviceBuffer<std::int64_t> output_d(input.size());
+  DeviceBuffer<std::uint8_t> workspace_d(get_argsort_total_workspace_size(input.size()));
+
+  copy_to_device(input_d.get(), input);
+
+  ASSERT_EQ(
+    argsort(
+      input_d.get(), output_d.get(), workspace_d.get(), input.size(),
+      get_argsort_workspace_size(input.size()), stream.get()),
+    cudaSuccess);
+  ASSERT_EQ(cudaStreamSynchronize(stream.get()), cudaSuccess);
+
+  EXPECT_EQ(copy_to_host(output_d.get(), input.size()), reference);
+}
+
+}  // namespace

--- a/perception/autoware_tensorrt_plugins/test/segment_csr_kernel_test.cpp
+++ b/perception/autoware_tensorrt_plugins/test/segment_csr_kernel_test.cpp
@@ -1,0 +1,189 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/scatter_ops/segment_csr.h"
+#include "test_utils.hpp"
+
+#include <autoware/cuda_utils/cuda_gtest_utils.hpp>
+
+#include <cuda_runtime_api.h>
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <limits>
+#include <string>
+#include <tuple>
+#include <vector>
+
+namespace
+{
+
+using autoware::tensorrt_plugins::test::copy_to_device;
+using autoware::tensorrt_plugins::test::copy_to_host;
+using autoware::tensorrt_plugins::test::CudaStreamGuard;
+using autoware::tensorrt_plugins::test::DeviceBuffer;
+
+struct SegmentCsrCase
+{
+  std::string name;
+  std::size_t rows;
+  std::size_t cols;
+  std::vector<float> src;
+  std::vector<std::int64_t> indptr;
+};
+
+std::vector<float> make_segment_reference_mean(
+  const std::vector<float> & src, const std::size_t rows, const std::size_t cols,
+  const std::vector<std::int64_t> & indptr)
+{
+  std::vector<float> out((indptr.size() - 1U) * cols, 0.0F);
+  for (std::size_t segment = 0; segment + 1U < indptr.size(); ++segment) {
+    const auto start = static_cast<std::size_t>(indptr[segment]);
+    const auto end = static_cast<std::size_t>(indptr[segment + 1U]);
+    const auto count = std::max<std::size_t>(end - start, 1U);
+    for (std::size_t col = 0; col < cols; ++col) {
+      float accum = 0.0F;
+      for (std::size_t row = start; row < end; ++row) {
+        accum += src[row * cols + col];
+      }
+      out[segment * cols + col] = accum / static_cast<float>(count);
+    }
+  }
+  (void)rows;
+  return out;
+}
+
+std::vector<float> make_segment_reference_max(
+  const std::vector<float> & src, const std::size_t rows, const std::size_t cols,
+  const std::vector<std::int64_t> & indptr)
+{
+  std::vector<float> out((indptr.size() - 1U) * cols, 0.0F);
+  for (std::size_t segment = 0; segment + 1U < indptr.size(); ++segment) {
+    const auto start = static_cast<std::size_t>(indptr[segment]);
+    const auto end = static_cast<std::size_t>(indptr[segment + 1U]);
+    for (std::size_t col = 0; col < cols; ++col) {
+      float best = 0.0F;
+      if (start < end) {
+        best = -std::numeric_limits<float>::infinity();
+        for (std::size_t row = start; row < end; ++row) {
+          best = std::max(best, src[row * cols + col]);
+        }
+      }
+      out[segment * cols + col] = best;
+    }
+  }
+  (void)rows;
+  return out;
+}
+
+void expect_float_vectors_equal(
+  const std::vector<float> & actual, const std::vector<float> & expected)
+{
+  ASSERT_EQ(actual.size(), expected.size());
+  for (std::size_t index = 0; index < actual.size(); ++index) {
+    EXPECT_FLOAT_EQ(actual[index], expected[index]) << "index=" << index;
+  }
+}
+
+template <ReductionType REDUCE>
+void run_segment_csr_case(const SegmentCsrCase & test_case, const std::vector<float> & reference)
+{
+  SKIP_TEST_IF_CUDA_UNAVAILABLE();
+
+  CudaStreamGuard stream;
+  DeviceBuffer<float> src_d(std::max<std::size_t>(test_case.src.size(), 1U));
+  DeviceBuffer<std::int64_t> indptr_d(test_case.indptr.size());
+  DeviceBuffer<float> out_d(std::max<std::size_t>(reference.size(), 1U));
+  const std::vector<std::int32_t> src_size{
+    static_cast<std::int32_t>(test_case.rows), static_cast<std::int32_t>(test_case.cols)};
+  const std::vector<std::int32_t> indptr_size{static_cast<std::int32_t>(test_case.indptr.size())};
+
+  if (!test_case.src.empty()) {
+    copy_to_device(src_d.get(), test_case.src);
+  }
+  copy_to_device(indptr_d.get(), test_case.indptr);
+
+  ASSERT_EQ(
+    (segment_csr_launch<float, REDUCE>(
+      src_d.get(), src_size, indptr_d.get(), indptr_size,
+      std::make_tuple(out_d.get(), static_cast<std::int64_t *>(nullptr)), stream.get())),
+    0);
+  ASSERT_EQ(cudaStreamSynchronize(stream.get()), cudaSuccess);
+
+  if (!reference.empty()) {
+    expect_float_vectors_equal(copy_to_host(out_d.get(), reference.size()), reference);
+  }
+}
+
+class SegmentCsrTest : public ::testing::TestWithParam<SegmentCsrCase>
+{
+};
+
+TEST_P(SegmentCsrTest, MeanMatchesCpuReference)
+{
+  const auto & test_case = GetParam();
+  const auto reference =
+    make_segment_reference_mean(test_case.src, test_case.rows, test_case.cols, test_case.indptr);
+  run_segment_csr_case<MEAN>(test_case, reference);
+}
+
+TEST_P(SegmentCsrTest, MaxMatchesCpuReference)
+{
+  const auto & test_case = GetParam();
+  const auto reference =
+    make_segment_reference_max(test_case.src, test_case.rows, test_case.cols, test_case.indptr);
+  run_segment_csr_case<MAX>(test_case, reference);
+}
+
+std::string segment_csr_case_name(const testing::TestParamInfo<SegmentCsrCase> & info)
+{
+  return info.param.name;
+}
+
+INSTANTIATE_TEST_SUITE_P(
+  ReferenceKernelsTest, SegmentCsrTest,
+  testing::Values(
+    SegmentCsrCase{
+      "NonEmptySegments",
+      6U,
+      2U,
+      {1.0F, 2.0F, 3.0F, 4.0F, 5.0F, 6.0F, 7.0F, 8.0F, 9.0F, 10.0F, 11.0F, 12.0F},
+      {0, 2, 5, 6}},
+    SegmentCsrCase{
+      "EmptyMiddleSegment",
+      6U,
+      2U,
+      {1.0F, 2.0F, 3.0F, 4.0F, 5.0F, 6.0F, 7.0F, 8.0F, 9.0F, 10.0F, 11.0F, 12.0F},
+      {0, 2, 2, 5, 6}},
+    SegmentCsrCase{
+      "EmptyBoundarySegments",
+      6U,
+      2U,
+      {1.0F, 2.0F, 3.0F, 4.0F, 5.0F, 6.0F, 7.0F, 8.0F, 9.0F, 10.0F, 11.0F, 12.0F},
+      {0, 0, 3, 6, 6}},
+    SegmentCsrCase{
+      "NoSegmentsWithRows",
+      6U,
+      2U,
+      {1.0F, 2.0F, 3.0F, 4.0F, 5.0F, 6.0F, 7.0F, 8.0F, 9.0F, 10.0F, 11.0F, 12.0F},
+      {0}},
+    SegmentCsrCase{"EmptyInputNoSegments", 0U, 2U, {}, {0}},
+    SegmentCsrCase{"EmptyInputEmptySegments", 0U, 2U, {}, {0, 0, 0}},
+    SegmentCsrCase{"ZeroColumns", 3U, 0U, {}, {0, 1, 3}}),
+  segment_csr_case_name);
+
+}  // namespace

--- a/perception/autoware_tensorrt_plugins/test/segment_csr_kernel_test.cpp
+++ b/perception/autoware_tensorrt_plugins/test/segment_csr_kernel_test.cpp
@@ -26,7 +26,6 @@
 #include <cstdint>
 #include <limits>
 #include <string>
-#include <tuple>
 #include <vector>
 
 namespace
@@ -119,8 +118,8 @@ void run_segment_csr_case(const SegmentCsrCase & test_case, const std::vector<fl
 
   ASSERT_EQ(
     (segment_csr_launch<float, REDUCE>(
-      src_d.get(), src_size, indptr_d.get(), indptr_size,
-      std::make_tuple(out_d.get(), static_cast<std::int64_t *>(nullptr)), stream.get())),
+      src_d.get(), src_size, indptr_d.get(), indptr_size, out_d.get(),
+      static_cast<std::int64_t *>(nullptr), stream.get())),
     0);
   ASSERT_EQ(cudaStreamSynchronize(stream.get()), cudaSuccess);
 

--- a/perception/autoware_tensorrt_plugins/test/segment_csr_kernel_test.cpp
+++ b/perception/autoware_tensorrt_plugins/test/segment_csr_kernel_test.cpp
@@ -107,9 +107,6 @@ void run_segment_csr_case(const SegmentCsrCase & test_case, const std::vector<fl
   DeviceBuffer<float> src_d(std::max<std::size_t>(test_case.src.size(), 1U));
   DeviceBuffer<std::int64_t> indptr_d(test_case.indptr.size());
   DeviceBuffer<float> out_d(std::max<std::size_t>(reference.size(), 1U));
-  const std::vector<std::int32_t> src_size{
-    static_cast<std::int32_t>(test_case.rows), static_cast<std::int32_t>(test_case.cols)};
-  const std::vector<std::int32_t> indptr_size{static_cast<std::int32_t>(test_case.indptr.size())};
 
   if (!test_case.src.empty()) {
     copy_to_device(src_d.get(), test_case.src);
@@ -118,7 +115,9 @@ void run_segment_csr_case(const SegmentCsrCase & test_case, const std::vector<fl
 
   ASSERT_EQ(
     (segment_csr_launch<float, REDUCE>(
-      src_d.get(), src_size, indptr_d.get(), indptr_size, out_d.get(),
+      src_d.get(), static_cast<std::int32_t>(test_case.rows),
+      static_cast<std::int32_t>(test_case.cols), indptr_d.get(),
+      static_cast<std::int32_t>(test_case.indptr.size()), out_d.get(),
       static_cast<std::int64_t *>(nullptr), stream.get())),
     0);
   ASSERT_EQ(cudaStreamSynchronize(stream.get()), cudaSuccess);
@@ -146,6 +145,47 @@ TEST_P(SegmentCsrTest, MaxMatchesCpuReference)
   const auto reference =
     make_segment_reference_max(test_case.src, test_case.rows, test_case.cols, test_case.indptr);
   run_segment_csr_case<MAX>(test_case, reference);
+}
+
+TEST(SegmentCsrZeroOutputTest, MaxWithArgIndicesAcceptsZeroOutputShape)
+{
+  SKIP_TEST_IF_CUDA_UNAVAILABLE();
+
+  const std::vector<SegmentCsrCase> test_cases{
+    SegmentCsrCase{
+      "NoSegmentsWithRows",
+      6U,
+      2U,
+      {1.0F, 2.0F, 3.0F, 4.0F, 5.0F, 6.0F, 7.0F, 8.0F, 9.0F, 10.0F, 11.0F, 12.0F},
+      {0}},
+    SegmentCsrCase{"ZeroColumns", 3U, 0U, {}, {0, 1, 3}},
+    SegmentCsrCase{"EmptyIndptr", 0U, 2U, {}, {}}};
+
+  for (const auto & test_case : test_cases) {
+    SCOPED_TRACE(test_case.name);
+
+    CudaStreamGuard stream;
+    DeviceBuffer<float> src_d(std::max<std::size_t>(test_case.src.size(), 1U));
+    DeviceBuffer<std::int64_t> indptr_d(std::max<std::size_t>(test_case.indptr.size(), 1U));
+    DeviceBuffer<float> out_d(1U);
+    DeviceBuffer<std::int64_t> arg_indices_d(1U);
+
+    if (!test_case.src.empty()) {
+      copy_to_device(src_d.get(), test_case.src);
+    }
+    if (!test_case.indptr.empty()) {
+      copy_to_device(indptr_d.get(), test_case.indptr);
+    }
+
+    ASSERT_EQ(
+      (segment_csr_launch<float, MAX>(
+        src_d.get(), static_cast<std::int32_t>(test_case.rows),
+        static_cast<std::int32_t>(test_case.cols), indptr_d.get(),
+        static_cast<std::int32_t>(test_case.indptr.size()), out_d.get(), arg_indices_d.get(),
+        stream.get())),
+      0);
+    ASSERT_EQ(cudaStreamSynchronize(stream.get()), cudaSuccess);
+  }
 }
 
 std::string segment_csr_case_name(const testing::TestParamInfo<SegmentCsrCase> & info)

--- a/perception/autoware_tensorrt_plugins/test/test_utils.hpp
+++ b/perception/autoware_tensorrt_plugins/test/test_utils.hpp
@@ -1,0 +1,109 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#pragma once
+
+#include <cuda_runtime_api.h>
+#include <gtest/gtest.h>
+
+#include <cstddef>
+#include <stdexcept>
+#include <vector>
+
+namespace autoware::tensorrt_plugins::test
+{
+
+class CudaStreamGuard
+{
+public:
+  CudaStreamGuard()
+  {
+    const cudaError_t status = cudaStreamCreate(&stream_);
+    if (status != cudaSuccess) {
+      throw std::runtime_error(cudaGetErrorString(status));
+    }
+  }
+
+  ~CudaStreamGuard()
+  {
+    if (stream_ != nullptr) {
+      cudaStreamDestroy(stream_);
+    }
+  }
+
+  CudaStreamGuard(const CudaStreamGuard &) = delete;
+  CudaStreamGuard & operator=(const CudaStreamGuard &) = delete;
+  CudaStreamGuard(CudaStreamGuard &&) = delete;
+  CudaStreamGuard & operator=(CudaStreamGuard &&) = delete;
+
+  [[nodiscard]] cudaStream_t get() const { return stream_; }
+
+private:
+  cudaStream_t stream_{nullptr};
+};
+
+template <typename T>
+class DeviceBuffer
+{
+public:
+  explicit DeviceBuffer(std::size_t element_count) : element_count_(element_count)
+  {
+    const cudaError_t status = cudaMalloc(&data_, sizeof(T) * element_count_);
+    if (status != cudaSuccess) {
+      throw std::runtime_error(cudaGetErrorString(status));
+    }
+  }
+
+  ~DeviceBuffer()
+  {
+    if (data_ != nullptr) {
+      cudaFree(data_);
+    }
+  }
+
+  DeviceBuffer(const DeviceBuffer &) = delete;
+  DeviceBuffer & operator=(const DeviceBuffer &) = delete;
+  DeviceBuffer(DeviceBuffer &&) = delete;
+  DeviceBuffer & operator=(DeviceBuffer &&) = delete;
+
+  [[nodiscard]] T * get() const { return static_cast<T *>(data_); }
+
+private:
+  void * data_{nullptr};
+  std::size_t element_count_{0U};
+};
+
+template <typename T>
+void copy_to_device(T * device_ptr, const std::vector<T> & host_values)
+{
+  const cudaError_t status = cudaMemcpy(
+    device_ptr, host_values.data(), sizeof(T) * host_values.size(), cudaMemcpyHostToDevice);
+  if (status != cudaSuccess) {
+    throw std::runtime_error(cudaGetErrorString(status));
+  }
+}
+
+template <typename T>
+std::vector<T> copy_to_host(const T * device_ptr, const std::size_t element_count)
+{
+  std::vector<T> host_values(element_count);
+  const cudaError_t status =
+    cudaMemcpy(host_values.data(), device_ptr, sizeof(T) * element_count, cudaMemcpyDeviceToHost);
+  if (status != cudaSuccess) {
+    throw std::runtime_error(cudaGetErrorString(status));
+  }
+  return host_values;
+}
+
+}  // namespace autoware::tensorrt_plugins::test

--- a/perception/autoware_tensorrt_plugins/test/unique_kernel_test.cpp
+++ b/perception/autoware_tensorrt_plugins/test/unique_kernel_test.cpp
@@ -78,14 +78,19 @@ TEST(ReferenceKernelsTest, UniqueMatchesCpuReference)
   DeviceBuffer<std::int64_t> unique_d(input.size());
   DeviceBuffer<std::int64_t> inverse_d(input.size());
   DeviceBuffer<std::int64_t> counts_d(input.size());
+  DeviceBuffer<std::int64_t> num_unique_d(1U);
   DeviceBuffer<std::uint8_t> workspace_d(get_unique_workspace_size(input.size()));
 
   copy_to_device(input_d.get(), input);
 
-  const auto num_unique = unique(
-    input_d.get(), unique_d.get(), inverse_d.get(), counts_d.get(), workspace_d.get(), input.size(),
-    get_unique_workspace_size(input.size()), stream.get());
+  ASSERT_EQ(
+    unique(
+      input_d.get(), unique_d.get(), inverse_d.get(), counts_d.get(), num_unique_d.get(),
+      workspace_d.get(), input.size(), get_unique_workspace_size(input.size()), stream.get()),
+    cudaSuccess);
   ASSERT_EQ(cudaStreamSynchronize(stream.get()), cudaSuccess);
+
+  const auto num_unique = copy_to_host(num_unique_d.get(), 1U).front();
 
   const auto unique_values = copy_to_host(unique_d.get(), static_cast<std::size_t>(num_unique));
   const auto inverse_indices = copy_to_host(inverse_d.get(), input.size());
@@ -94,6 +99,28 @@ TEST(ReferenceKernelsTest, UniqueMatchesCpuReference)
   EXPECT_EQ(unique_values, reference.unique_values);
   EXPECT_EQ(inverse_indices, reference.inverse_indices);
   EXPECT_EQ(counts, reference.counts);
+}
+
+TEST(ReferenceKernelsTest, UniqueEmptyInputWritesZeroCount)
+{
+  SKIP_TEST_IF_CUDA_UNAVAILABLE();
+
+  CudaStreamGuard stream;
+  DeviceBuffer<std::int64_t> input_d(1U);
+  DeviceBuffer<std::int64_t> unique_d(1U);
+  DeviceBuffer<std::int64_t> inverse_d(1U);
+  DeviceBuffer<std::int64_t> counts_d(1U);
+  DeviceBuffer<std::int64_t> num_unique_d(1U);
+  DeviceBuffer<std::uint8_t> workspace_d(1U);
+
+  ASSERT_EQ(
+    unique(
+      input_d.get(), unique_d.get(), inverse_d.get(), counts_d.get(), num_unique_d.get(),
+      workspace_d.get(), 0U, 0U, stream.get()),
+    cudaSuccess);
+  ASSERT_EQ(cudaStreamSynchronize(stream.get()), cudaSuccess);
+
+  EXPECT_EQ(copy_to_host(num_unique_d.get(), 1U).front(), 0);
 }
 
 }  // namespace

--- a/perception/autoware_tensorrt_plugins/test/unique_kernel_test.cpp
+++ b/perception/autoware_tensorrt_plugins/test/unique_kernel_test.cpp
@@ -1,0 +1,99 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/unique_ops/unique.hpp"
+#include "test_utils.hpp"
+
+#include <autoware/cuda_utils/cuda_gtest_utils.hpp>
+
+#include <cuda_runtime_api.h>
+#include <gtest/gtest.h>
+
+#include <algorithm>
+#include <cstddef>
+#include <cstdint>
+#include <map>
+#include <vector>
+
+namespace
+{
+
+using autoware::tensorrt_plugins::test::copy_to_device;
+using autoware::tensorrt_plugins::test::copy_to_host;
+using autoware::tensorrt_plugins::test::CudaStreamGuard;
+using autoware::tensorrt_plugins::test::DeviceBuffer;
+
+struct UniqueReference
+{
+  std::vector<std::int64_t> unique_values;
+  std::vector<std::int64_t> inverse_indices;
+  std::vector<std::int64_t> counts;
+};
+
+UniqueReference make_unique_reference(const std::vector<std::int64_t> & input)
+{
+  UniqueReference reference;
+  reference.unique_values = input;
+  std::sort(reference.unique_values.begin(), reference.unique_values.end());
+  reference.unique_values.erase(
+    std::unique(reference.unique_values.begin(), reference.unique_values.end()),
+    reference.unique_values.end());
+
+  std::map<std::int64_t, std::int64_t> value_to_index;
+  for (std::size_t index = 0; index < reference.unique_values.size(); ++index) {
+    value_to_index.emplace(reference.unique_values[index], static_cast<std::int64_t>(index));
+  }
+  reference.counts.resize(reference.unique_values.size(), 0);
+
+  reference.inverse_indices.reserve(input.size());
+  for (const auto value : input) {
+    const auto index = value_to_index.at(value);
+    reference.inverse_indices.push_back(index);
+    reference.counts[static_cast<std::size_t>(index)] += 1;
+  }
+
+  return reference;
+}
+
+TEST(ReferenceKernelsTest, UniqueMatchesCpuReference)
+{
+  SKIP_TEST_IF_CUDA_UNAVAILABLE();
+
+  const std::vector<std::int64_t> input{7, 3, 7, 5, 3, 3, 9, 5, 11, 7};
+  const UniqueReference reference = make_unique_reference(input);
+
+  CudaStreamGuard stream;
+  DeviceBuffer<std::int64_t> input_d(input.size());
+  DeviceBuffer<std::int64_t> unique_d(input.size());
+  DeviceBuffer<std::int64_t> inverse_d(input.size());
+  DeviceBuffer<std::int64_t> counts_d(input.size());
+  DeviceBuffer<std::uint8_t> workspace_d(get_unique_workspace_size(input.size()));
+
+  copy_to_device(input_d.get(), input);
+
+  const auto num_unique = unique(
+    input_d.get(), unique_d.get(), inverse_d.get(), counts_d.get(), workspace_d.get(), input.size(),
+    get_unique_workspace_size(input.size()), stream.get());
+  ASSERT_EQ(cudaStreamSynchronize(stream.get()), cudaSuccess);
+
+  const auto unique_values = copy_to_host(unique_d.get(), static_cast<std::size_t>(num_unique));
+  const auto inverse_indices = copy_to_host(inverse_d.get(), input.size());
+  const auto counts = copy_to_host(counts_d.get(), static_cast<std::size_t>(num_unique));
+
+  EXPECT_EQ(unique_values, reference.unique_values);
+  EXPECT_EQ(inverse_indices, reference.inverse_indices);
+  EXPECT_EQ(counts, reference.counts);
+}
+
+}  // namespace


### PR DESCRIPTION
## Summary

Sync `perception/autoware_tensorrt_plugins` from tier4 `feat/v0.64/e2e` (v0.50.0) to the latest [autowarefoundation/autoware_universe `main`](https://github.com/autowarefoundation/autoware_universe/tree/main/perception/autoware_tensorrt_plugins) (v0.52.0).

**Only** `perception/autoware_tensorrt_plugins/` is modified (26 files, +1494/-347 lines). Verified zero diff vs upstream after applying all patches.

### Functional changes

- **Inference correctness:** CustomUnique count offset fix, ImplicitGemm kBUILD/kRUNTIME deserialization fix, SegmentCSR edge-case guards
- **Performance:** Thrust removal from sort kernels, optional `do_sort` attribute, allocation-free SegmentCSR, CUDA-graph-safe workspace layout (no `tv::zeros`/`tv::empty` in enqueue)
- **Capability:** Fused bias/activation in ImplicitGemmPlugin (backward-compatible: 5 or 6 ONNX inputs)
- **Quality:** New gtest reference-kernel coverage for argsort, unique, SegmentCSR

### Cherry-picked AWF PRs (14 commits)

| AWF PR | Theme | Summary |
|--------|-------|---------|
| [#12378](https://github.com/autowarefoundation/autoware_universe/pull/12378) | CUDA-graph safety | Replace `tv::zeros`/`tv::empty` with workspace-carved blobs |
| [#12534](https://github.com/autowarefoundation/autoware_universe/pull/12534) | Version | Bump to 0.51.0 (package files only) |
| [#12502](https://github.com/autowarefoundation/autoware_universe/pull/12502) | Unique fix | Correct CustomUnique count offset |
| [#12561](https://github.com/autowarefoundation/autoware_universe/pull/12561) | Tests | Add argsort/unique reference kernel tests |
| [#12631](https://github.com/autowarefoundation/autoware_universe/pull/12631) | Inference | Add `do_sort` attribute to GetIndicePairsImplicitGemmPlugin |
| [#12554](https://github.com/autowarefoundation/autoware_universe/pull/12554) | Performance | Remove Thrust from sort kernels; add `kernel_utils.hpp` |
| [#12740](https://github.com/autowarefoundation/autoware_universe/pull/12740) | Tests | Add SegmentCSR kernel tests |
| [#12755](https://github.com/autowarefoundation/autoware_universe/pull/12755) | Metadata | Add maintainers |
| [#12741](https://github.com/autowarefoundation/autoware_universe/pull/12741) | SegmentCSR | Clarify 2D-source / 1D-indptr contract |
| [#12734](https://github.com/autowarefoundation/autoware_universe/pull/12734) | ImplicitGemm | Fix build/runtime deserialization |
| [#12739](https://github.com/autowarefoundation/autoware_universe/pull/12739) | SegmentCSR | Remove unused nD indptr path |
| [#12658](https://github.com/autowarefoundation/autoware_universe/pull/12658) | ImplicitGemm | Fused bias/activation support |
| [#12555](https://github.com/autowarefoundation/autoware_universe/pull/12555) | Performance | Allocation-free SegmentCSR output init |
| [#12888](https://github.com/autowarefoundation/autoware_universe/pull/12888) | Version | Bump to 0.52.0 (package files only) |

### Skipped AWF PRs (already in tier4)

| AWF PR | Tier4 equivalent | Reason |
|--------|------------------|--------|
| [#12191](https://github.com/autowarefoundation/autoware_universe/pull/12191) CUDA 12.0 build | [tier4#2707](https://github.com/tier4/autoware_universe/pull/2707) | CMakeLists nvcc gating already matches upstream |
| [#12211](https://github.com/autowarefoundation/autoware_universe/pull/12211) Turing `sm_75` | [tier4#2733](https://github.com/tier4/autoware_universe/pull/2733) | `compute_75` already present |
| [#12201](https://github.com/autowarefoundation/autoware_universe/pull/12201) emplace perf | [tier4#3023](https://github.com/tier4/autoware_universe/pull/3023) | `get_indices_pairs*.cpp` already use `emplace` |

### Downstream impact

No downstream package code changes required. Consumers (`autoware_bevfusion`, `autoware_ptv3`, `autoware_tensorrt_vad`, `autoware_diffusion_planner`) only declare `exec_depend`/`depend` on this package.

## Test plan

- [x] `pre-commit run --files perception/autoware_tensorrt_plugins/**/*` — passed
- [x] `colcon build --packages-select autoware_tensorrt_plugins` — passed
- [x] `colcon test --packages-select autoware_tensorrt_plugins` — passed
- [x] `git diff autowarefoundation/main -- perception/autoware_tensorrt_plugins/` — zero diff (matches upstream exactly)


Made with [Cursor](https://cursor.com)