### PR TITLE
fix(multi_object_tracker): enforce BOUNDING_BOX output type in PedestrianShapeModel export (#12938)

### DIFF
--- a/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/tracker/shape_model/pedestrian_shape_model.hpp
+++ b/perception/autoware_multi_object_tracker/include/autoware/multi_object_tracker/tracker/shape_model/pedestrian_shape_model.hpp
@@ -24,16 +24,16 @@
 namespace autoware::multi_object_tracker
 {
 
-// Manages shape extension (length, width, height, output type) for PedestrianTracker.
+// Manages shape extension (length, width, height) for PedestrianTracker.
 // All input shape types (BOUNDING_BOX, CYLINDER, POLYGON) are accepted.
 // Internally always stores BOUNDING_BOX {length, width, height} in tracker heading frame.
-// Output type (BOUNDING_BOX or CYLINDER) is decided at export time based on shape symmetry.
+// Output type is always BOUNDING_BOX with explicit length and width.
 //
 // Data flow:
 //   init()    — force all input types to internal BOUNDING_BOX; apply model-derived sanity bounds
 //   update()  — 3-branch update by input type (BBOX / CYLINDER / POLYGON);
 //               gains differ by type and trust_extension
-//   exportTo() — assemble output with correct shape type
+//   exportTo() — assemble output as a BOUNDING_BOX filling length and width
 class PedestrianShapeModel : public ShapeModelBase
 {
 public:
@@ -43,14 +43,9 @@ public:
   void init(const types::DynamicObject & object);
 
   // Update shape from new measurement.
-  // trust_extension: whether the channel provides reliable size measurements.
-  // tracker_yaw: current tracker heading; required for POLYGON branch.
-  // Returns false if update was rejected (implausible dimensions).
   bool update(const types::DynamicObject & object, bool trust_extension, double tracker_yaw);
 
   // Write shape into output object.
-  // Output type is CYLINDER when shape is nearly symmetric and not inflated; otherwise
-  // BOUNDING_BOX.
   void exportTo(types::DynamicObject & output) const;
 
 private:

--- a/perception/autoware_multi_object_tracker/lib/tracker/shape_model/pedestrian_shape_model.cpp
+++ b/perception/autoware_multi_object_tracker/lib/tracker/shape_model/pedestrian_shape_model.cpp
@@ -125,21 +125,11 @@ bool PedestrianShapeModel::update(
 
 void PedestrianShapeModel::exportTo(types::DynamicObject & output) const
 {
-  const double asymmetry = std::abs(length_ - width_) / std::max({length_, width_, 1e-6});
-
-  if (asymmetry < 0.15) {
-    // Nearly circular → CYLINDER
-    const double diameter = (length_ + width_) * 0.5;
-    output.shape.type = Shape::CYLINDER;
-    output.shape.dimensions.x = diameter;
-    output.shape.dimensions.y = diameter;
-    output.shape.dimensions.z = height_;
-  } else {
-    output.shape.type = Shape::BOUNDING_BOX;
-    output.shape.dimensions.x = length_;
-    output.shape.dimensions.y = width_;
-    output.shape.dimensions.z = height_;
-  }
+  // Always export a BOUNDING_BOX with explicit length (x) and width (y).
+  output.shape.type = Shape::BOUNDING_BOX;
+  output.shape.dimensions.x = length_;
+  output.shape.dimensions.y = width_;
+  output.shape.dimensions.z = height_;
   output.shape.footprint.points.clear();
   output.area = types::getArea(output.shape);
 }

--- a/perception/autoware_multi_object_tracker/lib/tracker/trackers/pedestrian_tracker.cpp
+++ b/perception/autoware_multi_object_tracker/lib/tracker/trackers/pedestrian_tracker.cpp
@@ -154,7 +154,7 @@ bool PedestrianTracker::getTrackedObject(
     updateCache(object, time);
   }
 
-  // Export shape from extend manager (type selection: CYLINDER vs BOUNDING_BOX)
+  // Export shape from extend manager
   assembleShapeTo(object, to_publish);
 
   if (to_publish) {


### PR DESCRIPTION
- Cherry-pick https://github.com/autowarefoundation/autoware_universe/pull/12938

---------