### PR TITLE
fix(mpc_lateral_controller): confidence soft-hold timer and LPF sync to published steer

### DIFF
--- a/control/autoware_mpc_lateral_controller/include/autoware/mpc_lateral_controller/lowpass_filter.hpp
+++ b/control/autoware_mpc_lateral_controller/include/autoware/mpc_lateral_controller/lowpass_filter.hpp
@@ -75,6 +75,12 @@ public:
   double filter(const double & u);
 
   /**
+   * @brief Force filter internal state (y,u history) to a value without changing coefficients.
+   * Used so the steering LPF tracks the published command after post-MPC soft hold / stop freeze.
+   */
+  void resetState(const double value);
+
+  /**
    * @brief filtering for time-series data
    * @param [in] t time-series data for input vector
    * @param [out] u object vector

--- a/control/autoware_mpc_lateral_controller/include/autoware/mpc_lateral_controller/mpc.hpp
+++ b/control/autoware_mpc_lateral_controller/include/autoware/mpc_lateral_controller/mpc.hpp
@@ -501,6 +501,12 @@ public:
   void resetPrevResult(const SteeringReport & current_steer);
 
   /**
+   * @brief Reset steering-command LPF internal state to a published command value.
+   * Keeps the filter tracking post-MPC output (soft hold / stop freeze) instead of raw Uex.
+   */
+  void resetSteeringCmdFilter(const double steering_tire_angle);
+
+  /**
    * @brief Set the vehicle model for this MPC.
    * @param vehicle_model_ptr Pointer to the vehicle model.
    */

--- a/control/autoware_mpc_lateral_controller/include/autoware/mpc_lateral_controller/mpc_lateral_controller.hpp
+++ b/control/autoware_mpc_lateral_controller/include/autoware/mpc_lateral_controller/mpc_lateral_controller.hpp
@@ -103,17 +103,22 @@ private:
   // Flag indicating whether to keep the steering control until it converges.
   bool m_keep_steer_control_until_converged;
 
-  // Duration to freeze steering in stop state before allowing MPC to restore steering [s].
-  double m_stop_state_steer_hold_duration{5.0};
+  // Shared duration [s]:
+  // - stop: eligibility must last longer than this before isStoppedState() is true
+  // - confidence: low-confidence soft hold expires after this without a confident refresh
+  double m_stop_state_steer_hold_duration{2.0};
 
   std::optional<rclcpp::Time> m_stop_state_hold_started_at;
 
-  // Reference-confidence steer slew limit (outside MPC QP).
+  // Reference-confidence steer soft hold (outside MPC QP).
   bool m_enable_confidence_steer_slew_limit{false};
   double m_reference_confidence_L_ahead_min{0.4};
   double m_reference_confidence_L_ahead_ref{2.0};
   double m_steer_slew_rate_min_rad_s{0.02};
   double m_ctrl_period{0.0};
+
+  // Started on first low-confidence cycle; cleared only when confidence returns.
+  std::optional<rclcpp::Time> m_confidence_hold_started_at;
 
   // MPC solver checker.
   ResultWithReason m_mpc_solved_status{true};
@@ -260,8 +265,9 @@ private:
   [[nodiscard]] Lateral getInitialControlCommand() const;
 
   /**
-   * @brief Check if the ego car is in a stopped state.
-   * @return True if the ego car is stopped, false otherwise.
+   * @brief Check if the ego car is in a confirmed full stop.
+   * True only after stop eligibility has lasted longer than stop_state_steer_hold_duration.
+   * Until then the controller stays in control.
    */
   [[nodiscard]] bool isStoppedState() const;
 
@@ -301,7 +307,7 @@ private:
   [[nodiscard]] bool isStopStateSteerHoldEligible() const;
 
   /**
-   * @brief Update the stop-state hold timer from current kinematics.
+   * @brief Update the stop-state confirmation timer from current kinematics.
    */
   void updateStopStateHoldTimer();
 
