### PR TITLE
feat(simple_plannig_simulator): add `DELAY_STEER_ACC_GEARED_FOR_DIFFUSION_PLANNER` model

### DIFF
--- a/simulator/autoware_simple_planning_simulator/CMakeLists.txt
+++ b/simulator/autoware_simple_planning_simulator/CMakeLists.txt
@@ -20,6 +20,7 @@ ament_auto_add_library(${PROJECT_NAME} SHARED
   src/simple_planning_simulator/vehicle_model/sim_model_delay_steer_acc.cpp
   src/simple_planning_simulator/vehicle_model/sim_model_delay_steer_acc_geared.cpp
   src/simple_planning_simulator/vehicle_model/sim_model_delay_steer_acc_geared_wo_fall_guard.cpp
+  src/simple_planning_simulator/vehicle_model/sim_model_delay_steer_acc_geared_for_diffusion_planner.cpp
   src/simple_planning_simulator/vehicle_model/sim_model_delay_steer_map_acc_geared.cpp
   src/simple_planning_simulator/vehicle_model/sim_model_actuation_cmd.cpp
   src/simple_planning_simulator/utils/csv_loader.cpp

--- a/simulator/autoware_simple_planning_simulator/README.md
+++ b/simulator/autoware_simple_planning_simulator/README.md
@@ -63,6 +63,7 @@ The purpose of this simulator is for the integration test of planning and contro
 - `DELAY_STEER_ACC`
 - `DELAY_STEER_ACC_GEARED`
 - `DELAY_STEER_ACC_GEARED_WO_FALL_GUARD`
+- `DELAY_STEER_ACC_GEARED_FOR_DIFFUSION_PLANNER`: same dynamics as `DELAY_STEER_ACC_GEARED_WO_FALL_GUARD`, but has customs for diffusion planner.
 - `DELAY_STEER_MAP_ACC_GEARED`: applies 1D dynamics and time delay to the steering and acceleration commands. The simulated acceleration is determined by a value converted through the provided acceleration map. This model is valuable for an accurate simulation with acceleration deviations in a real vehicle.
 - `LEARNED_STEER_VEL`: launches learned python models. More about this [here](../autoware_learning_based_vehicle_model).
 

--- a/simulator/autoware_simple_planning_simulator/include/autoware/simple_planning_simulator/simple_planning_simulator_core.hpp
+++ b/simulator/autoware_simple_planning_simulator/include/autoware/simple_planning_simulator/simple_planning_simulator_core.hpp
@@ -226,6 +226,7 @@ private:
     ACTUATION_CMD_VGR = 10,
     ACTUATION_CMD_MECHANICAL = 11,
     ACTUATION_CMD_STEER_MAP = 12,
+    DELAY_STEER_ACC_GEARED_FOR_DIFFUSION_PLANNER = 13,
   } vehicle_model_type_;  //!< @brief vehicle model type to decide the model dynamics
   std::shared_ptr<SimModelInterface> vehicle_model_ptr_;  //!< @brief vehicle model pointer
 

--- a/simulator/autoware_simple_planning_simulator/include/autoware/simple_planning_simulator/vehicle_model/sim_model.hpp
+++ b/simulator/autoware_simple_planning_simulator/include/autoware/simple_planning_simulator/vehicle_model/sim_model.hpp
@@ -18,6 +18,7 @@
 #include "autoware/simple_planning_simulator/vehicle_model/sim_model_actuation_cmd.hpp"
 #include "autoware/simple_planning_simulator/vehicle_model/sim_model_delay_steer_acc.hpp"
 #include "autoware/simple_planning_simulator/vehicle_model/sim_model_delay_steer_acc_geared.hpp"
+#include "autoware/simple_planning_simulator/vehicle_model/sim_model_delay_steer_acc_geared_for_diffusion_planner.hpp"
 #include "autoware/simple_planning_simulator/vehicle_model/sim_model_delay_steer_acc_geared_wo_fall_guard.hpp"
 #include "autoware/simple_planning_simulator/vehicle_model/sim_model_delay_steer_map_acc_geared.hpp"
 #include "autoware/simple_planning_simulator/vehicle_model/sim_model_delay_steer_vel.hpp"

