### PR TITLE
feat(map_based_prediction): cut VRU paths jumping onto the road at road boundaries

### DIFF
--- a/perception/autoware_map_based_prediction/CMakeLists.txt
+++ b/perception/autoware_map_based_prediction/CMakeLists.txt
@@ -36,6 +36,7 @@ ament_auto_add_library(map_based_prediction_node SHARED
   lib/predictor_vru/traffic_signal.cpp
   lib/predictor_vru/fence.cpp
   lib/predictor_vru/vegetation.cpp
+  lib/predictor_vru/road_boundary.cpp
   lib/predictor_vru/path_cut_debug.cpp
   lib/path_cut/path_cut_utils.cpp
   lib/utils.cpp

--- a/perception/autoware_map_based_prediction/include/autoware/map_based_prediction/predictor_vru/path_cut_debug.hpp
+++ b/perception/autoware_map_based_prediction/include/autoware/map_based_prediction/predictor_vru/path_cut_debug.hpp
@@ -31,7 +31,7 @@
 namespace autoware::map_based_prediction
 {
 
-enum class PathCutSource { Vegetation, Fence };
+enum class PathCutSource { Vegetation, Fence, RoadBoundary };
 
 struct PathCutDebug
 {

--- a/perception/autoware_map_based_prediction/include/autoware/map_based_prediction/predictor_vru/predictor_vru.hpp
+++ b/perception/autoware_map_based_prediction/include/autoware/map_based_prediction/predictor_vru/predictor_vru.hpp
@@ -19,6 +19,7 @@
 #include "autoware/map_based_prediction/path_generator/path_generator.hpp"
 #include "autoware/map_based_prediction/predictor_vru/fence.hpp"
 #include "autoware/map_based_prediction/predictor_vru/history.hpp"
+#include "autoware/map_based_prediction/predictor_vru/road_boundary.hpp"
 #include "autoware/map_based_prediction/predictor_vru/traffic_signal.hpp"
 #include "autoware/map_based_prediction/predictor_vru/vegetation.hpp"
 
@@ -51,6 +52,8 @@ public:
     double max_crosswalk_user_on_road_distance{2.0};
     // Signal interaction
     bool use_crosswalk_signal{true};
+    // Deceleration-aware road-boundary path cut
+    path_cut::MaxDecelerationParams max_deceleration;
     // Sub-module params
     TrafficSignalModule::Params traffic_signal;
     CrosswalkUserHistoryManager::Params history;
@@ -66,6 +69,7 @@ public:
     params_ = params;
     traffic_signal_module_.setParams(params.traffic_signal);
     history_manager_.setParams(params.history);
+    road_boundary_module_.set_max_deceleration(params.max_deceleration);
     path_generator_ = std::make_shared<PathGenerator>(
       params.prediction_sampling_time_interval, params.min_crosswalk_user_velocity);
   }
@@ -108,6 +112,7 @@ private:
   // Sub-modules
   FenceModule fence_module_;
   VegetationModule vegetation_module_;
+  RoadBoundaryModule road_boundary_module_;
   TrafficSignalModule traffic_signal_module_;
   CrosswalkUserHistoryManager history_manager_;
 

--- a/perception/autoware_map_based_prediction/include/autoware/map_based_prediction/predictor_vru/road_boundary.hpp
+++ b/perception/autoware_map_based_prediction/include/autoware/map_based_prediction/predictor_vru/road_boundary.hpp
@@ -21,7 +21,9 @@
 #include <autoware_perception_msgs/msg/predicted_objects.hpp>
 
 #include <lanelet2_core/LaneletMap.h>
+#include <lanelet2_core/primitives/Lanelet.h>
 
+#include <functional>
 #include <memory>
 #include <vector>
 
@@ -43,13 +45,20 @@ public:
     max_deceleration_params_ = params;
   }
 
+  /// Predicate returning true when the given crosswalk / walkway lanelet has a red signal.
+  using CrosswalkSignalRedFn = std::function<bool(const lanelet::ConstLanelet &)>;
+
   /// Return the object's predicted paths trimmed where they first cross a road boundary.
   /// When @p object_within_road is true the paths are returned unchanged. A path is cut only when
   /// the object can decelerate to a stop before the boundary; otherwise the jump-out is treated as
   /// unavoidable and the path is kept.
+  ///
+  /// A crossing that falls inside a crosswalk / walkway is normally exempt (kept), because it
+  /// represents a legitimate crossing. The exemption is overridden when @p is_crosswalk_signal_red
+  /// reports the crosswalk's signal as red: in that case the jump-out is cut like any other.
   [[nodiscard]] std::vector<PredictedPath> cut_paths_crossing_road_boundary(
-    const autoware_perception_msgs::msg::PredictedObject & predicted_object,
-    bool object_within_road) const;
+    const autoware_perception_msgs::msg::PredictedObject & predicted_object, bool object_within_road,
+    const CrosswalkSignalRedFn & is_crosswalk_signal_red) const;
 
 private:
   lanelet::LaneletMapUPtr road_boundary_layer_{nullptr};

