### PR TITLE
feat(minimum_rule_based_planner): add surround obstacle stop feature

### DIFF
--- a/planning/autoware_minimum_rule_based_planner/CMakeLists.txt
+++ b/planning/autoware_minimum_rule_based_planner/CMakeLists.txt
@@ -44,6 +44,7 @@ pluginlib_export_plugin_description_file(${PROJECT_NAME} plugins.xml)
 
 ament_auto_add_library(${PROJECT_NAME}_plugins SHARED
   plugins/obstacle_stop.cpp
+  plugins/surround_obstacle_stop.cpp
 )
 
 target_include_directories(${PROJECT_NAME}_plugins PRIVATE

--- a/planning/autoware_minimum_rule_based_planner/config/minimum_rule_based_planner.param.yaml
+++ b/planning/autoware_minimum_rule_based_planner/config/minimum_rule_based_planner.param.yaml
@@ -50,7 +50,7 @@
       arrived_distance_threshold: 0.5 # threshold to check if the ego vehicle has arrived at the stop point [m]
 
       objects:
-        object_types: ["car", "truck", "bus", "trailer", "motorcycle", "bicycle", "pedestrian", "unknown"] # object types to consider for obstacle stop
+        object_types: ["car", "truck", "bus", "trailer", "motorcycle", "bicycle", "pedestrian", "hazard"] # object types to consider for obstacle stop
         max_velocity_th: 3.0     # maximum velocity threshold for target object [m/s]
         stopped_velocity_th: 0.3 # velocity threshold for target object to be considered as stopped [m/s]
         max_lateral_velocity_th: 1.0 # maximum lateral velocity threshold for target object [m/s]
@@ -89,7 +89,7 @@
       enable: true
       use_objects: true
       use_pointcloud: false
-      object_types: ["car", "truck", "bus", "trailer", "motorcycle", "bicycle", "pedestrian", "unknown"] # object types to consider for surround obstacle stop
+      object_types: ["car", "truck", "bus", "trailer", "motorcycle", "bicycle", "pedestrian", "hazard", "animal", "unknown"] # object types to consider for surround obstacle stop
       front_distance_th:
         car: 0.5
         truck: 0.5
@@ -98,6 +98,8 @@
         motorcycle: 0.5
         bicycle: 0.5
         pedestrian: 0.5
+        hazard: 0.5
+        animal: 0.5
         unknown: 0.5
         pointcloud: 0.5
       side_distance_th:
@@ -108,6 +110,8 @@
         motorcycle: 1.0
         bicycle: 1.0
         pedestrian: 1.0
+        hazard: 0.5
+        animal: 0.5
         unknown: 0.5
         pointcloud: 0.5
       back_distance_th:
@@ -118,6 +122,8 @@
         motorcycle: 0.5
         bicycle: 0.5
         pedestrian: 0.5
+        hazard: 0.5
+        animal: 0.5
         unknown: 0.5
         pointcloud: 0.5
       hysteresis_distance: 0.1 # [m]

--- a/planning/autoware_minimum_rule_based_planner/config/minimum_rule_based_planner.param.yaml
+++ b/planning/autoware_minimum_rule_based_planner/config/minimum_rule_based_planner.param.yaml
@@ -82,6 +82,45 @@
         safety_margin: 2.0       # [m]
         lookahead_horizon: 1.5   # [s]
 
+    surround_obstacle_stop:
+      enable: true
+      use_objects: true
+      use_pointcloud: false
+      object_types: ["car", "truck", "bus", "trailer", "motorcycle", "bicycle", "pedestrian", "unknown"] # object types to consider for surround obstacle stop
+      front_distance_th:
+        car: 0.5
+        truck: 0.5
+        bus: 0.5
+        trailer: 0.5
+        motorcycle: 0.5
+        bicycle: 0.5
+        pedestrian: 0.5
+        unknown: 0.5
+        pointcloud: 0.5
+      side_distance_th:
+        car: 0.0
+        truck: 0.0
+        bus: 0.0
+        trailer: 0.0
+        motorcycle: 1.0
+        bicycle: 1.0
+        pedestrian: 1.0
+        unknown: 0.5
+        pointcloud: 0.5
+      back_distance_th:
+        car: 0.0
+        truck: 0.0
+        bus: 0.0
+        trailer: 0.0
+        motorcycle: 0.5
+        bicycle: 0.5
+        pedestrian: 0.5
+        unknown: 0.5
+        pointcloud: 0.5
+      hysteresis_distance: 0.1 # [m]
+      hysteresis_time: 0.2     # [s]
+      ego_stopped_vel_th: 0.1  # [m/s]
+
     velocity_smoother:
       nearest_dist_threshold_m: 1.5
       nearest_yaw_threshold_deg: 60.0

--- a/planning/autoware_minimum_rule_based_planner/config/minimum_rule_based_planner.param.yaml
+++ b/planning/autoware_minimum_rule_based_planner/config/minimum_rule_based_planner.param.yaml
@@ -2,6 +2,9 @@
   ros__parameters:
     # generate_parameter_library parameters
     planning_frequency_hz: 10.0
+    plugin_names:
+      - "autoware::minimum_rule_based_planner::plugin::ObstacleStop"
+      - "autoware::minimum_rule_based_planner::plugin::SurroundObstacleStop"
 
     path_planning:
       path_length:

--- a/planning/autoware_minimum_rule_based_planner/launch/minimum_rule_based_planner.launch.xml
+++ b/planning/autoware_minimum_rule_based_planner/launch/minimum_rule_based_planner.launch.xml
@@ -24,7 +24,7 @@
   <arg name="input_pointcloud" default="~/input/pointcloud"/>
   <arg name="output_candidate_trajectories" default="~/output/candidate_trajectories"/>
 
-  <node pkg="autoware_minimum_rule_based_planner" exec="autoware_minimum_rule_based_planner_node" name="minimum_rule_based_planner_node" output="both" launch-prefix="konsole -e gdb -ex run --args">
+  <node pkg="autoware_minimum_rule_based_planner" exec="autoware_minimum_rule_based_planner_node" name="minimum_rule_based_planner_node" output="both">
     <!-- Load parameter files -->
     <env name="LD_LIBRARY_PATH" value="/opt/acados/lib:$(env LD_LIBRARY_PATH)"/>
     <param from="$(var common_param_path)"/>

--- a/planning/autoware_minimum_rule_based_planner/launch/minimum_rule_based_planner.launch.xml
+++ b/planning/autoware_minimum_rule_based_planner/launch/minimum_rule_based_planner.launch.xml
@@ -24,34 +24,13 @@
   <arg name="input_pointcloud" default="~/input/pointcloud"/>
   <arg name="output_candidate_trajectories" default="~/output/candidate_trajectories"/>
 
-  <!-- Modifier plugins -->
-  <arg name="launch_obstacle_stop" default="true"/>
-  <arg name="launch_surround_obstacle_stop" default="true"/>
-  <arg name="launch_modules_list_end" default="&quot;&quot;]"/>
-  <arg name="minimum_rule_base_planner_trajectory_modifier_launch_modules" default="["/>
-  <let
-    name="minimum_rule_base_planner_trajectory_modifier_launch_modules"
-    value="$(eval &quot;'$(var minimum_rule_base_planner_trajectory_modifier_launch_modules)' + 'autoware::minimum_rule_based_planner::plugin::ObstacleStop, '&quot;)"
-    if="$(var launch_obstacle_stop)"
-  />
-  <let
-    name="minimum_rule_base_planner_trajectory_modifier_launch_modules"
-    value="$(eval &quot;'$(var minimum_rule_base_planner_trajectory_modifier_launch_modules)' + 'autoware::minimum_rule_based_planner::plugin::SurroundObstacleStop, '&quot;)"
-    if="$(var launch_surround_obstacle_stop)"
-  />
-  <let
-    name="minimum_rule_base_planner_trajectory_modifier_launch_modules"
-    value="$(eval &quot;'$(var minimum_rule_base_planner_trajectory_modifier_launch_modules)' + '$(var launch_modules_list_end)'&quot;)"
-  />
-
-  <node pkg="autoware_minimum_rule_based_planner" exec="autoware_minimum_rule_based_planner_node" name="minimum_rule_based_planner_node" output="both">
+  <node pkg="autoware_minimum_rule_based_planner" exec="autoware_minimum_rule_based_planner_node" name="minimum_rule_based_planner_node" output="both" launch-prefix="konsole -e gdb -ex run --args">
     <!-- Load parameter files -->
     <env name="LD_LIBRARY_PATH" value="/opt/acados/lib:$(env LD_LIBRARY_PATH)"/>
     <param from="$(var common_param_path)"/>
     <param from="$(var minimum_rule_base_planner_param_path)" allow_substs="true"/>
     <param from="$(var minimum_rule_base_planner_elastic_band_smoother_param_path)" allow_substs="true"/>
     <param from="$(var minimum_rule_base_planner_jerk_filtered_smoother_param_path)" allow_substs="true"/>
-    <param name="modifier_launch_modules" value="$(var minimum_rule_base_planner_trajectory_modifier_launch_modules)"/>
 
     <!-- Topic remappings -->
     <remap from="~/input/route" to="$(var input_route)"/>

--- a/planning/autoware_minimum_rule_based_planner/launch/minimum_rule_based_planner.launch.xml
+++ b/planning/autoware_minimum_rule_based_planner/launch/minimum_rule_based_planner.launch.xml
@@ -26,12 +26,18 @@
 
   <!-- Modifier plugins -->
   <arg name="launch_obstacle_stop" default="true"/>
+  <arg name="launch_surround_obstacle_stop" default="true"/>
   <arg name="launch_modules_list_end" default="&quot;&quot;]"/>
   <arg name="minimum_rule_base_planner_trajectory_modifier_launch_modules" default="["/>
   <let
     name="minimum_rule_base_planner_trajectory_modifier_launch_modules"
     value="$(eval &quot;'$(var minimum_rule_base_planner_trajectory_modifier_launch_modules)' + 'autoware::minimum_rule_based_planner::plugin::ObstacleStop, '&quot;)"
     if="$(var launch_obstacle_stop)"
+  />
+  <let
+    name="minimum_rule_base_planner_trajectory_modifier_launch_modules"
+    value="$(eval &quot;'$(var minimum_rule_base_planner_trajectory_modifier_launch_modules)' + 'autoware::minimum_rule_based_planner::plugin::SurroundObstacleStop, '&quot;)"
+    if="$(var launch_surround_obstacle_stop)"
   />
   <let
     name="minimum_rule_base_planner_trajectory_modifier_launch_modules"

--- a/planning/autoware_minimum_rule_based_planner/package.xml
+++ b/planning/autoware_minimum_rule_based_planner/package.xml
@@ -23,6 +23,7 @@
   <depend>autoware_lanelet2_extension</depend>
   <depend>autoware_map_msgs</depend>
   <depend>autoware_motion_utils</depend>
+  <depend>autoware_obstacle_proximity_checker</depend>
   <depend>autoware_perception_msgs</depend>
   <depend>autoware_planning_factor_interface</depend>
   <depend>autoware_planning_msgs</depend>

--- a/planning/autoware_minimum_rule_based_planner/param/minimum_rule_based_planner_parameters.yaml
+++ b/planning/autoware_minimum_rule_based_planner/param/minimum_rule_based_planner_parameters.yaml
@@ -4,6 +4,15 @@ minimum_rule_based_planner:
     default_value: 10.0
     validation:
       gt<>: [0.0]
+  plugin_names:
+    type: string_array
+    default_value:
+      [
+        autoware::minimum_rule_based_planner::plugin::ObstacleStop,
+        autoware::minimum_rule_based_planner::plugin::SurroundObstacleStop,
+      ]
+    description: List of plugin names to load
+    read_only: false
 
   path_planning:
     waypoint_group:
@@ -334,171 +343,28 @@ minimum_rule_based_planner:
       default_value: [car, truck, bus, trailer, motorcycle, bicycle, pedestrian, unknown]
       description: types of objects to consider for surround obstacle stop
       read_only: false
-    front_distance_th:
-      car:
-        type: double
-        default_value: 0.5
-        description: front surround check distance for car [m]
-        validation:
-          bounds<>: [0.0, 10.0]
-      truck:
-        type: double
-        default_value: 0.5
-        description: front surround check distance for truck [m]
-        validation:
-          bounds<>: [0.0, 10.0]
-      bus:
-        type: double
-        default_value: 0.5
-        description: front surround check distance for bus [m]
-        validation:
-          bounds<>: [0.0, 10.0]
-      trailer:
-        type: double
-        default_value: 0.5
-        description: front surround check distance for trailer [m]
-        validation:
-          bounds<>: [0.0, 10.0]
-      motorcycle:
-        type: double
-        default_value: 0.5
-        description: front surround check distance for motorcycle [m]
-        validation:
-          bounds<>: [0.0, 10.0]
-      bicycle:
-        type: double
-        default_value: 0.5
-        description: front surround check distance for bicycle [m]
-        validation:
-          bounds<>: [0.0, 10.0]
-      pedestrian:
-        type: double
-        default_value: 0.5
-        description: front surround check distance for pedestrian [m]
-        validation:
-          bounds<>: [0.0, 10.0]
-      unknown:
-        type: double
-        default_value: 0.5
-        description: front surround check distance for unknown [m]
-        validation:
-          bounds<>: [0.0, 10.0]
-      pointcloud:
-        type: double
-        default_value: 0.5
-        description: front surround check distance for pointcloud [m]
-        validation:
-          bounds<>: [0.0, 10.0]
-    side_distance_th:
-      car:
-        type: double
-        default_value: 0.0
-        description: side surround check distance for car [m]
-        validation:
-          bounds<>: [0.0, 10.0]
-      truck:
-        type: double
-        default_value: 0.0
-        description: side surround check distance for truck [m]
-        validation:
-          bounds<>: [0.0, 10.0]
-      bus:
-        type: double
-        default_value: 0.0
-        description: side surround check distance for bus [m]
-        validation:
-          bounds<>: [0.0, 10.0]
-      trailer:
-        type: double
-        default_value: 0.0
-        description: side surround check distance for trailer [m]
-        validation:
-          bounds<>: [0.0, 10.0]
-      motorcycle:
-        type: double
-        default_value: 1.0
-        description: side surround check distance for motorcycle [m]
-        validation:
-          bounds<>: [0.0, 10.0]
-      bicycle:
-        type: double
-        default_value: 1.0
-        description: side surround check distance for bicycle [m]
-        validation:
-          bounds<>: [0.0, 10.0]
-      pedestrian:
-        type: double
-        default_value: 1.0
-        description: side surround check distance for pedestrian [m]
-        validation:
-          bounds<>: [0.0, 10.0]
-      unknown:
-        type: double
-        default_value: 0.5
-        description: side surround check distance for unknown [m]
-        validation:
-          bounds<>: [0.0, 10.0]
-      pointcloud:
-        type: double
-        default_value: 0.5
-        description: side surround check distance for pointcloud [m]
-        validation:
-          bounds<>: [0.0, 10.0]
-    back_distance_th:
-      car:
-        type: double
-        default_value: 0.0
-        description: back surround check distance for car [m]
-        validation:
-          bounds<>: [0.0, 10.0]
-      truck:
-        type: double
-        default_value: 0.0
-        description: back surround check distance for truck [m]
-        validation:
-          bounds<>: [0.0, 10.0]
-      bus:
-        type: double
-        default_value: 0.0
-        description: back surround check distance for bus [m]
-        validation:
-          bounds<>: [0.0, 10.0]
-      trailer:
-        type: double
-        default_value: 0.0
-        description: back surround check distance for trailer [m]
-        validation:
-          bounds<>: [0.0, 10.0]
-      motorcycle:
-        type: double
-        default_value: 0.5
-        description: back surround check distance for motorcycle [m]
-        validation:
-          bounds<>: [0.0, 10.0]
-      bicycle:
-        type: double
-        default_value: 0.5
-        description: back surround check distance for bicycle [m]
-        validation:
-          bounds<>: [0.0, 10.0]
-      pedestrian:
-        type: double
-        default_value: 0.5
-        description: back surround check distance for pedestrian [m]
-        validation:
-          bounds<>: [0.0, 10.0]
-      unknown:
-        type: double
-        default_value: 0.5
-        description: back surround check distance for unknown [m]
-        validation:
-          bounds<>: [0.0, 10.0]
-      pointcloud:
-        type: double
-        default_value: 0.5
-        description: back surround check distance for pointcloud [m]
-        validation:
-          bounds<>: [0.0, 10.0]
+    base_distance_th:
+      &distance_th_template {
+        type: double,
+        default_value: 0.5,
+        validation: { bounds<>: [0.0, 10.0] },
+        read_only: false,
+      }
+    base:
+      &base_template {
+        car: *distance_th_template,
+        truck: *distance_th_template,
+        bus: *distance_th_template,
+        trailer: *distance_th_template,
+        motorcycle: *distance_th_template,
+        bicycle: *distance_th_template,
+        pedestrian: *distance_th_template,
+        unknown: *distance_th_template,
+        pointcloud: *distance_th_template,
+      }
+    front_distance_th: *base_template
+    side_distance_th: *base_template
+    back_distance_th: *base_template
     hysteresis_distance:
       type: double
       default_value: 0.1

--- a/planning/autoware_minimum_rule_based_planner/param/minimum_rule_based_planner_parameters.yaml
+++ b/planning/autoware_minimum_rule_based_planner/param/minimum_rule_based_planner_parameters.yaml
@@ -313,6 +313,214 @@ minimum_rule_based_planner:
         validation:
           bounds<>: [0.0, 10.0]
 
+  surround_obstacle_stop:
+    enable:
+      type: bool
+      default_value: true
+      description: enable surround obstacle stop
+      read_only: false
+    use_objects:
+      type: bool
+      default_value: true
+      description: enable the use of objects for surround obstacle stop
+      read_only: false
+    use_pointcloud:
+      type: bool
+      default_value: false
+      description: enable the use of pointcloud for surround obstacle stop
+      read_only: false
+    object_types:
+      type: string_array
+      default_value: [car, truck, bus, trailer, motorcycle, bicycle, pedestrian, unknown]
+      description: types of objects to consider for surround obstacle stop
+      read_only: false
+    front_distance_th:
+      car:
+        type: double
+        default_value: 0.5
+        description: front surround check distance for car [m]
+        validation:
+          bounds<>: [0.0, 10.0]
+      truck:
+        type: double
+        default_value: 0.5
+        description: front surround check distance for truck [m]
+        validation:
+          bounds<>: [0.0, 10.0]
+      bus:
+        type: double
+        default_value: 0.5
+        description: front surround check distance for bus [m]
+        validation:
+          bounds<>: [0.0, 10.0]
+      trailer:
+        type: double
+        default_value: 0.5
+        description: front surround check distance for trailer [m]
+        validation:
+          bounds<>: [0.0, 10.0]
+      motorcycle:
+        type: double
+        default_value: 0.5
+        description: front surround check distance for motorcycle [m]
+        validation:
+          bounds<>: [0.0, 10.0]
+      bicycle:
+        type: double
+        default_value: 0.5
+        description: front surround check distance for bicycle [m]
+        validation:
+          bounds<>: [0.0, 10.0]
+      pedestrian:
+        type: double
+        default_value: 0.5
+        description: front surround check distance for pedestrian [m]
+        validation:
+          bounds<>: [0.0, 10.0]
+      unknown:
+        type: double
+        default_value: 0.5
+        description: front surround check distance for unknown [m]
+        validation:
+          bounds<>: [0.0, 10.0]
+      pointcloud:
+        type: double
+        default_value: 0.5
+        description: front surround check distance for pointcloud [m]
+        validation:
+          bounds<>: [0.0, 10.0]
+    side_distance_th:
+      car:
+        type: double
+        default_value: 0.0
+        description: side surround check distance for car [m]
+        validation:
+          bounds<>: [0.0, 10.0]
+      truck:
+        type: double
+        default_value: 0.0
+        description: side surround check distance for truck [m]
+        validation:
+          bounds<>: [0.0, 10.0]
+      bus:
+        type: double
+        default_value: 0.0
+        description: side surround check distance for bus [m]
+        validation:
+          bounds<>: [0.0, 10.0]
+      trailer:
+        type: double
+        default_value: 0.0
+        description: side surround check distance for trailer [m]
+        validation:
+          bounds<>: [0.0, 10.0]
+      motorcycle:
+        type: double
+        default_value: 1.0
+        description: side surround check distance for motorcycle [m]
+        validation:
+          bounds<>: [0.0, 10.0]
+      bicycle:
+        type: double
+        default_value: 1.0
+        description: side surround check distance for bicycle [m]
+        validation:
+          bounds<>: [0.0, 10.0]
+      pedestrian:
+        type: double
+        default_value: 1.0
+        description: side surround check distance for pedestrian [m]
+        validation:
+          bounds<>: [0.0, 10.0]
+      unknown:
+        type: double
+        default_value: 0.5
+        description: side surround check distance for unknown [m]
+        validation:
+          bounds<>: [0.0, 10.0]
+      pointcloud:
+        type: double
+        default_value: 0.5
+        description: side surround check distance for pointcloud [m]
+        validation:
+          bounds<>: [0.0, 10.0]
+    back_distance_th:
+      car:
+        type: double
+        default_value: 0.0
+        description: back surround check distance for car [m]
+        validation:
+          bounds<>: [0.0, 10.0]
+      truck:
+        type: double
+        default_value: 0.0
+        description: back surround check distance for truck [m]
+        validation:
+          bounds<>: [0.0, 10.0]
+      bus:
+        type: double
+        default_value: 0.0
+        description: back surround check distance for bus [m]
+        validation:
+          bounds<>: [0.0, 10.0]
+      trailer:
+        type: double
+        default_value: 0.0
+        description: back surround check distance for trailer [m]
+        validation:
+          bounds<>: [0.0, 10.0]
+      motorcycle:
+        type: double
+        default_value: 0.5
+        description: back surround check distance for motorcycle [m]
+        validation:
+          bounds<>: [0.0, 10.0]
+      bicycle:
+        type: double
+        default_value: 0.5
+        description: back surround check distance for bicycle [m]
+        validation:
+          bounds<>: [0.0, 10.0]
+      pedestrian:
+        type: double
+        default_value: 0.5
+        description: back surround check distance for pedestrian [m]
+        validation:
+          bounds<>: [0.0, 10.0]
+      unknown:
+        type: double
+        default_value: 0.5
+        description: back surround check distance for unknown [m]
+        validation:
+          bounds<>: [0.0, 10.0]
+      pointcloud:
+        type: double
+        default_value: 0.5
+        description: back surround check distance for pointcloud [m]
+        validation:
+          bounds<>: [0.0, 10.0]
+    hysteresis_distance:
+      type: double
+      default_value: 0.1
+      description: distance hysteresis threshold for clearing surround stop [m]
+      validation:
+        bounds<>: [0.0, 10.0]
+      read_only: false
+    hysteresis_time:
+      type: double
+      default_value: 0.2
+      description: time hysteresis threshold for clearing surround stop [s]
+      validation:
+        bounds<>: [0.0, 10.0]
+      read_only: false
+    ego_stopped_vel_th:
+      type: double
+      default_value: 0.1
+      description: velocity threshold below which ego vehicle is considered stopped [m/s]
+      validation:
+        bounds<>: [0.0, 10.0]
+      read_only: false
+
   debug:
     enable_path:
       type: bool

--- a/planning/autoware_minimum_rule_based_planner/param/minimum_rule_based_planner_parameters.yaml
+++ b/planning/autoware_minimum_rule_based_planner/param/minimum_rule_based_planner_parameters.yaml
@@ -164,7 +164,7 @@ minimum_rule_based_planner:
     objects:
       object_types:
         type: string_array
-        default_value: [car, truck, bus, trailer, motorcycle, bicycle, pedestrian]
+        default_value: [car, truck, bus, trailer, motorcycle, bicycle, pedestrian, hazard]
         description: object types to consider for obstacle stop
       max_velocity_th:
         type: double
@@ -340,7 +340,8 @@ minimum_rule_based_planner:
       read_only: false
     object_types:
       type: string_array
-      default_value: [car, truck, bus, trailer, motorcycle, bicycle, pedestrian, unknown]
+      default_value:
+        [car, truck, bus, trailer, motorcycle, bicycle, pedestrian, hazard, animal, unknown]
       description: types of objects to consider for surround obstacle stop
       read_only: false
     base_distance_th:
@@ -359,6 +360,8 @@ minimum_rule_based_planner:
         motorcycle: *distance_th_template,
         bicycle: *distance_th_template,
         pedestrian: *distance_th_template,
+        hazard: *distance_th_template,
+        animal: *distance_th_template,
         unknown: *distance_th_template,
         pointcloud: *distance_th_template,
       }