--- a/simulator/autoware_simple_planning_simulator/include/autoware/simple_planning_simulator/vehicle_model/sim_model_delay_steer_acc_geared_for_diffusion_planner.hpp
+++ b/simulator/autoware_simple_planning_simulator/include/autoware/simple_planning_simulator/vehicle_model/sim_model_delay_steer_acc_geared_for_diffusion_planner.hpp
@@ -1,0 +1,197 @@
+// Copyright 2025 The Autoware Foundation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef AUTOWARE__SIMPLE_PLANNING_SIMULATOR__VEHICLE_MODEL__SIM_MODEL_DELAY_STEER_ACC_GEARED_FOR_DIFFUSION_PLANNER_HPP_  // NOLINT
+#define AUTOWARE__SIMPLE_PLANNING_SIMULATOR__VEHICLE_MODEL__SIM_MODEL_DELAY_STEER_ACC_GEARED_FOR_DIFFUSION_PLANNER_HPP_  // NOLINT
+
+#include "autoware/simple_planning_simulator/vehicle_model/sim_model_interface.hpp"
+
+#include <Eigen/Core>
+#include <Eigen/LU>
+
+#include <deque>
+#include <iostream>
+#include <queue>
+
+namespace autoware::simulator::simple_planning_simulator
+{
+class SimModelDelaySteerAccGearedForDiffusionPlanner : public SimModelInterface
+{
+public:
+  /**
+   * @param [in] vx_lim velocity limit [m/s]
+   * @param [in] steer_lim steering limit [rad]
+   * @param [in] vx_rate_lim acceleration limit [m/ss]
+   * @param [in] steer_rate_lim steering angular velocity limit [rad/ss]
+   * @param [in] wheelbase vehicle wheelbase length [m]
+   * @param [in] dt delta time information to set input buffer for delay
+   * @param [in] acc_delay time delay for accel command [s]
+   * @param [in] acc_time_constant time constant for 1D model of accel dynamics
+   * @param [in] steer_delay time delay for steering command [s]
+   * @param [in] steer_time_constant time constant for 1D model of steering dynamics
+   * @param [in] steer_dead_band dead band for steering angle [rad]
+   * @param [in] steer_bias steering bias [rad]
+   * @param [in] debug_acc_scaling_factor scaling factor for accel command
+   * @param [in] debug_steer_scaling_factor scaling factor for steering command
+   * @param [in] k_us understeer coefficient [rad/(m/s²)]; 0 = ideal bicycle model
+   *
+   * @note 全遅延 = 0 のとき wo_fall_guard と bit 一致。
+   */
+  SimModelDelaySteerAccGearedForDiffusionPlanner(
+    double vx_lim, double steer_lim, double vx_rate_lim, double steer_rate_lim, double wheelbase,
+    double dt, double acc_delay, double acc_time_constant, double steer_delay,
+    double steer_time_constant, double steer_dead_band, double steer_bias,
+    double debug_acc_scaling_factor, double debug_steer_scaling_factor, double k_us);
+
+  /**
+   * @brief default destructor
+   */
+  ~SimModelDelaySteerAccGearedForDiffusionPlanner() = default;
+
+  /**
+   * @brief replace internal acc / steer delay queues with caller-supplied histories.
+   *        Used by C wrapper to inject actual past command history for per-step
+   *        real-vs-sim replay (see vehicle_model_c_wrapper.cpp).
+   */
+  void setInputQueues(
+    const std::deque<double> & acc_queue, const std::deque<double> & steer_queue);
+
+  /**
+   * @brief re-fill the delayed-state history buffers (STEER / PEDAL_ACCX / VX) with a constant
+   *        equal to the current state. Call after seeding the state (reset / warmup restore) so the
+   *        full-RHS delay reads the steady pre-window state, not the warm-up transient.
+   */
+  void resetStateQueues();
+
+  /**
+   * @brief sizes of the internal delay queues (driven by acc_delay / steer_delay / dt).
+   */
+  int getAccQueueSize() const;
+  int getSteerQueueSize() const;
+
+private:
+  const double MIN_TIME_CONSTANT;  //!< @brief minimum time constant
+
+  enum IDX {
+    X = 0,
+    Y,
+    YAW,
+    VX,
+    STEER,
+    ACCX,
+    PEDAL_ACCX,
+  };
+  enum IDX_U { PEDAL_ACCX_DES = 0, GEAR, SLOPE_ACCX, STEER_DES };
+
+  const double vx_lim_;          //!< @brief velocity limit [m/s]
+  const double vx_rate_lim_;     //!< @brief acceleration limit [m/ss]
+  const double steer_lim_;       //!< @brief steering limit [rad]
+  const double steer_rate_lim_;  //!< @brief steering angular velocity limit [rad/s]
+  const double wheelbase_;       //!< @brief vehicle wheelbase length [m]
+
+  std::deque<double> acc_input_queue_;       //!< @brief buffer for accel command
+  std::deque<double> steer_input_queue_;     //!< @brief buffer for steering command
+  std::deque<double> steer_state_queue_;     //!< @brief buffer for STEER state (delayed feedback)
+  std::deque<double> pedal_state_queue_;     //!< @brief buffer for PEDAL_ACCX state (delayed feedback)
+  double delayed_steer_state_ = 0.0;         //!< @brief STEER at t−steer_delay (frozen per update)
+  double delayed_pedal_state_ = 0.0;         //!< @brief PEDAL_ACCX at t−acc_delay (frozen per update)
+  const double acc_delay_;                   //!< @brief time delay for accel command [s]
+  const double acc_time_constant_;           //!< @brief time constant for accel dynamics
+  const double steer_delay_;                 //!< @brief time delay for steering command [s]
+  const double steer_time_constant_;         //!< @brief time constant for steering dynamics
+  const double steer_dead_band_;             //!< @brief dead band for steering angle [rad]
+  const double steer_bias_;                  //!< @brief steering angle bias [rad]
+  const double debug_acc_scaling_factor_;    //!< @brief scaling factor for accel command
+  const double debug_steer_scaling_factor_;  //!< @brief scaling factor for steering command
+  const double k_us_;                        //!< @brief understeer coefficient [rad/(m/s²)]
+
+  /**
+   * @brief steady-state yaw rate including understeer (k_us) and steer bias.
+   *
+   *   ω = vx · tan(δ + steer_bias) / (L + k_us · vx²)
+   *
+   * Reduces to the ideal bicycle model when k_us = 0 and steer_bias = 0.
+   */
+  double calc_yaw_rate(double vel, double steer) const;
+
+  /**
+   * @brief set queue buffer for input command
+   * @param [in] dt delta time
+   */
+  void initializeInputQueue(const double & dt);
+
+  /**
+   * @brief set queue buffer for delayed state feedback (STEER / PEDAL_ACCX / VX)
+   * @param [in] dt delta time
+   */
+  void initializeStateQueue(const double & dt);
+
+  /**
+   * @brief get vehicle position x
+   */
+  double getX() override;
+
+  /**
+   * @brief get vehicle position y
+   */
+  double getY() override;
+
+  /**
+   * @brief get vehicle angle yaw
+   */
+  double getYaw() override;
+
+  /**
+   * @brief get vehicle velocity vx
+   */
+  double getVx() override;
+
+  /**
+   * @brief get vehicle lateral velocity
+   */
+  double getVy() override;
+
+  /**
+   * @brief get vehicle longitudinal acceleration
+   */
+  double getAx() override;
+
+  /**
+   * @brief get vehicle angular-velocity wz
+   */
+  double getWz() override;
+
+  /**
+   * @brief get vehicle steering angle
+   */
+  double getSteer() override;
+
+  /**
+   * @brief update vehicle states
+   * @param [in] dt delta time [s]
+   */
+  void update(const double & dt) override;
+
+  /**
+   * @brief calculate derivative of states with time delay steering model
+   * @param [in] state current model state
+   * @param [in] input input vector to model
+   */
+  Eigen::VectorXd calcModel(const Eigen::VectorXd & state, const Eigen::VectorXd & input) override;
+};
+
+}  // namespace autoware::simulator::simple_planning_simulator
+
+// NOLINTNEXTLINE
+#endif  // AUTOWARE__SIMPLE_PLANNING_SIMULATOR__VEHICLE_MODEL__SIM_MODEL_DELAY_STEER_ACC_GEARED_FOR_DIFFUSION_PLANNER_HPP_

