### PR TITLE
fix(trajectory_modifier): fix obstacle stop unstable stop wall

### DIFF
--- a/planning/autoware_minimum_rule_based_planner/plugins/obstacle_stop.cpp
+++ b/planning/autoware_minimum_rule_based_planner/plugins/obstacle_stop.cpp
@@ -33,6 +33,7 @@ namespace autoware::minimum_rule_based_planner::plugin
 {
 using autoware::trajectory_modifier::utils::clamp_stop_point_arc_length;
 using autoware::trajectory_modifier::utils::insert_stop_point;
+using autoware::trajectory_modifier::utils::replace_trajectory_with_stop_point;
 using autoware::trajectory_modifier::utils::obstacle_stop::get_nearest_object_collision;
 using autoware::trajectory_modifier::utils::obstacle_stop::get_nearest_pcd_collision;
 using autoware::trajectory_modifier::utils::obstacle_stop::get_trajectory_shape;
@@ -161,22 +162,10 @@ void ObstacleStop::set_stop_point(TrajectoryPoints & traj_points, const Modifier
     data.acceleration_ptr->accel.accel.linear.x, params_.nominal_stopping_decel,
     params_.stopping_jerk);
 
-  if (!insert_stop_point(
-        traj_points, target_stop_point_arc_length, debug_data_.trajectory_shape.trajectory_length))
-    return;
-
   if (
     target_stop_point_arc_length < params_.arrived_distance_threshold ||
-    !insert_stop_point(
-      traj_points, target_stop_point_arc_length, debug_data_.trajectory_shape.trajectory_length)) {
-    auto p = traj_points.front();
-    traj_points.clear();
-    p.longitudinal_velocity_mps = 0.0;
-    p.acceleration_mps2 = 0.0;
-    p.time_from_start = rclcpp::Duration::from_seconds(0.0);
-    traj_points.push_back(p);
-    p.time_from_start = rclcpp::Duration::from_seconds(0.1);
-    traj_points.push_back(p);
+    !insert_stop_point(traj_points, target_stop_point_arc_length)) {
+    replace_trajectory_with_stop_point(traj_points, data.odometry_ptr->pose.pose, 0.1);
   }
 
   const auto & stop_pose = traj_points.back().pose;

--- a/planning/autoware_minimum_rule_based_planner/plugins/obstacle_stop.cpp
+++ b/planning/autoware_minimum_rule_based_planner/plugins/obstacle_stop.cpp
@@ -165,7 +165,7 @@ void ObstacleStop::set_stop_point(TrajectoryPoints & traj_points, const Modifier
   if (
     target_stop_point_arc_length < params_.arrived_distance_threshold ||
     !insert_stop_point(traj_points, target_stop_point_arc_length)) {
-    replace_trajectory_with_stop_point(traj_points, data.odometry_ptr->pose.pose, 0.1);
+    replace_trajectory_with_stop_point(traj_points, data.odometry_ptr->pose.pose);
   }
 
   const auto & stop_pose = traj_points.back().pose;

--- a/planning/autoware_trajectory_modifier/config/trajectory_modifier.param.yaml
+++ b/planning/autoware_trajectory_modifier/config/trajectory_modifier.param.yaml
@@ -34,6 +34,7 @@
       enable_stop_for_objects: true
       enable_stop_for_pointcloud: false
       stop_margin: 6.0 # [m]
+      minimum_stop_margin: 3.0 # [m]
       lateral_margin: 0.2     # lateral margin on top of ego width from trajectory to consider for obstacle stop [m]
       duplicate_check_threshold: 0.5 # threshold to check if the stop point is already in the trajectory [m]
 

--- a/planning/autoware_trajectory_modifier/include/autoware/trajectory_modifier/trajectory_modifier_utils/obstacle_stop_utils.hpp
+++ b/planning/autoware_trajectory_modifier/include/autoware/trajectory_modifier/trajectory_modifier_utils/obstacle_stop_utils.hpp
@@ -141,6 +141,11 @@ struct TrajectoryShape
   autoware_utils_geometry::Box2d bounding_box;
   double trajectory_length;
   double forward_traj_length;
+
+  [[nodiscard]] double ego_arc_length() const
+  {
+    return trajectory_length - forward_traj_length;
+  }
 };
 
 struct DebugData

--- a/planning/autoware_trajectory_modifier/include/autoware/trajectory_modifier/trajectory_modifier_utils/obstacle_stop_utils.hpp
+++ b/planning/autoware_trajectory_modifier/include/autoware/trajectory_modifier/trajectory_modifier_utils/obstacle_stop_utils.hpp
@@ -142,10 +142,7 @@ struct TrajectoryShape
   double trajectory_length;
   double forward_traj_length;
 
-  [[nodiscard]] double ego_arc_length() const
-  {
-    return trajectory_length - forward_traj_length;
-  }
+  [[nodiscard]] double ego_arc_length() const { return trajectory_length - forward_traj_length; }
 };
 
 struct DebugData

