### PR TITLE
feat(avoidance_target_detector): add get_velocity_limit API and rewrite clearly about selection of PredictedObjects or TrackedObjects

### DIFF
--- a/planning/autoware_avoidance_target_detector/README.md
+++ b/planning/autoware_avoidance_target_detector/README.md
@@ -28,13 +28,13 @@ Headers:
 
 Rebuild `ExtendedRouteHandler` whenever the **map** or **route** changes. On each **objects** update, call `update_objects()` first, then `get_avoidance_targets()` and/or `get_driving_along_vehicles()` (with the latest trajectory and route handler). The same applies to the tracked-objects pipeline via `TrackedObjectSelector`.
 
-| Topic (reference node)    | Message type                                    | Role                                                                                                 |
-| ------------------------- | ----------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
-| `~/input/lanelet_map_bin` | `autoware_map_msgs/msg/LaneletMapBin`           | Vector map. QoS: transient local.                                                                    |
-| `~/input/route`           | `autoware_planning_msgs/msg/LaneletRoute`       | Current route. QoS: transient local.                                                                 |
-| `~/input/trajectory`      | `autoware_planning_msgs/msg/Trajectory`         | Reference trajectory for deviation / distance checks.                                                |
-| `~/input/objects`         | `autoware_perception_msgs/msg/PredictedObjects` | Predicted objects to filter.                                                                         |
-| `~/input/tracked_objects` | `autoware_perception_msgs/msg/TrackedObjects`   | Tracked objects to filter (reuses the route/ego state maintained by the predicted-objects callback). |
+| Topic (reference node)    | Message type                                    | Role                                                        |
+| ------------------------- | ----------------------------------------------- | ----------------------------------------------------------- |
+| `~/input/lanelet_map_bin` | `autoware_map_msgs/msg/LaneletMapBin`           | Vector map. QoS: transient local.                           |
+| `~/input/route`           | `autoware_planning_msgs/msg/LaneletRoute`       | Current route. QoS: transient local.                        |
+| `~/input/trajectory`      | `autoware_planning_msgs/msg/Trajectory`         | Reference trajectory for deviation / distance checks.       |
+| `~/input/objects`         | `autoware_perception_msgs/msg/PredictedObjects` | Predicted objects to filter.                                |
+| `~/input/tracked_objects` | `autoware_perception_msgs/msg/TrackedObjects`   | Tracked objects to filter when `use_tracked_objects:=true`. |
 
 Until map, route, and trajectory are available, boundary and object-selection APIs are not meaningful.
 
