### PR TITLE
fix(traffic_light_compliance_checker): improve stop point detection

### DIFF
--- a/common/autoware_traffic_light_compliance_checker/src/traffic_light_compliance_checker.cpp
+++ b/common/autoware_traffic_light_compliance_checker/src/traffic_light_compliance_checker.cpp
@@ -285,7 +285,9 @@ TrafficLightComplianceChecker::check_with_filtered_signals(
     input.current_velocity, input.current_acceleration,
     params_.checked_trajectory_length.deceleration_limit,
     params_.checked_trajectory_length.jerk_limit, params_.delay_response_time);
-  const auto max_trajectory_length = ego_stopping_distance.value_or(0.0);
+  // add the stop_overshoot_margin to not skip points beyond the stop line but within the margin
+  const auto max_trajectory_length =
+    ego_stopping_distance.value_or(0.0) + params_.stop_overshoot_margin;
   auto length = 0.0;
   auto backward_length = 0.0;
   std::optional<lanelet::BasicPoint2d> stop_point;
@@ -305,12 +307,11 @@ TrafficLightComplianceChecker::check_with_filtered_signals(
     trajectory.push_back(p);
     trajectory_ls.emplace_back(lanelet_p);
 
-    // skip points beyond the first stop, or skip once we reach the maximum length
-    if (p.longitudinal_velocity_mps <= 1e-6) {
+    // search for a stop point beyond the current ego position
+    if (length > 0.0 && p.longitudinal_velocity_mps <= params_.ego_stopped_velocity_threshold) {
       stop_point = trajectory_ls.back();
       break;
     }
-
     if (length > max_trajectory_length) break;
   }
 


### PR DESCRIPTION
## Description

Fix an issue with the stop margin used in the traffic_light_compliance_checker.
For this margin to work as expected, we need to correctly detect the stop point. However, in the current implementation, the trajectory can be cut too short, excluding a stop point within the margin and thus potentially causing a wrong violation detection.

In addition, the velocity used to determine stop points is now based on the parameter `ego_stopped_velocity_threshold`.

Cherry-pick of https://github.com/autowarefoundation/autoware_universe/pull/13003

## Related links

## How was this PR tested?

Psim
DLR

## Notes for reviewers

None.

## Interface changes

None.

## Effects on system behavior

Remove some false positives with the `traffic_light_filter`.
