### PR TITLE
fix: use highest probability classification

### DIFF
--- a/control/autoware_collision_detector/package.xml
+++ b/control/autoware_collision_detector/package.xml
@@ -20,6 +20,7 @@
 
   <depend>autoware_adapi_v1_msgs</depend>
   <depend>autoware_motion_utils</depend>
+  <depend>autoware_object_recognition_utils</depend>
   <depend>autoware_perception_msgs</depend>
   <depend>autoware_utils</depend>
   <depend>autoware_vehicle_info_utils</depend>

--- a/control/autoware_collision_detector/src/node.cpp
+++ b/control/autoware_collision_detector/src/node.cpp
@@ -224,7 +224,9 @@ PredictedObjects CollisionDetectorNode::filterObjects(const PredictedObjects & i
 
     // Determine if the object should be excluded based on its classification
     const auto classification =
-      autoware::object_recognition_utils::getHighestProbLabel(object.classification);
+      object.classification.empty()
+        ? autoware_perception_msgs::msg::ObjectClassification::UNKNOWN
+        : autoware::object_recognition_utils::getHighestProbLabel(object.classification);
     bool should_be_excluded = shouldBeExcluded(classification);
 
     const bool is_within_range_and_filtering_class = is_within_range && should_be_excluded;

--- a/control/autoware_collision_detector/src/node.cpp
+++ b/control/autoware_collision_detector/src/node.cpp
@@ -16,6 +16,7 @@
 
 #include "autoware/collision_detector/debug.hpp"
 
+#include <autoware/object_recognition_utils/object_classification.hpp>
 #include <autoware_utils/geometry/geometry.hpp>
 #include <autoware_utils/ros/uuid_helper.hpp>
 #include <autoware_utils_geometry/boost_geometry.hpp>
@@ -222,9 +223,8 @@ PredictedObjects CollisionDetectorNode::filterObjects(const PredictedObjects & i
     const bool is_within_range = (object_distance <= node_param_.nearby_filter_radius);
 
     // Determine if the object should be excluded based on its classification
-    const auto classification = object.classification.empty()
-                                  ? autoware_perception_msgs::msg::ObjectClassification::UNKNOWN
-                                  : object.classification.front().label;
+    const auto classification =
+      autoware::object_recognition_utils::getHighestProbLabel(object.classification);
     bool should_be_excluded = shouldBeExcluded(classification);
 
     const bool is_within_range_and_filtering_class = is_within_range && should_be_excluded;

--- a/planning/autoware_trajectory_modifier/include/autoware/trajectory_modifier/trajectory_modifier_utils/obstacle_stop_utils.hpp
+++ b/planning/autoware_trajectory_modifier/include/autoware/trajectory_modifier/trajectory_modifier_utils/obstacle_stop_utils.hpp
@@ -15,6 +15,7 @@
 #ifndef AUTOWARE__TRAJECTORY_MODIFIER__TRAJECTORY_MODIFIER_UTILS__OBSTACLE_STOP_UTILS_HPP_
 #define AUTOWARE__TRAJECTORY_MODIFIER__TRAJECTORY_MODIFIER_UTILS__OBSTACLE_STOP_UTILS_HPP_
 
+#include <autoware/object_recognition_utils/object_classification.hpp>
 #include <autoware_utils_geometry/boost_geometry.hpp>
 #include <autoware_vehicle_info_utils/vehicle_info.hpp>
 #include <rclcpp/time.hpp>
@@ -275,8 +276,8 @@ struct ObjectFilter
         [&](const auto & object) {
           if (object.kinematics.initial_twist_with_covariance.twist.linear.x > max_velocity_th_)
             return true;
-          const auto & label = object.classification.empty() ? ObjectClassification::UNKNOWN
-                                                             : object.classification.front().label;
+          const auto label =
+            autoware::object_recognition_utils::getHighestProbLabel(object.classification);
           if (classification_to_object_type.count(label) == 0) return true;
           return object_types_.count(classification_to_object_type.at(label)) == 0;
         }),

--- a/planning/autoware_trajectory_modifier/include/autoware/trajectory_modifier/trajectory_modifier_utils/obstacle_stop_utils.hpp
+++ b/planning/autoware_trajectory_modifier/include/autoware/trajectory_modifier/trajectory_modifier_utils/obstacle_stop_utils.hpp
@@ -277,7 +277,9 @@ struct ObjectFilter
           if (object.kinematics.initial_twist_with_covariance.twist.linear.x > max_velocity_th_)
             return true;
           const auto label =
-            autoware::object_recognition_utils::getHighestProbLabel(object.classification);
+            object.classification.empty()
+              ? ObjectClassification::UNKNOWN
+              : autoware::object_recognition_utils::getHighestProbLabel(object.classification);
           if (classification_to_object_type.count(label) == 0) return true;
           return object_types_.count(classification_to_object_type.at(label)) == 0;
         }),

--- a/planning/autoware_trajectory_modifier/package.xml
+++ b/planning/autoware_trajectory_modifier/package.xml
@@ -20,6 +20,7 @@
   <depend>autoware_internal_planning_msgs</depend>
   <depend>autoware_lanelet2_utils</depend>
   <depend>autoware_motion_utils</depend>
+  <depend>autoware_object_recognition_utils</depend>
   <depend>autoware_obstacle_proximity_checker</depend>
   <depend>autoware_path_optimizer</depend>
   <depend>autoware_path_smoother</depend>

