### PR TITLE
fix(simple_planning_simulator): latch initial pose Z until new trajectory

### DIFF
--- a/simulator/autoware_simple_planning_simulator/include/autoware/simple_planning_simulator/simple_planning_simulator_core.hpp
+++ b/simulator/autoware_simple_planning_simulator/include/autoware/simple_planning_simulator/simple_planning_simulator_core.hpp
@@ -201,6 +201,10 @@ private:
   /* flags */
   bool is_initialized_ = false;         //!< @brief flag to check the initial position is set
   bool add_measurement_noise_ = false;  //!< @brief flag to add measurement noise
+  bool use_latched_initial_pose_z_ =
+    false;                               //!< @brief use Z from latest initial pose after re-init
+  double latched_initial_pose_z_ = 0.0;  //!< @brief latched initial z in origin_frame_id_
+  rclcpp::Time latched_initial_pose_time_{0, 0, RCL_ROS_TIME};  //!< @brief stamp of latched pose
 
   InputCommand current_input_command_{};
 
@@ -342,6 +346,12 @@ private:
    * @param [in] twist initial velocity and angular velocity
    */
   void set_initial_state_with_transform(const PoseStamped & pose, const Twist & twist);
+
+  /**
+   * @brief latch Z from initial pose in origin_frame_id_ until a newer trajectory arrives
+   * @param [in] pose initial position and orientation with header
+   */
+  void latch_initial_pose_z(const PoseStamped & pose);
 
   /**
    * @brief publish velocity

--- a/simulator/autoware_simple_planning_simulator/include/autoware/simple_planning_simulator/simple_planning_simulator_core.hpp
+++ b/simulator/autoware_simple_planning_simulator/include/autoware/simple_planning_simulator/simple_planning_simulator_core.hpp
@@ -52,6 +52,7 @@
 #include <tf2_ros/transform_listener.h>
 
 #include <memory>
+#include <optional>
 #include <random>
 #include <string>
 #include <variant>
@@ -204,7 +205,7 @@ private:
   bool use_latched_initial_pose_z_ =
     false;                               //!< @brief use Z from latest initial pose after re-init
   double latched_initial_pose_z_ = 0.0;  //!< @brief latched initial z in origin_frame_id_
-  rclcpp::Time latched_initial_pose_time_{0, 0, RCL_ROS_TIME};  //!< @brief stamp of latched pose
+  std::optional<rclcpp::Time> latched_initial_pose_time_;  //!< @brief stamp of latched pose
 
   InputCommand current_input_command_{};
 

--- a/simulator/autoware_simple_planning_simulator/src/simple_planning_simulator/simple_planning_simulator_core.cpp
+++ b/simulator/autoware_simple_planning_simulator/src/simple_planning_simulator/simple_planning_simulator_core.cpp
@@ -688,8 +688,13 @@ void SimplePlanningSimulator::on_hazard_lights_cmd(const HazardLightsCommand::Co
 
 void SimplePlanningSimulator::on_trajectory(const Trajectory::ConstSharedPtr msg)
 {
-  if (use_latched_initial_pose_z_ && rclcpp::Time(msg->header.stamp) > latched_initial_pose_time_) {
+  // After re-init, keep map-fitted Z from /initialpose3d until planning publishes a newer
+  // trajectory. Older trajectory messages still carry the previous route's Z profile.
+  if (
+    use_latched_initial_pose_z_ && latched_initial_pose_time_.has_value() &&
+    rclcpp::Time(msg->header.stamp) > latched_initial_pose_time_.value()) {
     use_latched_initial_pose_z_ = false;
+    latched_initial_pose_time_.reset();
   }
   current_trajectory_ptr_ = msg;
 }
@@ -750,10 +755,7 @@ void SimplePlanningSimulator::latch_initial_pose_z(const PoseStamped & pose_stam
 {
   const auto transform = get_transform_msg(origin_frame_id_, pose_stamped.header.frame_id);
   latched_initial_pose_z_ = pose_stamped.pose.position.z + transform.transform.translation.z;
-  latched_initial_pose_time_ = rclcpp::Time(pose_stamped.header.stamp);
-  if (latched_initial_pose_time_.nanoseconds() == 0) {
-    latched_initial_pose_time_ = now();
-  }
+  latched_initial_pose_time_.emplace(pose_stamped.header.stamp);
   use_latched_initial_pose_z_ = true;
 }
 

--- a/simulator/autoware_simple_planning_simulator/src/simple_planning_simulator/simple_planning_simulator_core.cpp
+++ b/simulator/autoware_simple_planning_simulator/src/simple_planning_simulator/simple_planning_simulator_core.cpp
@@ -571,6 +571,7 @@ void SimplePlanningSimulator::on_initialpose(const PoseWithCovarianceStamped::Co
   initial_pose.header = msg->header;
   initial_pose.pose = msg->pose.pose;
   set_initial_state_with_transform(initial_pose, initial_twist);
+  latch_initial_pose_z(initial_pose);
 
   initial_pose_ = msg;
   current_odometry_.pose = msg->pose;
@@ -597,6 +598,7 @@ void SimplePlanningSimulator::on_set_pose(
   initial_pose.header = request->pose.header;
   initial_pose.pose = request->pose.pose.pose;
   set_initial_state_with_transform(initial_pose, initial_twist);
+  latch_initial_pose_z(initial_pose);
   response->status = tier4_api_utils::response_success();
 }
 
@@ -686,6 +688,9 @@ void SimplePlanningSimulator::on_hazard_lights_cmd(const HazardLightsCommand::Co
 
 void SimplePlanningSimulator::on_trajectory(const Trajectory::ConstSharedPtr msg)
 {
+  if (use_latched_initial_pose_z_ && rclcpp::Time(msg->header.stamp) > latched_initial_pose_time_) {
+    use_latched_initial_pose_z_ = false;
+  }
   current_trajectory_ptr_ = msg;
 }
 
@@ -741,6 +746,17 @@ void SimplePlanningSimulator::set_initial_state_with_transform(
   set_initial_state(pose, twist);
 }
 
+void SimplePlanningSimulator::latch_initial_pose_z(const PoseStamped & pose_stamped)
+{
+  const auto transform = get_transform_msg(origin_frame_id_, pose_stamped.header.frame_id);
+  latched_initial_pose_z_ = pose_stamped.pose.position.z + transform.transform.translation.z;
+  latched_initial_pose_time_ = rclcpp::Time(pose_stamped.header.stamp);
+  if (latched_initial_pose_time_.nanoseconds() == 0) {
+    latched_initial_pose_time_ = now();
+  }
+  use_latched_initial_pose_z_ = true;
+}
+
 void SimplePlanningSimulator::set_initial_state(const Pose & pose, const Twist & twist)
 {
   const double x = pose.position.x;
@@ -788,6 +804,10 @@ void SimplePlanningSimulator::set_initial_state(const Pose & pose, const Twist &
 double SimplePlanningSimulator::get_z_pose_from_trajectory(
   const double x, const double y, const Odometry & prev_odometry)
 {
+  if (use_latched_initial_pose_z_) {
+    return latched_initial_pose_z_;
+  }
+
   // calculate closest point on trajectory
   if (!current_trajectory_ptr_) {
     return prev_odometry.pose.pose.position.z;


### PR DESCRIPTION
## Summary
- Fix PSIM re-init Z regression: after the second RViz pose set, ego Z was taken from stale trajectory or historical odometry instead of the new `/initialpose3d` value.
- Latch map-fitted Z from initial pose on `on_initialpose` / simulator set-pose API; keep it until a trajectory with a newer `header.stamp` arrives, then resume trajectory-based Z for road profile.

## Test plan
- [x] Launch PSIM (`localization_sim_mode=api`), set initial pose — Z matches vector map height fitter
- [x] Set route and drive — Z follows trajectory
- [x] Re-set initial pose at a different location (without new route) — Z updates to new fitted height, not old trajectory Z
- [x] Set new goal/route after re-init — latched Z releases and trajectory Z resumes

## Notes for reviewers
- PSIM has no EKF; `simple_planning_simulator` subscribes directly to `/initialpose3d`.
- Vehicle dynamics remain 2D; only published odometry Z is affected.


Made with [Cursor](https://cursor.com)