### PR TITLE
fix(planning_validator): skip check for degenerate trajectory

### DIFF
--- a/planning/planning_validator/autoware_planning_validator_trajectory_checker/src/trajectory_checker.cpp
+++ b/planning/planning_validator/autoware_planning_validator_trajectory_checker/src/trajectory_checker.cpp
@@ -520,14 +520,15 @@ bool TrajectoryChecker::check_valid_longitudinal_distance_deviation()
 
   // Check if the valid longitudinal deviation for given segment index
   const auto has_valid_lon_deviation = [&](const size_t seg_idx, const bool is_last) {
-    auto long_offset = autoware::motion_utils::calcLongitudinalOffsetToSegment(
-      trajectory.points, seg_idx, ego_pose.position);
-
-    // Skip the check for degenerate (collapsed) trajectory where the offset is undefined (NaN).
-    if (std::isnan(long_offset)) {
+    // Skip when removeOverlapPoints leaves no segment (calcLongitudinalOffsetToSegment would return NaN).
+    const auto dedup_points = autoware::motion_utils::removeOverlapPoints(trajectory.points, seg_idx);
+    if (dedup_points.size() < seg_idx + 2) {
       status->longitudinal_distance_deviation = 0.0;
       return true;
     }
+
+    auto long_offset = autoware::motion_utils::calcLongitudinalOffsetToSegment(
+      trajectory.points, seg_idx, ego_pose.position);
 
     // for last, need to remove distance for the last segment.
     if (is_last) {

--- a/planning/planning_validator/autoware_planning_validator_trajectory_checker/src/trajectory_checker.cpp
+++ b/planning/planning_validator/autoware_planning_validator_trajectory_checker/src/trajectory_checker.cpp
@@ -25,6 +25,7 @@
 
 #include <angles/angles/angles.h>
 
+#include <cmath>
 #include <memory>
 #include <string>
 
@@ -521,6 +522,12 @@ bool TrajectoryChecker::check_valid_longitudinal_distance_deviation()
   const auto has_valid_lon_deviation = [&](const size_t seg_idx, const bool is_last) {
     auto long_offset = autoware::motion_utils::calcLongitudinalOffsetToSegment(
       trajectory.points, seg_idx, ego_pose.position);
+
+    // Skip the check for degenerate (collapsed) trajectory where the offset is undefined (NaN).
+    if (std::isnan(long_offset)) {
+      status->longitudinal_distance_deviation = 0.0;
+      return true;
+    }
 
     // for last, need to remove distance for the last segment.
     if (is_last) {

--- a/planning/planning_validator/autoware_planning_validator_trajectory_checker/src/trajectory_checker.cpp
+++ b/planning/planning_validator/autoware_planning_validator_trajectory_checker/src/trajectory_checker.cpp
@@ -520,8 +520,10 @@ bool TrajectoryChecker::check_valid_longitudinal_distance_deviation()
 
   // Check if the valid longitudinal deviation for given segment index
   const auto has_valid_lon_deviation = [&](const size_t seg_idx, const bool is_last) {
-    // Skip when removeOverlapPoints leaves no segment (calcLongitudinalOffsetToSegment would return NaN).
-    const auto dedup_points = autoware::motion_utils::removeOverlapPoints(trajectory.points, seg_idx);
+    // Skip when removeOverlapPoints leaves no segment (calcLongitudinalOffsetToSegment would return
+    // NaN).
+    const auto dedup_points =
+      autoware::motion_utils::removeOverlapPoints(trajectory.points, seg_idx);
     if (dedup_points.size() < seg_idx + 2) {
       status->longitudinal_distance_deviation = 0.0;
       return true;


### PR DESCRIPTION
trajectory_checkerがdiffusion_plannerの停止時にERROR判定する問題の修正です。

diffusion_plannerのtrajectory出力は停止時に2点かつ、同一点のtrajectoryを出力します。
[calcLongitudinalOffsetToSegment](https://github.com/tier4/autoware_core/blob/feat/v0.64/e2e/common/autoware_motion_utils/include/autoware/motion_utils/trajectory/trajectory.hpp#L439-L452)のlong_offset計算の過程で同一点が削除されるためnanが出力されます。
trajectory_checkerでnan<threshold比較になり停止時に毎回ERRORになるため、calcLongitudinalOffsetToSegmentを計算するより事前にremoveOverlapPointsにより重複点除去を行い、2点異常ない場合は判定をskipするように修正します。

https://tier4.atlassian.net/browse/T4DEV-56327