--- a/perception/autoware_map_based_prediction/include/autoware/map_based_prediction/predictor_vru/road_boundary.hpp
+++ b/perception/autoware_map_based_prediction/include/autoware/map_based_prediction/predictor_vru/road_boundary.hpp
@@ -1,0 +1,64 @@
+// Copyright 2026 TIER IV, inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef AUTOWARE__MAP_BASED_PREDICTION__PREDICTOR_VRU__ROAD_BOUNDARY_HPP_
+#define AUTOWARE__MAP_BASED_PREDICTION__PREDICTOR_VRU__ROAD_BOUNDARY_HPP_
+
+#include "autoware/map_based_prediction/path_cut/path_cut_utils.hpp"
+#include "autoware/map_based_prediction/path_generator/path_generator.hpp"
+
+#include <autoware_perception_msgs/msg/predicted_objects.hpp>
+
+#include <lanelet2_core/LaneletMap.h>
+
+#include <memory>
+#include <vector>
+
+namespace autoware::map_based_prediction
+{
+
+/// Trims VRU predicted paths that jump out onto the road at the right/left boundary of
+/// road-subtype lanelets. Objects that are already inside a road lanelet are left untouched.
+class RoadBoundaryModule
+{
+public:
+  RoadBoundaryModule() = default;
+
+  /// @pre lanelet_map_ptr is non-null when building from a map; nullptr clears the layer.
+  void build_from_map(std::shared_ptr<lanelet::LaneletMap> lanelet_map_ptr);
+
+  void set_max_deceleration(const path_cut::MaxDecelerationParams & params)
+  {
+    max_deceleration_params_ = params;
+  }
+
+  /// Return the object's predicted paths trimmed where they first cross a road boundary.
+  /// When @p object_within_road is true the paths are returned unchanged. A path is cut only when
+  /// the object can decelerate to a stop before the boundary; otherwise the jump-out is treated as
+  /// unavoidable and the path is kept.
+  [[nodiscard]] std::vector<PredictedPath> cut_paths_crossing_road_boundary(
+    const autoware_perception_msgs::msg::PredictedObject & predicted_object,
+    bool object_within_road) const;
+
+private:
+  lanelet::LaneletMapUPtr road_boundary_layer_{nullptr};
+  // Crosswalk / walkway lanelets. A boundary crossing that falls inside one of these is treated as
+  // a legitimate crosswalk crossing and is not cut.
+  lanelet::LaneletMapConstUPtr crosswalk_layer_{nullptr};
+  path_cut::MaxDecelerationParams max_deceleration_params_{};
+};
+
+}  // namespace autoware::map_based_prediction
+
+#endif  // AUTOWARE__MAP_BASED_PREDICTION__PREDICTOR_VRU__ROAD_BOUNDARY_HPP_