@@ -316,14 +322,22 @@ private:
   [[nodiscard]] double computeReferenceConfidenceWeight() const;
 
   /**
-   * @brief Apply post-MPC slew limit on steering command when reference confidence is low.
-   * ds_max blends linearly from min_rate*period (conf=0) to |MPC delta| (conf=1).
-   * @return true if the command was modified by the slew limiter
+   * @brief True when remaining spatial extent is at/above the full-confidence threshold.
    */
-  [[nodiscard]] bool applyConfidenceSteerSlewLimit(Lateral & ctrl_cmd) const;
+  [[nodiscard]] bool isReferenceFullyConfident() const;
 
   /**
-   * @brief Sync MPC internal delay-compensation state to the published steer command.
+   * @brief Soft-limit steering toward MPC while reference confidence is low.
+   * ds_max blends from min_rate*period (conf=0) to |MPC delta| (conf=1).
+   * Timer starts on first low-confidence cycle and refreshes only when confidence returns;
+   * after stop_state_steer_hold_duration without refresh, soft hold expires and MPC is used.
+   * Flickering short trajectories are treated as low confidence, not as stop.
+   * @return true if the command was modified by the slew limiter
+   */
+  bool applyConfidenceSteerSlewLimit(Lateral & ctrl_cmd);
+
+  /**
+   * @brief Sync delay buffer and steering LPF to the published steer command.
    */
   void syncMpcSteerStateToCommand(const float steering_tire_angle);
 

--- a/control/autoware_mpc_lateral_controller/param/lateral_controller_defaults.param.yaml
+++ b/control/autoware_mpc_lateral_controller/param/lateral_controller_defaults.param.yaml
@@ -59,7 +59,8 @@
     steering_lpf_cutoff_hz: 3.0 # cutoff frequency of lowpass filter for steering command [Hz]
     error_deriv_lpf_cutoff_hz: 5.0
 
-    # stop state: steering command is kept in the previous value in the stop state.
+    # stop state: confirmed full stop freezes previous steer; until then stay in control.
+    # stop_state_steer_hold_duration is also the low-confidence hold timeout (see below).
     stop_state_entry_ego_speed: 0.001
     stop_state_entry_target_speed: 0.001
     converged_steer_rad: 0.1
@@ -67,13 +68,13 @@
     new_traj_duration_time: 1.0
     new_traj_end_dist: 0.3
     mpc_converged_threshold_rps:  0.01 # threshold of mpc convergence check [rad/s]
-    stop_state_steer_hold_duration: 1.0  # [s] freeze steering in stop state, then allow MPC restore
+    stop_state_steer_hold_duration: 2.0  # [s] confirm full stop / expire confidence hold
 
-    # reference-confidence steer slew limit (post-MPC, outside QP)
+    # reference-confidence steer soft hold (post-MPC): flicker is low confidence, not stop
     enable_confidence_steer_slew_limit: true
     reference_confidence_L_ahead_min: 0.5   # [m] low-confidence remaining spatial extent
-    reference_confidence_L_ahead_ref: 1.0   # [m] full-confidence remaining spatial extent
-    steer_slew_rate_min_rad_s: 0.02         # [rad/s] soft-hold rate at zero reference confidence
+    reference_confidence_L_ahead_ref: 1.0   # [m] full confidence; refresh hold timer
+    steer_slew_rate_min_rad_s: 0.02         # [rad/s] soft-hold rate at zero confidence
 
     # steer offset
     steering_offset:

--- a/control/autoware_mpc_lateral_controller/schema/sub/reference_confidence_steer_slew.json
+++ b/control/autoware_mpc_lateral_controller/schema/sub/reference_confidence_steer_slew.json
@@ -8,17 +8,17 @@
       "properties": {
         "enable_confidence_steer_slew_limit": {
           "type": "boolean",
-          "description": "when enabled, limit published steering rate when reference spatial extent ahead of ego is short (soft hold on curves during planner hesitation)",
+          "description": "when enabled, soft-limit published steering rate when remaining spatial extent ahead of ego is short; timer refreshes only when confidence returns",
           "default": false
         },
         "reference_confidence_L_ahead_min": {
           "type": "number",
-          "description": "spatial arc length [m] below which reference curvature is treated as low-confidence",
+          "description": "spatial arc length [m] below which reference is treated as low-confidence",
           "default": 0.4
         },
         "reference_confidence_L_ahead_ref": {
           "type": "number",
-          "description": "spatial arc length [m] at or above which reference is fully trusted and slew limiting is disabled",
+          "description": "spatial arc length [m] at or above which reference is fully trusted and the low-confidence hold timer is refreshed",
           "default": 2.0
         },
         "steer_slew_rate_min_rad_s": {

--- a/control/autoware_mpc_lateral_controller/schema/sub/stop_state.json
+++ b/control/autoware_mpc_lateral_controller/schema/sub/stop_state.json
@@ -43,8 +43,8 @@
         },
         "stop_state_steer_hold_duration": {
           "type": "number",
-          "description": "duration [s] to freeze steering command in stop state; after this elapsed time while kinematically stopped, MPC output is used again so steering can restore",
-          "default": 5.0
+          "description": "shared duration [s]: (1) stop eligibility must last longer than this before isStoppedState() is true; (2) low-confidence soft hold expires after this without a confident refresh",
+          "default": 2.0
         }
       },
       "required": [

--- a/control/autoware_mpc_lateral_controller/src/lowpass_filter.cpp
+++ b/control/autoware_mpc_lateral_controller/src/lowpass_filter.cpp
@@ -63,6 +63,14 @@ double Butterworth2dFilter::filter(const double & u0)
   return y0;
 }
 
+void Butterworth2dFilter::resetState(const double value)
+{
+  m_y1 = value;
+  m_y2 = value;
+  m_u1 = value;
+  m_u2 = value;
+}
+
 void Butterworth2dFilter::filt_vector(const std::vector<double> & t, std::vector<double> & u) const
 {
   u.resize(t.size());

--- a/control/autoware_mpc_lateral_controller/src/mpc.cpp
+++ b/control/autoware_mpc_lateral_controller/src/mpc.cpp
@@ -372,6 +372,16 @@ void MPC::resetPrevResult(const SteeringReport & current_steer)
   m_raw_steer_cmd_pprev = std::clamp(current_steer.steering_tire_angle, -steer_lim_f, steer_lim_f);
 }
 
+void MPC::resetSteeringCmdFilter(const double steering_tire_angle)
+{
+  m_lpf_steering_cmd.resetState(steering_tire_angle);
+  m_raw_steer_cmd_prev = steering_tire_angle;
+  m_raw_steer_cmd_pprev = steering_tire_angle;
+  for (auto & value : m_input_buffer) {
+    value = steering_tire_angle;
+  }
+}
+
 std::pair<ResultWithReason, MPCData> MPC::getData(
   const MPCTrajectory & traj, const SteeringReport & current_steer,
   const Odometry & current_kinematics)