--- a/planning/autoware_trajectory_modifier/include/autoware/trajectory_modifier/trajectory_modifier_utils/utils.hpp
+++ b/planning/autoware_trajectory_modifier/include/autoware/trajectory_modifier/trajectory_modifier_utils/utils.hpp
@@ -48,8 +48,7 @@ bool stop_point_exists(
   const TrajectoryPoints & traj_points, const double stop_point_arc_length,
   const double duplicate_check_threshold = 0.0);
 
-bool insert_stop_point(
-  TrajectoryPoints & trajectory, const double stop_point_arc_length, const double traj_length);
+bool insert_stop_point(TrajectoryPoints & trajectory, const double stop_point_arc_length);
 
 bool is_stop_trajectory(const TrajectoryPoints & trajectory, const double stopped_vel_th = 1e-3);
 

--- a/planning/autoware_trajectory_modifier/include/autoware/trajectory_modifier/trajectory_modifier_utils/utils.hpp
+++ b/planning/autoware_trajectory_modifier/include/autoware/trajectory_modifier/trajectory_modifier_utils/utils.hpp
@@ -35,7 +35,7 @@ double calculate_distance_to_last_point(
 
 void replace_trajectory_with_stop_point(
   TrajectoryPoints & traj_points, const geometry_msgs::msg::Pose & ego_pose,
-  const double time_step);
+  const double time_step = 0.1);
 
 bool is_ego_vehicle_moving(
   const geometry_msgs::msg::Twist & twist, const double velocity_threshold);
@@ -48,7 +48,8 @@ bool stop_point_exists(
   const TrajectoryPoints & traj_points, const double stop_point_arc_length,
   const double duplicate_check_threshold = 0.0);
 
-bool insert_stop_point(TrajectoryPoints & trajectory, const double stop_point_arc_length);
+bool insert_stop_point(
+  TrajectoryPoints & trajectory, const double stop_point_arc_length, const double time_step = 0.1);
 
 bool is_stop_trajectory(const TrajectoryPoints & trajectory, const double stopped_vel_th = 1e-3);
 

--- a/planning/autoware_trajectory_modifier/param/trajectory_modifier_parameter_struct.yaml
+++ b/planning/autoware_trajectory_modifier/param/trajectory_modifier_parameter_struct.yaml
@@ -131,6 +131,13 @@ trajectory_modifier_params:
       validation:
         bounds<>: [0.0, 100.0]
       read_only: false
+    minimum_stop_margin:
+      type: double
+      default_value: 3.0
+      description: Minimum distance to maintain from an obstacle when stopped [m]
+      validation:
+        bounds<>: [0.0, 100.0]
+      read_only: false
     lateral_margin:
       type: double
       default_value: 0.5

--- a/planning/autoware_trajectory_modifier/schema/trajectory_modifier.schema.json
+++ b/planning/autoware_trajectory_modifier/schema/trajectory_modifier.schema.json
@@ -145,6 +145,12 @@
               "default": 6.0,
               "minimum": 0.0
             },
