### PR TITLE
fix(trajectory_validator_diagnostic): prevent mrm if active filter is empty

### DIFF
--- a/planning/autoware_trajectory_validator/include/autoware/trajectory_validator/detail/diagnostic.hpp
+++ b/planning/autoware_trajectory_validator/include/autoware/trajectory_validator/detail/diagnostic.hpp
@@ -115,7 +115,8 @@ public:
    *        here.
    * @param active_filter_names Filter names (from plugin->get_name()) of active (non-shadow)
    *        filters. Only metrics from these filters contribute to action aggregation.
-   *        An empty set means all filters are considered active.
+   *        An empty set means no active filters exist (all are shadow-mode): no metric
+   *        contributes and every status stays OK.
    * @param diag_by_name Pre-built DiagnosticsInterface map (use build_diagnostic_interface_map).
    */
   TrajectoryValidatorDiagnostic(

--- a/planning/autoware_trajectory_validator/src/detail/diagnostic.cpp
+++ b/planning/autoware_trajectory_validator/src/detail/diagnostic.cpp
@@ -95,9 +95,10 @@ void TrajectoryValidatorDiagnostic::update_and_publish(
   const auto compute_candidate_traj_action = [&](const auto & report) {
     std::unordered_map<std::string, Action> candidate_traj_action;
     for (const auto & metric : report.metrics) {
-      // Skip metrics from shadow-mode filters (those not in
-      // active_filter_names_).
-      if (!active_filter_names_.empty() && !active_filter_names_.count(metric.validator_name)) {
+      // Skip metrics from shadow-mode filters (those not in active_filter_names_). An empty
+      // active_filter_names_ means no active filters exist (all are shadow-mode), so every metric
+      // is skipped and all statuses stay OK.
+      if (active_filter_names_.empty() || !active_filter_names_.count(metric.validator_name)) {
         continue;
       }
       const Action metric_action = convert_risk_level_to_action(metric.risk.level);

--- a/planning/autoware_trajectory_validator/test/diagnostic/diagnostic_core_behavior.cpp
+++ b/planning/autoware_trajectory_validator/test/diagnostic/diagnostic_core_behavior.cpp
@@ -38,7 +38,7 @@ protected:
 TEST_F(TrajectoryValidatorDiagnosticTest, ValidatorPassesOnOneCandidateStatusOk)
 {
   DiagHarness h("t3_node");
-  auto diag = make_diag(*h.node, single_map("filter_1", "status_1"), "");
+  auto diag = make_diag(*h.node, single_map("filter_1", "status_1"), "", {"filter_1"});
 
   auto candidate1 = make_report({make_metric("filter_1", RiskLevel::SAFE)});
   auto candidate2 = make_report({make_metric("filter_1", RiskLevel::HIGH_CAUTION)});
@@ -55,7 +55,7 @@ TEST_F(TrajectoryValidatorDiagnosticTest, ValidatorPassesOnOneCandidateStatusOk)
 TEST_F(TrajectoryValidatorDiagnosticTest, BestHasBindingValidatorAtError)
 {
   DiagHarness h("t4_node");
-  auto diag = make_diag(*h.node, single_map("filter_1", "status_1"), "");
+  auto diag = make_diag(*h.node, single_map("filter_1", "status_1"), "", {"filter_1"});
 
   auto candidate1 = make_report({make_metric("filter_1", RiskLevel::DANGER)});
   std::vector<ValidationReport> reports = {candidate1};
@@ -75,7 +75,7 @@ TEST_F(TrajectoryValidatorDiagnosticTest, TwoValidatorsBindingBothFire)
   filter_map["filter_1"][Action::MODERATE] = "status_1";
   filter_map["filter_2"][Action::MODERATE] = "status_2";
 
-  auto diag = make_diag(*h.node, filter_map, "");
+  auto diag = make_diag(*h.node, filter_map, "", {"filter_1", "filter_2"});
 
   auto candidate1 = make_report(
     {make_metric("filter_1", RiskLevel::DANGER), make_metric("filter_2", RiskLevel::DANGER)});
@@ -95,7 +95,7 @@ TEST_F(TrajectoryValidatorDiagnosticTest, TwoValidatorsBindingBothFire)
 TEST_F(TrajectoryValidatorDiagnosticTest, ValidatorFailsOnAllCandidatesFires)
 {
   DiagHarness h("t6b_node");
-  auto diag = make_diag(*h.node, single_map("filter_1", "status_1"), "");
+  auto diag = make_diag(*h.node, single_map("filter_1", "status_1"), "", {"filter_1"});
 
   auto candidate1 = make_report({make_metric("filter_1", RiskLevel::DANGER)});
   auto candidate2 = make_report({make_metric("filter_1", RiskLevel::DANGER)});
@@ -115,7 +115,7 @@ TEST_F(TrajectoryValidatorDiagnosticTest, EachValidatorFailsOnDifferentCandidate
   FilterConfiguredActionsMap filter_map;
   filter_map["filter_1"][Action::MODERATE] = "status_1";
   filter_map["filter_2"][Action::MODERATE] = "status_2";
-  auto diag = make_diag(*h.node, filter_map, "");
+  auto diag = make_diag(*h.node, filter_map, "", {"filter_1", "filter_2"});
 
   auto candidate1 = make_report(
     {make_metric("filter_1", RiskLevel::DANGER),  // filter_1 fails here
@@ -142,7 +142,7 @@ TEST_F(TrajectoryValidatorDiagnosticTest, OneAlwaysFailsOtherHasSafeCandidateOnl
   FilterConfiguredActionsMap filter_map;
   filter_map["filter_1"][Action::MODERATE] = "status_1";
   filter_map["filter_2"][Action::MODERATE] = "status_2";
-  auto diag = make_diag(*h.node, filter_map, "");
+  auto diag = make_diag(*h.node, filter_map, "", {"filter_1", "filter_2"});
 
   auto candidate1 = make_report(
     {make_metric("filter_1", RiskLevel::DANGER),    // filter_1 fails
@@ -166,7 +166,7 @@ TEST_F(TrajectoryValidatorDiagnosticTest, OneAlwaysFailsOtherHasSafeCandidateOnl
 TEST_F(TrajectoryValidatorDiagnosticTest, Renew)
 {
   DiagHarness h("t7_node");
-  auto diag = make_diag(*h.node, single_map("filter_1", "status_1"), "");
+  auto diag = make_diag(*h.node, single_map("filter_1", "status_1"), "", {"filter_1"});
 
   auto error_candidate = make_report({make_metric("filter_1", RiskLevel::DANGER)});
   h.run(diag, {error_candidate});
@@ -192,7 +192,7 @@ TEST_F(TrajectoryValidatorDiagnosticTest, EmptyNameNoStatusFired)
   FilterConfiguredActionsMap filter_map;
   filter_map["filter_1"][Action::MODERATE] = "";  // empty name — no interface created
 
-  auto diag = make_diag(*h.node, filter_map, "");
+  auto diag = make_diag(*h.node, filter_map, "", {"filter_1"});
 
   auto candidate1 = make_report({make_metric("filter_1", RiskLevel::DANGER)});
 
@@ -240,7 +240,7 @@ TEST_F(TrajectoryValidatorDiagnosticTest, TwoValidatorsDistinctNamesPublishedEac
   FilterConfiguredActionsMap filter_map;
   filter_map["filter_1"][Action::MODERATE] = "status_1";
   filter_map["filter_2"][Action::MODERATE] = "status_2";
-  auto diag = make_diag(*h.node, filter_map, "");
+  auto diag = make_diag(*h.node, filter_map, "", {"filter_1", "filter_2"});
 
   auto candidate1 = make_report(
     {make_metric("filter_1", RiskLevel::SAFE), make_metric("filter_2", RiskLevel::SAFE)});
@@ -264,7 +264,7 @@ TEST_F(TrajectoryValidatorDiagnosticTest, MultiBindingSameValidatorThresholdExac
   FilterConfiguredActionsMap filter_map;
   filter_map["filter_1"][Action::MODERATE] = "status_moderate";
   filter_map["filter_1"][Action::EMERGENCY] = "status_emergency";
-  auto diag = make_diag(*h.node, filter_map, "");
+  auto diag = make_diag(*h.node, filter_map, "", {"filter_1"});
 
   // DANGER -> MODERATE action: only status_moderate fires
   auto candidate_danger = make_report({make_metric("filter_1", RiskLevel::DANGER)});


### PR DESCRIPTION
## Description

Fix trajectory validator diagnostics publishing `DiagnosticStatus::ERROR` for filters
running in shadow mode.

`active_filter_names_` is built from non-shadow plugins only, so when every filter is
configured as shadow-mode it is empty. The previous guard skipped a metric only when the
set was **non-empty** and did not contain the metric's filter:

```cpp
if (!active_filter_names_.empty() && !active_filter_names_.count(metric.validator_name))
```

With an empty set, `!active_filter_names_.empty()` is `false`, so nothing was skipped and
shadow-mode metrics fed the action pipeline (`DANGER → MODERATE/EMERGENCY → ERROR`).

The guard is corrected so an empty `active_filter_names_` (no active filters exist) skips
every metric and all statuses stay `OK`:

```cpp
if (active_filter_names_.empty() || !active_filter_names_.count(metric.validator_name))
```

The stale doc comment ("empty set means all filters are considered active") is also updated
to reflect the corrected meaning.

## Related links

**Parent Issue:**

- Link

## How was this PR tested?

Ran the validator with all filters in `shadow_mode_filter_names`. Confirmed via debug logging
that `active_filter_names_.size() == 0`, and verified the published diagnostic status is now
`OK` for shadow-mode filters instead of `ERROR`.

## Notes for reviewers

None.

## Interface changes

None.

## Effects on system behavior

Diagnostics for shadow-mode filters now correctly report `OK` and no longer raise a false
`ERROR`. Enforced (non-shadow) filter behavior is unchanged.
