### PR TITLE
fix(planning_validator, control_validator): fix include path for angles header (cherry-pick autowarefoundation#13026)

### DIFF
--- a/planning/planning_validator/autoware_planning_validator/src/node.cpp
+++ b/planning/planning_validator/autoware_planning_validator/src/node.cpp
@@ -18,7 +18,7 @@
 
 #include <autoware/motion_utils/trajectory/interpolation.hpp>
 
-#include <angles/angles/angles.h>
+#include <angles/angles.h>
 
 #include <memory>
 #include <string>

--- a/planning/planning_validator/autoware_planning_validator_rear_collision_checker/package.xml
+++ b/planning/planning_validator/autoware_planning_validator_rear_collision_checker/package.xml
@@ -17,6 +17,7 @@
   <buildtool_depend>ament_cmake_auto</buildtool_depend>
   <buildtool_depend>autoware_cmake</buildtool_depend>
 
+  <depend>angles</depend>
   <depend>autoware_internal_debug_msgs</depend>
   <depend>autoware_internal_planning_msgs</depend>
   <depend>autoware_lanelet2_extension</depend>

--- a/planning/planning_validator/autoware_planning_validator_rear_collision_checker/src/utils.cpp
+++ b/planning/planning_validator/autoware_planning_validator_rear_collision_checker/src/utils.cpp
@@ -38,7 +38,7 @@
 #include <boost/geometry/geometries/linestring.hpp>
 #include <boost/geometry/geometries/point_xy.hpp>
 
-#include <angles/angles/angles.h>
+#include <angles/angles.h>
 #include <lanelet2_core/geometry/Lanelet.h>
 #include <lanelet2_core/geometry/LineString.h>
 #include <lanelet2_core/geometry/Point.h>

--- a/planning/planning_validator/autoware_planning_validator_trajectory_checker/src/trajectory_checker.cpp
+++ b/planning/planning_validator/autoware_planning_validator_trajectory_checker/src/trajectory_checker.cpp
@@ -23,7 +23,7 @@
 #include <autoware_utils/ros/update_param.hpp>
 #include <rclcpp/rclcpp.hpp>
 
-#include <angles/angles/angles.h>
+#include <angles/angles.h>
 
 #include <cmath>
 #include <memory>


### PR DESCRIPTION
## Summary

Cherry-pick of [autowarefoundation/autoware_universe#13026](https://github.com/autowarefoundation/autoware_universe/pull/13026) onto `beta/x2/v4.4.1`.

This PR fixes build errors caused by incorrect include paths for the `angles` header.

```
Starting >>> autoware_planning_validator
--- stderr: autoware_planning_validator
fatal error: angles/angles/angles.h: No such file or directory
```

Incorrect include path `<angles/angles/angles.h>` is replaced by the correct one `<angles/angles.h>` in the following packages:
- autoware_planning_validator
- autoware_planning_validator_rear_collision_checker
- autoware_planning_validator_trajectory_checker

And missing package dependency is added to `autoware_planning_validator_rear_collision_checker`.

## Cherry-picked commits

- `776cb46` fix include path for angles header
- `114bff5` add missing package dependency