--- a/perception/autoware_map_based_prediction/include/autoware/map_based_prediction/predictor_vru/road_boundary.hpp
+++ b/perception/autoware_map_based_prediction/include/autoware/map_based_prediction/predictor_vru/road_boundary.hpp
@@ -57,8 +57,8 @@ public:
   /// represents a legitimate crossing. The exemption is overridden when @p is_crosswalk_signal_red
   /// reports the crosswalk's signal as red: in that case the jump-out is cut like any other.
   [[nodiscard]] std::vector<PredictedPath> cut_paths_crossing_road_boundary(
-    const autoware_perception_msgs::msg::PredictedObject & predicted_object, bool object_within_road,
-    const CrosswalkSignalRedFn & is_crosswalk_signal_red) const;
+    const autoware_perception_msgs::msg::PredictedObject & predicted_object,
+    bool object_within_road, const CrosswalkSignalRedFn & is_crosswalk_signal_red) const;
 
 private:
   lanelet::LaneletMapUPtr road_boundary_layer_{nullptr};

--- a/perception/autoware_map_based_prediction/include/autoware/map_based_prediction/predictor_vru/traffic_signal.hpp
+++ b/perception/autoware_map_based_prediction/include/autoware/map_based_prediction/predictor_vru/traffic_signal.hpp
@@ -66,6 +66,10 @@ public:
   [[nodiscard]] std::optional<lanelet::Id> getSignalId(
     const lanelet::ConstLanelet & way_lanelet) const;
 
+  /// True when @p way_lanelet has an associated traffic signal that is currently red.
+  /// Returns false when the lanelet has no signal or the signal is not red.
+  [[nodiscard]] bool isRedSignal(const lanelet::ConstLanelet & way_lanelet) const;
+
   bool calcIntentionToCross(
     const TrackedObject & object, const lanelet::ConstLanelet & crosswalk,
     const lanelet::Id & signal_id);

--- a/perception/autoware_map_based_prediction/lib/predictor_vru/path_cut_debug.cpp
+++ b/perception/autoware_map_based_prediction/lib/predictor_vru/path_cut_debug.cpp
@@ -60,6 +60,14 @@ SourceStyle style_for_source(PathCutSource source)
         "fence_cut",
         create_marker_color(0.0, 0.4, 1.0, 0.9),
         create_marker_color(0.0, 0.27, 0.8, 0.9)};