+            "minimum_stop_margin": {
+              "type": "number",
+              "description": "Minimum distance to maintain from an obstacle when stopped [m]",
+              "default": 3.0,
+              "minimum": 0.0
+            },
             "lateral_margin": {
               "type": "number",
               "description": "Lateral margin on top of ego width from trajectory to consider for obstacle stop [m]",

--- a/planning/autoware_trajectory_modifier/src/trajectory_modifier.cpp
+++ b/planning/autoware_trajectory_modifier/src/trajectory_modifier.cpp
@@ -102,10 +102,11 @@ void TrajectoryModifier::on_traj(const CandidateTrajectories::ConstSharedPtr msg
   std::string modified_plugins_str;
   for (auto & trajectory : output_trajectories.candidate_trajectories) {
     for (auto & modifier : plugins_) {
-      if (!modifier->modify_trajectory(trajectory.points, input_data)) continue;
-      modifier->publish_planning_factor();
+      const auto modified = modifier->modify_trajectory(trajectory.points, input_data);
       const auto ns = "trajectory_" + std::to_string(trajectory_count);
       modifier->publish_debug_data(ns);
+      if (!modified) continue;
+      modifier->publish_planning_factor();
       if (!modified_plugins_str.empty()) modified_plugins_str += ", ";
       modified_plugins_str += modifier->get_short_name();
     }

--- a/planning/autoware_trajectory_modifier/src/trajectory_modifier_plugins/obstacle_stop.cpp
+++ b/planning/autoware_trajectory_modifier/src/trajectory_modifier_plugins/obstacle_stop.cpp
@@ -235,7 +235,7 @@ bool ObstacleStop::set_stop_point(TrajectoryPoints & traj_points, const InputDat
 
   if (
     ego_to_stop_arc_length < stopping_params_.arrived_distance_threshold ||
-    !utils::insert_stop_point(traj_points, target_stop_point_arc_length)) {
+    !utils::insert_stop_point(traj_points, target_stop_point_arc_length, trajectory_time_step_)) {
     utils::replace_trajectory_with_stop_point(
       traj_points, input.current_odometry->pose.pose, trajectory_time_step_);
   }

--- a/planning/autoware_trajectory_modifier/src/trajectory_modifier_plugins/obstacle_stop.cpp
+++ b/planning/autoware_trajectory_modifier/src/trajectory_modifier_plugins/obstacle_stop.cpp
@@ -225,8 +225,11 @@ bool ObstacleStop::set_stop_point(TrajectoryPoints & traj_points, const InputDat
     return false;
   }
 
+  const auto ego_arc_length = debug_data_.trajectory_shape.ego_arc_length();
+  const auto ego_to_stop_arc_length = target_stop_point_arc_length - ego_arc_length;
+
   if (
-    target_stop_point_arc_length < stopping_params_.arrived_distance_threshold ||
+    ego_to_stop_arc_length < stopping_params_.arrived_distance_threshold ||
     !utils::insert_stop_point(
       traj_points, target_stop_point_arc_length, debug_data_.trajectory_shape.trajectory_length)) {
     utils::replace_trajectory_with_stop_point(
@@ -237,7 +240,7 @@ bool ObstacleStop::set_stop_point(TrajectoryPoints & traj_points, const InputDat
   const auto & ego_pose = input.current_odometry->pose.pose;
   auto distance =
     motion_utils::calcSignedArcLength(traj_points, ego_pose.position, stop_pose.position);
-  if (std::isnan(distance)) distance = 0.0;
+  if (std::isnan(distance) || distance < 1e-3) distance = 0.0;
   planning_factor_interface_->add(distance, stop_pose, PlanningFactor::STOP, safety_factors_);
 
   RCLCPP_WARN_THROTTLE(

--- a/planning/autoware_trajectory_modifier/src/trajectory_modifier_plugins/obstacle_stop.cpp
+++ b/planning/autoware_trajectory_modifier/src/trajectory_modifier_plugins/obstacle_stop.cpp
@@ -230,8 +230,7 @@ bool ObstacleStop::set_stop_point(TrajectoryPoints & traj_points, const InputDat
 
   if (
     ego_to_stop_arc_length < stopping_params_.arrived_distance_threshold ||
-    !utils::insert_stop_point(
-      traj_points, target_stop_point_arc_length, debug_data_.trajectory_shape.trajectory_length)) {
+    !utils::insert_stop_point(traj_points, target_stop_point_arc_length)) {
     utils::replace_trajectory_with_stop_point(
       traj_points, input.current_odometry->pose.pose, trajectory_time_step_);
   }

--- a/planning/autoware_trajectory_modifier/src/trajectory_modifier_plugins/obstacle_stop.cpp
+++ b/planning/autoware_trajectory_modifier/src/trajectory_modifier_plugins/obstacle_stop.cpp
@@ -210,15 +210,20 @@ bool ObstacleStop::set_stop_point(TrajectoryPoints & traj_points, const InputDat
 {
   autoware_utils_debug::ScopedTimeTrack st("ObstacleStop::set_stop_point", *get_time_keeper());
 
-  const auto stop_margin = params_.stop_margin + context_->vehicle_info.max_longitudinal_offset_m;
+  const auto ego_longitudinal_offset = context_->vehicle_info.max_longitudinal_offset_m;
+  const auto target_stop_margin = params_.stop_margin + ego_longitudinal_offset;
   const auto target_stop_point_arc_length = utils::clamp_stop_point_arc_length(
-    nearest_collision_point_->arc_length - stop_margin,
+    nearest_collision_point_->arc_length - target_stop_margin,
     debug_data_.trajectory_shape.trajectory_length, input.current_odometry->twist.twist.linear.x,
     input.current_acceleration->accel.accel.linear.x, stopping_params_.maximum_deceleration,
     stopping_params_.jerk_limit);
 
-  if (utils::stop_point_exists(
-        traj_points, target_stop_point_arc_length, params_.duplicate_check_threshold)) {
+  // actual stop margin from ego front to collision point
+  const auto stop_margin =
+    nearest_collision_point_->arc_length - (target_stop_point_arc_length + ego_longitudinal_offset);
+  const auto overlap_th =
+    stop_margin > params_.minimum_stop_margin ? params_.duplicate_check_threshold : 0.0;
+  if (utils::stop_point_exists(traj_points, target_stop_point_arc_length, overlap_th)) {
     RCLCPP_WARN_THROTTLE(
       get_node_ptr()->get_logger(), *get_clock(), 1000,
       "[TM ObstacleStop] Preceding (or duplicate) stop point exists, skip inserting stop point");

--- a/planning/autoware_trajectory_modifier/src/trajectory_modifier_plugins/traffic_light_stop.cpp
+++ b/planning/autoware_trajectory_modifier/src/trajectory_modifier_plugins/traffic_light_stop.cpp
@@ -166,18 +166,9 @@ bool TrafficLightStop::set_stop_point(TrajectoryPoints & traj_points, const Inpu
 
   if (
     target_stop_point_arc_length < stopping_params_.arrived_distance_threshold ||
-    !utils::insert_stop_point(traj_points, target_stop_point_arc_length, trajectory_length)) {
-    traj_points = std::invoke([&]() {
-      TrajectoryPoints stop_points;
-      auto p = traj_points.front();
-      p.longitudinal_velocity_mps = 0.0;
-      p.acceleration_mps2 = 0.0;
-      p.time_from_start = rclcpp::Duration::from_seconds(0.0);
-      stop_points.push_back(p);
-      p.time_from_start = rclcpp::Duration::from_seconds(trajectory_time_step_);
-      stop_points.push_back(p);
-      return stop_points;
-    });
+    !utils::insert_stop_point(traj_points, target_stop_point_arc_length)) {
+    utils::replace_trajectory_with_stop_point(
+      traj_points, input.current_odometry->pose.pose, trajectory_time_step_);
   }
 
   const auto & stop_pose = traj_points.back().pose;

--- a/planning/autoware_trajectory_modifier/src/trajectory_modifier_utils/obstacle_stop_utils.cpp
+++ b/planning/autoware_trajectory_modifier/src/trajectory_modifier_utils/obstacle_stop_utils.cpp
@@ -67,50 +67,73 @@ double get_detection_length(
   return forward_traj_length + margin;
 }
 
+std::optional<std::pair<double, double>> get_curvature_at_end(
+  const TrajectoryPoints & trajectory_points, const double lookback_distance)
+{
+  // need at least 3 points to calculate curvature
+  if (trajectory_points.size() < 3) return std::nullopt;
+
+  const auto & last_p = trajectory_points.back();
+  const auto lookback_pose = motion_utils::calcLongitudinalOffsetPose(
+    trajectory_points, trajectory_points.size() - 1, -1.0 * lookback_distance);
+  if (!lookback_pose) return std::nullopt;
+
+  const auto mid_pose = motion_utils::calcLongitudinalOffsetPose(
+    trajectory_points, trajectory_points.size() - 1, -1.0 * lookback_distance / 2.0);
+  if (!mid_pose) return std::nullopt;
+
+  double curvature = 0.0;
+  try {
+    curvature = autoware_utils_geometry::calc_curvature(
+      lookback_pose.value().position, mid_pose.value().position, last_p.pose.position);
+  } catch (const std::exception &) {
+    return std::nullopt;
+  }
+
+  const auto yaw = autoware_utils_geometry::calc_azimuth_angle(mid_pose.value().position, last_p.pose.position);
+  return std::make_pair(curvature, yaw);
+}
+
 TrajectoryPoints extend_trajectory(
-  const TrajectoryPoints & trajectory_points, const double length, const double wheelbase_length)
+  const TrajectoryPoints & trajectory_points, const double length)
 {
   if (length < 1e-3 || trajectory_points.empty()) return trajectory_points;
 
+  TrajectoryPoints extended_trajectory = trajectory_points;
+
   const auto & last_p = trajectory_points.back();
-  const auto yaw_last = tf2::getYaw(last_p.pose.orientation);
   constexpr double lookback_distance = 2.0;  // [m]
-  const auto lookback_pose = motion_utils::calcLongitudinalOffsetPose(
-    trajectory_points, trajectory_points.size() - 1, -1.0 * lookback_distance);
+  const auto curvature_at_end = get_curvature_at_end(trajectory_points, lookback_distance);
+  const auto [curvature, yaw] = curvature_at_end
+    ? curvature_at_end.value()
+    : std::pair{0.0, tf2::getYaw(last_p.pose.orientation)};
 
-  auto steering_angle = 0.0;
-  if (lookback_pose) {
-    const auto lookback_yaw = tf2::getYaw(lookback_pose.value().orientation);
-    const auto delta_yaw = autoware_utils_geometry::normalize_radian(yaw_last - lookback_yaw);
-    const auto k = delta_yaw / lookback_distance;
-    steering_angle = std::atan(k * wheelbase_length);
-  }
-
-  if (std::abs(steering_angle) < 1e-3) {
-    auto extended_trajectory = trajectory_points;
+  const auto end_vel = last_p.longitudinal_velocity_mps;
+  constexpr double low_speed_threshold = 0.5;
+  constexpr double low_curvature_threshold = 1e-3;
+  if (std::abs(curvature) < low_curvature_threshold || end_vel < low_speed_threshold) {
     auto p = trajectory_points.back();
+    p.pose.orientation = autoware_utils::create_quaternion_from_yaw(yaw);
     p.pose = autoware_utils::calc_offset_pose(p.pose, length, 0, 0);
     extended_trajectory.push_back(p);
     return extended_trajectory;
   }
 
-  const auto turn_radius = wheelbase_length / std::tan(steering_angle);
-  const auto yaw = tf2::getYaw(last_p.pose.orientation);
-
+  const auto turn_radius = 1.0 / curvature;
   constexpr double step = 0.5;
-  TrajectoryPoints extended_trajectory;
+  TrajectoryPoints extension_points;
   for (auto d = length; d > 0; d -= step) {
     auto p = last_p;
     const auto beta = d / turn_radius;
     p.pose.position.x += turn_radius * (std::sin(yaw + beta) - std::sin(yaw));
     p.pose.position.y += turn_radius * (std::cos(yaw) - std::cos(yaw + beta));
     p.pose.orientation = autoware_utils::create_quaternion_from_yaw(yaw + beta);
-    extended_trajectory.push_back(p);
+    extension_points.push_back(p);
   }
-  std::reverse(extended_trajectory.begin(), extended_trajectory.end());
+  std::reverse(extension_points.begin(), extension_points.end());
 
   extended_trajectory.insert(
-    extended_trajectory.begin(), trajectory_points.begin(), trajectory_points.end());
+    extended_trajectory.end(), extension_points.begin(), extension_points.end());
   return extended_trajectory;
 }
 
@@ -137,7 +160,7 @@ TrajectoryShape get_trajectory_shape(
       return motion_utils::cropForwardPoints(
         trajectory_points, ego_pose.position, start_idx, detection_length);
     }
-    return extend_trajectory(trajectory_points, stop_margin, vehicle_info.wheel_base_m);
+    return extend_trajectory(trajectory_points, stop_margin);
   });
 
   autoware_utils_geometry::LineString2d ls_front_right;

--- a/planning/autoware_trajectory_modifier/src/trajectory_modifier_utils/obstacle_stop_utils.cpp
+++ b/planning/autoware_trajectory_modifier/src/trajectory_modifier_utils/obstacle_stop_utils.cpp
@@ -90,12 +90,12 @@ std::optional<std::pair<double, double>> get_curvature_at_end(
     return std::nullopt;
   }
 
-  const auto yaw = autoware_utils_geometry::calc_azimuth_angle(mid_pose.value().position, last_p.pose.position);
+  const auto yaw =
+    autoware_utils_geometry::calc_azimuth_angle(mid_pose.value().position, last_p.pose.position);
   return std::make_pair(curvature, yaw);
 }
 
-TrajectoryPoints extend_trajectory(
-  const TrajectoryPoints & trajectory_points, const double length)
+TrajectoryPoints extend_trajectory(const TrajectoryPoints & trajectory_points, const double length)
 {
   if (length < 1e-3 || trajectory_points.empty()) return trajectory_points;
 
@@ -105,8 +105,8 @@ TrajectoryPoints extend_trajectory(
   constexpr double lookback_distance = 2.0;  // [m]
   const auto curvature_at_end = get_curvature_at_end(trajectory_points, lookback_distance);
   const auto [curvature, yaw] = curvature_at_end
-    ? curvature_at_end.value()
-    : std::pair{0.0, tf2::getYaw(last_p.pose.orientation)};
+                                  ? curvature_at_end.value()
+                                  : std::pair{0.0, tf2::getYaw(last_p.pose.orientation)};
 
   const auto end_vel = last_p.longitudinal_velocity_mps;
   constexpr double low_speed_threshold = 0.5;

--- a/planning/autoware_trajectory_modifier/src/trajectory_modifier_utils/utils.cpp
+++ b/planning/autoware_trajectory_modifier/src/trajectory_modifier_utils/utils.cpp
@@ -102,9 +102,15 @@ bool stop_point_exists(
   return false;
 }
 
-bool insert_stop_point(TrajectoryPoints & trajectory, const double stop_point_arc_length)
+bool insert_stop_point(
+  TrajectoryPoints & trajectory, const double stop_point_arc_length, const double time_step)
 {
-  if (trajectory.empty() || stop_point_arc_length < 1e-3) return false;
+  if (trajectory.empty()) return false;
+
+  if (stop_point_arc_length < 1e-3) {
+    replace_trajectory_with_stop_point(trajectory, trajectory.front().pose, time_step);
+    return true;
+  }
 
   constexpr double overlap_threshold = 0.1;
 

--- a/planning/autoware_trajectory_modifier/src/trajectory_modifier_utils/utils.cpp
+++ b/planning/autoware_trajectory_modifier/src/trajectory_modifier_utils/utils.cpp
@@ -102,37 +102,42 @@ bool stop_point_exists(
   return false;
 }
 
-bool insert_stop_point(
-  TrajectoryPoints & trajectory, const double stop_point_arc_length, const double traj_length)
+bool insert_stop_point(TrajectoryPoints & trajectory, const double stop_point_arc_length)
 {
-  if (stop_point_arc_length < 1e-3) return false;
+  if (trajectory.empty() || stop_point_arc_length < 1e-3) return false;
 
-  const auto stop_index = [&]() -> size_t {
-    const auto index = motion_utils::insertStopPoint(stop_point_arc_length, trajectory);
-    if (index) return index.value();
+  constexpr double overlap_threshold = 0.1;
 
-    // TODO(Quda): this is a temporary fix, need to check why insertStopPoint fails when target
-    // distance is equal to trajectory length
-    if (stop_point_arc_length < traj_length) {
-      auto dist = 0.0;
-      auto it = std::adjacent_find(
-        trajectory.begin(), trajectory.end(), [&](const auto & p, const auto & next) {
-          dist += autoware_utils_geometry::calc_distance2d(p.pose.position, next.pose.position);
-          return dist >= stop_point_arc_length - 1e-3;
-        });
-      if (it != trajectory.end()) {
-        it->longitudinal_velocity_mps = 0.0;
-        it->acceleration_mps2 = 0.0;
-        return std::distance(trajectory.begin(), it);
-      }
-    }
+  auto distance = 0.0;
+  auto seg_length = 0.0;
+  size_t idx = 0;
+  for (; idx < trajectory.size() - 1; ++idx) {
+    seg_length = autoware_utils_geometry::calc_distance2d(
+      trajectory[idx].pose.position, trajectory[idx + 1].pose.position);
+    if (distance + seg_length > stop_point_arc_length) break;
+    distance += seg_length;
+  }
 
+  if (idx == trajectory.size() - 1) {
     trajectory.back().longitudinal_velocity_mps = 0.0;
     trajectory.back().acceleration_mps2 = 0.0;
-    return trajectory.size() - 1;
-  }();
+    return true;
+  }
 
-  trajectory.erase(trajectory.begin() + stop_index + 1, trajectory.end());
+  auto stop_idx = idx;
+  if (std::abs(distance - stop_point_arc_length) < overlap_threshold) {
+    stop_idx = idx;
+  } else if (std::abs(distance + seg_length - stop_point_arc_length) < overlap_threshold) {
+    stop_idx = idx + 1;
+  } else {
+    auto target_idx =
+      motion_utils::insertStopPoint(idx, stop_point_arc_length - distance, trajectory);
+    stop_idx = target_idx ? target_idx.value() : idx;
+  }
+
+  if (stop_idx + 1 < trajectory.size()) {
+    trajectory.erase(trajectory.begin() + stop_idx + 1, trajectory.end());
+  }
   trajectory.back().longitudinal_velocity_mps = 0.0;
   trajectory.back().acceleration_mps2 = 0.0;
 


### PR DESCRIPTION
`obstacle_stop` stopwall is sometimes unstable, toggling on/off, and appearing behind ego.

<img width="2227" height="889" alt="Screenshot from 2026-07-15 14-00-19" src="https://github.com/user-attachments/assets/347889fa-d5a8-4254-90b8-6a6100b15db5" />

The issues are caused by:
- Unstable trajectory end extension (which relies unstable of trajectory points orientations at end of trajectory)
- Buggy insert_stop_point function which sometimes inserts stop pose with opposite orientation

This PR fixes the above issues by:
- Improving trajectory end extension to use path curvature instead of trajectory points orientation
- Improving trajectory end extension to apply straight extension for slow end velocity
- Refactor `insert_stop_point` function to prevent wrong orientation

Additionally this PR introduces `minimum_stop_margin` to set a hard limit by which ego must remain stopped, to prevent creeping behavior caused by DP trajectory instability when ego approached front obstacle.

requires https://github.com/tier4/autoware_launch.x2/pull/2708