### PR TITLE
chore: cherry-pick #13011 to fix contention bug in RoiFusion

### DIFF
--- a/perception/autoware_image_projection_based_fusion/include/autoware/image_projection_based_fusion/fusion_node.hpp
+++ b/perception/autoware_image_projection_based_fusion/include/autoware/image_projection_based_fusion/fusion_node.hpp
@@ -46,6 +46,7 @@
 #include <cstddef>
 #include <list>
 #include <memory>
+#include <mutex>
 #include <optional>
 #include <string>
 #include <unordered_map>
@@ -120,6 +121,7 @@ private:
     concatenated_info_map_;
 
   diagnostic_updater::Updater diagnostic_updater_{this};
+  mutable std::mutex diagnostic_mutex_;
   std::shared_ptr<FusionCollectorInfoBase> diagnostic_collector_info_;
   std::unordered_map<std::size_t, double> diagnostic_id_to_stamp_map_;
 

--- a/perception/autoware_image_projection_based_fusion/src/fusion_node.cpp
+++ b/perception/autoware_image_projection_based_fusion/src/fusion_node.cpp
@@ -304,6 +304,8 @@ void FusionNode<Msg3D, Msg2D, ExportObj>::export_process(
   std::unordered_map<std::size_t, double> id_to_stamp_map,
   std::shared_ptr<FusionCollectorInfoBase> collector_info)
 {
+  std::unique_lock<std::mutex> diagnostic_lock(diagnostic_mutex_);
+
   ExportObj output_msg;
   postprocess(*(output_det3d_msg), output_msg);
 
@@ -329,7 +331,6 @@ void FusionNode<Msg3D, Msg2D, ExportObj>::export_process(
   // Move collected diagnostics info
   diagnostic_collector_info_ = std::move(collector_info);
   diagnostic_id_to_stamp_map_ = std::move(id_to_stamp_map);
-  diagnostic_updater_.force_update();
 
   // Add processing time for debugging
   if (debug_publisher_) {
@@ -360,6 +361,9 @@ void FusionNode<Msg3D, Msg2D, ExportObj>::export_process(
         timestamp_interval_ms - id_to_offset_map_[rois_id] * 1000);
     }
   }
+
+  diagnostic_lock.unlock();
+  diagnostic_updater_.force_update();
 }
 
 template <class Msg3D, class Msg2D, class ExportObj>
@@ -648,9 +652,13 @@ void FusionNode<Msg3D, Msg2D, ExportObj>::show_diagnostic_message(
   std::unordered_map<std::size_t, double> id_to_stamp_map,
   std::shared_ptr<FusionCollectorInfoBase> collector_info)
 {
+  std::unique_lock<std::mutex> diagnostic_lock(diagnostic_mutex_);
+
   msg3d_fused_ = false;
   diagnostic_collector_info_ = std::move(collector_info);
   diagnostic_id_to_stamp_map_ = std::move(id_to_stamp_map);
+
+  diagnostic_lock.unlock();
   diagnostic_updater_.force_update();
 }
 
@@ -658,6 +666,8 @@ template <class Msg3D, class Msg2D, class ExportObj>
 void FusionNode<Msg3D, Msg2D, ExportObj>::check_fusion_status(
   diagnostic_updater::DiagnosticStatusWrapper & stat)
 {
+  std::lock_guard<std::mutex> diagnostic_lock(diagnostic_mutex_);
+
   if (publish_output_msg_ || drop_previous_but_late_output_msg_ || !msg3d_fused_) {
     stat.add("msg3d/is_fused", msg3d_fused_);
 


### PR DESCRIPTION
## Description
https://star4.slack.com/archives/CRUE57C30/p1784163758920769
上記のスレッドで言及されている、スレッド競合起因のcrashを修正するためのfix PRをcherry-pickするPRです。

FoiFusionノードにおいて、ロックを正しく取ることで、守るべきデータのアクセスをserializeします。

Cherry-pick元 PR：https://github.com/autowarefoundation/autoware_universe/pull/13011