@@ -67,6 +67,13 @@ const auto driving_along = object_selector_.get_driving_along_vehicles(
 ```
 
 Parameter `use_extended_route_bounds` (reference node) switches between original and extended route bounds for the drivable area.
+
+Parameter `use_tracked_objects` (reference node, default `false`) selects which object pipeline is active:
+
+- `false` — subscribe to `~/input/objects` and run `PredictedObjectSelector`
+- `true` — subscribe to `~/input/tracked_objects` and run `TrackedObjectSelector`
+
+Only one subscription and its matching output publishers are created.
 
 ---
 

--- a/planning/autoware_avoidance_target_detector/README.md
+++ b/planning/autoware_avoidance_target_detector/README.md
@@ -152,6 +152,43 @@ lanelet::BasicPolygon2d get_near_segment_polygon(
 
 ![Original and extended route comparison](assets/orignal_and_extended_route_lanelets.png)
 
+#### `get_velocity_limit(point)`
+
+```cpp
+std::optional<double> get_velocity_limit(const lanelet::BasicPoint2d & point) const;
+std::optional<double> get_velocity_limit(const lanelet::Point2d & point) const;
+std::optional<double> get_velocity_limit(const geometry_msgs::msg::Point & point) const;
+```
+
+Looks up the speed limit [m/s] at a map position on the route map.
+
+| Argument | Description                                                                                                               |
+| -------- | ------------------------------------------------------------------------------------------------------------------------- |
+| `point`  | Query position (map frame). Overloads accept `lanelet::BasicPoint2d`, `lanelet::Point2d`, or `geometry_msgs::msg::Point`. |
+
+| Returns                 | Description                                                                      |
+| ----------------------- | -------------------------------------------------------------------------------- |
+| `std::optional<double>` | Speed limit in m/s, or `std::nullopt` if no limit can be resolved for the point. |
+
+**Behavior:**
+
+1. Finds up to 5 nearest lanelets on `route_map_` that contain the point.
+2. For each lanelet, reads its speed-limit attribute when present.
+3. If a lanelet has no speed-limit attribute but is a `road_shoulder` or `pedestrian_lane`, falls back to the left/right neighbor from the extended routing graph.
+4. When multiple limits are found, returns the **minimum**.
+
+**Preconditions:** `create_map()` completed (`route_map_` and `extended_routing_graph_` ready).
+
+**Example:**
+
+```cpp
+const auto & ego_position = trajectory.points.front().pose.position;
+const auto velocity_limit = extended_route_handler_->get_velocity_limit(ego_position);
+if (velocity_limit) {
+  // *velocity_limit is in m/s
+}
+```
+
 ---
 
 ### Route bounds and `to_path_msg`

--- a/planning/autoware_avoidance_target_detector/README.md
+++ b/planning/autoware_avoidance_target_detector/README.md
@@ -4,17 +4,19 @@ Experimental toy package for developing auxiliary planning functions. The refere
 
 The object-selection logic is templated on the object message type (`ObjectSelectorBase<ObjectT>`) and exposed as two concrete types:
 
-- **`PredictedObjectSelector`** (`= ObjectSelectorBase<PredictedObject>`) — for `autoware_perception_msgs/msg/PredictedObjects`.
-- **`TrackedObjectSelector`** (`= ObjectSelectorBase<TrackedObject>`) — for `autoware_perception_msgs/msg/TrackedObjects`.
+- **`PredictedObjectSelector`** (`= ObjectSelectorBase<PredictedObject>`) — for `autoware_perception_msgs/msg/PredictedObjects`
+- **`TrackedObjectSelector`** (`= ObjectSelectorBase<TrackedObject>`) — for `autoware_perception_msgs/msg/TrackedObjects`
 
-Per-object state is held by `AvoidanceTargetDetectorBase<ObjectT>`, aliased as **`AvoidanceTargetDetectorPredicted`** and **`AvoidanceTargetDetectorTracked`**.
+Choose **one** of these based on which object topic you subscribe to. You do **not** need both. Per-object state is held by `AvoidanceTargetDetectorBase<ObjectT>`, aliased as **`AvoidanceTargetDetectorPredicted`** and **`AvoidanceTargetDetectorTracked`**.
 
-When integrating into another package, your node typically owns:
+When integrating into another package, own a route handler and the selector that matches your subscription:
 
 ```cpp
 std::shared_ptr<ExtendedRouteHandler> extended_route_handler_;
-PredictedObjectSelector object_selector_;          // predicted-objects pipeline
-TrackedObjectSelector tracked_object_selector_;    // tracked-objects pipeline
+
+// Use exactly one of the following:
+PredictedObjectSelector object_selector_;        // if you subscribe to PredictedObjects
+// TrackedObjectSelector object_selector_;       // if you subscribe to TrackedObjects
 ```
 
 Headers:
@@ -26,15 +28,14 @@ Headers:
 
 ## Required subscriptions
 
-Rebuild `ExtendedRouteHandler` whenever the **map** or **route** changes. On each **objects** update, call `update_objects()` first, then `get_avoidance_targets()` and/or `get_driving_along_vehicles()` (with the latest trajectory and route handler). The same applies to the tracked-objects pipeline via `TrackedObjectSelector`.
+Rebuild `ExtendedRouteHandler` whenever the **map** or **route** changes. On each **objects** update, call `update_objects()` first, then `get_avoidance_targets()` and/or `get_driving_along_vehicles()` (with the latest trajectory and route handler).
 
-| Topic (reference node)    | Message type                                    | Role                                                        |
-| ------------------------- | ----------------------------------------------- | ----------------------------------------------------------- |
-| `~/input/lanelet_map_bin` | `autoware_map_msgs/msg/LaneletMapBin`           | Vector map. QoS: transient local.                           |
-| `~/input/route`           | `autoware_planning_msgs/msg/LaneletRoute`       | Current route. QoS: transient local.                        |
-| `~/input/trajectory`      | `autoware_planning_msgs/msg/Trajectory`         | Reference trajectory for deviation / distance checks.       |
-| `~/input/objects`         | `autoware_perception_msgs/msg/PredictedObjects` | Predicted objects to filter.                                |
-| `~/input/tracked_objects` | `autoware_perception_msgs/msg/TrackedObjects`   | Tracked objects to filter when `use_tracked_objects:=true`. |
+| Topic (reference node)                             | Message type                               | Role                                                  |
+| -------------------------------------------------- | ------------------------------------------ | ----------------------------------------------------- |
+| `~/input/lanelet_map_bin`                          | `autoware_map_msgs/msg/LaneletMapBin`      | Vector map. QoS: transient local.                     |
+| `~/input/route`                                    | `autoware_planning_msgs/msg/LaneletRoute`  | Current route. QoS: transient local.                  |
+| `~/input/trajectory`                               | `autoware_planning_msgs/msg/Trajectory`    | Reference trajectory for deviation / distance checks. |
+| `~/input/objects` **or** `~/input/tracked_objects` | `PredictedObjects` **or** `TrackedObjects` | Object stream to filter. Subscribe to **only one**.   |
 
 Until map, route, and trajectory are available, boundary and object-selection APIs are not meaningful.
 
@@ -52,7 +53,7 @@ Minimal pattern (see `src/node.cpp`):
 extended_route_handler_ = std::make_shared<ExtendedRouteHandler>(*map_bin_, *route_);
 extended_route_handler_->create_map();
 
-// Each cycle (with trajectory + objects):
+// Each cycle (with trajectory + objects of the chosen type):
 const auto & bounds = extended_route_handler_->get_extended_route_bounds();  // or get_original_route_bounds()
 pub_drivable_area_path_->publish(to_path_msg(bounds, trajectory));
 
@@ -62,18 +63,17 @@ object_selector_.update_objects(
 
 const auto targets = object_selector_.get_avoidance_targets(objects, trajectory, bounds);
 
-const auto driving_along = object_selector_.get_driving_along_vehicles(
-  objects, *extended_route_handler_, ego_trajectory_, trajectory);
+const auto driving_along = object_selector_.get_driving_along_vehicles(objects);
 ```
 
 Parameter `use_extended_route_bounds` (reference node) switches between original and extended route bounds for the drivable area.
 
-Parameter `use_tracked_objects` (reference node, default `false`) selects which object pipeline is active:
+Parameter `use_tracked_objects` (reference node, default `false`) picks which object source the reference node uses. Both sources are **not** required:
 
-- `false` — subscribe to `~/input/objects` and run `PredictedObjectSelector`
-- `true` — subscribe to `~/input/tracked_objects` and run `TrackedObjectSelector`
+- `false` — subscribe only to `~/input/objects` (`PredictedObjects`) and run `PredictedObjectSelector`
+- `true` — subscribe only to `~/input/tracked_objects` (`TrackedObjects`) and run `TrackedObjectSelector`
 
-Only one subscription and its matching output publishers are created.
+Only the chosen subscription and its matching output publishers are created.
 
 ---
 
@@ -220,7 +220,9 @@ Path to_path_msg(const RouteBounds & bounds, const Trajectory & trajectory);
 
 ### `ObjectSelectorBase<ObjectT>` (`PredictedObjectSelector` / `TrackedObjectSelector`)
 
-Per-object Bayesian filters are updated via `update_objects()`. Getter methods (`get_avoidance_targets()`, `get_driving_along_vehicles()`) read the latest filter state. Reuse the same selector instance across callbacks. The signatures below use `PredictedObjects` for the predicted pipeline; the tracked pipeline is identical with `TrackedObjects` substituted for the container type.
+Per-object Bayesian filters are updated via `update_objects()`. Getter methods (`get_avoidance_targets()`, `get_driving_along_vehicles()`) read the latest filter state. Reuse the same selector instance across callbacks.
+
+Pick the selector that matches your object subscription — you only need one. The signatures below use `PredictedObjects`; for tracked objects, substitute `TrackedObjects` / `TrackedObjectSelector` the same way.
 
 #### `update_objects()`
 
@@ -234,14 +236,14 @@ void update_objects(
   bool ego_trajectory_built);
 ```
 
-| Argument                 | Description                                                                                                                                                                                                           |
-| ------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `current_time`           | ROS time for this update cycle. Used for filter staleness, hysteresis timing, and Bayesian updates. Typically `node->get_clock()->now()`.                                                                             |
-| `objects`                | Full predicted-objects message for the current frame. Every object in `objects.objects` is observed; objects not seen for longer than `FilterManagerParams::stale_threshold_seconds` are removed from internal state. |
-| `trajectory`             | Reference trajectory (same source as subscribed trajectory). Must have **at least two points** for deviation and distance checks.                                                                                     |
-| `extended_route_handler` | Handler with built `route_map_` and `route_map_routing_graph_`. Used for driving-along spatial checks during observation.                                                                                             |
-| `ego_trajectory`         | Built ego history trajectory. Used with `trajectory` to build the near-segment polygon and resolve ego lanelets.                                                                                                      |
-| `ego_trajectory_built`   | Whether `ego_trajectory` is valid. When false, driving-along spatial checks are skipped for that cycle.                                                                                                               |
+| Argument                 | Description                                                                                                                                                                                                                                                                 |
+| ------------------------ | --------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `current_time`           | ROS time for this update cycle. Used for filter staleness, hysteresis timing, and Bayesian updates. Typically `node->get_clock()->now()`.                                                                                                                                   |
+| `objects`                | Full objects message for the current frame (`PredictedObjects` or `TrackedObjects`, matching the selector). Every object in `objects.objects` is observed; objects not seen for longer than `FilterManagerParams::stale_threshold_seconds` are removed from internal state. |
+| `trajectory`             | Reference trajectory (same source as subscribed trajectory). Must have **at least two points** for deviation and distance checks.                                                                                                                                           |
+| `extended_route_handler` | Handler with built `route_map_` and `route_map_routing_graph_`. Used for driving-along spatial checks during observation.                                                                                                                                                   |
+| `ego_trajectory`         | Built ego history trajectory. Used with `trajectory` to build the near-segment polygon and resolve ego lanelets.                                                                                                                                                            |
+| `ego_trajectory_built`   | Whether `ego_trajectory` is valid. When false, driving-along spatial checks are skipped for that cycle.                                                                                                                                                                     |
 
 Call once per objects callback before any getter in the same cycle. Runs per-object Bayesian observation, driving-along spatial evaluation (for moving objects of interest), and stale pruning. Hysteresis tracking runs inside each getter.
 
@@ -256,13 +258,13 @@ PredictedObjects get_avoidance_targets(
 
 | Argument       | Description                                                                                                                                                                                     |
 | -------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| `objects`      | Same predicted-objects message passed to `update_objects()` for this cycle.                                                                                                                     |
+| `objects`      | Same objects message passed to `update_objects()` for this cycle.                                                                                                                               |
 | `trajectory`   | Reference trajectory. Used for on-trajectory deviation, longitudinal extent filtering, and lateral corridor checks.                                                                             |
 | `route_bounds` | Left/right corridor for lateral filtering. Objects whose footprint lies entirely outside the bounds are removed. Typically from `get_original_route_bounds()` or `get_extended_route_bounds()`. |
 
-| Returns            | Description                                                                                |
-| ------------------ | ------------------------------------------------------------------------------------------ |
-| `PredictedObjects` | Subset of input objects classified as stationary avoidance targets. Empty if none qualify. |
+| Returns                               | Description                                                                                 |
+| ------------------------------------- | ------------------------------------------------------------------------------------------- |
+| `PredictedObjects` / `TrackedObjects` | Subset of input objects classified as stationary avoidance targets. Matches the input type. |
 
 **Brief behavior:**
 
@@ -273,42 +275,36 @@ PredictedObjects get_avoidance_targets(
 #### `get_driving_along_vehicles()`
 
 ```cpp
-PredictedObjects get_driving_along_vehicles(
-  const PredictedObjects & objects,
-  const ExtendedRouteHandler & extended_route_handler,
-  const autoware::experimental::trajectory::Trajectory<TrajectoryPoint> & ego_trajectory,
-  const Trajectory & trajectory);
+PredictedObjects get_driving_along_vehicles(const PredictedObjects & objects);
+// or, when using tracked objects:
+// TrackedObjects get_driving_along_vehicles(const TrackedObjects & objects);
 ```
 
 Selects **moving vehicles along the extended route corridor** near ego (e.g. traffic in sibling / adjacent lanes), complementary to stationary `get_avoidance_targets()`.
 
-**Preconditions:** `update_objects()` called for the same `objects` in the same cycle with the same `extended_route_handler`, `ego_trajectory`, and `ego_trajectory_built` flag.
+**Preconditions:** `update_objects()` called for the same `objects` in the same cycle.
 
-| Argument                 | Description                                                                                       |
-| ------------------------ | ------------------------------------------------------------------------------------------------- |
-| `objects`                | Same predicted-objects message passed to `update_objects()` for this cycle.                       |
-| `extended_route_handler` | Retained for API compatibility with the reference node. Spatial checks run in `update_objects()`. |
-| `ego_trajectory`         | Retained for API compatibility with the reference node.                                           |
-| `trajectory`             | Retained for API compatibility with the reference node.                                           |
+| Argument  | Description                                                                                                |
+| --------- | ---------------------------------------------------------------------------------------------------------- |
+| `objects` | Same objects message passed to `update_objects()` for this cycle (`PredictedObjects` or `TrackedObjects`). |
 
-| Returns            | Description                                                           |
-| ------------------ | --------------------------------------------------------------------- |
-| `PredictedObjects` | Subset of input objects whose tracked state is `is_moving_vehicle()`. |
+| Returns                               | Description                                                                           |
+| ------------------------------------- | ------------------------------------------------------------------------------------- |
+| `PredictedObjects` / `TrackedObjects` | Subset of input objects whose state is `is_moving_vehicle()`. Matches the input type. |
 
 **Selection criteria:**
 
-1. **Tracked state** — `is_moving_vehicle()` after driving-along hysteresis (updated when this getter is called).
+1. **Moving-vehicle state** — `is_moving_vehicle()` after driving-along hysteresis (updated when this getter is called).
 
 Spatial checks (near-segment overlap, lanelet on `route_map_`, not routably connected to ego without lane change) are evaluated during `update_objects()` for moving objects of interest and folded into the driving-along candidate signal before tracking.
 
-**Reference node:**
+**Reference node outputs** (only the pair matching `use_tracked_objects` is published):
 
-| Topic                             | Message type                                         |
-| --------------------------------- | ---------------------------------------------------- |
-| `~/output/driving_along_vehicles` | `autoware_perception_msgs/msg/PredictedObjects`      |
-| `~/debug/near_segment_polygon`    | `visualization_msgs/msg/MarkerArray` (debug polygon) |
-
-Default output remap: `/planning/avoidance_target_detector/output/driving_along_vehicles`.
+| Topic                                     | Message type                                    | When                         |
+| ----------------------------------------- | ----------------------------------------------- | ---------------------------- |
+| `~/output/driving_along_vehicles`         | `autoware_perception_msgs/msg/PredictedObjects` | `use_tracked_objects:=false` |
+| `~/output/tracked_driving_along_vehicles` | `autoware_perception_msgs/msg/TrackedObjects`   | `use_tracked_objects:=true`  |
+| `~/debug/near_segment_polygon`            | `visualization_msgs/msg/MarkerArray`            | always                       |
 
 ---
 
@@ -320,14 +316,14 @@ ros2 launch autoware_avoidance_target_detector avoidance_target_detector.launch.
 
 Default remaps are defined in `launch/avoidance_target_detector.launch.xml`.
 
-| Output (reference node)                   | Default topic                                                               |
-| ----------------------------------------- | --------------------------------------------------------------------------- |
-| `~/output/avoidance_targets`              | `/planning/avoidance_target_detector/output/avoidance_targets`              |
-| `~/output/driving_along_vehicles`         | `/planning/avoidance_target_detector/output/driving_along_vehicles`         |
-| `~/output/tracked_avoidance_targets`      | `/planning/avoidance_target_detector/output/tracked_avoidance_targets`      |
-| `~/output/tracked_driving_along_vehicles` | `/planning/avoidance_target_detector/output/tracked_driving_along_vehicles` |
-| `~/output/drivable_area`                  | `/planning/avoidance_target_detector/output/drivable_area`                  |
-| `~/debug/near_segment_polygon`            | `/planning/avoidance_target_detector/debug/near_segment_polygon`            |
+| Output (reference node)                   | Default topic                                                                                                  |
+| ----------------------------------------- | -------------------------------------------------------------------------------------------------------------- |
+| `~/output/avoidance_targets`              | `/planning/avoidance_target_detector/output/avoidance_targets` (when `use_tracked_objects:=false`)             |
+| `~/output/driving_along_vehicles`         | `/planning/avoidance_target_detector/output/driving_along_vehicles` (when `use_tracked_objects:=false`)        |
+| `~/output/tracked_avoidance_targets`      | `/planning/avoidance_target_detector/output/tracked_avoidance_targets` (when `use_tracked_objects:=true`)      |
+| `~/output/tracked_driving_along_vehicles` | `/planning/avoidance_target_detector/output/tracked_driving_along_vehicles` (when `use_tracked_objects:=true`) |
+| `~/output/drivable_area`                  | `/planning/avoidance_target_detector/output/drivable_area`                                                     |
+| `~/debug/near_segment_polygon`            | `/planning/avoidance_target_detector/debug/near_segment_polygon`                                               |
 
 ---
 

--- a/planning/autoware_avoidance_target_detector/include/autoware/avoidance_target_detector/boundary.hpp
+++ b/planning/autoware_avoidance_target_detector/include/autoware/avoidance_target_detector/boundary.hpp
@@ -159,6 +159,11 @@ public:
     const geometry_msgs::msg::Point & prev_end_point,
     const geometry_msgs::msg::Point & following_end_point) const;
 
+  [[nodiscard]] std::optional<double> get_velocity_limit(const lanelet::BasicPoint2d & point) const;
+  [[nodiscard]] std::optional<double> get_velocity_limit(const lanelet::Point2d & point) const;
+  [[nodiscard]] std::optional<double> get_velocity_limit(
+    const geometry_msgs::msg::Point & point) const;
+
 private:
   [[nodiscard]] std::optional<std::size_t> find_segment_index_for_point(
     const geometry_msgs::msg::Point & point) const;

--- a/planning/autoware_avoidance_target_detector/include/autoware/avoidance_target_detector/node.hpp
+++ b/planning/autoware_avoidance_target_detector/include/autoware/avoidance_target_detector/node.hpp
@@ -70,6 +70,16 @@ private:
 
   void update_ego_trajectory(const TrajectoryPoint & ego_point);
 
+  /**
+   * @brief Poll map/route/trajectory and refresh shared planning state.
+   * @return True when route handler and trajectory are ready for object selection.
+   */
+  [[nodiscard]] bool update_common_inputs();
+
+  void publish_debug_visualizations(const Trajectory & trajectory_msg);
+
+  bool use_tracked_objects_{false};
+
   rclcpp::Subscription<PredictedObjects>::SharedPtr sub_objects_;
   rclcpp::Subscription<TrackedObjects>::SharedPtr sub_tracked_objects_;
   autoware_utils::InterProcessPollingSubscriber<Trajectory> sub_trajectory_{

--- a/planning/autoware_avoidance_target_detector/include/autoware/avoidance_target_detector/object_filtering.hpp
+++ b/planning/autoware_avoidance_target_detector/include/autoware/avoidance_target_detector/object_filtering.hpp
@@ -247,10 +247,7 @@ public:
   [[nodiscard]] Objects get_avoidance_targets(
     const Objects & objects, const Trajectory & trajectory, const RouteBounds & route_bounds);
 
-  [[nodiscard]] Objects get_driving_along_vehicles(
-    const Objects & objects, const ExtendedRouteHandler & extended_route_handler,
-    const autoware::experimental::trajectory::Trajectory<TrajectoryPoint> & ego_trajectory,
-    const Trajectory & trajectory);
+  [[nodiscard]] Objects get_driving_along_vehicles(const Objects & objects);
 
 private:
   void track_avoidance_targets();

--- a/planning/autoware_avoidance_target_detector/launch/avoidance_target_detector.launch.xml
+++ b/planning/autoware_avoidance_target_detector/launch/avoidance_target_detector.launch.xml
@@ -13,9 +13,11 @@
   <arg name="output_drivable_area" default="/planning/avoidance_target_detector/output/drivable_area"/>
   <arg name="debug_near_segment_polygon" default="/planning/avoidance_target_detector/debug/near_segment_polygon"/>
   <arg name="vehicle_info_param_path" default="$(find-pkg-share j6_gen2_description)/config/vehicle_info.param.yaml"/>
+  <arg name="use_tracked_objects" default="false"/>
 
   <node pkg="autoware_avoidance_target_detector" exec="autoware_avoidance_target_detector_node" name="avoidance_target_detector" output="screen">
     <param from="$(var vehicle_info_param_path)"/>
+    <param name="use_tracked_objects" value="$(var use_tracked_objects)"/>
     <remap from="~/input/objects" to="$(var input_objects)"/>
     <remap from="~/input/tracked_objects" to="$(var input_tracked_objects)"/>
     <remap from="~/input/trajectory" to="$(var input_trajectory)"/>

--- a/planning/autoware_avoidance_target_detector/src/boundary.cpp
+++ b/planning/autoware_avoidance_target_detector/src/boundary.cpp
@@ -373,6 +373,51 @@ void add_bounds_linestring_to_map(
   map.add(linestring);
 }
 
+std::vector<lanelet::ConstLanelet> get_nearest_lanelets(
+  const lanelet::LaneletMap & route_map, const lanelet::BasicPoint2d & search_point)
+{
+  constexpr size_t k_max_nearest_lanelets = 5;
+  std::vector<lanelet::ConstLanelet> nearest_lanelets;
+  nearest_lanelets.reserve(k_max_nearest_lanelets);
+
+  route_map.laneletLayer.nearestUntil(
+    search_point, [&](const lanelet::BoundingBox2d & bbox, const lanelet::ConstLanelet & lanelet) {
+      if (lanelet::geometry::inside(lanelet, search_point)) {
+        nearest_lanelets.push_back(lanelet);
+        return nearest_lanelets.size() >= k_max_nearest_lanelets;
+      }
+      constexpr double k_bbox_touch_epsilon_m = 1e-3;
+      return lanelet::geometry::distance2d(bbox, search_point) > k_bbox_touch_epsilon_m;
+    });
+
+  return nearest_lanelets;
+}
+
+bool is_road_shoulder(const lanelet::ConstLanelet & lanelet)
+{
+  return std::string(lanelet.attributeOr(lanelet::AttributeName::Subtype, "none")) ==
+         "road_shoulder";
+}
+
+bool is_pedestrian_lane(const lanelet::ConstLanelet & lanelet)
+{
+  return std::string(lanelet.attributeOr(lanelet::AttributeName::Subtype, "none")) ==
+         "pedestrian_lane";
+}
+
+std::optional<double> read_speed_limit_from_lanelet(const lanelet::ConstLanelet & lanelet)
+{
+  constexpr const char * k_speed_limit_attribute = "speed_limit";
+  if (!lanelet.hasAttribute(k_speed_limit_attribute)) {
+    return std::nullopt;
+  }
+  const auto v = lanelet.attribute(k_speed_limit_attribute).asDouble();
+  if (!v) {
+    return std::nullopt;
+  }
+  return v.get();
+}
+
 lanelet::LaneletMap build_debug_map(lanelet::LaneletMap & route_map)
 {
   lanelet::LaneletMap debug_map;
@@ -724,6 +769,63 @@ lanelet::BasicPolygon2d ExtendedRouteHandler::get_near_segment_polygon(
   ring.emplace_back(ring.front());
 
   return lanelet::BasicPolygon2d(ring);
+}
+
+std::optional<double> ExtendedRouteHandler::get_velocity_limit(
+  const lanelet::BasicPoint2d & point) const
+{
+  const auto nearest_lanelets = get_nearest_lanelets(*route_map_, point);
+  if (nearest_lanelets.empty()) {
+    return std::nullopt;
+  }
+
+  std::optional<double> velocity_limit;
+
+  for (const auto & lanelet : nearest_lanelets) {
+    // If the lanelet has a speed limit attribute, use it.
+    const auto speed_limit = read_speed_limit_from_lanelet(lanelet);
+    if (speed_limit) {
+      velocity_limit = (velocity_limit) ? std::min(*velocity_limit, *speed_limit) : *speed_limit;
+      continue;
+    }
+
+    // If the lanelet has no speed limit attribute, but is a road_shoulder or pedestrian_lane, get
+    // the speed limit from the left and right lanelets.
+    if (is_road_shoulder(lanelet) || is_pedestrian_lane(lanelet)) {
+      const auto left_lanelet = traffic_rules::get_left_lanelet(*extended_routing_graph_, lanelet);
+      const auto right_lanelet =
+        traffic_rules::get_right_lanelet(*extended_routing_graph_, lanelet);
+      if (right_lanelet) {
+        const auto right_speed_limit = read_speed_limit_from_lanelet(*right_lanelet);
+        if (right_speed_limit) {
+          velocity_limit =
+            (velocity_limit) ? std::min(*velocity_limit, *right_speed_limit) : *right_speed_limit;
+          continue;
+        }
+      }
+      if (left_lanelet) {
+        const auto left_speed_limit = read_speed_limit_from_lanelet(*left_lanelet);
+        if (left_speed_limit) {
+          velocity_limit =
+            (velocity_limit) ? std::min(*velocity_limit, *left_speed_limit) : *left_speed_limit;
+          continue;
+        }
+      }
+    }
+  }
+
+  return velocity_limit;
+}
+
+std::optional<double> ExtendedRouteHandler::get_velocity_limit(const lanelet::Point2d & point) const
+{
+  return get_velocity_limit(lanelet::BasicPoint2d(point.x(), point.y()));
+}
+
+std::optional<double> ExtendedRouteHandler::get_velocity_limit(
+  const geometry_msgs::msg::Point & point) const
+{
+  return get_velocity_limit(lanelet::BasicPoint2d(point.x, point.y));
 }
 
 Path to_path_msg(const RouteBounds & bounds, const Trajectory & trajectory)

--- a/planning/autoware_avoidance_target_detector/src/node.cpp
+++ b/planning/autoware_avoidance_target_detector/src/node.cpp
@@ -29,24 +29,30 @@ namespace autoware::avoidance_target_detector
  */
 AvoidanceTargetDetectorNode::AvoidanceTargetDetectorNode(const rclcpp::NodeOptions & node_options)
 : Node{"avoidance_target_detector", node_options},
-  sub_objects_{create_subscription<PredictedObjects>(
-    "~/input/objects", rclcpp::QoS{1},
-    std::bind(&AvoidanceTargetDetectorNode::on_objects, this, std::placeholders::_1))},
-  sub_tracked_objects_{create_subscription<TrackedObjects>(
-    "~/input/tracked_objects", rclcpp::QoS{1},
-    std::bind(&AvoidanceTargetDetectorNode::on_tracked_objects, this, std::placeholders::_1))},
-  pub_avoidance_targets_{create_publisher<PredictedObjects>("~/output/avoidance_targets", 1)},
-  pub_driving_along_vehicles_{
-    create_publisher<PredictedObjects>("~/output/driving_along_vehicles", 1)},
-  pub_tracked_avoidance_targets_{
-    create_publisher<TrackedObjects>("~/output/tracked_avoidance_targets", 1)},
-  pub_tracked_driving_along_vehicles_{
-    create_publisher<TrackedObjects>("~/output/tracked_driving_along_vehicles", 1)},
   pub_drivable_area_path_{create_publisher<Path>("~/output/drivable_area", 1)},
   pub_near_segment_polygon_{
     create_publisher<MarkerArray>("~/debug/near_segment_polygon", rclcpp::QoS{1}.transient_local())}
 {
   declare_parameter<bool>("use_extended_route_bounds", true);
+  declare_parameter<bool>("use_tracked_objects", false);
+  use_tracked_objects_ = get_parameter("use_tracked_objects").as_bool();
+
+  if (use_tracked_objects_) {
+    sub_tracked_objects_ = create_subscription<TrackedObjects>(
+      "~/input/tracked_objects", rclcpp::QoS{1},
+      std::bind(&AvoidanceTargetDetectorNode::on_tracked_objects, this, std::placeholders::_1));
+    pub_tracked_avoidance_targets_ =
+      create_publisher<TrackedObjects>("~/output/tracked_avoidance_targets", 1);
+    pub_tracked_driving_along_vehicles_ =
+      create_publisher<TrackedObjects>("~/output/tracked_driving_along_vehicles", 1);
+  } else {
+    sub_objects_ = create_subscription<PredictedObjects>(
+      "~/input/objects", rclcpp::QoS{1},
+      std::bind(&AvoidanceTargetDetectorNode::on_objects, this, std::placeholders::_1));
+    pub_avoidance_targets_ = create_publisher<PredictedObjects>("~/output/avoidance_targets", 1);
+    pub_driving_along_vehicles_ =
+      create_publisher<PredictedObjects>("~/output/driving_along_vehicles", 1);
+  }
 }
 
 void AvoidanceTargetDetectorNode::update_ego_trajectory(const TrajectoryPoint & ego_point)
@@ -79,16 +85,8 @@ void AvoidanceTargetDetectorNode::update_ego_trajectory(const TrajectoryPoint & 
   }
 }
 
-/**
- * @brief Callback for incoming predicted objects.
- * @param msg Predicted objects message.
- */
-void AvoidanceTargetDetectorNode::on_objects(const PredictedObjects::ConstSharedPtr msg)
+bool AvoidanceTargetDetectorNode::update_common_inputs()
 {
-  if (!msg) {
-    return;
-  }
-
   bool map_or_route_updated = false;
 
   if (const auto route_msg = sub_route_.take_data()) {
@@ -110,20 +108,23 @@ void AvoidanceTargetDetectorNode::on_objects(const PredictedObjects::ConstShared
   }
 
   if (!route_ || !extended_route_handler_) {
-    return;
+    return false;
   }
 
   trajectory_ = sub_trajectory_.take_data();
-  const Trajectory trajectory_msg = trajectory_ ? *trajectory_ : Trajectory{};
-
   if (!trajectory_ || !extended_route_handler_->getOriginalRouteHandler()->isHandlerReady()) {
-    return;
+    return false;
   }
 
   if (!trajectory_->points.empty()) {
     update_ego_trajectory(trajectory_->points.front());
   }
 
+  return true;
+}
+
+void AvoidanceTargetDetectorNode::publish_debug_visualizations(const Trajectory & trajectory_msg)
+{
   const auto use_extended_bounds = get_parameter("use_extended_route_bounds").as_bool();
   const auto & route_bounds = use_extended_bounds
                                 ? extended_route_handler_->get_extended_route_bounds()
@@ -145,6 +146,29 @@ void AvoidanceTargetDetectorNode::on_objects(const PredictedObjects::ConstShared
       }
     }
   }
+}
+
+/**
+ * @brief Callback for incoming predicted objects.
+ * @param msg Predicted objects message.
+ */
+void AvoidanceTargetDetectorNode::on_objects(const PredictedObjects::ConstSharedPtr msg)
+{
+  if (!msg || use_tracked_objects_) {
+    return;
+  }
+
+  if (!update_common_inputs()) {
+    return;
+  }
+
+  const Trajectory trajectory_msg = *trajectory_;
+  publish_debug_visualizations(trajectory_msg);
+
+  const auto use_extended_bounds = get_parameter("use_extended_route_bounds").as_bool();
+  const auto & route_bounds = use_extended_bounds
+                                ? extended_route_handler_->get_extended_route_bounds()
+                                : extended_route_handler_->get_original_route_bounds();
 
   object_selector_.update_objects(
     get_clock()->now(), *msg, trajectory_msg, *extended_route_handler_, ego_trajectory_,
@@ -157,8 +181,7 @@ void AvoidanceTargetDetectorNode::on_objects(const PredictedObjects::ConstShared
 
   PredictedObjects driving_along_vehicles;
   if (ego_trajectory_built_ && !trajectory_msg.points.empty()) {
-    driving_along_vehicles = object_selector_.get_driving_along_vehicles(
-      *msg, *extended_route_handler_, ego_trajectory_, trajectory_msg);
+    driving_along_vehicles = object_selector_.get_driving_along_vehicles(*msg);
   }
   pub_driving_along_vehicles_->publish(driving_along_vehicles);
 }
@@ -166,23 +189,19 @@ void AvoidanceTargetDetectorNode::on_objects(const PredictedObjects::ConstShared
 /**
  * @brief Callback for incoming tracked objects.
  * @param msg Tracked objects message.
- * @details Reuses the route handler and ego trajectory maintained by on_objects().
  */
 void AvoidanceTargetDetectorNode::on_tracked_objects(const TrackedObjects::ConstSharedPtr msg)
 {
-  if (!msg) {
+  if (!msg || !use_tracked_objects_) {
     return;
   }
 
-  if (!route_ || !extended_route_handler_ || !trajectory_) {
-    return;
-  }
-
-  if (!extended_route_handler_->getOriginalRouteHandler()->isHandlerReady()) {
+  if (!update_common_inputs()) {
     return;
   }
 
   const Trajectory trajectory_msg = *trajectory_;
+  publish_debug_visualizations(trajectory_msg);
 
   const auto use_extended_bounds = get_parameter("use_extended_route_bounds").as_bool();
   const auto & route_bounds = use_extended_bounds
@@ -200,8 +219,7 @@ void AvoidanceTargetDetectorNode::on_tracked_objects(const TrackedObjects::Const
 
   TrackedObjects driving_along_vehicles;
   if (ego_trajectory_built_ && !trajectory_msg.points.empty()) {
-    driving_along_vehicles = tracked_object_selector_.get_driving_along_vehicles(
-      *msg, *extended_route_handler_, ego_trajectory_, trajectory_msg);
+    driving_along_vehicles = tracked_object_selector_.get_driving_along_vehicles(*msg);
   }
   pub_tracked_driving_along_vehicles_->publish(driving_along_vehicles);
 }

--- a/planning/autoware_avoidance_target_detector/src/object_filtering.cpp
+++ b/planning/autoware_avoidance_target_detector/src/object_filtering.cpp
@@ -1035,14 +1035,8 @@ typename ObjectSelectorBase<ObjectT>::Objects ObjectSelectorBase<ObjectT>::get_a
 
 template <typename ObjectT>
 typename ObjectSelectorBase<ObjectT>::Objects
-ObjectSelectorBase<ObjectT>::get_driving_along_vehicles(
-  const Objects & objects, const ExtendedRouteHandler & extended_route_handler,
-  const aw_trajectory::Trajectory<TrajectoryPoint> & ego_trajectory, const Trajectory & trajectory)
+ObjectSelectorBase<ObjectT>::get_driving_along_vehicles(const Objects & objects)
 {
-  (void)extended_route_handler;
-  (void)ego_trajectory;
-  (void)trajectory;
-
   track_driving_along_vehicles();
 
   Objects driving_along_vehicles = objects;


### PR DESCRIPTION
This PR has mainly two changes

1. Add get_velocity_limit(point) API in the ExtendedRouteHandler
  a. The argument can be `lanelet::BasicPoint2d`, `lanelet::Point2d`, or `geometry_msgs/Point`.
2. Rewrite documentation and node example about using `PredictedObjectSelector` or `TrackedObjectSelector` that it can be read that the user has to use both selectors which is wrong.