--- a/planning/autoware_minimum_rule_based_planner/plugins.xml
+++ b/planning/autoware_minimum_rule_based_planner/plugins.xml
@@ -6,4 +6,10 @@
       Obstacle stop plugin for minimum rule based planner
     </description>
   </class>
+  <class type="autoware::minimum_rule_based_planner::plugin::SurroundObstacleStop"
+         base_class_type="autoware::minimum_rule_based_planner::plugin::PluginInterface">
+    <description>
+      Surround obstacle stop plugin for minimum rule based planner
+    </description>
+  </class>
 </library>

--- a/planning/autoware_minimum_rule_based_planner/plugins/obstacle_stop.cpp
+++ b/planning/autoware_minimum_rule_based_planner/plugins/obstacle_stop.cpp
@@ -67,32 +67,33 @@ void ObstacleStop::on_initialize(const MinimumRuleBasedPlannerParams & params)
   update_object_decel_map();
 }
 
-void ObstacleStop::run(TrajectoryPoints & traj_points)
+void ObstacleStop::run(TrajectoryPoints & traj_points, const ModifierData & data)
 {
   if (!params_.enable) return;
 
-  const auto detected = is_obstacle_detected(traj_points);
+  const auto detected = is_obstacle_detected(traj_points, data);
   publish_debug_string(!detected);
-  publish_debug_data("obstacle_stop");
+  publish_debug_data("obstacle_stop", data);
 
   if (!detected) return;
   if (!nearest_collision_point_) return;
 
-  set_stop_point(traj_points);
+  set_stop_point(traj_points, data);
 }
 
-bool ObstacleStop::is_obstacle_detected(const TrajectoryPoints & traj_points)
+bool ObstacleStop::is_obstacle_detected(
+  const TrajectoryPoints & traj_points, const ModifierData & data)
 {
   debug_data_ = DebugData();
   safety_factors_ = SafetyFactorArray{};
   debug_data_.trajectory_shape = get_trajectory_shape(
-    traj_points, data_->odometry_ptr->pose.pose, vehicle_info_,
-    data_->odometry_ptr->twist.twist.linear.x, data_->acceleration_ptr->accel.accel.linear.x,
+    traj_points, data.odometry_ptr->pose.pose, context_->vehicle_info,
+    data.odometry_ptr->twist.twist.linear.x, data.acceleration_ptr->accel.accel.linear.x,
     params_.nominal_stopping_decel, params_.stopping_jerk, params_.stop_margin,
     params_.lateral_margin);
-  const auto collision_point_pcd = check_pointcloud(traj_points);
+  const auto collision_point_pcd = check_pointcloud(traj_points, data);
   update_collision_points_buffer(collision_points_buffer_.pcd, traj_points, collision_point_pcd);
-  const auto collision_point_objects = check_predicted_objects(traj_points);
+  const auto collision_point_objects = check_predicted_objects(traj_points, data);
   update_collision_points_buffer(
     collision_points_buffer_.objects, traj_points, collision_point_objects);
 
@@ -151,13 +152,13 @@ bool ObstacleStop::is_obstacle_detected(const TrajectoryPoints & traj_points)
   return nearest_collision_point_ != std::nullopt;
 }
 