--- a/control/autoware_mpc_lateral_controller/src/mpc_lateral_controller.cpp
+++ b/control/autoware_mpc_lateral_controller/src/mpc_lateral_controller.cpp
@@ -75,7 +75,7 @@ MpcLateralController::MpcLateralController(
   m_mpc_converged_threshold_rps = dp_double("mpc_converged_threshold_rps");  // [rad/s]
   m_stop_state_steer_hold_duration = dp_double("stop_state_steer_hold_duration");
 
-  /* reference-confidence steer slew limit */
+  /* reference-confidence steer soft hold */
   m_enable_confidence_steer_slew_limit = dp_bool("enable_confidence_steer_slew_limit");
   m_reference_confidence_L_ahead_min = dp_double("reference_confidence_L_ahead_min");
   m_reference_confidence_L_ahead_ref = dp_double("reference_confidence_L_ahead_ref");
@@ -353,21 +353,18 @@ trajectory_follower::LateralOutput MpcLateralController::run(
 
   updateStopStateHoldTimer();
 
+  // Confirmed full stop only (elapsed > duration). Until then stay in control.
   if (isStoppedState()) {
-    // Reset input buffer
-    debug_throttle("Stopped state detected, use previous control command");
-    for (auto & value : m_mpc->m_input_buffer) {
-      value = m_ctrl_cmd_prev.steering_tire_angle;
-    }
-    // Use previous command value as previous raw steer command
-    m_mpc->m_raw_steer_cmd_prev = m_ctrl_cmd_prev.steering_tire_angle;
+    syncMpcSteerStateToCommand(m_ctrl_cmd_prev.steering_tire_angle);
     return createLateralOutput(m_ctrl_cmd_prev, false, ctrl_cmd_horizon);
   }
 
   if (!mpc_solved_status.result) {
     debug_throttle("MPC is not solved, use stop control command");
     ctrl_cmd = getStopControlCommand();
+    syncMpcSteerStateToCommand(ctrl_cmd.steering_tire_angle);
   } else if (m_enable_confidence_steer_slew_limit && applyConfidenceSteerSlewLimit(ctrl_cmd)) {
+    // Low-confidence / flicker: soft-slew (not stop). Sync LPF to published output.
     syncMpcSteerStateToCommand(ctrl_cmd.steering_tire_angle);
   }
 
@@ -533,12 +530,10 @@ void MpcLateralController::updateStopStateHoldTimer()
 
 bool MpcLateralController::isStoppedState() const
 {
-  if (!isStopStateSteerHoldEligible()) {
+  // Confirmed full stop only after eligibility lasts longer than the hold duration.
+  // Until then the system is still in control. Flickering short trajectories are not stop.
+  if (!isStopStateSteerHoldEligible() || !m_stop_state_hold_started_at.has_value()) {
     return false;
-  }
-
-  if (!m_stop_state_hold_started_at.has_value()) {
-    return true;
   }
 
   const double elapsed = (clock_->now() - m_stop_state_hold_started_at.value()).seconds();
@@ -767,17 +762,31 @@ double MpcLateralController::computeReferenceConfidenceWeight() const
   return std::clamp((L_ahead - m_reference_confidence_L_ahead_min) / L_span, 0.0, 1.0);
 }
 
-bool MpcLateralController::applyConfidenceSteerSlewLimit(Lateral & ctrl_cmd) const
+bool MpcLateralController::isReferenceFullyConfident() const
 {
-  // Full stop: same kinematic judgement as stop state (without steer-convergence gate).
-  // Allow MPC / downstream controllers to restore steering instead of soft-holding on a
-  // spatially collapsed trajectory.
-  if (isEgoAndTrajectoryStopped()) {
+  return computeReferenceConfidenceWeight() >= 1.0 - 1.0e-6;
+}
+
+bool MpcLateralController::applyConfidenceSteerSlewLimit(Lateral & ctrl_cmd)
+{
+  // Confident: accept MPC and refresh the low-confidence hold timer.
+  if (isReferenceFullyConfident()) {
+    m_confidence_hold_started_at.reset();
+    return false;
+  }
+
+  // Low confidence / flicker: not a stop. Soft-limit |Δsteer| toward MPC until confidence
+  // returns (timer refresh) or hold duration expires (allow full MPC restore).
+  if (!m_confidence_hold_started_at.has_value()) {
+    m_confidence_hold_started_at = clock_->now();
+  }
+
+  const double elapsed = (clock_->now() - m_confidence_hold_started_at.value()).seconds();
+  if (elapsed > m_stop_state_steer_hold_duration) {
     return false;
   }
 
   const double confidence_weight = computeReferenceConfidenceWeight();
-
   const double ds =
     static_cast<double>(ctrl_cmd.steering_tire_angle - m_ctrl_cmd_prev.steering_tire_angle);
   const double ds_abs = std::abs(ds);
@@ -794,16 +803,16 @@ bool MpcLateralController::applyConfidenceSteerSlewLimit(Lateral & ctrl_cmd) con
   const double ds_clamped = std::clamp(ds, -ds_max, ds_max);
   ctrl_cmd.steering_tire_angle =
     m_ctrl_cmd_prev.steering_tire_angle + static_cast<float>(ds_clamped);
-  ctrl_cmd.steering_tire_rotation_rate = static_cast<float>(ds_clamped / m_ctrl_period);
+  ctrl_cmd.steering_tire_rotation_rate =
+    m_ctrl_period > 0.0 ? static_cast<float>(ds_clamped / m_ctrl_period) : 0.0f;
   return true;
 }
 
 void MpcLateralController::syncMpcSteerStateToCommand(const float steering_tire_angle)
 {
-  m_mpc->m_raw_steer_cmd_prev = steering_tire_angle;
-  for (auto & value : m_mpc->m_input_buffer) {
-    value = steering_tire_angle;
-  }
+  // Align delay buffer and steering LPF with the published command so soft hold / stop freeze
+  // is not undone by LPF state that tracked raw Uex.
+  m_mpc->resetSteeringCmdFilter(static_cast<double>(steering_tire_angle));
 }
 
 bool MpcLateralController::isTrajectoryShapeChanged() const

--- a/control/autoware_trajectory_follower_node/param/lateral/mpc.param.yaml
+++ b/control/autoware_trajectory_follower_node/param/lateral/mpc.param.yaml
@@ -57,7 +57,7 @@
     steering_lpf_cutoff_hz: 3.0 # cutoff frequency of lowpass filter for steering command [Hz]
     error_deriv_lpf_cutoff_hz: 5.0
 
-    # stop state: steering command is kept in the previous value in the stop state.
+    # stop state: confirmed full stop freezes previous steer; until then stay in control.
     stop_state_entry_ego_speed: 0.001
     stop_state_entry_target_speed: 0.001
     converged_steer_rad: 0.1
@@ -65,9 +65,9 @@
     new_traj_duration_time: 1.0
     new_traj_end_dist: 0.3
     mpc_converged_threshold_rps:  0.01 # threshold of mpc convergence check [rad/s]
-    stop_state_steer_hold_duration: 1.0
+    stop_state_steer_hold_duration: 2.0
 
-    # reference-confidence steer slew limit (post-MPC, outside QP)
+    # reference-confidence steer soft hold (post-MPC): flicker is low confidence, not stop
     enable_confidence_steer_slew_limit: true
     reference_confidence_L_ahead_min: 0.5
     reference_confidence_L_ahead_ref: 1.0


### PR DESCRIPTION
## Summary
- Treat short/flickering trajectories as **low confidence**, not stop: soft-slew toward MPC while a hold timer runs; refresh the timer only when reference confidence returns (`L_ahead >= L_ref`).
- Soft hold expires after `stop_state_steer_hold_duration` (default **2.0 s**), then full MPC is allowed again; confirmed full stop (`isStoppedState`) still requires `elapsed > duration`.
- Sync the steering LPF (and delay buffer) to the **published** command on soft hold / stop freeze / MPC-fail fallback, so confidence unlock does not spike from an LPF that tracked raw `Uex` toward center.

## Steering state logic

| Situation | Detection | Behavior | Timer |
|-----------|-----------|----------|-------|
| High confidence | `L_ahead >= reference_confidence_L_ahead_ref` | Normal MPC; publish filtered MPC output | Confidence-hold timer **cleared / refreshed** |
| Low confidence / flicker | `L_ahead` short (spatially collapsed traj) | **Not stop.** Soft-slew toward MPC: `ds_max = (1-conf)*min_rate*period + conf*\|ds\|` | Timer **starts once**, keeps running across flicker |
| Low confidence longer than duration | Soft-hold elapsed `> stop_state_steer_hold_duration` | Soft hold **expires** → full MPC (may restore toward 0) | No further soft limit until confidence returns |
| Confirmed full stop | `isEgoAndTrajectoryStopped` eligible for `> stop_state_steer_hold_duration` → `isStoppedState()==true` | Freeze previous published steer; sync LPF + delay buffer | Stop confirmation timer (`elapsed > duration`) |
| Still in control before full stop | Kinematic stop candidate but `elapsed <= duration` | Stay in control (MPC + confidence soft hold if low `L_ahead`) | Stop timer arms; soft hold may still apply |

### Predicate contract

| Predicate | Meaning |
|-----------|---------|
| `isReferenceFullyConfident()` | Remaining arc length ≥ `reference_confidence_L_ahead_ref` |
| `isEgoAndTrajectoryStopped()` | Kinematic stop candidate (ego + target ahead thresholds) |
| `!isStoppedState()` | Still in control (MPC + post-MPC shaping) |
| `isStoppedState()` | Confirmed full stop: eligibility continuous for `> stop_state_steer_hold_duration` |

Flickering short trajectories are **low confidence**, not stop.

### LPF sync (smoothing strategy)

When soft hold / confirmed stop / MPC-fail publishes a shaped command, sync:

| State | Synced to published command |
|-------|-----------------------------|
| Steering LPF (`m_lpf_steering_cmd`) | `Butterworth2dFilter::resetState(published)` |
| Delay buffer (`m_input_buffer`) | filled with published steer |
| `m_raw_steer_cmd_prev` / `pprev` | published steer |

So the LPF tracks the **published** output, not raw QP `Uex`. This prevents unlock spikes where soft hold kept `≈-0.44` while LPF had drifted toward `≈-0.08`.

### Workflow

```
run()
  → calculateMPC()                    # Uex → LPF → ctrl_cmd
  → updateStopStateHoldTimer()
  → if isStoppedState():              # confirmed full stop only
        sync LPF to prev; freeze prev; return
  → if enable_confidence_slew:
        applyConfidenceSteerSlewLimit()
          confident  → clear timer; pass MPC
          low conf   → soft slew until timeout; then pass MPC
        if modified → sync LPF + delay buffer to published
```

## Parameters

| Parameter | Default | Role |
|-----------|---------|------|
| `stop_state_steer_hold_duration` | **2.0** s | Shared: confirm full stop **and** expire confidence soft hold |
| `enable_confidence_steer_slew_limit` | true | Enable soft hold |
| `reference_confidence_L_ahead_min` | 0.5 m | Below → lowest confidence |
| `reference_confidence_L_ahead_ref` | 1.0 m | At/above → full confidence; refresh timer |
| `steer_slew_rate_min_rad_s` | 0.02 rad/s | Soft-hold rate at zero confidence |

## Test plan
- [x] `colcon build --packages-select autoware_mpc_lateral_controller`
- [x] pre-commit on changed files
- [x] Logging sim: brief curve hesitation / short traj flicker — soft hold, no center snap on unlock
- [x] Logging sim: long stop — confirmed freeze after duration; LPF stays aligned with published steer
- [ ] Confirm no diagnostic spam (debug logs removed)

## Notes for reviewers
- Root cause of the unlock spike (`out≈-0.08` while `Uex≈-0.53`): soft hold published ~`-0.44` while `m_lpf_steering_cmd` kept filtering raw `Uex→0`; on confidence refresh the LPF output was published. Fix is `resetSteeringCmdFilter` on shaped publish.
- `stop_state_steer_hold_duration` is shared for stop confirmation and confidence soft-hold expiry.

## Related links
- Follow-up to https://github.com/tier4/autoware_universe/pull/3134