--- a/planning/autoware_trajectory_modifier/src/trajectory_modifier_utils/obstacle_stop_utils.cpp
+++ b/planning/autoware_trajectory_modifier/src/trajectory_modifier_utils/obstacle_stop_utils.cpp
@@ -371,7 +371,8 @@ std::optional<CollisionPoint> get_nearest_object_collision(
                    const auto & object, const double obj_arc_length, const double obj_lon_vel,
                    const double ego_arc_length, const double ego_vel) -> std::pair<bool, bool> {
     if (object.classification.empty()) return {false, false};
-    const auto obj_type = classification_to_object_type.at(object.classification.front().label);
+    const auto obj_type = classification_to_object_type.at(
+      autoware::object_recognition_utils::getHighestProbLabel(object.classification));
     if (!object_decel_map.count(obj_type)) return {false, false};
     const auto obj_decel = object_decel_map.at(obj_type);
     if (obj_lon_vel < stopped_vel_th) return {false, false};
@@ -578,11 +579,10 @@ void ObstacleTracker::update_objects(
     if (persistent_objects_map_.empty()) return std::nullopt;
     double min_distance = object_distance_th_ + std::numeric_limits<double>::epsilon();
     for (const auto & [uuid, existing_object] : persistent_objects_map_) {
-      const auto existing_obj_label = existing_object.object.classification.empty()
-                                        ? ObjectClassification::UNKNOWN
-                                        : existing_object.object.classification.front().label;
-      const auto obj_label = object.classification.empty() ? ObjectClassification::UNKNOWN
-                                                           : object.classification.front().label;
+      const auto existing_obj_label = autoware::object_recognition_utils::getHighestProbLabel(
+        existing_object.object.classification);
+      const auto obj_label =
+        autoware::object_recognition_utils::getHighestProbLabel(object.classification);
       if (existing_obj_label != obj_label) continue;
       const auto distance = autoware_utils::calc_distance2d(
         object.kinematics.initial_pose_with_covariance.pose.position,

--- a/planning/autoware_trajectory_modifier/src/trajectory_modifier_utils/obstacle_stop_utils.cpp
+++ b/planning/autoware_trajectory_modifier/src/trajectory_modifier_utils/obstacle_stop_utils.cpp
@@ -370,9 +370,11 @@ std::optional<CollisionPoint> get_nearest_object_collision(
   auto is_safe = [&](
                    const auto & object, const double obj_arc_length, const double obj_lon_vel,
                    const double ego_arc_length, const double ego_vel) -> std::pair<bool, bool> {
-    if (object.classification.empty()) return {false, false};
-    const auto obj_type = classification_to_object_type.at(
-      autoware::object_recognition_utils::getHighestProbLabel(object.classification));
+    const auto label =
+      object.classification.empty()
+        ? ObjectClassification::UNKNOWN
+        : autoware::object_recognition_utils::getHighestProbLabel(object.classification);
+    const auto obj_type = classification_to_object_type.at(label);
     if (!object_decel_map.count(obj_type)) return {false, false};
     const auto obj_decel = object_decel_map.at(obj_type);
     if (obj_lon_vel < stopped_vel_th) return {false, false};
@@ -579,10 +581,14 @@ void ObstacleTracker::update_objects(
     if (persistent_objects_map_.empty()) return std::nullopt;
     double min_distance = object_distance_th_ + std::numeric_limits<double>::epsilon();
     for (const auto & [uuid, existing_object] : persistent_objects_map_) {
-      const auto existing_obj_label = autoware::object_recognition_utils::getHighestProbLabel(
-        existing_object.object.classification);
+      const auto existing_obj_label = existing_object.object.classification.empty()
+                                        ? ObjectClassification::UNKNOWN
+                                        : autoware::object_recognition_utils::getHighestProbLabel(
+                                            existing_object.object.classification);
       const auto obj_label =
-        autoware::object_recognition_utils::getHighestProbLabel(object.classification);
+        object.classification.empty()
+          ? ObjectClassification::UNKNOWN
+          : autoware::object_recognition_utils::getHighestProbLabel(object.classification);
       if (existing_obj_label != obj_label) continue;
       const auto distance = autoware_utils::calc_distance2d(
         object.kinematics.initial_pose_with_covariance.pose.position,


### PR DESCRIPTION
## Summary

  - Update `autoware_trajectory_modifier` to use the highest-probability `ObjectClassification` label instead of the first classification entry.
  - Update `autoware_collision_detector` to use the highest-probability `ObjectClassification` label instead of the first classification entry.
  - Add `autoware_object_recognition_utils` dependencies where `getHighestProbLabel()` is now used.

  ## Motivation

  `PredictedObject.classification` may contain multiple labels. The previous implementation assumed the first entry represented the object class, which can select a lower-confidence label when classifications are not ordered by probability.

  This change makes the behavior consistent with modules that already use the most probable classification label.

- [x] https://evaluation.ci.tier4.jp/evaluation/reports/16bb945c-d7e6-5b56-9b22-38ac5b3cb676?project_id=x2_dev
- [x] https://evaluation.ci.tier4.jp/evaluation/reports/503e6f1b-3e0c-54ca-93e6-6e2ca2eab692?project_id=x2_dev