-void ObstacleStop::set_stop_point(TrajectoryPoints & traj_points)
+void ObstacleStop::set_stop_point(TrajectoryPoints & traj_points, const ModifierData & data)
 {
-  const auto stop_margin = params_.stop_margin + vehicle_info_.max_longitudinal_offset_m;
+  const auto stop_margin = params_.stop_margin + context_->vehicle_info.max_longitudinal_offset_m;
   const auto target_stop_point_arc_length = clamp_stop_point_arc_length(
     nearest_collision_point_->arc_length - stop_margin,
-    debug_data_.trajectory_shape.trajectory_length, data_->odometry_ptr->twist.twist.linear.x,
-    data_->acceleration_ptr->accel.accel.linear.x, params_.nominal_stopping_decel,
+    debug_data_.trajectory_shape.trajectory_length, data.odometry_ptr->twist.twist.linear.x,
+    data.acceleration_ptr->accel.accel.linear.x, params_.nominal_stopping_decel,
     params_.stopping_jerk);
 
   if (!insert_stop_point(
@@ -179,7 +180,7 @@ void ObstacleStop::set_stop_point(TrajectoryPoints & traj_points)
   }
 
   const auto & stop_pose = traj_points.back().pose;
-  const auto & ego_pose = data_->odometry_ptr->pose.pose;
+  const auto & ego_pose = data.odometry_ptr->pose.pose;
   planning_factor_interface_->add(
     traj_points, ego_pose, stop_pose, PlanningFactor::STOP, safety_factors_);
 
@@ -190,38 +191,39 @@ void ObstacleStop::set_stop_point(TrajectoryPoints & traj_points)
 }
 
 std::optional<CollisionPoint> ObstacleStop::check_predicted_objects(
-  const TrajectoryPoints & traj_points)
+  const TrajectoryPoints & traj_points, const ModifierData & data)
 {
   if (!params_.use_objects) return std::nullopt;
 
-  if (!data_->predicted_objects_ptr || data_->predicted_objects_ptr->objects.empty())
+  if (!data.predicted_objects_ptr || data.predicted_objects_ptr->objects.empty())
     return std::nullopt;
-  auto predicted_objects = *data_->predicted_objects_ptr;
+  auto predicted_objects = *data.predicted_objects_ptr;
 
   object_filter_->filter_objects(predicted_objects);
   object_filter_->filter_by_target_area(
-    predicted_objects, traj_points, vehicle_info_, debug_data_.trajectory_shape.polygon,
+    predicted_objects, traj_points, context_->vehicle_info, debug_data_.trajectory_shape.polygon,
     debug_data_.target_polygons);
 
   autoware_perception_msgs::msg::PredictedObject colliding_object;
   auto collision_point = get_nearest_object_collision(
-    traj_points, vehicle_info_, predicted_objects, object_decel_map_, params_.rss_params.ego_decel,
-    params_.rss_params.reaction_time, params_.rss_params.safety_margin,
-    params_.objects.stopped_velocity_th, params_.rss_params.lookahead_horizon, colliding_object,
-    params_.rss_params.enable);
+    traj_points, context_->vehicle_info, predicted_objects, object_decel_map_,
+    params_.rss_params.ego_decel, params_.rss_params.reaction_time,
+    params_.rss_params.safety_margin, params_.objects.stopped_velocity_th,
+    params_.rss_params.lookahead_horizon, colliding_object, params_.rss_params.enable);
 
   if (collision_point) debug_data_.colliding_object = colliding_object;
   return collision_point;
 }
 