--- a/simulator/autoware_simple_planning_simulator/include/autoware/simple_planning_simulator/vehicle_model/sim_model_delay_steer_acc_geared_for_diffusion_planner.hpp
+++ b/simulator/autoware_simple_planning_simulator/include/autoware/simple_planning_simulator/vehicle_model/sim_model_delay_steer_acc_geared_for_diffusion_planner.hpp
@@ -64,8 +64,7 @@ public:
    *        Used by C wrapper to inject actual past command history for per-step
    *        real-vs-sim replay (see vehicle_model_c_wrapper.cpp).
    */
-  void setInputQueues(
-    const std::deque<double> & acc_queue, const std::deque<double> & steer_queue);
+  void setInputQueues(const std::deque<double> & acc_queue, const std::deque<double> & steer_queue);
 
   /**
    * @brief re-fill the delayed-state history buffers (STEER / PEDAL_ACCX / VX) with a constant
@@ -100,18 +99,18 @@ private:
   const double steer_rate_lim_;  //!< @brief steering angular velocity limit [rad/s]
   const double wheelbase_;       //!< @brief vehicle wheelbase length [m]
 
-  std::deque<double> acc_input_queue_;       //!< @brief buffer for accel command
-  std::deque<double> steer_input_queue_;     //!< @brief buffer for steering command
-  std::deque<double> steer_state_queue_;     //!< @brief buffer for STEER state (delayed feedback)
-  std::deque<double> pedal_state_queue_;     //!< @brief buffer for PEDAL_ACCX state (delayed feedback)
-  double delayed_steer_state_ = 0.0;         //!< @brief STEER at t−steer_delay (frozen per update)
-  double delayed_pedal_state_ = 0.0;         //!< @brief PEDAL_ACCX at t−acc_delay (frozen per update)
-  const double acc_delay_;                   //!< @brief time delay for accel command [s]
-  const double acc_time_constant_;           //!< @brief time constant for accel dynamics
-  const double steer_delay_;                 //!< @brief time delay for steering command [s]
-  const double steer_time_constant_;         //!< @brief time constant for steering dynamics
-  const double steer_dead_band_;             //!< @brief dead band for steering angle [rad]
-  const double steer_bias_;                  //!< @brief steering angle bias [rad]
+  std::deque<double> acc_input_queue_;    //!< @brief buffer for accel command
+  std::deque<double> steer_input_queue_;  //!< @brief buffer for steering command
+  std::deque<double> steer_state_queue_;  //!< @brief buffer for STEER state (delayed feedback)
+  std::deque<double> pedal_state_queue_;  //!< @brief buffer for PEDAL_ACCX state (delayed feedback)
+  double delayed_steer_state_ = 0.0;      //!< @brief STEER at t−steer_delay (frozen per update)
+  double delayed_pedal_state_ = 0.0;      //!< @brief PEDAL_ACCX at t−acc_delay (frozen per update)
+  const double acc_delay_;                //!< @brief time delay for accel command [s]
+  const double acc_time_constant_;        //!< @brief time constant for accel dynamics
+  const double steer_delay_;              //!< @brief time delay for steering command [s]
+  const double steer_time_constant_;      //!< @brief time constant for steering dynamics
+  const double steer_dead_band_;          //!< @brief dead band for steering angle [rad]
+  const double steer_bias_;               //!< @brief steering angle bias [rad]
   const double debug_acc_scaling_factor_;    //!< @brief scaling factor for accel command
   const double debug_steer_scaling_factor_;  //!< @brief scaling factor for steering command
   const double k_us_;                        //!< @brief understeer coefficient [rad/(m/s²)]

--- a/simulator/autoware_simple_planning_simulator/src/simple_planning_simulator/simple_planning_simulator_core.cpp
+++ b/simulator/autoware_simple_planning_simulator/src/simple_planning_simulator/simple_planning_simulator_core.cpp
@@ -295,8 +295,8 @@ void SimplePlanningSimulator::initialize_vehicle_model(const std::string & vehic
     const int delay_steer_acc_geared_for_diffusion_planner_version =
       declare_parameter<int>("delay_steer_acc_geared_for_diffusion_planner.version", 1);
     const std::string ns = "delay_steer_acc_geared_for_diffusion_planner.v" +
-                            std::to_string(delay_steer_acc_geared_for_diffusion_planner_version) +
-                            ".";
+                           std::to_string(delay_steer_acc_geared_for_diffusion_planner_version) +
+                           ".";
     vehicle_model_ptr_ = std::make_shared<SimModelDelaySteerAccGearedForDiffusionPlanner>(
       vel_lim, steer_lim, vel_rate_lim, steer_rate_lim, wheelbase, timer_sampling_time_ms_ / 1000.0,
       declare_parameter<double>(ns + "acc_time_delay", 0.1),

--- a/simulator/autoware_simple_planning_simulator/src/simple_planning_simulator/simple_planning_simulator_core.cpp
+++ b/simulator/autoware_simple_planning_simulator/src/simple_planning_simulator/simple_planning_simulator_core.cpp
@@ -289,6 +289,25 @@ void SimplePlanningSimulator::initialize_vehicle_model(const std::string & vehic
       vel_lim, steer_lim, vel_rate_lim, steer_rate_lim, wheelbase, timer_sampling_time_ms_ / 1000.0,
       acc_time_delay, acc_time_constant, steer_time_delay, steer_time_constant, steer_dead_band,
       steer_bias, debug_acc_scaling_factor, debug_steer_scaling_factor, k_us);
+  } else if (vehicle_model_type_str == "DELAY_STEER_ACC_GEARED_FOR_DIFFUSION_PLANNER") {
+    vehicle_model_type_ = VehicleModelType::DELAY_STEER_ACC_GEARED_FOR_DIFFUSION_PLANNER;
+    // load parameters from delay_steer_acc_geared_for_diffusion_planner.v{N}.*
+    const int delay_steer_acc_geared_for_diffusion_planner_version =
+      declare_parameter<int>("delay_steer_acc_geared_for_diffusion_planner.version", 1);
+    const std::string ns = "delay_steer_acc_geared_for_diffusion_planner.v" +
+                            std::to_string(delay_steer_acc_geared_for_diffusion_planner_version) +
+                            ".";
+    vehicle_model_ptr_ = std::make_shared<SimModelDelaySteerAccGearedForDiffusionPlanner>(
+      vel_lim, steer_lim, vel_rate_lim, steer_rate_lim, wheelbase, timer_sampling_time_ms_ / 1000.0,
+      declare_parameter<double>(ns + "acc_time_delay", 0.1),
+      declare_parameter<double>(ns + "acc_time_constant", 0.1),
+      declare_parameter<double>(ns + "steer_time_delay", 0.24),
+      declare_parameter<double>(ns + "steer_time_constant", 0.27),
+      declare_parameter<double>(ns + "steer_dead_band", 0.0),
+      declare_parameter<double>(ns + "steer_bias", 0.0),
+      declare_parameter<double>(ns + "debug_acc_scaling_factor", 1.0),
+      declare_parameter<double>(ns + "debug_steer_scaling_factor", 1.0),
+      declare_parameter<double>(ns + "k_us", 0.0));
   } else if (vehicle_model_type_str == "DELAY_STEER_MAP_ACC_GEARED") {
     vehicle_model_type_ = VehicleModelType::DELAY_STEER_MAP_ACC_GEARED;
     const std::string acceleration_map_path =
@@ -647,7 +666,8 @@ void SimplePlanningSimulator::set_input(const Control & cmd, const double acc_by
     vehicle_model_type_ == VehicleModelType::DELAY_STEER_MAP_ACC_GEARED) {
     input << combined_acc, steer;
   } else if (  // NOLINT
-    vehicle_model_type_ == VehicleModelType::DELAY_STEER_ACC_GEARED_WO_FALL_GUARD) {
+    vehicle_model_type_ == VehicleModelType::DELAY_STEER_ACC_GEARED_WO_FALL_GUARD ||
+    vehicle_model_type_ == VehicleModelType::DELAY_STEER_ACC_GEARED_FOR_DIFFUSION_PLANNER) {
     input << acc_by_cmd, gear, acc_by_slope, steer;
   }
   vehicle_model_ptr_->setInput(input);
@@ -746,7 +766,9 @@ void SimplePlanningSimulator::set_initial_state(const Pose & pose, const Twist &
     state << x, y, yaw, vx, steer;
   } else if (vehicle_model_type_ == VehicleModelType::LEARNED_STEER_VEL) {
     state << x, y, yaw, yaw_rate, vx, vy, steer;
-  } else if (vehicle_model_type_ == VehicleModelType::DELAY_STEER_ACC_GEARED_WO_FALL_GUARD) {
+  } else if (
+    vehicle_model_type_ == VehicleModelType::DELAY_STEER_ACC_GEARED_WO_FALL_GUARD ||
+    vehicle_model_type_ == VehicleModelType::DELAY_STEER_ACC_GEARED_FOR_DIFFUSION_PLANNER) {
     state << x, y, yaw, vx, steer, accx, pedal_accx;
   } else if (  // NOLINT
     vehicle_model_type_ == VehicleModelType::DELAY_STEER_ACC ||

--- a/simulator/autoware_simple_planning_simulator/src/simple_planning_simulator/vehicle_model/sim_model_delay_steer_acc_geared_for_diffusion_planner.cpp
+++ b/simulator/autoware_simple_planning_simulator/src/simple_planning_simulator/vehicle_model/sim_model_delay_steer_acc_geared_for_diffusion_planner.cpp
@@ -1,0 +1,255 @@
+// Copyright 2025 The Autoware Foundation.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/simple_planning_simulator/vehicle_model/sim_model_delay_steer_acc_geared_for_diffusion_planner.hpp"
+
+#include "autoware_vehicle_msgs/msg/gear_command.hpp"
+
+#include <algorithm>
+#include <cmath>
+
+namespace autoware::simulator::simple_planning_simulator
+{
+
+SimModelDelaySteerAccGearedForDiffusionPlanner::SimModelDelaySteerAccGearedForDiffusionPlanner(
+  double vx_lim, double steer_lim, double vx_rate_lim, double steer_rate_lim, double wheelbase,
+  double dt, double acc_delay, double acc_time_constant, double steer_delay,
+  double steer_time_constant, double steer_dead_band, double steer_bias,
+  double debug_acc_scaling_factor, double debug_steer_scaling_factor, double k_us)
+: SimModelInterface(7 /* dim x */, 4 /* dim u */),
+  MIN_TIME_CONSTANT(0.03),
+  vx_lim_(vx_lim),
+  vx_rate_lim_(vx_rate_lim),
+  steer_lim_(steer_lim),
+  steer_rate_lim_(steer_rate_lim),
+  wheelbase_(wheelbase),
+  acc_delay_(acc_delay),
+  acc_time_constant_(std::max(acc_time_constant, MIN_TIME_CONSTANT)),
+  steer_delay_(steer_delay),
+  steer_time_constant_(std::max(steer_time_constant, MIN_TIME_CONSTANT)),
+  steer_dead_band_(steer_dead_band),
+  steer_bias_(steer_bias),
+  debug_acc_scaling_factor_(std::max(debug_acc_scaling_factor, 0.0)),
+  debug_steer_scaling_factor_(std::max(debug_steer_scaling_factor, 0.0)),
+  k_us_(k_us)
+{
+  initializeInputQueue(dt);
+  initializeStateQueue(dt);
+}
+
+double SimModelDelaySteerAccGearedForDiffusionPlanner::calc_yaw_rate(double vel, double steer) const
+{
+  const double denom = wheelbase_ + k_us_ * vel * vel;
+  return vel * std::tan(steer + steer_bias_) / denom;
+}
+
+double SimModelDelaySteerAccGearedForDiffusionPlanner::getX() { return state_(IDX::X); }
+
+double SimModelDelaySteerAccGearedForDiffusionPlanner::getY() { return state_(IDX::Y); }
+
+double SimModelDelaySteerAccGearedForDiffusionPlanner::getYaw() { return state_(IDX::YAW); }
+
+double SimModelDelaySteerAccGearedForDiffusionPlanner::getVx() { return state_(IDX::VX); }
+
+double SimModelDelaySteerAccGearedForDiffusionPlanner::getVy() { return 0.0; }
+
+double SimModelDelaySteerAccGearedForDiffusionPlanner::getAx() { return state_(IDX::ACCX); }
+
+double SimModelDelaySteerAccGearedForDiffusionPlanner::getWz()
+{
+  return calc_yaw_rate(state_(IDX::VX), state_(IDX::STEER));
+}
+
+double SimModelDelaySteerAccGearedForDiffusionPlanner::getSteer()
+{
+  // Steer bias now enters the yaw equation (calc_yaw_rate, as the viewer's β), not the
+  // measured-steer/tracking loop, so that the bias produces a net yaw offset instead of being
+  // cancelled by the steer controller. The reported/tracked steer is the actual state value.
+  return state_(IDX::STEER);
+}
+
+void SimModelDelaySteerAccGearedForDiffusionPlanner::update(const double & dt)
+{
+  Eigen::VectorXd delayed_input = Eigen::VectorXd::Zero(dim_u_);
+
+  // Command delay queues advance once per update() call (as wo_fall_guard).
+  acc_input_queue_.push_back(input_(IDX_U::PEDAL_ACCX_DES));
+  delayed_input(IDX_U::PEDAL_ACCX_DES) = acc_input_queue_.front();
+  acc_input_queue_.pop_front();
+  steer_input_queue_.push_back(input_(IDX_U::STEER_DES));
+  delayed_input(IDX_U::STEER_DES) = steer_input_queue_.front();
+  steer_input_queue_.pop_front();
+  delayed_input(IDX_U::GEAR) = input_(IDX_U::GEAR);
+  delayed_input(IDX_U::SLOPE_ACCX) = input_(IDX_U::SLOPE_ACCX);
+
+  // full-RHS delay: sample the state feedback for the steer / accel channels at t-d as well.
+  // The queues advance identically to the command queues (same size round(delay/dt)); the popped
+  // value is frozen for the whole update so the steer / pedal derivatives are constant over
+  // dt, matching Python's per-step frozen RHS (e_eff / e_a_eff computed once per step).
+  steer_state_queue_.push_back(state_(IDX::STEER));
+  delayed_steer_state_ = steer_state_queue_.front();
+  steer_state_queue_.pop_front();
+  pedal_state_queue_.push_back(state_(IDX::PEDAL_ACCX));
+  delayed_pedal_state_ = pedal_state_queue_.front();
+  pedal_state_queue_.pop_front();
+
+  const auto prev_state = state_;
+  // we cannot use updateRungeKutta() because the differentiability or the continuity
+  // condition is not satisfied, but we can use Runge-Kutta method with code reconstruction.
+  updateEuler(dt, delayed_input);
+  // take velocity limit
+  state_(IDX::VX) = std::max(-vx_lim_, std::min(state_(IDX::VX), vx_lim_));
+
+  // Stop condition: detect zero crossing over the full dt window using the outer prev_state.
+  if (
+    prev_state(IDX::VX) * state_(IDX::VX) <= 0.0 &&
+    -state_(IDX::PEDAL_ACCX) >= std::abs(delayed_input(IDX_U::SLOPE_ACCX))) {
+    state_(IDX::VX) = 0.0;
+  }
+
+  state_(IDX::ACCX) = (state_(IDX::VX) - prev_state(IDX::VX)) / dt;
+}
+
+void SimModelDelaySteerAccGearedForDiffusionPlanner::initializeInputQueue(const double & dt)
+{
+  size_t acc_input_queue_size = static_cast<size_t>(round(acc_delay_ / dt));
+  acc_input_queue_.resize(acc_input_queue_size);
+  std::fill(acc_input_queue_.begin(), acc_input_queue_.end(), 0.0);
+
+  size_t steer_input_queue_size = static_cast<size_t>(round(steer_delay_ / dt));
+  steer_input_queue_.resize(steer_input_queue_size);
+  std::fill(steer_input_queue_.begin(), steer_input_queue_.end(), 0.0);
+}
+
+void SimModelDelaySteerAccGearedForDiffusionPlanner::initializeStateQueue(const double & dt)
+{
+  // State history buffers mirror the command-queue sizes so the delayed state feedback lags by the
+  // same round(delay/dt) samples. Zero-fill (exactly like initializeInputQueue's command-queue fill)
+  // so the realtime path — which constructs the model and never calls resetStateQueues() — reads a
+  // well-defined at-rest pre-window state for the first round(delay/dt) steps, without relying on
+  // the base class having zero-initialised state_.
+  const size_t steer_state_queue_size = static_cast<size_t>(round(steer_delay_ / dt));
+  steer_state_queue_.assign(steer_state_queue_size, 0.0);
+
+  const size_t acc_state_queue_size = static_cast<size_t>(round(acc_delay_ / dt));
+  pedal_state_queue_.assign(acc_state_queue_size, 0.0);
+}
+
+void SimModelDelaySteerAccGearedForDiffusionPlanner::resetStateQueues()
+{
+  // Re-fill the delayed-state history with the current state (constant). Called after the state is
+  // seeded (reset / warmup restore) so full-RHS delay reads the steady pre-window state instead of
+  // the warm-up transient the substep loop would otherwise have pushed.
+  std::fill(steer_state_queue_.begin(), steer_state_queue_.end(), state_(IDX::STEER));
+  std::fill(pedal_state_queue_.begin(), pedal_state_queue_.end(), state_(IDX::PEDAL_ACCX));
+}
+
+void SimModelDelaySteerAccGearedForDiffusionPlanner::setInputQueues(
+  const std::deque<double> & acc_queue, const std::deque<double> & steer_queue)
+{
+  acc_input_queue_ = acc_queue;
+  steer_input_queue_ = steer_queue;
+}
+
+int SimModelDelaySteerAccGearedForDiffusionPlanner::getAccQueueSize() const
+{
+  return static_cast<int>(acc_input_queue_.size());
+}
+
+int SimModelDelaySteerAccGearedForDiffusionPlanner::getSteerQueueSize() const
+{
+  return static_cast<int>(steer_input_queue_.size());
+}
+
+Eigen::VectorXd SimModelDelaySteerAccGearedForDiffusionPlanner::calcModel(
+  const Eigen::VectorXd & state, const Eigen::VectorXd & input)
+{
+  auto sat = [](double val, double u, double l) { return std::max(std::min(val, u), l); };
+
+  // Current state — used by the un-delayed channels (position, yaw, and the VX gear law, which
+  // integrates the current PEDAL_ACCX exactly as Python's dot_v = a uses the current a).
+  const double vel = sat(state(IDX::VX), vx_lim_, -vx_lim_);
+  const double pedal_acc = sat(state(IDX::PEDAL_ACCX), vx_rate_lim_, -vx_rate_lim_);
+  const double yaw = state(IDX::YAW);
+  const double steer = state(IDX::STEER);
+  // Delayed state feedback (frozen per update) — used by the steer / accel channel derivatives so
+  // that their whole RHS is evaluated at t-d (full-RHS delay). Reduces to the current state when
+  // the corresponding delay is 0.
+  const double pedal_acc_delayed = sat(delayed_pedal_state_, vx_rate_lim_, -vx_rate_lim_);
+  const double steer_delayed = delayed_steer_state_;
+  const double pedal_acc_des =
+    sat(input(IDX_U::PEDAL_ACCX_DES), vx_rate_lim_, -vx_rate_lim_) * debug_acc_scaling_factor_;
+  const double steer_des =
+    sat(input(IDX_U::STEER_DES), steer_lim_, -steer_lim_) * debug_steer_scaling_factor_;
+
+  // Yaw rate (with k_us understeer and steer-bias β); un-delayed (yaw observation delay d_tt is out
+  // of scope for this derivative and left for a future improvement).
+  const double yaw_rate = calc_yaw_rate(vel, steer);
+  // Acceleration target: the actuator (PEDAL_ACCX) tracks the desired accel with a single-tau
+  // first-order lag (same form as wo_fall_guard).
+  const double pedal_acc_target = pedal_acc_des;
+  const double acc_tau = acc_time_constant_;
+  // NOTE: `steer_des` is calculated by control from measured values, delayed by the command queue.
+  // full-RHS delay: the measured steer that closes the tracking loop is also taken at t-steer_delay
+  // (delayed_steer_state_), not the current steer, so the steer channel's whole RHS lags together.
+  const double steer_diff = steer_delayed - steer_des;
+  const double steer_diff_with_dead_band = std::invoke([&]() {
+    if (steer_diff > steer_dead_band_) {
+      return steer_diff - steer_dead_band_;
+    } else if (steer_diff < -steer_dead_band_) {
+      return steer_diff + steer_dead_band_;
+    } else {
+      return 0.0;
+    }
+  });
+  const double steer_rate =
+    sat(-steer_diff_with_dead_band / steer_time_constant_, steer_rate_lim_, -steer_rate_lim_);
+
+  Eigen::VectorXd d_state = Eigen::VectorXd::Zero(dim_x_);
+
+  d_state(IDX::X) = vel * cos(yaw);
+  d_state(IDX::Y) = vel * sin(yaw);
+  d_state(IDX::YAW) = yaw_rate;
+  d_state(IDX::VX) = [&] {
+    if (pedal_acc >= 0.0) {
+      using autoware_vehicle_msgs::msg::GearCommand;
+      const auto gear = input(IDX_U::GEAR);
+      if (gear == GearCommand::NONE || gear == GearCommand::PARK) {
+        return 0.0;
+      } else if (gear == GearCommand::NEUTRAL) {
+        return input(IDX_U::SLOPE_ACCX);
+      } else if (gear == GearCommand::REVERSE || gear == GearCommand::REVERSE_2) {
+        return -pedal_acc + input(IDX_U::SLOPE_ACCX);
+      } else {
+        return pedal_acc + input(IDX_U::SLOPE_ACCX);
+      }
+    } else {
+      if (vel > 0.0) {
+        return pedal_acc + input(IDX_U::SLOPE_ACCX);
+      } else if (vel < 0.0) {
+        return -pedal_acc + input(IDX_U::SLOPE_ACCX);
+      } else if (-pedal_acc >= std::abs(input(IDX_U::SLOPE_ACCX))) {
+        return 0.0;
+      } else {
+        return input(IDX_U::SLOPE_ACCX);
+      }
+    }
+  }();
+  d_state(IDX::STEER) = steer_rate;
+  d_state(IDX::PEDAL_ACCX) = -(pedal_acc_delayed - pedal_acc_target) / acc_tau;
+
+  return d_state;
+}
+
+}  // namespace autoware::simulator::simple_planning_simulator

