### PR TITLE
refactor(tier4_planning_factor_rviz_plugin): use service call to retrieve vehicle info (backport #3170)

### DIFF
--- a/vehicle/autoware_accel_brake_map_calibrator/README.md
+++ b/vehicle/autoware_accel_brake_map_calibrator/README.md
@@ -21,7 +21,7 @@ ros2 launch autoware_accel_brake_map_calibrator accel_brake_map_calibrator.launc
 ros2 bag play <rosbag_file> --clock
 ```
 
-During the calibration with setting the parameter `progress_file_output` to true, the log file is output in [directory of *autoware_accel_brake_map_calibrator*]/config/ . You can also see accel and brake maps in [directory of *autoware_accel_brake_map_calibrator*]/config/accel_map.csv and [directory of *autoware_accel_brake_map_calibrator*]/config/brake_map.csv after calibration.
+During the calibration with setting the parameter `progress_file_output` to true, the log file is output in [directory of _autoware_accel_brake_map_calibrator_]/config/ . You can also see accel and brake maps in [directory of _autoware_accel_brake_map_calibrator_]/config/accel_map.csv and [directory of _autoware_accel_brake_map_calibrator_]/config/brake_map.csv after calibration.
 
 ### Calibration plugin
 
@@ -140,8 +140,8 @@ You can also save accel and brake map in the default directory where Autoware re
 | get_pitch_method         | string | "tf": get pitch from tf, "none": unable to perform pitch validation and pitch compensation                                                                                        | "tf"                                                              |
 | pedal_accel_graph_output | bool   | if true, it will output a log of the pedal accel graph.                                                                                                                           | true                                                              |
 | progress_file_output     | bool   | if true, it will output a log and csv file of the update process.                                                                                                                 | false                                                             |
-| default_map_dir          | str    | directory of default map                                                                                                                                                          | [directory of *autoware_raw_vehicle_cmd_converter*]/data/default/ |
-| calibrated_map_dir       | str    | directory of calibrated map                                                                                                                                                       | [directory of *autoware_accel_brake_map_calibrator*]/config/      |
+| default_map_dir          | str    | directory of default map                                                                                                                                                          | [directory of _autoware_raw_vehicle_cmd_converter_]/data/default/ |
+| calibrated_map_dir       | str    | directory of calibrated map                                                                                                                                                       | [directory of _autoware_accel_brake_map_calibrator_]/config/      |
 | update_hz                | double | hz for update                                                                                                                                                                     | 10.0                                                              |
 
 ## Algorithm Parameters

--- a/visualization/tier4_planning_factor_rviz_plugin/package.xml
+++ b/visualization/tier4_planning_factor_rviz_plugin/package.xml
@@ -17,7 +17,7 @@
   <depend>autoware_internal_planning_msgs</depend>
   <depend>autoware_motion_utils</depend>
   <depend>autoware_utils</depend>
-  <depend>autoware_vehicle_info_utils</depend>
+  <depend>rcl_interfaces</depend>
   <depend>rviz_common</depend>
   <depend>rviz_default_plugins</depend>
 

--- a/visualization/tier4_planning_factor_rviz_plugin/src/planning_factor_rviz_plugin.hpp
+++ b/visualization/tier4_planning_factor_rviz_plugin/src/planning_factor_rviz_plugin.hpp
@@ -15,7 +15,8 @@
 #ifndef PLANNING_FACTOR_RVIZ_PLUGIN_HPP_
 #define PLANNING_FACTOR_RVIZ_PLUGIN_HPP_
 
-#include <autoware_vehicle_info_utils/vehicle_info_utils.hpp>
+#include <rcl_interfaces/srv/get_parameters.hpp>
+#include <rclcpp/rclcpp.hpp>
 #include <rviz_common/display.hpp>
 #include <rviz_common/properties/bool_property.hpp>
 #include <rviz_common/properties/float_property.hpp>
@@ -24,6 +25,8 @@
 
 #include <autoware_internal_planning_msgs/msg/planning_factor_array.hpp>
 
+#include <mutex>
+#include <optional>
 #include <string>
 
 namespace autoware::rviz_plugins
@@ -53,10 +56,8 @@ public:
     this->topic_property_->setValue(topic_name_.c_str());
     this->topic_property_->setDescription("Topic to subscribe to.");
 
-    const auto vehicle_info =
-      autoware::vehicle_info_utils::VehicleInfoUtils(*rviz_ros_node_.lock()->get_raw_node())
-        .getVehicleInfo();
-    baselink2front_ = vehicle_info.max_longitudinal_offset_m;
+    // Start background vehicle info request (non-blocking)
+    start_vehicle_info_request();
   }
 
   void load(const rviz_common::Config & config) override
@@ -104,12 +105,18 @@ private:
   void processMessage(
     const autoware_internal_planning_msgs::msg::PlanningFactorArray::ConstSharedPtr msg) override;
 
+  static void start_vehicle_info_request();
+
   rviz_default_plugins::displays::MarkerCommon marker_common_;
 
-  double baselink2front_ = 0;
   rviz_common::properties::BoolProperty show_safety_factors_;
 
   std::string topic_name_;
+
+  // Static members for cached vehicle info
+  static std::mutex s_mutex_;
+  static std::optional<double> s_baselink2front_;
+  static bool s_request_started_;
 };
 }  // namespace autoware::rviz_plugins
 


### PR DESCRIPTION
## Description
https://github.com/autowarefoundation/autoware_universe/pull/11827 のbackport

## Related links

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?

## Notes for reviewers

None.

## Interface changes

None.

<!-- ⬇️🔴

### Topic changes

#### Additions and removals

| Change type   | Topic Type      | Topic Name    | Message Type        | Description       |
|:--------------|:----------------|:--------------|:--------------------|:------------------|
| Added/Removed | Pub/Sub/Srv/Cli | `/topic_name` | `std_msgs/String`   | Topic description |

#### Modifications

| Version | Topic Type      | Topic Name        | Message Type        | Description       |
|:--------|:----------------|:------------------|:--------------------|:------------------|
| Old     | Pub/Sub/Srv/Cli | `/old_topic_name` | `sensor_msgs/Image` | Topic description |
| New     | Pub/Sub/Srv/Cli | `/new_topic_name` | `sensor_msgs/Image` | Topic description |

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added/Removed | `param_name`   | `double` | `1.0`         | Param description |

#### Modifications

| Version | Parameter Name   | Type     | Default Value | Description       |
|:--------|:-----------------|:---------|:--------------|:------------------|
| Old     | `old_param_name` | `double` | `1.0`         | Param description |
| New     | `new_param_name` | `double` | `1.0`         | Param description |

🔴⬆️ -->

## Effects on system behavior

None.