-std::optional<CollisionPoint> ObstacleStop::check_pointcloud(const TrajectoryPoints & traj_points)
+std::optional<CollisionPoint> ObstacleStop::check_pointcloud(
+  const TrajectoryPoints & traj_points, const ModifierData & data)
 {
   if (!params_.use_pointcloud) return std::nullopt;
 
-  if (!data_->obstacle_pointcloud_ptr || data_->obstacle_pointcloud_ptr->data.empty())
+  if (!data.obstacle_pointcloud_ptr || data.obstacle_pointcloud_ptr->data.empty())
     return std::nullopt;
 
-  const auto & pointcloud = data_->obstacle_pointcloud_ptr;
+  const auto & pointcloud = data.obstacle_pointcloud_ptr;
 
   PointCloud::Ptr filtered_pointcloud(new PointCloud);
   pcl::fromROSMsg(*pointcloud, *filtered_pointcloud);
@@ -229,11 +231,11 @@ std::optional<CollisionPoint> ObstacleStop::check_pointcloud(const TrajectoryPoi
   {
     const auto & bounding_box = debug_data_.trajectory_shape.bounding_box;
     const auto rel_min_point = autoware_utils_geometry::inverse_transform_point(
-      bounding_box.min_corner().to_3d(), data_->odometry_ptr->pose.pose);
+      bounding_box.min_corner().to_3d(), data.odometry_ptr->pose.pose);
     const auto rel_max_point = autoware_utils_geometry::inverse_transform_point(
-      bounding_box.max_corner().to_3d(), data_->odometry_ptr->pose.pose);
+      bounding_box.max_corner().to_3d(), data.odometry_ptr->pose.pose);
     const auto min_z = params_.pointcloud.min_height;
-    const auto max_z = vehicle_info_.vehicle_height_m + params_.pointcloud.height_buffer;
+    const auto max_z = context_->vehicle_info.vehicle_height_m + params_.pointcloud.height_buffer;
     pointcloud_filter_->filter_pointcloud(
       filtered_pointcloud, rel_min_point.x(), rel_max_point.x(), rel_min_point.y(),
       rel_max_point.y(), min_z, max_z);
@@ -246,7 +248,7 @@ std::optional<CollisionPoint> ObstacleStop::check_pointcloud(const TrajectoryPoi
   {
     geometry_msgs::msg::TransformStamped transform_stamped;
     try {
-      transform_stamped = data_->tf_buffer.lookupTransform(
+      transform_stamped = context_->tf_buffer.lookupTransform(
         "map", pointcloud->header.frame_id, pointcloud->header.stamp,
         rclcpp::Duration::from_seconds(0.1));
     } catch (tf2::TransformException & e) {
@@ -265,9 +267,8 @@ std::optional<CollisionPoint> ObstacleStop::check_pointcloud(const TrajectoryPoi
     debug_data_.cluster_points = cluster_pointcloud;
   }
 
-  if (data_->predicted_objects_ptr && !data_->predicted_objects_ptr->objects.empty()) {
-    pointcloud_filter_->filter_pointcloud_by_object(
-      clustered_points, *data_->predicted_objects_ptr);
+  if (data.predicted_objects_ptr && !data.predicted_objects_ptr->objects.empty()) {
+    pointcloud_filter_->filter_pointcloud_by_object(clustered_points, *data.predicted_objects_ptr);
   }
 
   return get_nearest_pcd_collision(
@@ -377,12 +378,12 @@ void ObstacleStop::publish_debug_string(bool is_safe) const
   pub_debug_text_->publish(string_stamp);
 }
 
-void ObstacleStop::publish_debug_data(const std::string & ns) const
+void ObstacleStop::publish_debug_data(const std::string & ns, const ModifierData & data) const
 {
   if (debug_data_.cluster_points) pub_clustered_pointcloud_->publish(*debug_data_.cluster_points);
 
   MarkerArray marker_array;
-  const auto ego_z = data_->odometry_ptr->pose.pose.position.z;
+  const auto ego_z = data.odometry_ptr->pose.pose.position.z;
   const auto white = autoware_utils::create_marker_color(1.0, 1.0, 1.0, 1.0);
   const auto yellow = autoware_utils::create_marker_color(1.0, 1.0, 0.0, 1.0);
   const auto magenta = autoware_utils::create_marker_color(1.0, 0.0, 1.0, 1.0);

--- a/planning/autoware_minimum_rule_based_planner/plugins/obstacle_stop.hpp
+++ b/planning/autoware_minimum_rule_based_planner/plugins/obstacle_stop.hpp
@@ -50,7 +50,7 @@ class ObstacleStop : public PluginInterface
 public:
   ObstacleStop() = default;
 
-  void run(TrajectoryPoints & traj_points) override;
+  void run(TrajectoryPoints & traj_points, const ModifierData & data) override;
 
   void update_params(const MinimumRuleBasedPlannerParams & params) override
   {
@@ -118,10 +118,12 @@ private:
       {ObjectType::PEDESTRIAN, p.object_decel.pedestrian}};
   }
 
-  bool is_obstacle_detected(const TrajectoryPoints & traj_points);
+  bool is_obstacle_detected(const TrajectoryPoints & traj_points, const ModifierData & data);
 
-  std::optional<CollisionPoint> check_predicted_objects(const TrajectoryPoints & traj_points);
-  std::optional<CollisionPoint> check_pointcloud(const TrajectoryPoints & traj_points);
+  std::optional<CollisionPoint> check_predicted_objects(
+    const TrajectoryPoints & traj_points, const ModifierData & data);
+  std::optional<CollisionPoint> check_pointcloud(
+    const TrajectoryPoints & traj_points, const ModifierData & data);
 
   void update_collision_points_buffer(
     std::vector<CollisionPoint> & collision_points_buffer, const TrajectoryPoints & traj_points,
@@ -130,10 +132,10 @@ private:
   std::optional<CollisionPoint> get_nearest_collision_point(
     const std::vector<CollisionPoint> & collision_points_buffer) const;
 
-  void set_stop_point(TrajectoryPoints & traj_points);
+  void set_stop_point(TrajectoryPoints & traj_points, const ModifierData & data);
 
   void publish_debug_string(bool is_safe) const;
-  void publish_debug_data(const std::string & ns) const;
+  void publish_debug_data(const std::string & ns, const ModifierData & data) const;
 };
 
 }  // namespace autoware::minimum_rule_based_planner::plugin

--- a/planning/autoware_minimum_rule_based_planner/plugins/plugin_interface.hpp
+++ b/planning/autoware_minimum_rule_based_planner/plugins/plugin_interface.hpp
@@ -19,6 +19,7 @@
 
 #include <autoware/planning_factor_interface/planning_factor_interface.hpp>
 #include <autoware/vehicle_info_utils/vehicle_info.hpp>
+#include <autoware/vehicle_info_utils/vehicle_info_utils.hpp>
 #include <autoware_minimum_rule_based_planner/minimum_rule_based_planner_parameters.hpp>
 #include <autoware_utils_debug/time_keeper.hpp>
 #include <rclcpp/rclcpp.hpp>
@@ -53,14 +54,22 @@ using MinimumRuleBasedPlannerParams = ::minimum_rule_based_planner::Params;
 
 struct ModifierData
 {
-  explicit ModifierData(rclcpp::Node * node) : tf_buffer{node->get_clock()}, tf_listener{tf_buffer}
-  {
-  }
-
   Odometry::ConstSharedPtr odometry_ptr;
   AccelWithCovarianceStamped::ConstSharedPtr acceleration_ptr;
   PointCloud2::ConstSharedPtr obstacle_pointcloud_ptr;
   PredictedObjects::ConstSharedPtr predicted_objects_ptr;
+};
+
+struct ModifierContext
+{
+  explicit ModifierContext(rclcpp::Node * node)
+  : vehicle_info(autoware::vehicle_info_utils::VehicleInfoUtils(*node).getVehicleInfo()),
+    tf_buffer{node->get_clock()},
+    tf_listener{tf_buffer}
+  {
+  }
+
+  VehicleInfo vehicle_info;
   tf2_ros::Buffer tf_buffer;
   tf2_ros::TransformListener tf_listener;
 };
@@ -73,20 +82,18 @@ public:
   void initialize(
     std::string name, rclcpp::Node * node_ptr,
     const std::shared_ptr<autoware_utils_debug::TimeKeeper> time_keeper,
-    const std::shared_ptr<ModifierData> & modifier_data, const VehicleInfo & vehicle_info,
-    [[maybe_unused]] const MinimumRuleBasedPlannerParams & params)
+    const std::shared_ptr<ModifierContext> & context, const MinimumRuleBasedPlannerParams & params)
   {
     name_ = std::move(name);
     node_ptr_ = node_ptr;
     time_keeper_ = time_keeper;
-    data_ = modifier_data;
-    vehicle_info_ = vehicle_info;
+    context_ = context;
     RCLCPP_DEBUG(node_ptr_->get_logger(), "instantiated PluginInterface: %s", name_.c_str());
     on_initialize(params);
   }
 
   virtual ~PluginInterface() = default;
-  virtual void run(TrajectoryPoints & traj_points) = 0;
+  virtual void run(TrajectoryPoints & traj_points, const ModifierData & modifier_data) = 0;
   std::string get_name() const { return name_; }
   rclcpp::Node * get_node_ptr() const { return node_ptr_; }
   std::shared_ptr<autoware_utils_debug::TimeKeeper> get_time_keeper() const { return time_keeper_; }
@@ -110,8 +117,7 @@ protected:
   virtual void on_initialize(const MinimumRuleBasedPlannerParams & params) = 0;
   std::unique_ptr<autoware::planning_factor_interface::PlanningFactorInterface>
     planning_factor_interface_;
-  VehicleInfo vehicle_info_;
-  std::shared_ptr<ModifierData> data_;
+  std::shared_ptr<ModifierContext> context_;
 
   rclcpp::Clock::SharedPtr get_clock() const { return node_ptr_->get_clock(); }
 

--- a/planning/autoware_minimum_rule_based_planner/plugins/surround_obstacle_stop.cpp
+++ b/planning/autoware_minimum_rule_based_planner/plugins/surround_obstacle_stop.cpp
@@ -1,0 +1,284 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "surround_obstacle_stop.hpp"
+
+#include "autoware/trajectory_modifier/trajectory_modifier_utils/utils.hpp"
+
+#include <autoware/motion_utils/trajectory/trajectory.hpp>
+#include <autoware_utils/transform/transforms.hpp>
+#include <tf2_eigen/tf2_eigen.hpp>
+
+#include <pcl/point_cloud.h>
+#include <pcl_conversions/pcl_conversions.h>
+
+#include <iomanip>
+#include <memory>
+#include <sstream>
+#include <string>
+#include <unordered_set>
+
+namespace
+{
+using autoware::obstacle_proximity_checker::ObstacleTypeParameters;
+using autoware::obstacle_proximity_checker::Parameters;
+using SurroundObstacleStopParams =
+  autoware::minimum_rule_based_planner::plugin::MinimumRuleBasedPlannerParams::SurroundObstacleStop;
+
+ObstacleTypeParameters to_obstacle_type_parameters(
+  const double front_distance, const double side_distance, const double back_distance)
+{
+  ObstacleTypeParameters parameters;
+  parameters.surround_check_front_distance = front_distance;
+  parameters.surround_check_side_distance = side_distance;
+  parameters.surround_check_back_distance = back_distance;
+  return parameters;
+}
+
+Parameters to_proximity_checker_parameters(const SurroundObstacleStopParams & params)
+{
+  Parameters parameters;
+  parameters.pointcloud_enable_check = params.use_pointcloud;
+
+  const std::unordered_set<std::string> enabled_object_types(
+    params.object_types.begin(), params.object_types.end());
+
+  const auto set_object_enable = [&](const std::string & label) {
+    parameters.object_type_enable_check[label] = enabled_object_types.count(label) > 0;
+  };
+  set_object_enable("unknown");
+  set_object_enable("car");
+  set_object_enable("truck");
+  set_object_enable("bus");
+  set_object_enable("trailer");
+  set_object_enable("motorcycle");
+  set_object_enable("bicycle");
+  set_object_enable("pedestrian");
+
+  const auto & front = params.front_distance_th;
+  const auto & side = params.side_distance_th;
+  const auto & back = params.back_distance_th;
+
+  parameters.obstacle_types_map["pointcloud"] =
+    to_obstacle_type_parameters(front.pointcloud, side.pointcloud, back.pointcloud);
+  parameters.obstacle_types_map["unknown"] =
+    to_obstacle_type_parameters(front.unknown, side.unknown, back.unknown);
+  parameters.obstacle_types_map["car"] = to_obstacle_type_parameters(front.car, side.car, back.car);
+  parameters.obstacle_types_map["truck"] =
+    to_obstacle_type_parameters(front.truck, side.truck, back.truck);
+  parameters.obstacle_types_map["bus"] = to_obstacle_type_parameters(front.bus, side.bus, back.bus);
+  parameters.obstacle_types_map["trailer"] =
+    to_obstacle_type_parameters(front.trailer, side.trailer, back.trailer);
+  parameters.obstacle_types_map["motorcycle"] =
+    to_obstacle_type_parameters(front.motorcycle, side.motorcycle, back.motorcycle);
+  parameters.obstacle_types_map["bicycle"] =
+    to_obstacle_type_parameters(front.bicycle, side.bicycle, back.bicycle);
+  parameters.obstacle_types_map["pedestrian"] =
+    to_obstacle_type_parameters(front.pedestrian, side.pedestrian, back.pedestrian);
+
+  return parameters;
+}
+}  // namespace
+
+namespace autoware::minimum_rule_based_planner::plugin
+{
+namespace utils = autoware::trajectory_modifier::utils;
+
+void SurroundObstacleStop::on_initialize(const MinimumRuleBasedPlannerParams & params)
+{
+  params_ = params.surround_obstacle_stop;
+
+  planning_factor_interface_ =
+    std::make_unique<autoware::planning_factor_interface::PlanningFactorInterface>(
+      get_node_ptr(), "backup_planner_surround_obstacle_stop");
+
+  pub_debug_text_ = get_node_ptr()->create_publisher<StringStamped>(
+    "~/surround_obstacle_stop/debug/text", 1);
+
+  proximity_checker_ = std::make_unique<obstacle_proximity_checker::ProximityChecker>(
+    to_proximity_checker_parameters(params_), vehicle_info_);
+}
+
+void SurroundObstacleStop::update_params(const MinimumRuleBasedPlannerParams & params)
+{
+  params_ = params.surround_obstacle_stop;
+  proximity_checker_->update_parameters(to_proximity_checker_parameters(params_));
+}
+
+void SurroundObstacleStop::run(TrajectoryPoints & traj_points)
+{
+  proximity_check_result_ = std::nullopt;
+
+  if (!is_stop_required(traj_points)) {
+    publish_debug_string(false);
+    return;
+  }
+
+  set_stop_point(traj_points);
+  publish_debug_string(true);
+}
+
+bool SurroundObstacleStop::check_inputs() const
+{
+  if (!data_->odometry_ptr) {
+    return false;
+  }
+
+  if (!params_.use_pointcloud && !params_.use_objects) {
+    return false;
+  }
+
+  const bool has_pointcloud = params_.use_pointcloud && data_->obstacle_pointcloud_ptr;
+  const bool has_objects = params_.use_objects && data_->predicted_objects_ptr;
+
+  return has_pointcloud || has_objects;
+}
+
+obstacle_proximity_checker::Inputs SurroundObstacleStop::to_proximity_checker_inputs() const
+{
+  obstacle_proximity_checker::Inputs checker_inputs;
+  checker_inputs.ego_pose = data_->odometry_ptr->pose.pose;
+  checker_inputs.objects = data_->predicted_objects_ptr;
+
+  if (!data_->obstacle_pointcloud_ptr) return checker_inputs;
+
+  const auto transform_stamped = get_transform(
+    "base_link", data_->obstacle_pointcloud_ptr->header.frame_id,
+    data_->obstacle_pointcloud_ptr->header.stamp, 0.5);
+
+  if (!transform_stamped.has_value()) return checker_inputs;
+
+  Eigen::Affine3f isometry =
+    tf2::transformToEigen(transform_stamped.value().transform).cast<float>();
+  pcl::PointCloud<pcl::PointXYZ> transformed_pointcloud;
+  pcl::fromROSMsg(*data_->obstacle_pointcloud_ptr, transformed_pointcloud);
+  autoware_utils::transform_pointcloud(transformed_pointcloud, transformed_pointcloud, isometry);
+
+  checker_inputs.pointcloud_in_base_link = transformed_pointcloud.makeShared();
+
+  return checker_inputs;
+}
+
+std::optional<geometry_msgs::msg::TransformStamped> SurroundObstacleStop::get_transform(
+  const std::string & target, const std::string & source, const rclcpp::Time & stamp,
+  double duration_sec) const
+{
+  geometry_msgs::msg::TransformStamped transform_stamped;
+
+  try {
+    transform_stamped =
+      data_->tf_buffer.lookupTransform(target, source, stamp, tf2::durationFromSec(duration_sec));
+  } catch (const tf2::TransformException & ex) {
+    RCLCPP_WARN_THROTTLE(
+      get_node_ptr()->get_logger(), *get_clock(), 1000, "no transform found for pointcloud: %s",
+      ex.what());
+    return {};
+  }
+
+  return transform_stamped;
+}
+
+bool SurroundObstacleStop::is_obstacle_nearby()
+{
+  const double contact_distance_threshold = is_stop_active_ ? params_.hysteresis_distance : 1e-3;
+
+  if (!proximity_check_result_.has_value()) {
+    proximity_check_result_ =
+      proximity_checker_->check(to_proximity_checker_inputs(), contact_distance_threshold);
+  }
+
+  const auto & result = proximity_check_result_.value();
+  if (result.is_obstacle_found) {
+    last_obstacle_found_time_ = get_clock()->now();
+    is_stop_active_ = true;
+    return true;
+  }
+
+  if (is_stop_active_ && last_obstacle_found_time_.has_value()) {
+    const auto elapsed_time = get_clock()->now() - last_obstacle_found_time_.value();
+    if (elapsed_time.seconds() <= params_.hysteresis_time) {
+      return true;
+    }
+  }
+
+  is_stop_active_ = false;
+  last_obstacle_found_time_ = std::nullopt;
+  return false;
+}
+
+bool SurroundObstacleStop::is_stop_required(const TrajectoryPoints & traj_points)
+{
+  if (!params_.enable || !check_inputs()) {
+    return false;
+  }
+
+  if (
+    utils::is_stop_trajectory(traj_points, params_.ego_stopped_vel_th) ||
+    utils::is_ego_vehicle_moving(data_->odometry_ptr->twist.twist, params_.ego_stopped_vel_th)) {
+    is_stop_active_ = false;
+    last_obstacle_found_time_ = std::nullopt;
+    return false;
+  }
+
+  return is_obstacle_nearby();
+}
+
+void SurroundObstacleStop::set_stop_point(TrajectoryPoints & traj_points)
+{
+  if (traj_points.empty()) return;
+
+  const auto & ego_pose = data_->odometry_ptr->pose.pose;
+
+  // Insert a zero-velocity stop point at the ego pose while keeping the trajectory shape.
+  const auto stop_index = motion_utils::insertStopPoint(ego_pose, 0.0, traj_points);
+  if (!stop_index) {
+    // Fall back to stopping from the front of the trajectory when insertion at ego fails.
+    for (auto & point : traj_points) {
+      point.longitudinal_velocity_mps = 0.0;
+      point.acceleration_mps2 = 0.0;
+    }
+  }
+
+  const auto & stop_pose = stop_index ? traj_points.at(stop_index.value()).pose : ego_pose;
+
+  planning_factor_interface_->add(
+    traj_points, ego_pose, stop_pose, PlanningFactor::STOP,
+    autoware_internal_planning_msgs::msg::SafetyFactorArray{});
+
+  RCLCPP_WARN_THROTTLE(
+    get_node_ptr()->get_logger(), *get_clock(), 1000,
+    "[Backup Planner SurroundObstacleStop] Inserted stop point at ego pose due to nearby "
+    "obstacle.");
+}
+
+void SurroundObstacleStop::publish_debug_string(const bool is_active) const
+{
+  std::ostringstream ss;
+  ss << std::fixed << std::setprecision(2) << std::boolalpha;
+  ss << "SURROUND OBSTACLE STOP (Backup Planner):" << "\n";
+  ss << "\t\t" << "ACTIVE: " << is_active << "\n";
+  ss << "\t\t" << "STOP_ACTIVE: " << is_stop_active_ << "\n";
+
+  StringStamped string_stamp;
+  string_stamp.stamp = get_clock()->now();
+  string_stamp.data = ss.str();
+  pub_debug_text_->publish(string_stamp);
+}
+
+}  // namespace autoware::minimum_rule_based_planner::plugin
+
+#include <pluginlib/class_list_macros.hpp>
+PLUGINLIB_EXPORT_CLASS(
+  autoware::minimum_rule_based_planner::plugin::SurroundObstacleStop,
+  autoware::minimum_rule_based_planner::plugin::PluginInterface)

--- a/planning/autoware_minimum_rule_based_planner/plugins/surround_obstacle_stop.cpp
+++ b/planning/autoware_minimum_rule_based_planner/plugins/surround_obstacle_stop.cpp
@@ -65,6 +65,8 @@ Parameters to_proximity_checker_parameters(const SurroundObstacleStopParams & pa
   set_object_enable("motorcycle");
   set_object_enable("bicycle");
   set_object_enable("pedestrian");
+  set_object_enable("hazard");
+  set_object_enable("animal");
 
   const auto & front = params.front_distance_th;
   const auto & side = params.side_distance_th;
@@ -86,6 +88,10 @@ Parameters to_proximity_checker_parameters(const SurroundObstacleStopParams & pa
     to_obstacle_type_parameters(front.bicycle, side.bicycle, back.bicycle);
   parameters.obstacle_types_map["pedestrian"] =
     to_obstacle_type_parameters(front.pedestrian, side.pedestrian, back.pedestrian);
+  parameters.obstacle_types_map["hazard"] =
+    to_obstacle_type_parameters(front.hazard, side.hazard, back.hazard);
+  parameters.obstacle_types_map["animal"] =
+    to_obstacle_type_parameters(front.animal, side.animal, back.animal);
 
   return parameters;
 }

--- a/planning/autoware_minimum_rule_based_planner/plugins/surround_obstacle_stop.cpp
+++ b/planning/autoware_minimum_rule_based_planner/plugins/surround_obstacle_stop.cpp
@@ -103,8 +103,8 @@ void SurroundObstacleStop::on_initialize(const MinimumRuleBasedPlannerParams & p
     std::make_unique<autoware::planning_factor_interface::PlanningFactorInterface>(
       get_node_ptr(), "backup_planner_surround_obstacle_stop");
 
-  pub_debug_text_ = get_node_ptr()->create_publisher<StringStamped>(
-    "~/surround_obstacle_stop/debug/text", 1);
+  pub_debug_text_ =
+    get_node_ptr()->create_publisher<StringStamped>("~/surround_obstacle_stop/debug/text", 1);
 
   proximity_checker_ = std::make_unique<obstacle_proximity_checker::ProximityChecker>(
     to_proximity_checker_parameters(params_), vehicle_info_);
@@ -151,7 +151,9 @@ obstacle_proximity_checker::Inputs SurroundObstacleStop::to_proximity_checker_in
   checker_inputs.ego_pose = data_->odometry_ptr->pose.pose;
   checker_inputs.objects = data_->predicted_objects_ptr;
 
-  if (!data_->obstacle_pointcloud_ptr) return checker_inputs;
+  if (!data_->obstacle_pointcloud_ptr || data_->obstacle_pointcloud_ptr->data.empty()) {
+    return checker_inputs;
+  }
 
   const auto transform_stamped = get_transform(
     "base_link", data_->obstacle_pointcloud_ptr->header.frame_id,

--- a/planning/autoware_minimum_rule_based_planner/plugins/surround_obstacle_stop.cpp
+++ b/planning/autoware_minimum_rule_based_planner/plugins/surround_obstacle_stop.cpp
@@ -113,7 +113,7 @@ void SurroundObstacleStop::on_initialize(const MinimumRuleBasedPlannerParams & p
     get_node_ptr()->create_publisher<StringStamped>("~/surround_obstacle_stop/debug/text", 1);
 
   proximity_checker_ = std::make_unique<obstacle_proximity_checker::ProximityChecker>(
-    to_proximity_checker_parameters(params_), vehicle_info_);
+    to_proximity_checker_parameters(params_), context_->vehicle_info);
 }
 
 void SurroundObstacleStop::update_params(const MinimumRuleBasedPlannerParams & params)
@@ -122,22 +122,22 @@ void SurroundObstacleStop::update_params(const MinimumRuleBasedPlannerParams & p
   proximity_checker_->update_parameters(to_proximity_checker_parameters(params_));
 }
 
-void SurroundObstacleStop::run(TrajectoryPoints & traj_points)
+void SurroundObstacleStop::run(TrajectoryPoints & traj_points, const ModifierData & data)
 {
   proximity_check_result_ = std::nullopt;
 
-  if (!is_stop_required(traj_points)) {
+  if (!is_stop_required(traj_points, data)) {
     publish_debug_string(false);
     return;
   }
 
-  set_stop_point(traj_points);
+  set_stop_point(traj_points, data);
   publish_debug_string(true);
 }
 
-bool SurroundObstacleStop::check_inputs() const
+bool SurroundObstacleStop::check_inputs(const ModifierData & data) const
 {
-  if (!data_->odometry_ptr) {
+  if (!data.odometry_ptr) {
     return false;
   }
 
@@ -145,32 +145,33 @@ bool SurroundObstacleStop::check_inputs() const
     return false;
   }
 
-  const bool has_pointcloud = params_.use_pointcloud && data_->obstacle_pointcloud_ptr;
-  const bool has_objects = params_.use_objects && data_->predicted_objects_ptr;
+  const bool has_pointcloud = params_.use_pointcloud && data.obstacle_pointcloud_ptr;
+  const bool has_objects = params_.use_objects && data.predicted_objects_ptr;
 
   return has_pointcloud || has_objects;
 }
 
-obstacle_proximity_checker::Inputs SurroundObstacleStop::to_proximity_checker_inputs() const
+obstacle_proximity_checker::Inputs SurroundObstacleStop::to_proximity_checker_inputs(
+  const ModifierData & data) const
 {
   obstacle_proximity_checker::Inputs checker_inputs;
-  checker_inputs.ego_pose = data_->odometry_ptr->pose.pose;
-  checker_inputs.objects = data_->predicted_objects_ptr;
+  checker_inputs.ego_pose = data.odometry_ptr->pose.pose;
+  checker_inputs.objects = data.predicted_objects_ptr;
 
-  if (!data_->obstacle_pointcloud_ptr || data_->obstacle_pointcloud_ptr->data.empty()) {
+  if (!data.obstacle_pointcloud_ptr || data.obstacle_pointcloud_ptr->data.empty()) {
     return checker_inputs;
   }
 
   const auto transform_stamped = get_transform(
-    "base_link", data_->obstacle_pointcloud_ptr->header.frame_id,
-    data_->obstacle_pointcloud_ptr->header.stamp, 0.5);
+    "base_link", data.obstacle_pointcloud_ptr->header.frame_id,
+    data.obstacle_pointcloud_ptr->header.stamp, 0.5);
 
   if (!transform_stamped.has_value()) return checker_inputs;
 
   Eigen::Affine3f isometry =
     tf2::transformToEigen(transform_stamped.value().transform).cast<float>();
   pcl::PointCloud<pcl::PointXYZ> transformed_pointcloud;
-  pcl::fromROSMsg(*data_->obstacle_pointcloud_ptr, transformed_pointcloud);
+  pcl::fromROSMsg(*data.obstacle_pointcloud_ptr, transformed_pointcloud);
   autoware_utils::transform_pointcloud(transformed_pointcloud, transformed_pointcloud, isometry);
 
   checker_inputs.pointcloud_in_base_link = transformed_pointcloud.makeShared();
@@ -185,8 +186,8 @@ std::optional<geometry_msgs::msg::TransformStamped> SurroundObstacleStop::get_tr
   geometry_msgs::msg::TransformStamped transform_stamped;
 
   try {
-    transform_stamped =
-      data_->tf_buffer.lookupTransform(target, source, stamp, tf2::durationFromSec(duration_sec));
+    transform_stamped = context_->tf_buffer.lookupTransform(
+      target, source, stamp, tf2::durationFromSec(duration_sec));
   } catch (const tf2::TransformException & ex) {
     RCLCPP_WARN_THROTTLE(
       get_node_ptr()->get_logger(), *get_clock(), 1000, "no transform found for pointcloud: %s",
@@ -197,13 +198,13 @@ std::optional<geometry_msgs::msg::TransformStamped> SurroundObstacleStop::get_tr
   return transform_stamped;
 }
 
-bool SurroundObstacleStop::is_obstacle_nearby()
+bool SurroundObstacleStop::is_obstacle_nearby(const ModifierData & data)
 {
   const double contact_distance_threshold = is_stop_active_ ? params_.hysteresis_distance : 1e-3;
 
   if (!proximity_check_result_.has_value()) {
     proximity_check_result_ =
-      proximity_checker_->check(to_proximity_checker_inputs(), contact_distance_threshold);
+      proximity_checker_->check(to_proximity_checker_inputs(data), contact_distance_threshold);
   }
 
   const auto & result = proximity_check_result_.value();
@@ -225,28 +226,29 @@ bool SurroundObstacleStop::is_obstacle_nearby()
   return false;
 }
 
-bool SurroundObstacleStop::is_stop_required(const TrajectoryPoints & traj_points)
+bool SurroundObstacleStop::is_stop_required(
+  const TrajectoryPoints & traj_points, const ModifierData & data)
 {
-  if (!params_.enable || !check_inputs()) {
+  if (!params_.enable || !check_inputs(data)) {
     return false;
   }
 
   if (
     utils::is_stop_trajectory(traj_points, params_.ego_stopped_vel_th) ||
-    utils::is_ego_vehicle_moving(data_->odometry_ptr->twist.twist, params_.ego_stopped_vel_th)) {
+    utils::is_ego_vehicle_moving(data.odometry_ptr->twist.twist, params_.ego_stopped_vel_th)) {
     is_stop_active_ = false;
     last_obstacle_found_time_ = std::nullopt;
     return false;
   }
 
-  return is_obstacle_nearby();
+  return is_obstacle_nearby(data);
 }
 
-void SurroundObstacleStop::set_stop_point(TrajectoryPoints & traj_points)
+void SurroundObstacleStop::set_stop_point(TrajectoryPoints & traj_points, const ModifierData & data)
 {
   if (traj_points.empty()) return;
 
-  const auto & ego_pose = data_->odometry_ptr->pose.pose;
+  const auto & ego_pose = data.odometry_ptr->pose.pose;
 
   // Insert a zero-velocity stop point at the ego pose while keeping the trajectory shape.
   const auto stop_index = motion_utils::insertStopPoint(ego_pose, 0.0, traj_points);

--- a/planning/autoware_minimum_rule_based_planner/plugins/surround_obstacle_stop.hpp
+++ b/planning/autoware_minimum_rule_based_planner/plugins/surround_obstacle_stop.hpp
@@ -1,0 +1,82 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef PLANNING__AUTOWARE_MINIMUM_RULE_BASED_PLANNER__PLUGINS__SURROUND_OBSTACLE_STOP_HPP_
+#define PLANNING__AUTOWARE_MINIMUM_RULE_BASED_PLANNER__PLUGINS__SURROUND_OBSTACLE_STOP_HPP_
+
+#include "autoware/obstacle_proximity_checker/obstacle_proximity_checker.hpp"
+#include "plugin_interface.hpp"
+
+#include <rclcpp/rclcpp.hpp>
+
+#include <autoware_internal_debug_msgs/msg/string_stamped.hpp>
+#include <geometry_msgs/msg/transform_stamped.hpp>
+
+#include <memory>
+#include <optional>
+#include <string>
+#include <vector>
+
+namespace autoware::minimum_rule_based_planner::plugin
+{
+using autoware_internal_debug_msgs::msg::StringStamped;
+using autoware_planning_msgs::msg::TrajectoryPoint;
+using TrajectoryPoints = std::vector<TrajectoryPoint>;
+
+class SurroundObstacleStop : public PluginInterface
+{
+public:
+  SurroundObstacleStop() = default;
+
+  void run(TrajectoryPoints & traj_points) override;
+
+  void update_params(const MinimumRuleBasedPlannerParams & params) override;
+
+  const MinimumRuleBasedPlannerParams::SurroundObstacleStop & get_params() const { return params_; }
+
+protected:
+  void on_initialize(const MinimumRuleBasedPlannerParams & params) override;
+
+private:
+  MinimumRuleBasedPlannerParams::SurroundObstacleStop params_;
+
+  std::unique_ptr<obstacle_proximity_checker::ProximityChecker> proximity_checker_;
+
+  std::optional<obstacle_proximity_checker::CheckResult> proximity_check_result_;
+
+  bool is_stop_active_{false};
+  std::optional<rclcpp::Time> last_obstacle_found_time_;
+
+  rclcpp::Publisher<StringStamped>::SharedPtr pub_debug_text_;
+
+  [[nodiscard]] bool check_inputs() const;
+
+  [[nodiscard]] obstacle_proximity_checker::Inputs to_proximity_checker_inputs() const;
+
+  [[nodiscard]] bool is_obstacle_nearby();
+
+  [[nodiscard]] bool is_stop_required(const TrajectoryPoints & traj_points);
+
+  std::optional<geometry_msgs::msg::TransformStamped> get_transform(
+    const std::string & target, const std::string & source, const rclcpp::Time & stamp,
+    double duration_sec) const;
+
+  void set_stop_point(TrajectoryPoints & traj_points);
+
+  void publish_debug_string(bool is_active) const;
+};
+
+}  // namespace autoware::minimum_rule_based_planner::plugin
+
+#endif  // PLANNING__AUTOWARE_MINIMUM_RULE_BASED_PLANNER__PLUGINS__SURROUND_OBSTACLE_STOP_HPP_

--- a/planning/autoware_minimum_rule_based_planner/plugins/surround_obstacle_stop.hpp
+++ b/planning/autoware_minimum_rule_based_planner/plugins/surround_obstacle_stop.hpp
@@ -39,7 +39,7 @@ class SurroundObstacleStop : public PluginInterface
 public:
   SurroundObstacleStop() = default;
 
-  void run(TrajectoryPoints & traj_points) override;
+  void run(TrajectoryPoints & traj_points, const ModifierData & data) override;
 
   void update_params(const MinimumRuleBasedPlannerParams & params) override;
 
@@ -60,19 +60,21 @@ private:
 
   rclcpp::Publisher<StringStamped>::SharedPtr pub_debug_text_;
 
-  [[nodiscard]] bool check_inputs() const;
+  [[nodiscard]] bool check_inputs(const ModifierData & data) const;
 
-  [[nodiscard]] obstacle_proximity_checker::Inputs to_proximity_checker_inputs() const;
+  [[nodiscard]] obstacle_proximity_checker::Inputs to_proximity_checker_inputs(
+    const ModifierData & data) const;
 
-  [[nodiscard]] bool is_obstacle_nearby();
+  [[nodiscard]] bool is_obstacle_nearby(const ModifierData & data);
 
-  [[nodiscard]] bool is_stop_required(const TrajectoryPoints & traj_points);
+  [[nodiscard]] bool is_stop_required(
+    const TrajectoryPoints & traj_points, const ModifierData & data);
 
   std::optional<geometry_msgs::msg::TransformStamped> get_transform(
     const std::string & target, const std::string & source, const rclcpp::Time & stamp,
     double duration_sec) const;
 
-  void set_stop_point(TrajectoryPoints & traj_points);
+  void set_stop_point(TrajectoryPoints & traj_points, const ModifierData & data);
 
   void publish_debug_string(bool is_active) const;
 };

--- a/planning/autoware_minimum_rule_based_planner/schema/minimum_rule_based_planner.schema.json
+++ b/planning/autoware_minimum_rule_based_planner/schema/minimum_rule_based_planner.schema.json
@@ -451,6 +451,276 @@
           "required": [],
           "additionalProperties": false
         },
+        "surround_obstacle_stop": {
+          "type": "object",
+          "properties": {
+            "enable": {
+              "type": "boolean",
+              "description": "Enable surround obstacle stop",
+              "default": true
+            },
+            "use_objects": {
+              "type": "boolean",
+              "description": "Enable the use of objects for surround obstacle stop",
+              "default": true
+            },
+            "use_pointcloud": {
+              "type": "boolean",
+              "description": "Enable the use of pointcloud for surround obstacle stop",
+              "default": false
+            },
+            "object_types": {
+              "type": "array",
+              "description": "Types of objects to consider for surround obstacle stop",
+              "default": [
+                "car",
+                "truck",
+                "bus",
+                "trailer",
+                "motorcycle",
+                "bicycle",
+                "pedestrian",
+                "unknown"
+              ],
+              "items": {
+                "type": "string"
+              }
+            },
+            "front_distance_th": {
+              "type": "object",
+              "properties": {
+                "car": {
+                  "type": "number",
+                  "description": "Front surround check distance for car [m]",
+                  "default": 0.5,
+                  "minimum": 0.0,
+                  "maximum": 10.0
+                },
+                "truck": {
+                  "type": "number",
+                  "description": "Front surround check distance for truck [m]",
+                  "default": 0.5,
+                  "minimum": 0.0,
+                  "maximum": 10.0
+                },
+                "bus": {
+                  "type": "number",
+                  "description": "Front surround check distance for bus [m]",
+                  "default": 0.5,
+                  "minimum": 0.0,
+                  "maximum": 10.0
+                },
+                "trailer": {
+                  "type": "number",
+                  "description": "Front surround check distance for trailer [m]",
+                  "default": 0.5,
+                  "minimum": 0.0,
+                  "maximum": 10.0
+                },
+                "motorcycle": {
+                  "type": "number",
+                  "description": "Front surround check distance for motorcycle [m]",
+                  "default": 0.5,
+                  "minimum": 0.0,
+                  "maximum": 10.0
+                },
+                "bicycle": {
+                  "type": "number",
+                  "description": "Front surround check distance for bicycle [m]",
+                  "default": 0.5,
+                  "minimum": 0.0,
+                  "maximum": 10.0
+                },
+                "pedestrian": {
+                  "type": "number",
+                  "description": "Front surround check distance for pedestrian [m]",
+                  "default": 0.5,
+                  "minimum": 0.0,
+                  "maximum": 10.0
+                },
+                "unknown": {
+                  "type": "number",
+                  "description": "Front surround check distance for unknown [m]",
+                  "default": 0.5,
+                  "minimum": 0.0,
+                  "maximum": 10.0
+                },
+                "pointcloud": {
+                  "type": "number",
+                  "description": "Front surround check distance for pointcloud [m]",
+                  "default": 0.5,
+                  "minimum": 0.0,
+                  "maximum": 10.0
+                }
+              },
+              "required": [],
+              "additionalProperties": false
+            },
+            "side_distance_th": {
+              "type": "object",
+              "properties": {
+                "car": {
+                  "type": "number",
+                  "description": "Side surround check distance for car [m]",
+                  "default": 0.0,
+                  "minimum": 0.0,
+                  "maximum": 10.0
+                },
+                "truck": {
+                  "type": "number",
+                  "description": "Side surround check distance for truck [m]",
+                  "default": 0.0,
+                  "minimum": 0.0,
+                  "maximum": 10.0
+                },
+                "bus": {
+                  "type": "number",
+                  "description": "Side surround check distance for bus [m]",
+                  "default": 0.0,
+                  "minimum": 0.0,
+                  "maximum": 10.0
+                },
+                "trailer": {
+                  "type": "number",
+                  "description": "Side surround check distance for trailer [m]",
+                  "default": 0.0,
+                  "minimum": 0.0,
+                  "maximum": 10.0
+                },
+                "motorcycle": {
+                  "type": "number",
+                  "description": "Side surround check distance for motorcycle [m]",
+                  "default": 1.0,
+                  "minimum": 0.0,
+                  "maximum": 10.0
+                },
+                "bicycle": {
+                  "type": "number",
+                  "description": "Side surround check distance for bicycle [m]",
+                  "default": 1.0,
+                  "minimum": 0.0,
+                  "maximum": 10.0
+                },
+                "pedestrian": {
+                  "type": "number",
+                  "description": "Side surround check distance for pedestrian [m]",
+                  "default": 1.0,
+                  "minimum": 0.0,
+                  "maximum": 10.0
+                },
+                "unknown": {
+                  "type": "number",
+                  "description": "Side surround check distance for unknown [m]",
+                  "default": 0.5,
+                  "minimum": 0.0,
+                  "maximum": 10.0
+                },
+                "pointcloud": {
+                  "type": "number",
+                  "description": "Side surround check distance for pointcloud [m]",
+                  "default": 0.5,
+                  "minimum": 0.0,
+                  "maximum": 10.0
+                }
+              },
+              "required": [],
+              "additionalProperties": false
+            },
+            "back_distance_th": {
+              "type": "object",
+              "properties": {
+                "car": {
+                  "type": "number",
+                  "description": "Back surround check distance for car [m]",
+                  "default": 0.0,
+                  "minimum": 0.0,
+                  "maximum": 10.0
+                },
+                "truck": {
+                  "type": "number",
+                  "description": "Back surround check distance for truck [m]",
+                  "default": 0.0,
+                  "minimum": 0.0,
+                  "maximum": 10.0
+                },
+                "bus": {
+                  "type": "number",
+                  "description": "Back surround check distance for bus [m]",
+                  "default": 0.0,
+                  "minimum": 0.0,
+                  "maximum": 10.0
+                },
+                "trailer": {
+                  "type": "number",
+                  "description": "Back surround check distance for trailer [m]",
+                  "default": 0.0,
+                  "minimum": 0.0,
+                  "maximum": 10.0
+                },
+                "motorcycle": {
+                  "type": "number",
+                  "description": "Back surround check distance for motorcycle [m]",
+                  "default": 0.5,
+                  "minimum": 0.0,
+                  "maximum": 10.0
+                },
+                "bicycle": {
+                  "type": "number",
+                  "description": "Back surround check distance for bicycle [m]",
+                  "default": 0.5,
+                  "minimum": 0.0,
+                  "maximum": 10.0
+                },
+                "pedestrian": {
+                  "type": "number",
+                  "description": "Back surround check distance for pedestrian [m]",
+                  "default": 0.5,
+                  "minimum": 0.0,
+                  "maximum": 10.0
+                },
+                "unknown": {
+                  "type": "number",
+                  "description": "Back surround check distance for unknown [m]",
+                  "default": 0.5,
+                  "minimum": 0.0,
+                  "maximum": 10.0
+                },
+                "pointcloud": {
+                  "type": "number",
+                  "description": "Back surround check distance for pointcloud [m]",
+                  "default": 0.5,
+                  "minimum": 0.0,
+                  "maximum": 10.0
+                }
+              },
+              "required": [],
+              "additionalProperties": false
+            },
+            "hysteresis_distance": {
+              "type": "number",
+              "description": "Distance hysteresis threshold for clearing surround stop [m]",
+              "default": 0.1,
+              "minimum": 0.0,
+              "maximum": 10.0
+            },
+            "hysteresis_time": {
+              "type": "number",
+              "description": "Time hysteresis threshold for clearing surround stop [s]",
+              "default": 0.2,
+              "minimum": 0.0,
+              "maximum": 10.0
+            },
+            "ego_stopped_vel_th": {
+              "type": "number",
+              "description": "Velocity threshold below which ego vehicle is considered stopped [m/s]",
+              "default": 0.1,
+              "minimum": 0.0,
+              "maximum": 10.0
+            }
+          },
+          "required": [],
+          "additionalProperties": false
+        },
         "velocity_smoother": {
           "type": "object",
           "properties": {

--- a/planning/autoware_minimum_rule_based_planner/schema/minimum_rule_based_planner.schema.json
+++ b/planning/autoware_minimum_rule_based_planner/schema/minimum_rule_based_planner.schema.json
@@ -250,7 +250,8 @@
                     "trailer",
                     "motorcycle",
                     "bicycle",
-                    "pedestrian"
+                    "pedestrian",
+                    "hazard"
                   ],
                   "items": {
                     "type": "string"
@@ -491,6 +492,8 @@
                 "motorcycle",
                 "bicycle",
                 "pedestrian",
+                "hazard",
+                "animal",
                 "unknown"
               ],
               "items": {
@@ -545,6 +548,20 @@
                 "pedestrian": {
                   "type": "number",
                   "description": "Front surround check distance for pedestrian [m]",
+                  "default": 0.5,
+                  "minimum": 0.0,
+                  "maximum": 10.0
+                },
+                "hazard": {
+                  "type": "number",
+                  "description": "Front surround check distance for hazard [m]",
+                  "default": 0.5,
+                  "minimum": 0.0,
+                  "maximum": 10.0
+                },
+                "animal": {
+                  "type": "number",
+                  "description": "Front surround check distance for animal [m]",
                   "default": 0.5,
                   "minimum": 0.0,
                   "maximum": 10.0
@@ -619,6 +636,20 @@
                   "minimum": 0.0,
                   "maximum": 10.0
                 },
+                "hazard": {
+                  "type": "number",
+                  "description": "Side surround check distance for hazard [m]",
+                  "default": 0.5,
+                  "minimum": 0.0,
+                  "maximum": 10.0
+                },
+                "animal": {
+                  "type": "number",
+                  "description": "Side surround check distance for animal [m]",
+                  "default": 0.5,
+                  "minimum": 0.0,
+                  "maximum": 10.0
+                },
                 "unknown": {
                   "type": "number",
                   "description": "Side surround check distance for unknown [m]",
@@ -685,6 +716,20 @@
                 "pedestrian": {
                   "type": "number",
                   "description": "Back surround check distance for pedestrian [m]",
+                  "default": 0.5,
+                  "minimum": 0.0,
+                  "maximum": 10.0
+                },
+                "hazard": {
+                  "type": "number",
+                  "description": "Back surround check distance for hazard [m]",
+                  "default": 0.5,
+                  "minimum": 0.0,
+                  "maximum": 10.0
+                },
+                "animal": {
+                  "type": "number",
+                  "description": "Back surround check distance for animal [m]",
                   "default": 0.5,
                   "minimum": 0.0,
                   "maximum": 10.0

--- a/planning/autoware_minimum_rule_based_planner/schema/minimum_rule_based_planner.schema.json
+++ b/planning/autoware_minimum_rule_based_planner/schema/minimum_rule_based_planner.schema.json
@@ -12,6 +12,17 @@
           "default": 10.0,
           "minimum": 0.0
         },
+        "plugin_names": {
+          "type": "array",
+          "description": "List of plugins to load",
+          "default": [
+            "autoware::minimum_rule_based_planner::plugin::ObstacleStop",
+            "autoware::minimum_rule_based_planner::plugin::SurroundObstacleStop"
+          ],
+          "items": {
+            "type": "string"
+          }
+        },
         "path_planning": {
           "type": "object",
           "properties": {

--- a/planning/autoware_minimum_rule_based_planner/src/minimum_rule_based_planner.cpp
+++ b/planning/autoware_minimum_rule_based_planner/src/minimum_rule_based_planner.cpp
@@ -150,8 +150,7 @@ void MinimumRuleBasedPlannerNode::load_optimizer_plugins()
 
 void MinimumRuleBasedPlannerNode::load_modifier_plugins()
 {
-  for (const auto & name : this->declare_parameter<std::vector<std::string>>(
-         "modifier_launch_modules", std::vector<std::string>{})) {
+  for (const auto & name : params_.plugin_names) {
     if (name.empty()) continue;
     load_plugin(name);
   }
@@ -163,11 +162,16 @@ void MinimumRuleBasedPlannerNode::load_modifier_plugins()
 
 void MinimumRuleBasedPlannerNode::load_plugin(const std::string & name)
 {
-  // Check if the plugin is already loaded.
-  if (modifier_plugin_loader_.isClassLoaded(name)) {
-    RCLCPP_WARN(this->get_logger(), "The plugin '%s' is already loaded.", name.c_str());
+  // Check if the plugin is already instantiated
+  auto it = std::find_if(modifier_plugins_.begin(), modifier_plugins_.end(), [&](const auto & p) {
+    return p->get_name() == name;
+  });
+  if (it != modifier_plugins_.end()) {
+    RCLCPP_WARN(
+      this->get_logger(), "The plugin '%s' is already in the plugins list.", name.c_str());
     return;
   }
+
   if (modifier_plugin_loader_.isClassAvailable(name)) {
     const auto plugin = modifier_plugin_loader_.createSharedInstance(name);
     plugin->initialize(name, this, time_keeper_, modifier_data_, vehicle_info_, params_);

--- a/planning/autoware_minimum_rule_based_planner/src/minimum_rule_based_planner.cpp
+++ b/planning/autoware_minimum_rule_based_planner/src/minimum_rule_based_planner.cpp
@@ -227,18 +227,19 @@ void MinimumRuleBasedPlannerNode::set_modifier_data(
   modifier_data_->obstacle_pointcloud_ptr = input_data.obstacle_pointcloud_ptr;
 }
 
+void MinimumRuleBasedPlannerNode::publish_debug_trajectory(
+  const std::string & plugin_name, const TrajectoryPoints & traj_points)
+{
+  Trajectory traj;
+  traj.points = traj_points;
+  pub_debug_modifier_module_trajectories_[plugin_name]->publish(traj);
+}
+
 void MinimumRuleBasedPlannerNode::on_timer()
 {
   autoware_utils_debug::ScopedTimeTrack st(__func__, *time_keeper_);
   stop_watch_ptr_ = std::make_unique<autoware_utils_system::StopWatch<std::chrono::milliseconds>>();
   stop_watch_ptr_->tic("processing_time");
-
-  auto publish_debug_trajectory =
-    [](const auto & publisher_map, const auto & plugin, const TrajectoryPoints & points) {
-      Trajectory traj;
-      traj.points = points;
-      publisher_map.at(plugin->get_name())->publish(traj);
-    };
 
   // 1. Check data availability
   const auto input_data = take_data();
@@ -255,14 +256,7 @@ void MinimumRuleBasedPlannerNode::on_timer()
   }
 
   // 2. Get path
-  const auto path = [&]() -> std::optional<PathWithLaneId> {
-    autoware_utils_debug::ScopedTimeTrack st("plan_path", *time_keeper_);
-    if (input_data.test_path_with_lane_id_ptr) {
-      return *input_data.test_path_with_lane_id_ptr;
-    }
-    return path_planner_->plan_path(
-      input_data.odometry_ptr->pose.pose, input_data.odometry_ptr->twist.twist.linear.x);
-  }();
+  const auto path = plan_path(input_data);
 
   if (!path) {
     RCLCPP_WARN_THROTTLE(this->get_logger(), *this->get_clock(), 5000, "Failed to plan path.");
@@ -272,136 +266,29 @@ void MinimumRuleBasedPlannerNode::on_timer()
   // 3. Convert path to trajectory
   auto traj_from_path =
     path_planner_->convert_path_to_trajectory(*path, params_.path_planning.output.delta_arc_length);
+  traj_from_path.header = path->header;
 
   // 4. Shift trajectory to ego position
-  if (params_.path_planning.path_shift.enable) {
-    autoware_utils_debug::ScopedTimeTrack st("shift_trajectory_to_ego", *time_keeper_);
-    TrajectoryShiftParams shift_params;
-    shift_params.minimum_shift_length = params_.path_planning.path_shift.minimum_shift_length;
-    shift_params.minimum_shift_yaw = params_.path_planning.path_shift.minimum_shift_yaw;
-    shift_params.minimum_shift_distance = params_.path_planning.path_shift.minimum_shift_distance;
-    shift_params.min_speed_for_curvature = params_.path_planning.path_shift.min_speed_for_curvature;
-    shift_params.lateral_accel_limit = params_.path_planning.path_shift.lateral_accel_limit;
-
-    const double ego_velocity = input_data.odometry_ptr->twist.twist.linear.x;
-    const double ego_yaw_rate = input_data.odometry_ptr->twist.twist.angular.z;
-    traj_from_path = path_planner_->shift_trajectory_to_ego(
-      traj_from_path, input_data.odometry_ptr->pose.pose, ego_velocity, ego_yaw_rate, shift_params,
-      params_.path_planning.output.delta_arc_length);
-
-    if (params_.debug.enable_shifted_trajectory) {
-      Trajectory shifted_traj;
-      shifted_traj.header = path->header;
-      shifted_traj.points = traj_from_path.points;
-      pub_debug_shifted_trajectory_->publish(shifted_traj);
-    }
-  }
+  const auto shifted_trajectory = shift_trajectory_to_ego(traj_from_path, input_data);
 
   // 5. Smooth path
-  auto smoothed_path = [&]() {
-    autoware_utils_debug::ScopedTimeTrack st("smoothing_path", *time_keeper_);
-    auto optimizer_data = make_optimizer_data(input_data);
-
-    trajectory_optimizer::TrajectoryOptimizerParams optimizer_params;
-    optimizer_params.use_eb_smoother = true;
-
-    auto trajectory_points = traj_from_path.points;
-    if (path_smoother_) {
-      autoware_utils_debug::ScopedTimeTrack st(path_smoother_->get_name(), *time_keeper_);
-      path_smoother_->optimize_trajectory(trajectory_points, optimizer_params, optimizer_data);
-      if (params_.debug.enable_optimizer_trajectory) {
-        publish_debug_trajectory(
-          pub_debug_optimizer_module_trajectories_, path_smoother_, trajectory_points);
-      }
-    }
-
-    Trajectory traj = traj_from_path;
-    traj.points = trajectory_points;
-    return traj;
-  }();
+  auto smoothed_trajectory = smooth_trajectory(shifted_trajectory, input_data);
 
   // 6. Apply trajectory modifiers
-  {
-    set_modifier_data(input_data);
-    for (auto & modifier : modifier_plugins_) {
-      autoware_utils_debug::ScopedTimeTrack st(modifier->get_name(), *time_keeper_);
-      modifier->run(smoothed_path.points);
-      modifier->publish_planning_factor();
-      if (params_.debug.enable_modifier_trajectory) {
-        publish_debug_trajectory(
-          pub_debug_modifier_module_trajectories_, modifier, smoothed_path.points);
-      }
-    }
-  }
+  apply_modifiers(smoothed_trajectory, input_data);
 
   // 7. Velocity optimization
-  const auto smoothed_traj = [&]() {
-    autoware_utils_debug::ScopedTimeTrack st("velocity_optimization", *time_keeper_);
-
-    auto trajectory_points = smoothed_path.points;
-
-    velocity_smoother_->optimize(
-      trajectory_points, *input_data.odometry_ptr,
-      input_data.acceleration_ptr->accel.accel.linear.x);
-
-    // Post-optimization resample
-    {
-      autoware::velocity_smoother::resampling::ResampleParam post_resample_param;
-      post_resample_param.max_trajectory_length = params_.post_resample.max_trajectory_length;
-      post_resample_param.min_trajectory_length = params_.post_resample.min_trajectory_length;
-      post_resample_param.resample_time = params_.post_resample.resample_time;
-      post_resample_param.dense_resample_dt = params_.post_resample.dense_resample_dt;
-      post_resample_param.dense_min_interval_distance =
-        params_.post_resample.dense_min_interval_distance;
-      post_resample_param.sparse_resample_dt = params_.post_resample.sparse_resample_dt;
-      post_resample_param.sparse_min_interval_distance =
-        params_.post_resample.sparse_min_interval_distance;
-
-      const auto & ego_pose = input_data.odometry_ptr->pose.pose;
-      const double v_current = input_data.odometry_ptr->twist.twist.linear.x;
-
-      trajectory_points = autoware::velocity_smoother::resampling::resampleTrajectory(
-        trajectory_points, v_current, ego_pose,
-        params_.path_planning.ego_nearest_lanelet.dist_threshold,
-        params_.path_planning.ego_nearest_lanelet.yaw_threshold, post_resample_param, false);
-
-      if (!trajectory_points.empty()) {
-        trajectory_points.back().longitudinal_velocity_mps = 0.0;
-      }
-    }
-
-    autoware::motion_utils::calculate_time_from_start(
-      trajectory_points, input_data.odometry_ptr->pose.pose.position);
-
-    Trajectory traj = traj_from_path;
-    traj.points = trajectory_points;
-    return traj;
-  }();
+  const auto trajectory = optimize_velocity(smoothed_trajectory, input_data);
 
   // 8. Create and publish CandidateTrajectories message
-  {
-    CandidateTrajectories msg;
-
-    autoware_internal_planning_msgs::msg::CandidateTrajectory candidate_traj;
-    candidate_traj.header = path->header;
-    candidate_traj.generator_id = generator_uuid_;
-    candidate_traj.points = smoothed_traj.points;
-    msg.candidate_trajectories.push_back(candidate_traj);
-
-    autoware_internal_planning_msgs::msg::GeneratorInfo generator_info;
-    generator_info.generator_id = generator_uuid_;
-    generator_info.generator_name.data = "MinimumRuleBasedPlanner";
-    msg.generator_info.push_back(generator_info);
-
-    pub_trajectories_->publish(msg);
-  }
+  publish_candidate_trajectories(trajectory);
 
   // 9. Publish debug information if enabled
   if (params_.debug.enable_path) {
     pub_debug_path_->publish(*path);
   }
   if (params_.debug.enable_output_trajectory) {
-    pub_debug_trajectory_->publish(smoothed_traj);
+    pub_debug_trajectory_->publish(trajectory);
   }
 
   // Publish processing time
@@ -409,6 +296,149 @@ void MinimumRuleBasedPlannerNode::on_timer()
   processing_time_msg.stamp = get_clock()->now();
   processing_time_msg.data = stop_watch_ptr_->toc("processing_time", true);
   debug_processing_time_pub_->publish(processing_time_msg);
+}
+
+std::optional<PathWithLaneId> MinimumRuleBasedPlannerNode::plan_path(const InputData & input_data)
+{
+  autoware_utils_debug::ScopedTimeTrack st(__func__, *time_keeper_);
+  if (input_data.test_path_with_lane_id_ptr) {
+    return *input_data.test_path_with_lane_id_ptr;
+  }
+  return path_planner_->plan_path(
+    input_data.odometry_ptr->pose.pose, input_data.odometry_ptr->twist.twist.linear.x);
+}
+
+Trajectory MinimumRuleBasedPlannerNode::shift_trajectory_to_ego(
+  const Trajectory & trajectory, const InputData & input_data)
+{
+  autoware_utils_debug::ScopedTimeTrack st(__func__, *time_keeper_);
+
+  if (!params_.path_planning.path_shift.enable) return trajectory;
+
+  TrajectoryShiftParams shift_params;
+  shift_params.minimum_shift_length = params_.path_planning.path_shift.minimum_shift_length;
+  shift_params.minimum_shift_yaw = params_.path_planning.path_shift.minimum_shift_yaw;
+  shift_params.minimum_shift_distance = params_.path_planning.path_shift.minimum_shift_distance;
+  shift_params.min_speed_for_curvature = params_.path_planning.path_shift.min_speed_for_curvature;
+  shift_params.lateral_accel_limit = params_.path_planning.path_shift.lateral_accel_limit;
+
+  const double ego_velocity = input_data.odometry_ptr->twist.twist.linear.x;
+  const double ego_yaw_rate = input_data.odometry_ptr->twist.twist.angular.z;
+  const auto shifted_trajectory = path_planner_->shift_trajectory_to_ego(
+    trajectory, input_data.odometry_ptr->pose.pose, ego_velocity, ego_yaw_rate, shift_params,
+    params_.path_planning.output.delta_arc_length);
+
+  if (params_.debug.enable_shifted_trajectory) {
+    Trajectory shifted_traj;
+    shifted_traj.header = trajectory.header;
+    shifted_traj.points = shifted_trajectory.points;
+    pub_debug_shifted_trajectory_->publish(shifted_traj);
+  }
+  return shifted_trajectory;
+}
+
+Trajectory MinimumRuleBasedPlannerNode::smooth_trajectory(
+  const Trajectory & trajectory, const InputData & input_data)
+{
+  autoware_utils_debug::ScopedTimeTrack st(__func__, *time_keeper_);
+  auto optimizer_data = make_optimizer_data(input_data);
+
+  trajectory_optimizer::TrajectoryOptimizerParams optimizer_params;
+  optimizer_params.use_eb_smoother = true;
+
+  auto trajectory_points = trajectory.points;
+  if (path_smoother_) {
+    autoware_utils_debug::ScopedTimeTrack st(path_smoother_->get_name(), *time_keeper_);
+    path_smoother_->optimize_trajectory(trajectory_points, optimizer_params, optimizer_data);
+    if (params_.debug.enable_optimizer_trajectory) {
+      publish_debug_trajectory(path_smoother_->get_name(), trajectory_points);
+    }
+  }
+
+  Trajectory traj;
+  traj.header = trajectory.header;
+  traj.points = trajectory_points;
+  return traj;
+}
+
+void MinimumRuleBasedPlannerNode::apply_modifiers(
+  Trajectory & trajectory, const InputData & input_data)
+{
+  autoware_utils_debug::ScopedTimeTrack st(__func__, *time_keeper_);
+  set_modifier_data(input_data);
+  for (auto & modifier : modifier_plugins_) {
+    autoware_utils_debug::ScopedTimeTrack st(modifier->get_name(), *time_keeper_);
+    modifier->run(trajectory.points);
+    modifier->publish_planning_factor();
+    if (params_.debug.enable_modifier_trajectory) {
+      publish_debug_trajectory(modifier->get_name(), trajectory.points);
+    }
+  }
+}
+
+Trajectory MinimumRuleBasedPlannerNode::optimize_velocity(
+  const Trajectory & trajectory, const InputData & input_data)
+{
+  autoware_utils_debug::ScopedTimeTrack st(__func__, *time_keeper_);
+
+  auto trajectory_points = trajectory.points;
+
+  velocity_smoother_->optimize(
+    trajectory_points, *input_data.odometry_ptr, input_data.acceleration_ptr->accel.accel.linear.x);
+
+  // Post-optimization resample
+  {
+    autoware::velocity_smoother::resampling::ResampleParam post_resample_param;
+    post_resample_param.max_trajectory_length = params_.post_resample.max_trajectory_length;
+    post_resample_param.min_trajectory_length = params_.post_resample.min_trajectory_length;
+    post_resample_param.resample_time = params_.post_resample.resample_time;
+    post_resample_param.dense_resample_dt = params_.post_resample.dense_resample_dt;
+    post_resample_param.dense_min_interval_distance =
+      params_.post_resample.dense_min_interval_distance;
+    post_resample_param.sparse_resample_dt = params_.post_resample.sparse_resample_dt;
+    post_resample_param.sparse_min_interval_distance =
+      params_.post_resample.sparse_min_interval_distance;
+
+    const auto & ego_pose = input_data.odometry_ptr->pose.pose;
+    const double v_current = input_data.odometry_ptr->twist.twist.linear.x;
+
+    trajectory_points = autoware::velocity_smoother::resampling::resampleTrajectory(
+      trajectory_points, v_current, ego_pose,
+      params_.path_planning.ego_nearest_lanelet.dist_threshold,
+      params_.path_planning.ego_nearest_lanelet.yaw_threshold, post_resample_param, false);
+
+    if (!trajectory_points.empty()) {
+      trajectory_points.back().longitudinal_velocity_mps = 0.0;
+    }
+  }
+
+  autoware::motion_utils::calculate_time_from_start(
+    trajectory_points, input_data.odometry_ptr->pose.pose.position);
+
+  Trajectory traj;
+  traj.header = trajectory.header;
+  traj.points = trajectory_points;
+  return traj;
+}
+
+void MinimumRuleBasedPlannerNode::publish_candidate_trajectories(const Trajectory & trajectory)
+{
+  autoware_utils_debug::ScopedTimeTrack st(__func__, *time_keeper_);
+
+  autoware_internal_planning_msgs::msg::CandidateTrajectory candidate_traj;
+  candidate_traj.header = trajectory.header;
+  candidate_traj.generator_id = generator_uuid_;
+  candidate_traj.points = trajectory.points;
+
+  CandidateTrajectories msg;
+  msg.candidate_trajectories.push_back(candidate_traj);
+
+  autoware_internal_planning_msgs::msg::GeneratorInfo generator_info;
+  generator_info.generator_id = generator_uuid_;
+  generator_info.generator_name.data = "MinimumRuleBasedPlanner";
+  msg.generator_info.push_back(generator_info);
+
+  pub_trajectories_->publish(msg);
 }
 
 MinimumRuleBasedPlannerNode::InputData MinimumRuleBasedPlannerNode::take_data()

--- a/planning/autoware_minimum_rule_based_planner/src/minimum_rule_based_planner.cpp
+++ b/planning/autoware_minimum_rule_based_planner/src/minimum_rule_based_planner.cpp
@@ -43,6 +43,17 @@ trajectory_optimizer::TrajectoryOptimizerData make_optimizer_data(
   }
   return data;
 }
+
+minimum_rule_based_planner::plugin::ModifierData make_modifier_data(
+  const MinimumRuleBasedPlannerNode::InputData & input_data)
+{
+  minimum_rule_based_planner::plugin::ModifierData data;
+  data.odometry_ptr = input_data.odometry_ptr;
+  data.acceleration_ptr = input_data.acceleration_ptr;
+  data.predicted_objects_ptr = input_data.predicted_objects_ptr;
+  data.obstacle_pointcloud_ptr = input_data.obstacle_pointcloud_ptr;
+  return data;
+}
 }  // namespace
 
 MinimumRuleBasedPlannerNode::MinimumRuleBasedPlannerNode(const rclcpp::NodeOptions & options)
@@ -52,7 +63,7 @@ MinimumRuleBasedPlannerNode::MinimumRuleBasedPlannerNode(const rclcpp::NodeOptio
   modifier_plugin_loader_(
     "autoware_minimum_rule_based_planner",
     "autoware::minimum_rule_based_planner::plugin::PluginInterface"),
-  modifier_data_(std::make_shared<plugin::ModifierData>(this))
+  modifier_context_(std::make_shared<plugin::ModifierContext>(this))
 {
   param_listener_ =
     std::make_shared<::minimum_rule_based_planner::ParamListener>(get_node_parameters_interface());
@@ -174,7 +185,7 @@ void MinimumRuleBasedPlannerNode::load_plugin(const std::string & name)
 
   if (modifier_plugin_loader_.isClassAvailable(name)) {
     const auto plugin = modifier_plugin_loader_.createSharedInstance(name);
-    plugin->initialize(name, this, time_keeper_, modifier_data_, vehicle_info_, params_);
+    plugin->initialize(name, this, time_keeper_, modifier_context_, params_);
 
     // Convert "autoware::...::ObstacleStop" to "obstacle_stop"
     const auto short_name = [](const std::string & plugin_name) {
@@ -218,21 +229,12 @@ void MinimumRuleBasedPlannerNode::unload_plugin(const std::string & name)
   }
 }
 
-void MinimumRuleBasedPlannerNode::set_modifier_data(
-  const MinimumRuleBasedPlannerNode::InputData & input_data)
-{
-  modifier_data_->odometry_ptr = input_data.odometry_ptr;
-  modifier_data_->acceleration_ptr = input_data.acceleration_ptr;
-  modifier_data_->predicted_objects_ptr = input_data.predicted_objects_ptr;
-  modifier_data_->obstacle_pointcloud_ptr = input_data.obstacle_pointcloud_ptr;
-}
-
 void MinimumRuleBasedPlannerNode::publish_debug_trajectory(
-  const std::string & plugin_name, const TrajectoryPoints & traj_points)
+  const std::string & plugin_name, const TrajectoryPoints & traj_points) const
 {
   Trajectory traj;
   traj.points = traj_points;
-  pub_debug_modifier_module_trajectories_[plugin_name]->publish(traj);
+  pub_debug_modifier_module_trajectories_.at(plugin_name)->publish(traj);
 }
 
 void MinimumRuleBasedPlannerNode::on_timer()
@@ -309,7 +311,7 @@ std::optional<PathWithLaneId> MinimumRuleBasedPlannerNode::plan_path(const Input
 }
 
 Trajectory MinimumRuleBasedPlannerNode::shift_trajectory_to_ego(
-  const Trajectory & trajectory, const InputData & input_data)
+  const Trajectory & trajectory, const InputData & input_data) const
 {
   autoware_utils_debug::ScopedTimeTrack st(__func__, *time_keeper_);
 
@@ -338,7 +340,7 @@ Trajectory MinimumRuleBasedPlannerNode::shift_trajectory_to_ego(
 }
 
 Trajectory MinimumRuleBasedPlannerNode::smooth_trajectory(
-  const Trajectory & trajectory, const InputData & input_data)
+  const Trajectory & trajectory, const InputData & input_data) const
 {
   autoware_utils_debug::ScopedTimeTrack st(__func__, *time_keeper_);
   auto optimizer_data = make_optimizer_data(input_data);
@@ -348,7 +350,8 @@ Trajectory MinimumRuleBasedPlannerNode::smooth_trajectory(
 
   auto trajectory_points = trajectory.points;
   if (path_smoother_) {
-    autoware_utils_debug::ScopedTimeTrack st(path_smoother_->get_name(), *time_keeper_);
+    autoware_utils_debug::ScopedTimeTrack st_path_smoother(
+      path_smoother_->get_name(), *time_keeper_);
     path_smoother_->optimize_trajectory(trajectory_points, optimizer_params, optimizer_data);
     if (params_.debug.enable_optimizer_trajectory) {
       publish_debug_trajectory(path_smoother_->get_name(), trajectory_points);
@@ -362,13 +365,13 @@ Trajectory MinimumRuleBasedPlannerNode::smooth_trajectory(
 }
 
 void MinimumRuleBasedPlannerNode::apply_modifiers(
-  Trajectory & trajectory, const InputData & input_data)
+  Trajectory & trajectory, const InputData & input_data) const
 {
   autoware_utils_debug::ScopedTimeTrack st(__func__, *time_keeper_);
-  set_modifier_data(input_data);
+  const auto modifier_data = make_modifier_data(input_data);
   for (auto & modifier : modifier_plugins_) {
-    autoware_utils_debug::ScopedTimeTrack st(modifier->get_name(), *time_keeper_);
-    modifier->run(trajectory.points);
+    autoware_utils_debug::ScopedTimeTrack st_modifier(modifier->get_name(), *time_keeper_);
+    modifier->run(trajectory.points, modifier_data);
     modifier->publish_planning_factor();
     if (params_.debug.enable_modifier_trajectory) {
       publish_debug_trajectory(modifier->get_name(), trajectory.points);
@@ -377,7 +380,7 @@ void MinimumRuleBasedPlannerNode::apply_modifiers(
 }
 
 Trajectory MinimumRuleBasedPlannerNode::optimize_velocity(
-  const Trajectory & trajectory, const InputData & input_data)
+  const Trajectory & trajectory, const InputData & input_data) const
 {
   autoware_utils_debug::ScopedTimeTrack st(__func__, *time_keeper_);
 
@@ -421,7 +424,8 @@ Trajectory MinimumRuleBasedPlannerNode::optimize_velocity(
   return traj;
 }
 
-void MinimumRuleBasedPlannerNode::publish_candidate_trajectories(const Trajectory & trajectory)
+void MinimumRuleBasedPlannerNode::publish_candidate_trajectories(
+  const Trajectory & trajectory) const
 {
   autoware_utils_debug::ScopedTimeTrack st(__func__, *time_keeper_);
 

--- a/planning/autoware_minimum_rule_based_planner/src/minimum_rule_based_planner.hpp
+++ b/planning/autoware_minimum_rule_based_planner/src/minimum_rule_based_planner.hpp
@@ -68,6 +68,17 @@ private:
   bool is_data_ready(const InputData & input_data);
   void update_params();
 
+  std::optional<PathWithLaneId> plan_path(const InputData & input_data);
+  Trajectory shift_trajectory_to_ego(const Trajectory & trajectory, const InputData & input_data);
+  Trajectory smooth_trajectory(const Trajectory & trajectory, const InputData & input_data);
+  void apply_modifiers(Trajectory & trajectory, const InputData & input_data);
+  Trajectory optimize_velocity(const Trajectory & trajectory, const InputData & input_data);
+
+  void publish_candidate_trajectories(const Trajectory & trajectory);
+
+  void publish_debug_trajectory(
+    const std::string & plugin_name, const TrajectoryPoints & traj_points);
+
   rclcpp::TimerBase::SharedPtr timer_;
   std::shared_ptr<::minimum_rule_based_planner::ParamListener> param_listener_;
   const UUID generator_uuid_;

--- a/planning/autoware_minimum_rule_based_planner/src/minimum_rule_based_planner.hpp
+++ b/planning/autoware_minimum_rule_based_planner/src/minimum_rule_based_planner.hpp
@@ -69,15 +69,16 @@ private:
   void update_params();
 
   std::optional<PathWithLaneId> plan_path(const InputData & input_data);
-  Trajectory shift_trajectory_to_ego(const Trajectory & trajectory, const InputData & input_data);
-  Trajectory smooth_trajectory(const Trajectory & trajectory, const InputData & input_data);
-  void apply_modifiers(Trajectory & trajectory, const InputData & input_data);
-  Trajectory optimize_velocity(const Trajectory & trajectory, const InputData & input_data);
+  Trajectory shift_trajectory_to_ego(
+    const Trajectory & trajectory, const InputData & input_data) const;
+  Trajectory smooth_trajectory(const Trajectory & trajectory, const InputData & input_data) const;
+  void apply_modifiers(Trajectory & trajectory, const InputData & input_data) const;
+  Trajectory optimize_velocity(const Trajectory & trajectory, const InputData & input_data) const;
 
-  void publish_candidate_trajectories(const Trajectory & trajectory);
+  void publish_candidate_trajectories(const Trajectory & trajectory) const;
 
   void publish_debug_trajectory(
-    const std::string & plugin_name, const TrajectoryPoints & traj_points);
+    const std::string & plugin_name, const TrajectoryPoints & traj_points) const;
 
   rclcpp::TimerBase::SharedPtr timer_;
   std::shared_ptr<::minimum_rule_based_planner::ParamListener> param_listener_;
@@ -130,15 +131,13 @@ private:
   void load_plugin(const std::string & name);
   void unload_plugin(const std::string & name);
 
-  void set_modifier_data(const MinimumRuleBasedPlannerNode::InputData & input_data);
-
   bool initialized_modifiers_{false};
   ModifierPluginLoader modifier_plugin_loader_;
   std::vector<std::shared_ptr<plugin::PluginInterface>> modifier_plugins_;
   std::map<std::string, rclcpp::Publisher<Trajectory>::SharedPtr>
     pub_debug_modifier_module_trajectories_;
 
-  std::shared_ptr<plugin::ModifierData> modifier_data_;
+  std::shared_ptr<plugin::ModifierContext> modifier_context_;
   /** @} */
 
 private:

--- a/planning/autoware_minimum_rule_based_planner/src/path_planner.cpp
+++ b/planning/autoware_minimum_rule_based_planner/src/path_planner.cpp
@@ -1674,7 +1674,7 @@ void PathPlanner::interpolate_lane_change_sections(
 
 Trajectory PathPlanner::shift_trajectory_to_ego(
   const Trajectory & trajectory, const geometry_msgs::msg::Pose & ego_pose,
-  const double ego_velocity, const double ego_yaw_rate, const TrajectoryShiftParams & params,
+  const double ego_velocity, const double ego_yaw_rate, const TrajectoryShiftParams & shift_params,
   const double delta_arc_length)
 {
   if (trajectory.points.size() < 2) {
@@ -1691,16 +1691,16 @@ Trajectory PathPlanner::shift_trajectory_to_ego(
   const double abs_yaw_dev = std::abs(signed_yaw_dev);
 
   if (
-    std::abs(lateral_offset) < params.minimum_shift_length &&
-    abs_yaw_dev < params.minimum_shift_yaw) {
+    std::abs(lateral_offset) < shift_params.minimum_shift_length &&
+    abs_yaw_dev < shift_params.minimum_shift_yaw) {
     return trajectory;
   }
 
   const double clamped_velocity =
-    std::max(std::max(0.0, ego_velocity), params.min_speed_for_curvature);
+    std::max(std::max(0.0, ego_velocity), shift_params.min_speed_for_curvature);
   const double abs_d = std::abs(lateral_offset);
   double L = compute_shift_length_from_lateral_accel(
-    abs_d, clamped_velocity, params.lateral_accel_limit, params.minimum_shift_distance);
+    abs_d, clamped_velocity, shift_params.lateral_accel_limit, shift_params.minimum_shift_distance);
 
   double accumulated_length = 0.0;
   size_t merge_idx = nearest_idx;

--- a/planning/autoware_trajectory_modifier/src/trajectory_modifier_plugins/surround_obstacle_stop.cpp
+++ b/planning/autoware_trajectory_modifier/src/trajectory_modifier_plugins/surround_obstacle_stop.cpp
@@ -149,7 +149,9 @@ obstacle_proximity_checker::Inputs SurroundObstacleStop::to_proximity_checker_in
   checker_inputs.ego_pose = input.current_odometry->pose.pose;
   checker_inputs.objects = input.predicted_objects;
 
-  if (!input.obstacle_pointcloud) return checker_inputs;
+  if (!input.obstacle_pointcloud || input.obstacle_pointcloud->data.empty()) {
+    return checker_inputs;
+  }
 
   const auto transform_stamped = get_transform(
     "base_link", input.obstacle_pointcloud->header.frame_id,


### PR DESCRIPTION
## Description

Add `surround_obstacle_stop` plugin to backup_planner to prevent ego from moving when nearby obstacle is detected.

Implementation is identical to the one in trajectory_modifier, core logic for checking nearby obstacles utilizes common package `autoware_obstacle_proximity_checker`

## Related links

- [Launcher PR](https://github.com/tier4/autoware_launch.x2/pull/2626)

## How was this PR tested?
- `colcon build --packages-select autoware_minimum_rule_based_planner --symlink-install --cmake-args -DCMAKE_EXPORT_COMPILE_COMMANDS=1 -DCMAKE_BUILD_TYPE=Release`
- PSIM