--- a/simulator/autoware_simple_planning_simulator/src/simple_planning_simulator/vehicle_model/sim_model_delay_steer_acc_geared_for_diffusion_planner.cpp
+++ b/simulator/autoware_simple_planning_simulator/src/simple_planning_simulator/vehicle_model/sim_model_delay_steer_acc_geared_for_diffusion_planner.cpp
@@ -54,17 +54,35 @@ double SimModelDelaySteerAccGearedForDiffusionPlanner::calc_yaw_rate(double vel,
   return vel * std::tan(steer + steer_bias_) / denom;
 }
 
-double SimModelDelaySteerAccGearedForDiffusionPlanner::getX() { return state_(IDX::X); }
+double SimModelDelaySteerAccGearedForDiffusionPlanner::getX()
+{
+  return state_(IDX::X);
+}
 
-double SimModelDelaySteerAccGearedForDiffusionPlanner::getY() { return state_(IDX::Y); }
+double SimModelDelaySteerAccGearedForDiffusionPlanner::getY()
+{
+  return state_(IDX::Y);
+}
 
-double SimModelDelaySteerAccGearedForDiffusionPlanner::getYaw() { return state_(IDX::YAW); }
+double SimModelDelaySteerAccGearedForDiffusionPlanner::getYaw()
+{
+  return state_(IDX::YAW);
+}
 
