### PR TITLE
fix(minimum_rule_based_planner): fix node crash when debug trajectory publish

### DIFF
--- a/planning/autoware_minimum_rule_based_planner/src/minimum_rule_based_planner.cpp
+++ b/planning/autoware_minimum_rule_based_planner/src/minimum_rule_based_planner.cpp
@@ -234,7 +234,17 @@ void MinimumRuleBasedPlannerNode::publish_debug_trajectory(
 {
   Trajectory traj;
   traj.points = traj_points;
-  pub_debug_modifier_module_trajectories_.at(plugin_name)->publish(traj);
+  if (const auto it = pub_debug_modifier_module_trajectories_.find(plugin_name);
+      it != pub_debug_modifier_module_trajectories_.end()) {
+    it->second->publish(traj);
+  } else if (const auto opt_it = pub_debug_optimizer_module_trajectories_.find(plugin_name);
+             opt_it != pub_debug_optimizer_module_trajectories_.end()) {
+    opt_it->second->publish(traj);
+  } else {
+    RCLCPP_WARN_ONCE(
+      this->get_logger(), "No debug trajectory publisher registered for plugin '%s'",
+      plugin_name.c_str());
+  }
 }
 
 void MinimumRuleBasedPlannerNode::on_timer()


### PR DESCRIPTION
## Description

This fixes a node crash that produces the following glog output:

```
[autoware_minimum_rule_based_planner_node-25] terminate called after throwing an instance of 'std::out_of_range'
[autoware_minimum_rule_based_planner_node-25]   what():  map::at
...
[autoware_minimum_rule_based_planner_node-25]     @     0x714c4da07bb1 autoware::minimum_rule_based_planner::MinimumRuleBasedPlannerNode::publish_debug_trajectory()
[autoware_minimum_rule_based_planner_node-25]     @     0x714c4da080e7 autoware::minimum_rule_based_planner::MinimumRuleBasedPlannerNode::smooth_trajectory()
[autoware_minimum_rule_based_planner_node-25]     @     0x714c4da0cf5e autoware::minimum_rule_based_planner::MinimumRuleBasedPlannerNode::on_timer()
```

`publish_debug_trajectory()` is used to publish both the results of modifier plugins and the results of optimizer plugins. However, it only referenced the publisher map for modifiers (`pub_debug_modifier_module_trajectories_`). When it was called from `smooth_trajectory()` with an optimizer plugin name (e.g. `eb_smoother`), that name was not present in the modifier map, so `std::map::at()` threw `std::out_of_range` and the node crashed.

## Changes

- Instead of calling `.at()` on the modifier publisher map, look up the plugin name in both the modifier map and the optimizer map (`pub_debug_optimizer_module_trajectories_`, which was already populated at construction), and publish from whichever contains it.
- If the name is found in neither map, log a warning instead of crashing.
