### PR TITLE
fix(pid_longitudinal_controller): use trajectory point acc on flat full-stop decel

### DIFF
--- a/control/autoware_pid_longitudinal_controller/src/pid_longitudinal_controller.cpp
+++ b/control/autoware_pid_longitudinal_controller/src/pid_longitudinal_controller.cpp
@@ -1257,7 +1257,8 @@ double PidLongitudinalController::applyVelocityFeedback(const ControlData & cont
     if (
       abs(target_motion.vel) < m_state_transition_params.stopped_state_entry_vel &&
       target_motion.acc < m_state_transition_params.stopped_state_entry_acc) {
-      target_acc = m_stopped_state_params.acc;
+      target_acc =
+        control_data.interpolated_traj.points.at(control_data.target_idx).acceleration_mps2;
     }
 
     const double feedback_acc = w * a_connect + (1.0 - w) * target_acc;


### PR DESCRIPTION
## Summary
- When decelerating toward a full stop and the lookahead point is on a flat segment (zero acceleration), use the **current trajectory point acceleration** instead of the fixed `stopped_state` acc parameter (`-2.0 m/s²`).
- In practice the planner’s current-point deceleration is typically gentler than the configured stopped acc, yielding smoother braking while still stopping before critical stop lines.
- Deceleration now tracks diffusion-planner intent more closely during low-speed nudging.

**Change:** In `applyVelocityFeedback()`, the flat full-stop branch now sets `target_acc` from `control_data.interpolated_traj.points.at(control_data.target_idx).acceleration_mps2` instead of `m_stopped_state_params.acc`.

## Test plan
- [x] Vehicle experiment 2026-07-16: verified gentler deceleration on flat full-stop cases; stopping remains strong enough before critical stop lines
- [ ] CI build/test on `feat/v0.64/e2e`

## Notes for reviewers
- Behavior change is scoped to the stopped-state entry condition (`|target_vel|` below threshold and `target_acc` below stopped entry acc).
- No parameter or interface changes.

## Interface changes
None.

## Effects on system behavior
Gentler longitudinal braking when approaching a full stop on flat trajectory segments; better alignment with diffusion-planner acceleration intent at low speed.


Made with [Cursor](https://cursor.com)