### PR TITLE
fix(behavior_velocity_crosswalk_module): use getHighestProbLabel inst…

### DIFF
--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_crosswalk_module/package.xml
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_crosswalk_module/package.xml
@@ -26,6 +26,7 @@
   <depend>autoware_interpolation</depend>
   <depend>autoware_lanelet2_extension</depend>
   <depend>autoware_motion_utils</depend>
+  <depend>autoware_object_recognition_utils</depend>
   <depend>autoware_perception_msgs</depend>
   <depend>autoware_planning_msgs</depend>
   <depend>autoware_route_handler</depend>

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_crosswalk_module/src/experimental/occluded_crosswalk.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_crosswalk_module/src/experimental/occluded_crosswalk.cpp
@@ -15,6 +15,7 @@
 #include "occluded_crosswalk.hpp"
 
 #include <autoware/grid_map_utils/polygon_iterator.hpp>
+#include <autoware/object_recognition_utils/object_classification.hpp>
 #include <autoware_utils/geometry/boost_polygon_utils.hpp>
 #include <grid_map_ros/GridMapRosConverter.hpp>
 
@@ -91,7 +92,9 @@ std::vector<autoware_perception_msgs::msg::PredictedObject> select_and_inflate_o
 {
   std::vector<autoware_perception_msgs::msg::PredictedObject> selected_objects;
   for (const auto & o : objects) {
-    const auto vel_threshold = velocity_thresholds[o.classification.front().label];
+    const auto vel_threshold =
+      velocity_thresholds[autoware::object_recognition_utils::getHighestProbLabel(
+        o.classification)];
     if (o.kinematics.initial_twist_with_covariance.twist.linear.x >= vel_threshold) {
       auto selected_object = o;
       selected_object.shape.dimensions.x += inflate_size;

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_crosswalk_module/src/experimental/scene_crosswalk.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_crosswalk_module/src/experimental/scene_crosswalk.cpp
@@ -20,6 +20,7 @@
 
 #include <autoware/motion_utils/distance/distance.hpp>
 #include <autoware/motion_utils/resample/resample.hpp>
+#include <autoware/object_recognition_utils/object_classification.hpp>
 #include <autoware/trajectory/path_point_with_lane_id.hpp>
 #include <autoware/trajectory/utils/crossed.hpp>
 #include <autoware/trajectory/utils/find_nearest.hpp>
@@ -1614,7 +1615,8 @@ void CrosswalkModule::updateObjectState(
       findEgoPassageDirectionAlongPath(ego_path);
     object_info_manager_.update(
       obj_uuid, obj_pos, std::hypot(obj_vel.x, obj_vel.y), objects_ptr->header.stamp,
-      is_ego_yielding, has_traffic_light, collision_point, object.classification.front().label, p,
+      is_ego_yielding, has_traffic_light, collision_point,
+      autoware::object_recognition_utils::getHighestProbLabel(object.classification), p,
       crosswalk_.polygon2d().basicPolygon(), attention_area, ego_crosswalk_passage_direction);
 
     const auto collision_state = object_info_manager_.getCollisionState(obj_uuid);
@@ -1693,7 +1695,7 @@ bool CrosswalkModule::isVehicle(const PredictedObject & object)
     return false;
   }
 
-  const auto & label = object.classification.front().label;
+  const auto label = autoware::object_recognition_utils::getHighestProbLabel(object.classification);
 
   if (label == ObjectClassification::CAR) {
     return true;
@@ -1724,7 +1726,7 @@ bool CrosswalkModule::isCrosswalkUserType(const PredictedObject & object) const
     return false;
   }
 
-  const auto & label = object.classification.front().label;
+  const auto label = autoware::object_recognition_utils::getHighestProbLabel(object.classification);
 
   if (label == ObjectClassification::UNKNOWN && planner_param_.look_unknown) {
     return true;

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_crosswalk_module/src/occluded_crosswalk.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_crosswalk_module/src/occluded_crosswalk.cpp
@@ -15,6 +15,7 @@
 #include "occluded_crosswalk.hpp"
 
 #include <autoware/grid_map_utils/polygon_iterator.hpp>
+#include <autoware/object_recognition_utils/object_classification.hpp>
 #include <autoware_utils/geometry/boost_polygon_utils.hpp>
 #include <grid_map_ros/GridMapRosConverter.hpp>
 
@@ -91,7 +92,9 @@ std::vector<autoware_perception_msgs::msg::PredictedObject> select_and_inflate_o
 {
   std::vector<autoware_perception_msgs::msg::PredictedObject> selected_objects;
   for (const auto & o : objects) {
-    const auto vel_threshold = velocity_thresholds[o.classification.front().label];
+    const auto vel_threshold =
+      velocity_thresholds[autoware::object_recognition_utils::getHighestProbLabel(
+        o.classification)];
     if (o.kinematics.initial_twist_with_covariance.twist.linear.x >= vel_threshold) {
       auto selected_object = o;
       selected_object.shape.dimensions.x += inflate_size;

--- a/planning/behavior_velocity_planner/autoware_behavior_velocity_crosswalk_module/src/scene_crosswalk.cpp
+++ b/planning/behavior_velocity_planner/autoware_behavior_velocity_crosswalk_module/src/scene_crosswalk.cpp
@@ -25,6 +25,7 @@
 #include <autoware/motion_utils/resample/resample.hpp>
 #include <autoware/motion_utils/trajectory/interpolation.hpp>
 #include <autoware/motion_utils/trajectory/trajectory.hpp>
+#include <autoware/object_recognition_utils/object_classification.hpp>
 #include <autoware_utils/geometry/boost_geometry.hpp>
 #include <autoware_utils/geometry/boost_polygon_utils.hpp>
 #include <autoware_utils/geometry/geometry.hpp>
@@ -1369,7 +1370,8 @@ void CrosswalkModule::updateObjectState(
       findEgoPassageDirectionAlongPath(sparse_resample_path);
     object_info_manager_.update(
       obj_uuid, obj_pos, std::hypot(obj_vel.x, obj_vel.y), objects_ptr->header.stamp,
-      is_ego_yielding, has_traffic_light, collision_point, object.classification.front().label, p,
+      is_ego_yielding, has_traffic_light, collision_point,
+      autoware::object_recognition_utils::getHighestProbLabel(object.classification), p,
       crosswalk_.polygon2d().basicPolygon(), attention_area, ego_crosswalk_passage_direction);
 
     const auto collision_state = object_info_manager_.getCollisionState(obj_uuid);
@@ -1447,7 +1449,7 @@ bool CrosswalkModule::isVehicle(const PredictedObject & object)
     return false;
   }
 
-  const auto & label = object.classification.front().label;
+  const auto label = autoware::object_recognition_utils::getHighestProbLabel(object.classification);
 
   if (label == ObjectClassification::CAR) {
     return true;
@@ -1478,7 +1480,7 @@ bool CrosswalkModule::isCrosswalkUserType(const PredictedObject & object) const
     return false;
   }
 
-  const auto & label = object.classification.front().label;
+  const auto label = autoware::object_recognition_utils::getHighestProbLabel(object.classification);
 
   if (label == ObjectClassification::UNKNOWN && planner_param_.look_unknown) {
     return true;


### PR DESCRIPTION
## Description

- cherry-pick of https://github.com/autowarefoundation/autoware_universe/pull/12970

- [TIER IV INTERNAL BACKPORT WORKFLOW](https://star4.slack.com/archives/C07K1PPNPTR/p1783994606129739)

## Original PR's Descritpion

> ## Description
> 
> The crosswalk module was reading object labels via `classification.front().label`, implicitly assuming the first entry is the most likely class. In `autoware_perception_msgs`, however, `ObjectClassification` entries are **not** guaranteed to be ordered by probability.
> 
> This PR replaces those usages with `autoware::object_recognition_utils::getHighestProbLabel()`, which explicitly selects the label with the highest probability. 
> 
> The change affects:
> - Vehicle / crosswalk-user type checks (`isVehicle`, `isCrosswalkUserType`)
> - Object state updates passed to the object info manager
> - Velocity-threshold lookup for occluded-crosswalk object selection
> 
> A dependency on `autoware_object_recognition_utils` is added to share this utility.
> [TIER IV INTERNAL DISCUSSION](https://star4.slack.com/archives/C076ZGRC15X/p1783563053795209)