+    case PathCutSource::RoadBoundary:
+      return {
+        "road_boundary_vru_box",
+        "road_boundary_vru_path",
+        "road_boundary_vru_kept",
+        "road_boundary_cut",
+        create_marker_color(1.0, 0.0, 0.53, 0.9),
+        create_marker_color(0.8, 0.0, 0.4, 0.9)};
     case PathCutSource::Vegetation:
     default:
       return {

--- a/perception/autoware_map_based_prediction/lib/predictor_vru/predictor_vru.cpp
+++ b/perception/autoware_map_based_prediction/lib/predictor_vru/predictor_vru.cpp
@@ -405,8 +405,12 @@ PredictedObject PredictorVru::getPredictedObjectAsCrosswalkUser(
 
   predicted_object.kinematics.predicted_paths = paths_cut_with_vegetation;
 
+  const auto is_crosswalk_signal_red = [this](const lanelet::ConstLanelet & crosswalk) {
+    return params_.use_crosswalk_signal && traffic_signal_module_.isRedSignal(crosswalk);
+  };
   const std::vector<PredictedPath> paths_cut_with_road_boundary =
-    road_boundary_module_.cut_paths_crossing_road_boundary(predicted_object, within_road);
+    road_boundary_module_.cut_paths_crossing_road_boundary(
+      predicted_object, within_road, is_crosswalk_signal_red);
 
   debug::append_path_cut_event_markers(
     debug_markers, predicted_object.kinematics.predicted_paths, paths_cut_with_road_boundary,

--- a/perception/autoware_map_based_prediction/lib/predictor_vru/predictor_vru.cpp
+++ b/perception/autoware_map_based_prediction/lib/predictor_vru/predictor_vru.cpp
@@ -151,6 +151,7 @@ void PredictorVru::setLaneletMap(std::shared_ptr<lanelet::LaneletMap> lanelet_ma
 
   fence_module_.buildFromMap(lanelet_map_ptr_);
   vegetation_module_.build_from_map(lanelet_map_ptr_);
+  road_boundary_module_.build_from_map(lanelet_map_ptr_);
 }
 
 void PredictorVru::loadCurrentCrosswalkUsers(const TrackedObjects & objects)
@@ -403,6 +404,16 @@ PredictedObject PredictorVru::getPredictedObjectAsCrosswalkUser(
     predicted_object, PathCutSource::Vegetation, stamp);
 
   predicted_object.kinematics.predicted_paths = paths_cut_with_vegetation;
+
+  const std::vector<PredictedPath> paths_cut_with_road_boundary =
+    road_boundary_module_.cut_paths_crossing_road_boundary(predicted_object, within_road);
+
+  debug::append_path_cut_event_markers(
+    debug_markers, predicted_object.kinematics.predicted_paths, paths_cut_with_road_boundary,
+    predicted_object, PathCutSource::RoadBoundary, stamp);
+
+  predicted_object.kinematics.predicted_paths = paths_cut_with_road_boundary;
+
   const auto n_path = predicted_object.kinematics.predicted_paths.size();
   for (auto & predicted_path : predicted_object.kinematics.predicted_paths) {
     predicted_path.confidence = 1.0 / n_path;

--- a/perception/autoware_map_based_prediction/lib/predictor_vru/road_boundary.cpp
+++ b/perception/autoware_map_based_prediction/lib/predictor_vru/road_boundary.cpp
@@ -1,0 +1,199 @@
+// Copyright 2026 TIER IV, inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "autoware/map_based_prediction/predictor_vru/road_boundary.hpp"
+
+#include "autoware/map_based_prediction/path_cut/path_cut_utils.hpp"
+
+#include <autoware/motion_utils/trajectory/trajectory.hpp>
+#include <autoware/object_recognition_utils/object_classification.hpp>
+#include <autoware_lanelet2_extension/utility/query.hpp>
+
+#include <boost/geometry.hpp>
+
+#include <lanelet2_core/geometry/BoundingBox.h>
+#include <lanelet2_core/geometry/LineString.h>
+#include <lanelet2_core/geometry/Polygon.h>
+#include <lanelet2_core/primitives/Lanelet.h>
+
+#include <cmath>
+#include <memory>
+#include <optional>
+#include <string>
+#include <unordered_set>
+#include <vector>
+
+namespace autoware::map_based_prediction
+{
+
+namespace
+{
+bool does_path_cross_boundary(
+  const lanelet::BasicLineString2d & predicted_path,
+  const lanelet::ConstLineString3d & boundary_line)
+{
+  return boost::geometry::intersects(
+    predicted_path, lanelet::utils::to2D(boundary_line.basicLineString()));
+}
+
+bool is_point_within_crosswalk(
+  const lanelet::LaneletMap * crosswalk_layer, const lanelet::BasicPoint2d & point)
+{
+  if (!crosswalk_layer) {
+    return false;
+  }
+  const lanelet::BoundingBox2d query(point, point);
+  for (const auto & crosswalk : crosswalk_layer->laneletLayer.search(query)) {
+    if (boost::geometry::within(point, crosswalk.polygon2d().basicPolygon())) {
+      return true;
+    }
+  }
+  return false;
+}
+
+// A crossing on this segment counts as a cut point unless every intersection with the boundary
+// falls inside a crosswalk / walkway (i.e. the object is predicted to cross at a crosswalk).
+bool segment_has_cuttable_crossing(
+  const lanelet::BasicLineString2d & path_segment, const lanelet::ConstLineString3d & boundary,
+  const lanelet::LaneletMap * crosswalk_layer)
+{
+  const auto boundary_2d = lanelet::utils::to2D(boundary).basicLineString();
+  if (!boost::geometry::intersects(path_segment, boundary_2d)) {
+    return false;
+  }
+  lanelet::BasicPoints2d intersections;
+  boost::geometry::intersection(path_segment, boundary_2d, intersections);
+  // Fall back to cutting when the intersection points cannot be resolved (e.g. collinear overlap).
+  if (intersections.empty()) {
+    return true;
+  }
+  for (const auto & intersection : intersections) {
+    if (!is_point_within_crosswalk(crosswalk_layer, intersection)) {
+      return true;
+    }
+  }
+  return false;
+}
+
+std::optional<size_t> find_road_boundary_crossing_index(
+  const lanelet::LaneletMap & road_boundary_layer, const lanelet::LaneletMap * crosswalk_layer,
+  const PredictedPath & predicted_path)
+{
+  const auto & path = predicted_path.path;
+  if (path.size() < 2) {
+    return std::nullopt;
+  }
+
+  lanelet::BasicLineString2d predicted_path_ls;
+  predicted_path_ls.reserve(path.size());
+  for (const auto & pt : path) {
+    predicted_path_ls.emplace_back(pt.position.x, pt.position.y);
+  }
+
+  const auto candidates =
+    road_boundary_layer.lineStringLayer.search(lanelet::geometry::boundingBox2d(predicted_path_ls));
+  std::vector<lanelet::ConstLineString3d> crossed_boundaries{};
+  for (const auto & candidate : candidates) {
+    if (does_path_cross_boundary(predicted_path_ls, candidate)) {
+      crossed_boundaries.push_back(candidate);
+    }
+  }
+  if (crossed_boundaries.empty()) {
+    return std::nullopt;
+  }
+
+  for (auto i = 0UL; i + 1 < predicted_path_ls.size(); ++i) {
+    const lanelet::BasicLineString2d path_segment(
+      lanelet::BasicPoints2d{predicted_path_ls.at(i), predicted_path_ls.at(i + 1)});
+    for (const auto & boundary : crossed_boundaries) {
+      if (segment_has_cuttable_crossing(path_segment, boundary, crosswalk_layer)) {
+        return i;
+      }
+    }
+  }
+  return std::nullopt;
+}
+}  // namespace
+
+void RoadBoundaryModule::build_from_map(std::shared_ptr<lanelet::LaneletMap> lanelet_map_ptr)
+{
+  if (!lanelet_map_ptr) {
+    road_boundary_layer_ = nullptr;
+    crosswalk_layer_ = nullptr;
+    return;
+  }
+
+  lanelet::LineStrings3d boundaries;
+  std::unordered_set<lanelet::Id> added_ids;
+  lanelet::ConstLanelets crosswalks;
+  for (const auto & lanelet : lanelet_map_ptr->laneletLayer) {
+    const std::string subtype = lanelet.attributeOr(lanelet::AttributeName::Subtype, "none");
+    if (
+      subtype == lanelet::AttributeValueString::Crosswalk ||
+      subtype == lanelet::AttributeValueString::Walkway) {
+      crosswalks.push_back(lanelet);
+      continue;
+    }
+    if (subtype != lanelet::AttributeValueString::Road && subtype != "road_shoulder") {
+      continue;
+    }
+    for (const auto & bound : {lanelet.leftBound(), lanelet.rightBound()}) {
+      if (added_ids.insert(bound.id()).second) {
+        boundaries.emplace_back(
+          std::const_pointer_cast<lanelet::LineStringData>(bound.constData()));
+      }
+    }
+  }
+  road_boundary_layer_ = lanelet::utils::createMap(boundaries);
+  crosswalk_layer_ = lanelet::utils::createConstMap(crosswalks, {});
+}
+
+std::vector<PredictedPath> RoadBoundaryModule::cut_paths_crossing_road_boundary(
+  const autoware_perception_msgs::msg::PredictedObject & predicted_object,
+  const bool object_within_road) const
+{
+  std::vector<PredictedPath> cut_paths = predicted_object.kinematics.predicted_paths;
+  // Objects already inside a road lanelet are left untouched so that a path exiting the road
+  // (i.e. its first boundary crossing) is not mistaken for a jump-out and cut.
+  if (!road_boundary_layer_ || object_within_road) {
+    return cut_paths;
+  }
+
+  const auto & linear_velocity =
+    predicted_object.kinematics.initial_twist_with_covariance.twist.linear;
+  const double object_speed = std::hypot(linear_velocity.x, linear_velocity.y);
+  const double max_deceleration = path_cut::max_deceleration_for_label(
+    max_deceleration_params_,
+    autoware::object_recognition_utils::getHighestProbLabel(predicted_object.classification));
+
+  for (PredictedPath & predicted_path : cut_paths) {
+    const std::optional<size_t> crossing_index =
+      find_road_boundary_crossing_index(*road_boundary_layer_, crosswalk_layer_.get(), predicted_path);
+    if (!crossing_index) {
+      continue;
+    }
+    // Only cut when the object can decelerate to a stop before the boundary. If it cannot stop in
+    // time, the jump-out onto the road is unavoidable and the full path is kept.
+    const double distance_to_cross = autoware::motion_utils::calcSignedArcLength(
+      predicted_path.path, 0, crossing_index.value());
+    if (!path_cut::can_stop_before_the_line(distance_to_cross, object_speed, max_deceleration)) {
+      continue;
+    }
+    // Keep the last pose before the path crosses into the road.
+    predicted_path = path_cut::force_cut_at_index(predicted_path, crossing_index.value());
+  }
+  return cut_paths;
+}
+
+}  // namespace autoware::map_based_prediction

--- a/perception/autoware_map_based_prediction/lib/predictor_vru/road_boundary.cpp
+++ b/perception/autoware_map_based_prediction/lib/predictor_vru/road_boundary.cpp
@@ -39,6 +39,10 @@ namespace autoware::map_based_prediction
 
 namespace
 {
+// Crosswalk polygons are expanded by this margin before the containment test so that intersection
+// points lying exactly on (or just outside) the crosswalk edge are still recognised as inside.
+constexpr double kCrosswalkContainmentMargin = 0.5;  // [m]
+
 bool does_path_cross_boundary(
   const lanelet::BasicLineString2d & predicted_path,
   const lanelet::ConstLineString3d & boundary_line)
@@ -47,26 +51,34 @@ bool does_path_cross_boundary(
     predicted_path, lanelet::utils::to2D(boundary_line.basicLineString()));
 }
 
-bool is_point_within_crosswalk(
+std::optional<lanelet::ConstLanelet> find_crosswalk_at_point(
   const lanelet::LaneletMap * crosswalk_layer, const lanelet::BasicPoint2d & point)
 {
   if (!crosswalk_layer) {
-    return false;
+    return std::nullopt;
   }
-  const lanelet::BoundingBox2d query(point, point);
+  const lanelet::BasicPoint2d margin(kCrosswalkContainmentMargin, kCrosswalkContainmentMargin);
+  const lanelet::BoundingBox2d query(point - margin, point + margin);
   for (const auto & crosswalk : crosswalk_layer->laneletLayer.search(query)) {
-    if (boost::geometry::within(point, crosswalk.polygon2d().basicPolygon())) {
-      return true;
+    // distance() is 0 when the point is inside the polygon and the gap to the edge otherwise, so
+    // this is equivalent to a within() test against a polygon expanded by the margin.
+    if (
+      boost::geometry::distance(point, crosswalk.polygon2d().basicPolygon()) <=
+      kCrosswalkContainmentMargin) {
+      return crosswalk;
     }
   }
-  return false;
+  return std::nullopt;
 }
 
-// A crossing on this segment counts as a cut point unless every intersection with the boundary
-// falls inside a crosswalk / walkway (i.e. the object is predicted to cross at a crosswalk).
+// A crossing on this segment counts as a cut point unless every intersection with the boundary is
+// exempt. An intersection is exempt when it falls inside a crosswalk / walkway whose signal is not
+// red (no signal or non-red) i.e. a legitimate crossing. An intersection outside any crosswalk, or
+// inside a crosswalk with a red signal, is a cuttable jump-out.
 bool segment_has_cuttable_crossing(
   const lanelet::BasicLineString2d & path_segment, const lanelet::ConstLineString3d & boundary,
-  const lanelet::LaneletMap * crosswalk_layer)
+  const lanelet::LaneletMap * crosswalk_layer,
+  const RoadBoundaryModule::CrosswalkSignalRedFn & is_crosswalk_signal_red)
 {
   const auto boundary_2d = lanelet::utils::to2D(boundary).basicLineString();
   if (!boost::geometry::intersects(path_segment, boundary_2d)) {
@@ -79,7 +91,9 @@ bool segment_has_cuttable_crossing(
     return true;
   }
   for (const auto & intersection : intersections) {
-    if (!is_point_within_crosswalk(crosswalk_layer, intersection)) {
+    const auto crosswalk = find_crosswalk_at_point(crosswalk_layer, intersection);
+    const bool exempt = crosswalk.has_value() && !is_crosswalk_signal_red(crosswalk.value());
+    if (!exempt) {
       return true;
     }
   }
@@ -88,6 +102,7 @@ bool segment_has_cuttable_crossing(
 
 std::optional<size_t> find_road_boundary_crossing_index(
   const lanelet::LaneletMap & road_boundary_layer, const lanelet::LaneletMap * crosswalk_layer,
+  const RoadBoundaryModule::CrosswalkSignalRedFn & is_crosswalk_signal_red,
   const PredictedPath & predicted_path)
 {
   const auto & path = predicted_path.path;
@@ -117,7 +132,8 @@ std::optional<size_t> find_road_boundary_crossing_index(
     const lanelet::BasicLineString2d path_segment(
       lanelet::BasicPoints2d{predicted_path_ls.at(i), predicted_path_ls.at(i + 1)});
     for (const auto & boundary : crossed_boundaries) {
-      if (segment_has_cuttable_crossing(path_segment, boundary, crosswalk_layer)) {
+      if (segment_has_cuttable_crossing(
+            path_segment, boundary, crosswalk_layer, is_crosswalk_signal_red)) {
         return i;
       }
     }
@@ -161,7 +177,7 @@ void RoadBoundaryModule::build_from_map(std::shared_ptr<lanelet::LaneletMap> lan
 
 std::vector<PredictedPath> RoadBoundaryModule::cut_paths_crossing_road_boundary(
   const autoware_perception_msgs::msg::PredictedObject & predicted_object,
-  const bool object_within_road) const
+  const bool object_within_road, const CrosswalkSignalRedFn & is_crosswalk_signal_red) const
 {
   std::vector<PredictedPath> cut_paths = predicted_object.kinematics.predicted_paths;
   // Objects already inside a road lanelet are left untouched so that a path exiting the road
@@ -178,8 +194,8 @@ std::vector<PredictedPath> RoadBoundaryModule::cut_paths_crossing_road_boundary(
     autoware::object_recognition_utils::getHighestProbLabel(predicted_object.classification));
 
   for (PredictedPath & predicted_path : cut_paths) {
-    const std::optional<size_t> crossing_index =
-      find_road_boundary_crossing_index(*road_boundary_layer_, crosswalk_layer_.get(), predicted_path);
+    const std::optional<size_t> crossing_index = find_road_boundary_crossing_index(
+      *road_boundary_layer_, crosswalk_layer_.get(), is_crosswalk_signal_red, predicted_path);
     if (!crossing_index) {
       continue;
     }

--- a/perception/autoware_map_based_prediction/lib/predictor_vru/road_boundary.cpp
+++ b/perception/autoware_map_based_prediction/lib/predictor_vru/road_boundary.cpp
@@ -201,8 +201,8 @@ std::vector<PredictedPath> RoadBoundaryModule::cut_paths_crossing_road_boundary(
     }
     // Only cut when the object can decelerate to a stop before the boundary. If it cannot stop in
     // time, the jump-out onto the road is unavoidable and the full path is kept.
-    const double distance_to_cross = autoware::motion_utils::calcSignedArcLength(
-      predicted_path.path, 0, crossing_index.value());
+    const double distance_to_cross =
+      autoware::motion_utils::calcSignedArcLength(predicted_path.path, 0, crossing_index.value());
     if (!path_cut::can_stop_before_the_line(distance_to_cross, object_speed, max_deceleration)) {
       continue;
     }

--- a/perception/autoware_map_based_prediction/lib/predictor_vru/traffic_signal.cpp
+++ b/perception/autoware_map_based_prediction/lib/predictor_vru/traffic_signal.cpp
@@ -72,6 +72,16 @@ std::optional<lanelet::Id> TrafficSignalModule::getSignalId(
   return traffic_light_reg_elems.front()->id();
 }
 
+bool TrafficSignalModule::isRedSignal(const lanelet::ConstLanelet & way_lanelet) const
+{
+  const auto signal_id = getSignalId(way_lanelet);
+  if (!signal_id) {
+    return false;
+  }
+  const auto elem_opt = getSignalElement(signal_id.value());
+  return elem_opt.has_value() && elem_opt.value().color == TrafficLightElement::RED;
+}
+
 bool TrafficSignalModule::calcIntentionToCross(
   const TrackedObject & object, const lanelet::ConstLanelet & crosswalk,
   const lanelet::Id & signal_id)

--- a/perception/autoware_map_based_prediction/src/map_based_prediction_node.cpp
+++ b/perception/autoware_map_based_prediction/src/map_based_prediction_node.cpp
@@ -132,6 +132,7 @@ MapBasedPredictionNode::MapBasedPredictionNode(const rclcpp::NodeOptions & node_
       declare_parameter<double>("max_crosswalk_user_on_road_distance");
     vru_params.use_crosswalk_signal =
       declare_parameter<bool>("crosswalk_with_signal.use_crosswalk_signal");
+    vru_params.max_deceleration = max_decel_params;
     vru_params.traffic_signal.threshold_velocity_assumed_as_stopping =
       declare_parameter<double>("crosswalk_with_signal.threshold_velocity_assumed_as_stopping");
     vru_params.traffic_signal.distance_set_for_no_intention_to_walk =


### PR DESCRIPTION
## Description

Adds a `RoadBoundaryModule` to the VRU predictor that trims predicted paths jumping out onto the road, cutting them at the right/left bound of `road` / `road_shoulder` lanelets. It mirrors the existing `FenceModule` / `VegetationModule` (dedicated `road_boundary.cpp`, invoked only from `predictor_vru.cpp`), so it applies to VRUs only.

## Behavior

Applied to every VRU path, at the boundary crossing nearest the object, with these rules:

- Object already inside a road lanelet → not cut.
- Crossing inside a crosswalk / walkway → kept as a legitimate crossing, **unless** the crosswalk's signal is red (gated by `use_crosswalk_signal`). Crosswalk polygons use a 0.5 m margin for the containment test.
- Cut only when the object can stop before the boundary (per-class max deceleration, reusing `path_cut::can_stop_before_the_line`); otherwise the jump-out is kept as unavoidable.

Intersection is judged on the path segments (polyline between consecutive points), not the object footprint. Cut events are shown via the existing debug marker publisher (`~/maneuver`) with a new `PathCutSource::RoadBoundary` style.

## Tests

- [x] https://evaluation.ci.tier4.jp/evaluation/reports/b30bc52e-8670-561f-ae73-499b2ead64b4?project_id=x2_dev
- [x] https://evaluation.ci.tier4.jp/evaluation/reports/3cab6acf-4013-541a-98cb-950a54e9814b?project_id=x2_dev

- `colcon build --packages-select autoware_map_based_prediction` passes on the rebased base (`feat/v0.64/e2e`).

### A pedestrian moving from the sidewalk toward the roadway

<img width="2833" height="1620" alt="image" src="https://github.com/user-attachments/assets/78349f31-ff9d-4e1d-87a1-cc0dd94fa745" />

### A pedestrian showing no sign of stopping on the sidewalk

<img width="2833" height="1620" alt="image" src="https://github.com/user-attachments/assets/6662f478-6eef-48ae-ab5a-cf1debe29c29" />

### A pedestrian approaching a crosswalk with a green signal

<img width="2833" height="1620" alt="image" src="https://github.com/user-attachments/assets/bed50cb7-9537-48bb-8a5a-af90f27f9381" />

### A pedestrian approaching a crosswalk with a red signal

<img width="2833" height="1620" alt="Screenshot from 2026-07-22 13-20-10" src="https://github.com/user-attachments/assets/465f808a-a7f9-4f91-a080-6b454628764c" />

### A pedestrian attempting to cross against a red signal

<img width="2833" height="1620" alt="Screenshot from 2026-07-22 13-20-13" src="https://github.com/user-attachments/assets/6e1b6c5e-f836-4e75-99c7-485783e3ef4f" />

🤖 Generated with [Claude Code](https://claude.com/claude-code)