-double SimModelDelaySteerAccGearedForDiffusionPlanner::getVx() { return state_(IDX::VX); }
+double SimModelDelaySteerAccGearedForDiffusionPlanner::getVx()
+{
+  return state_(IDX::VX);
+}
 
-double SimModelDelaySteerAccGearedForDiffusionPlanner::getVy() { return 0.0; }
+double SimModelDelaySteerAccGearedForDiffusionPlanner::getVy()
+{
+  return 0.0;
+}
 
-double SimModelDelaySteerAccGearedForDiffusionPlanner::getAx() { return state_(IDX::ACCX); }
+double SimModelDelaySteerAccGearedForDiffusionPlanner::getAx()
+{
+  return state_(IDX::ACCX);
+}
 
 double SimModelDelaySteerAccGearedForDiffusionPlanner::getWz()
 {
@@ -135,10 +153,10 @@ void SimModelDelaySteerAccGearedForDiffusionPlanner::initializeInputQueue(const 
 void SimModelDelaySteerAccGearedForDiffusionPlanner::initializeStateQueue(const double & dt)
 {
   // State history buffers mirror the command-queue sizes so the delayed state feedback lags by the
-  // same round(delay/dt) samples. Zero-fill (exactly like initializeInputQueue's command-queue fill)
-  // so the realtime path — which constructs the model and never calls resetStateQueues() — reads a
-  // well-defined at-rest pre-window state for the first round(delay/dt) steps, without relying on
-  // the base class having zero-initialised state_.
+  // same round(delay/dt) samples. Zero-fill (exactly like initializeInputQueue's command-queue
+  // fill) so the realtime path — which constructs the model and never calls resetStateQueues() —
+  // reads a well-defined at-rest pre-window state for the first round(delay/dt) steps, without
+  // relying on the base class having zero-initialised state_.
   const size_t steer_state_queue_size = static_cast<size_t>(round(steer_delay_ / dt));
   steer_state_queue_.assign(steer_state_queue_size, 0.0);
 

--- a/simulator/autoware_simple_planning_simulator/src/simple_planning_simulator/vehicle_model/sim_model_delay_steer_acc_geared_for_diffusion_planner.cpp
+++ b/simulator/autoware_simple_planning_simulator/src/simple_planning_simulator/vehicle_model/sim_model_delay_steer_acc_geared_for_diffusion_planner.cpp
@@ -18,6 +18,7 @@
 
 #include <algorithm>
 #include <cmath>
+#include <deque>
 
 namespace autoware::simulator::simple_planning_simulator
 {

--- a/simulator/autoware_simple_planning_simulator/test/test_simple_planning_simulator.cpp
+++ b/simulator/autoware_simple_planning_simulator/test/test_simple_planning_simulator.cpp
@@ -445,6 +445,7 @@ INSTANTIATE_TEST_SUITE_P(
     std::make_tuple(CommandType::Ackermann, "DELAY_STEER_ACC"),
     std::make_tuple(CommandType::Ackermann, "DELAY_STEER_ACC_GEARED"),
     std::make_tuple(CommandType::Ackermann, "DELAY_STEER_ACC_GEARED_WO_FALL_GUARD"),
+    std::make_tuple(CommandType::Ackermann, "DELAY_STEER_ACC_GEARED_FOR_DIFFUSION_PLANNER"),
     /* Actuation type */
     // NOTE: Just "ACTUATION_CMD" sim model converts only accel/brake actuation commands. The test
     // is performed for models that convert all accel/brake/steer commands, so the test for


### PR DESCRIPTION
This model is based on `DELAY_STEER_ACC_GEARED_WO_FALL_GUARD`.

The differences are as follows.
- A delay was introduced into the state feedback(red circle in the state equation)
- A versionning mechanism is introduced for model and parameters

<img width="941" height="341" alt="image" src="https://github.com/user-attachments/assets/671f3522-3eee-4b13-97fc-1bacc596257b" />
