### PR TITLE
feat(traffic_light_compliance_checker): allow when close and cannot stop

### DIFF
--- a/common/autoware_traffic_light_compliance_checker/README.md
+++ b/common/autoware_traffic_light_compliance_checker/README.md
@@ -5,6 +5,7 @@ The `traffic_light_compliance_checker` package provides a deterministic validati
 ## Core Features
 
 1. **Signal State Tracking (`TrafficLightStatusTracker`)**
+
    - Eliminates perception jitter and signal flickering by maintaining a temporal state history for each traffic light group ID.
    - Leverages stable duration thresholds before validating a transition to `RED` or `AMBER`.
    - Utilizes a hysteresis buffer to sustain known states during transient object occlusions.
@@ -116,19 +117,20 @@ The interfaces pass inputs and output results through the following standard dat
 
 ## Parameters
 
-| Parameter Name                                 | Type     | Description                                                                                |
-| :--------------------------------------------- | :------- | :----------------------------------------------------------------------------------------- |
-| `deceleration_limit`                           | `double` | Max deceleration limit during braking ($m/s^2$) for assessing stopping feasibility.        |
-| `jerk_limit`                                   | `double` | Max jerk limit during braking ($m/s^3$) for assessing stopping feasibility.                |
-| `delay_response_time`                          | `double` | Combined latency buffer for compute cycle lag and brake actuation (seconds).               |
-| `crossing_time_limit`                          | `double` | Maximum duration allowed for the vehicle to clear an amber light intersection (seconds).   |
-| `stop_overshoot_margin`                        | `double` | Allowed physical distance buffer beyond a stop line for a stopped vehicle (meters).        |
-| `stable_duration_threshold_red`                | `double` | Required continuous duration for a `RED` state to be confirmed as valid (seconds).         |
-| `stable_duration_threshold_amber`              | `double` | Required continuous duration for an `AMBER` state to be confirmed as valid (seconds).      |
-| `stable_duration_threshold_unknown`            | `double` | Required continuous duration for an `UNKNOWN` state to be confirmed as valid (seconds).    |
-| `amber_rejection_hysteresis_duration`          | `double` | Duration to retain an active amber light state if perception updates drop out (seconds).   |
-| `ego_stopped_velocity_threshold`               | `double` | Velocity threshold beneath which the ego vehicle is considered completely stopped ($m/s$). |
-| `treat_amber_light_as_red_light`               | `bool`   | If true, disables amber passing logic and treats all amber states as strict red signals.   |
-| `treat_unknown_light_as_red_light`             | `bool`   | If true, evaluates unclassified or blank signal states as strict red signals.              |
-| `checked_trajectory_length.deceleration_limit` | `double` | Comfortable stop deceleration limit ($m/s^2$) for computing trajectory checking length.    |
-| `checked_trajectory_length.jerk_limit`         | `double` | Comfortable stop jerk limit ($m/s^3$) for computing trajectory checking length.            |
+| Parameter Name                                 | Type     | Description                                                                                                |
+| :--------------------------------------------- | :------- | :--------------------------------------------------------------------------------------------------------- |
+| `deceleration_limit`                           | `double` | Max deceleration limit during braking ($m/s^2$) for assessing stopping feasibility.                        |
+| `jerk_limit`                                   | `double` | Max jerk limit during braking ($m/s^3$) for assessing stopping feasibility.                                |
+| `delay_response_time`                          | `double` | Combined latency buffer for compute cycle lag and brake actuation (seconds).                               |
+| `crossing_time_limit`                          | `double` | Maximum duration allowed for the vehicle to clear an amber light intersection (seconds).                   |
+| `stop_overshoot_margin`                        | `double` | Allowed physical distance buffer beyond a stop line for a stopped vehicle (meters).                        |
+| `allow_if_cannot_stop_distance`                | `double` | Distance within which a crossing trajectory is allowed when ego cannot stop before the stop line (meters). |
+| `stable_duration_threshold_red`                | `double` | Required continuous duration for a `RED` state to be confirmed as valid (seconds).                         |
+| `stable_duration_threshold_amber`              | `double` | Required continuous duration for an `AMBER` state to be confirmed as valid (seconds).                      |
+| `stable_duration_threshold_unknown`            | `double` | Required continuous duration for an `UNKNOWN` state to be confirmed as valid (seconds).                    |
+| `amber_rejection_hysteresis_duration`          | `double` | Duration to retain an active amber light state if perception updates drop out (seconds).                   |
+| `ego_stopped_velocity_threshold`               | `double` | Velocity threshold beneath which the ego vehicle is considered completely stopped ($m/s$).                 |
+| `treat_amber_light_as_red_light`               | `bool`   | If true, disables amber passing logic and treats all amber states as strict red signals.                   |
+| `treat_unknown_light_as_red_light`             | `bool`   | If true, evaluates unclassified or blank signal states as strict red signals.                              |
+| `checked_trajectory_length.deceleration_limit` | `double` | Comfortable stop deceleration limit ($m/s^2$) for computing trajectory checking length.                    |
+| `checked_trajectory_length.jerk_limit`         | `double` | Comfortable stop jerk limit ($m/s^3$) for computing trajectory checking length.                            |

--- a/common/autoware_traffic_light_compliance_checker/include/autoware/traffic_light_compliance_checker/structs.hpp
+++ b/common/autoware_traffic_light_compliance_checker/include/autoware/traffic_light_compliance_checker/structs.hpp
@@ -102,6 +102,7 @@ struct Parameters
   bool treat_amber_light_as_red_light;
   bool treat_unknown_light_as_red_light;
   double stop_overshoot_margin;
+  double allow_if_cannot_stop_distance;
   double stable_duration_threshold_red;
   double stable_duration_threshold_amber;
   double stable_duration_threshold_unknown;

--- a/common/autoware_traffic_light_compliance_checker/src/traffic_light_compliance_checker.cpp
+++ b/common/autoware_traffic_light_compliance_checker/src/traffic_light_compliance_checker.cpp
@@ -345,6 +345,20 @@ TrafficLightComplianceChecker::check_with_filtered_signals(
       result.violations.end(), amber_light_violations.begin(), amber_light_violations.end());
   }
 
+  if (ego_stopping_distance.has_value() && params_.allow_if_cannot_stop_distance > 0.0) {
+    result.violations.erase(
+      std::remove_if(
+        result.violations.begin(), result.violations.end(),
+        [&](const auto & violation) {
+          const auto distance_from_ego_front = violation.arc_length_to_cross_point -
+                                               backward_length -
+                                               vehicle_info_.max_longitudinal_offset_m;
+          return distance_from_ego_front < params_.allow_if_cannot_stop_distance &&
+                 distance_from_ego_front < *ego_stopping_distance - params_.stop_overshoot_margin;
+        }),
+      result.violations.end());
+  }
+
   return result;
 }
 

--- a/planning/autoware_trajectory_modifier/config/trajectory_modifier.param.yaml
+++ b/planning/autoware_trajectory_modifier/config/trajectory_modifier.param.yaml
@@ -91,6 +91,7 @@
       treat_amber_light_as_red: false
       treat_unknown_light_as_red: false
       overshoot_tolerance: 0.0 # [m]
+      allow_if_cannot_stop_distance: 0.0 # [m]
       th_stable_duration_red: 0.2 # [s]
       th_stable_duration_amber: 0.2 # [s]
       th_amber_rejection_hysteresis: 0.5 # [s]

--- a/planning/autoware_trajectory_modifier/docs/TrafficLightStop.md
+++ b/planning/autoware_trajectory_modifier/docs/TrafficLightStop.md
@@ -79,6 +79,7 @@ The module parameters are grouped under `traffic_light_stop` section of `traject
 | `treat_amber_light_as_red`      | bool   | false   | When true, amber lights are treated identically to red lights (rejection on intersection regardless of distance). |
 | `treat_unknown_light_as_red`    | bool   | false   | When true, unknown lights are treated identically to red lights (rejection on intersection).                      |
 | `overshoot_tolerance`           | double | 0.0     | [m] Maximum distance between the stop line and the trajectory stop point to consider the trajectory feasible.     |
+| `allow_if_cannot_stop_distance` | double | 0.0     | [m] Allow crossing when the ego front is within this distance and ego cannot stop before the stop line.           |
 | `th_stable_duration_red`        | double | 0.2     | [s] Minimum duration a RED light must be seen before it is considered active (only when ego is moving).           |
 | `th_stable_duration_amber`      | double | 0.2     | [s] Minimum duration an AMBER light must be seen before it is considered active (only when ego is moving).        |
 | `th_amber_rejection_hysteresis` | double | 0.5     | [s] Duration to persist an amber rejection state to prevent "flipping" due to minor velocity/distance changes.    |

--- a/planning/autoware_trajectory_modifier/param/trajectory_modifier_parameter_struct.yaml
+++ b/planning/autoware_trajectory_modifier/param/trajectory_modifier_parameter_struct.yaml
@@ -425,6 +425,13 @@ trajectory_modifier_params:
       validation:
         bounds<>: [0.0, 10.0]
       read_only: false
+    allow_if_cannot_stop_distance:
+      type: double
+      default_value: 0.0
+      description: allow crossing a stop line within this distance if ego cannot stop before the line plus its margin [m]
+      validation:
+        bounds<>: [0.0, 100.0]
+      read_only: false
     th_stable_duration_red:
       type: double
       default_value: 0.2

--- a/planning/autoware_trajectory_modifier/schema/trajectory_modifier.schema.json
+++ b/planning/autoware_trajectory_modifier/schema/trajectory_modifier.schema.json
@@ -465,6 +465,12 @@
               "default": 0.0,
               "minimum": 0.0
             },
+            "allow_if_cannot_stop_distance": {
+              "type": "number",
+              "description": "allow crossing a stop line within this distance if ego cannot stop before the line plus its margin [m]",
+              "default": 0.0,
+              "minimum": 0.0
+            },
             "th_stable_duration_red": {
               "type": "number",
               "description": "Threshold for stable duration of red light [s]",

--- a/planning/autoware_trajectory_modifier/src/trajectory_modifier_plugins/traffic_light_stop.cpp
+++ b/planning/autoware_trajectory_modifier/src/trajectory_modifier_plugins/traffic_light_stop.cpp
@@ -35,6 +35,7 @@ autoware::traffic_light_compliance_checker::Parameters to_checker_params(
   p.treat_amber_light_as_red_light = tl_stop_p.treat_amber_light_as_red;
   p.treat_unknown_light_as_red_light = tl_stop_p.treat_unknown_light_as_red;
   p.stop_overshoot_margin = tl_stop_p.overshoot_tolerance;
+  p.allow_if_cannot_stop_distance = tl_stop_p.allow_if_cannot_stop_distance;
   p.stable_duration_threshold_red = tl_stop_p.th_stable_duration_red;
   p.stable_duration_threshold_amber = tl_stop_p.th_stable_duration_amber;
   p.amber_rejection_hysteresis_duration = tl_stop_p.th_amber_rejection_hysteresis;

--- a/planning/autoware_trajectory_validator/config/trajectory_validator.param.yaml
+++ b/planning/autoware_trajectory_validator/config/trajectory_validator.param.yaml
@@ -102,6 +102,7 @@
       treat_amber_light_as_red_light: true # [-] when true, amber lights are handled like red lights
       treat_unknown_light_as_red_light: false # [-] when true, unknown lights are handled like red lights
       stop_overshoot_margin: 0.5 # [m] maximum distance between the stop line and the trajectory stop point to consider the trajectory feasible
+      allow_if_cannot_stop_distance: 0.0 # [m] allow crossing a stop line within this distance if ego cannot stop before the line plus its margin
       stable_duration_threshold_red: 0.0 # [s] minimum duration a red light must be seen before it is considered active
       stable_duration_threshold_amber: 0.0 # [s] minimum duration an amber light must be seen before it is considered active
       stable_duration_threshold_unknown: 0.0 # [s] minimum duration an unknown light must be seen before it is considered active

--- a/planning/autoware_trajectory_validator/docs/TrafficLightFilter.md
+++ b/planning/autoware_trajectory_validator/docs/TrafficLightFilter.md
@@ -9,6 +9,13 @@ This filter uses the TrafficLightComplianceChecker to check for violations. For 
 
 The TrafficLightComplianceChecker will check for violations and return the results. The traffic light filter will then scan the provided results for any red/amber light crossing. If the trajectory is crossing a red/amber light then the trajectory is rejected.
 
+When a crossing violation is detected, the trajectory is nevertheless allowed if both of the following conditions are met:
+
+- The distance from the current ego vehicle front point to the stop line is strictly less than `traffic_light.allow_if_cannot_stop_distance`.
+- The same distance is strictly less than the current stopping distance minus `traffic_light.stop_overshoot_margin`.
+
+The current stopping distance is calculated from the ego velocity and acceleration using `traffic_light.checked_trajectory_length.deceleration_limit`, `traffic_light.checked_trajectory_length.jerk_limit`, and `traffic_light.delay_response_time`. Setting `traffic_light.allow_if_cannot_stop_distance` to `0.0` disables this allowance.
+
 ## Algorithm Overview
 
 The following diagram shows the overall logic flow of the TrafficLightFilter:
@@ -70,6 +77,7 @@ The filter utilizes the following data from the `FilterContext`:
 | `traffic_light.treat_amber_light_as_red_light`               | bool   | true    | When true, amber lights are treated identically to red lights (rejection on intersection regardless of distance). |
 | `traffic_light.treat_unknown_light_as_red_light`             | bool   | false   | When true, unknown lights are treated identically to red lights (rejection on intersection).                      |
 | `traffic_light.stop_overshoot_margin`                        | double | 0.5     | [m] Maximum distance between the stop line and the trajectory stop point to consider the trajectory feasible.     |
+| `traffic_light.allow_if_cannot_stop_distance`                | double | 0.0     | [m] Allow crossing when the ego front is within this distance and ego cannot stop before the stop line.           |
 | `traffic_light.stable_duration_threshold_red`                | double | 0.0     | [s] Minimum duration a RED light must be seen before it is considered active (only when ego is moving).           |
 | `traffic_light.stable_duration_threshold_amber`              | double | 0.0     | [s] Minimum duration an AMBER light must be seen before it is considered active (only when ego is moving).        |
 | `traffic_light.stable_duration_threshold_unknown`            | double | 0.0     | [s] Minimum duration an UNKNOWN light must be seen before it is considered active (only when ego is moving).      |

--- a/planning/autoware_trajectory_validator/param/parameter_struct.yaml
+++ b/planning/autoware_trajectory_validator/param/parameter_struct.yaml
@@ -294,6 +294,13 @@ validator:
       default_value: 0.5
       description: Maximum distance between the stop line and the trajectory stop point to consider the trajectory feasible (m)
       read_only: false
+    allow_if_cannot_stop_distance:
+      type: double
+      default_value: 0.0
+      description: allow crossing a stop line within this distance if ego cannot stop before the line plus its margin (m)
+      validation:
+        bounds<>: [0.0, 100.0]
+      read_only: false
     stable_duration_threshold_red:
       type: double
       default_value: 0.0

--- a/planning/autoware_trajectory_validator/schema/trajectory_validator.schema.json
+++ b/planning/autoware_trajectory_validator/schema/trajectory_validator.schema.json
@@ -367,6 +367,12 @@
               "default": 0.5,
               "minimum": 0.0
             },
+            "allow_if_cannot_stop_distance": {
+              "type": "number",
+              "description": "allow crossing a stop line within this distance if ego cannot stop before the line plus its margin [m].",
+              "default": 0.0,
+              "minimum": 0.0
+            },
             "stable_duration_threshold_red": {
               "type": "number",
               "description": "Minimum duration a RED light must be seen before it is considered active (only when ego is moving) [s].",

--- a/planning/autoware_trajectory_validator/src/filters/traffic_rule/traffic_light_filter.cpp
+++ b/planning/autoware_trajectory_validator/src/filters/traffic_rule/traffic_light_filter.cpp
@@ -83,6 +83,7 @@ autoware::traffic_light_compliance_checker::Parameters to_checker_params(
   p.treat_amber_light_as_red_light = params.treat_amber_light_as_red_light;
   p.treat_unknown_light_as_red_light = params.treat_unknown_light_as_red_light;
   p.stop_overshoot_margin = params.stop_overshoot_margin;
+  p.allow_if_cannot_stop_distance = params.allow_if_cannot_stop_distance;
   p.stable_duration_threshold_red = params.stable_duration_threshold_red;
   p.stable_duration_threshold_amber = params.stable_duration_threshold_amber;
   p.stable_duration_threshold_unknown = params.stable_duration_threshold_unknown;

--- a/planning/autoware_trajectory_validator/test/plugins/test_traffic_light_filter.cpp
+++ b/planning/autoware_trajectory_validator/test/plugins/test_traffic_light_filter.cpp
@@ -175,6 +175,18 @@ protected:
     return points;
   }
 
+  void set_ego_motion(const double velocity, const double acceleration)
+  {
+    auto odometry = std::make_shared<nav_msgs::msg::Odometry>(*context_.odometry);
+    odometry->twist.twist.linear.x = velocity;
+    context_.odometry = odometry;
+
+    auto accel =
+      std::make_shared<geometry_msgs::msg::AccelWithCovarianceStamped>(*context_.acceleration);
+    accel->accel.accel.linear.x = acceleration;
+    context_.acceleration = accel;
+  }
+
   void expect_feasibility(
     const std::vector<TrajectoryPoint> & points, const bool expected_feasible,
     const std::string & message = "")
@@ -191,7 +203,7 @@ protected:
   FilterContext context_;
 };
 
-TEST_F(TrafficLightFilterTest, IsFeasibleEmptyInput)
+TEST_F(TrafficLightFilterTest, HandlesEmptyTrajectorySafely)
 {
   std::vector<TrajectoryPoint> points;
   create_and_set_map(0, 0);
@@ -304,6 +316,184 @@ TEST_F(TrafficLightFilterTest, IsInfeasibleWithFrontOverhang)
   filter_->set_vehicle_info(vehicle_info);
 
   expect_feasibility(points, false, "Should return false when crossing red light stop line");
+}
+
+TEST_F(TrafficLightFilterTest, AllowsCrossingIfEgoFrontIsTooCloseToStop)
+{
+  const lanelet::Id light_id = 104;
+  const double stop_x = 5.0;
+
+  create_and_set_map(light_id, stop_x);
+  set_traffic_light_signal(light_id, TrafficLightElement::RED);
+
+  autoware::vehicle_info_utils::VehicleInfo vehicle_info;
+  vehicle_info.max_longitudinal_offset_m = 2.0;
+  filter_->set_vehicle_info(vehicle_info);
+
+  validator::Params params;
+  params.traffic_light.delay_response_time = 0.5;
+  params.traffic_light.stop_overshoot_margin = 0.5;
+  params.traffic_light.allow_if_cannot_stop_distance = 4.0;
+  params.traffic_light.stable_duration_threshold_red = 0.0;
+  params.traffic_light.stable_duration_threshold_amber = 0.0;
+  params.traffic_light.stable_duration_threshold_unknown = 0.0;
+  params.traffic_light.ego_stopped_velocity_threshold = 0.01;
+  params.traffic_light.checked_trajectory_length.deceleration_limit = 2.0;
+  params.traffic_light.checked_trajectory_length.jerk_limit = 2.0;
+  filter_->update_parameters(params);
+
+  const auto points = create_trajectory(0.0, 10.0, 10.0);
+  expect_feasibility(
+    points, true, "Should allow crossing when the ego front is too close to stop safely");
+
+  params.traffic_light.allow_if_cannot_stop_distance = 3.0;
+  filter_->update_parameters(params);
+  expect_feasibility(points, false, "Should reject crossing at the strict allow-distance boundary");
+}
+
+TEST_F(TrafficLightFilterTest, AllowsCrossingWhenEgoFrontHasPassedStopLine)
+{
+  const lanelet::Id light_id = 109;
+  constexpr double stop_x = 3.0;
+
+  create_and_set_map(light_id, stop_x);
+  set_traffic_light_signal(light_id, TrafficLightElement::RED);
+
+  // The vehicle reference point is at x=0, but its front is at x=5 and has therefore passed the
+  // stop line by 2 m.
+  autoware::vehicle_info_utils::VehicleInfo vehicle_info;
+  vehicle_info.max_longitudinal_offset_m = 5.0;
+  filter_->set_vehicle_info(vehicle_info);
+
+  validator::Params params;
+  params.traffic_light.delay_response_time = 1.0;
+  params.traffic_light.stop_overshoot_margin = 0.5;
+  params.traffic_light.allow_if_cannot_stop_distance = 3.0;
+  params.traffic_light.stable_duration_threshold_red = 0.0;
+  params.traffic_light.stable_duration_threshold_amber = 0.0;
+  params.traffic_light.stable_duration_threshold_unknown = 0.0;
+  params.traffic_light.ego_stopped_velocity_threshold = 0.01;
+  params.traffic_light.checked_trajectory_length.deceleration_limit = 2.0;
+  params.traffic_light.checked_trajectory_length.jerk_limit = 2.0;
+  filter_->update_parameters(params);
+
+  set_ego_motion(10.0, 0.0);
+  const auto points = create_trajectory(0.0, 10.0, 10.0);
+  expect_feasibility(
+    points, true, "Should allow proceeding when the ego front has passed the stop line");
+}
+
+TEST_F(TrafficLightFilterTest, RejectsCrossingWhenEgoCanStopSafely)
+{
+  const lanelet::Id light_id = 105;
+  constexpr double stop_x = 4.0;
+
+  create_and_set_map(light_id, stop_x);
+  set_traffic_light_signal(light_id, TrafficLightElement::RED);
+
+  validator::Params params;
+  params.traffic_light.delay_response_time = 2.0;
+  params.traffic_light.stop_overshoot_margin = 0.5;
+  params.traffic_light.allow_if_cannot_stop_distance = 10.0;
+  params.traffic_light.stable_duration_threshold_red = 0.0;
+  params.traffic_light.stable_duration_threshold_amber = 0.0;
+  params.traffic_light.stable_duration_threshold_unknown = 0.0;
+  params.traffic_light.ego_stopped_velocity_threshold = 0.01;
+  params.traffic_light.checked_trajectory_length.deceleration_limit = 5.0;
+  params.traffic_light.checked_trajectory_length.jerk_limit = 2.0;
+  filter_->update_parameters(params);
+
+  // At 2 m/s and -2 m/s^2, ego stops naturally after 1 m during the response delay.
+  set_ego_motion(2.0, -2.0);
+  const auto points = create_trajectory(0.0, 5.0, 2.0);
+  expect_feasibility(
+    points, false, "Should reject crossing when ego can stop safely before the stop line");
+}
+
+TEST_F(TrafficLightFilterTest, RejectsAtStoppingDistanceBoundary)
+{
+  const lanelet::Id light_id = 106;
+  constexpr double velocity = 2.0;
+  constexpr double acceleration = -2.0;
+  constexpr double deceleration_limit = 5.0;
+  constexpr double jerk_limit = 2.0;
+  constexpr double delay_response_time = 2.0;
+  constexpr double stop_overshoot_margin = 0.5;
+  // Ego naturally stops after exactly 1.0 m during the response delay, so the stop line at
+  // 0.5 m is exactly stopping_distance - stop_overshoot_margin.
+  constexpr double stop_x = 0.5;
+
+  create_and_set_map(light_id, stop_x);
+  set_traffic_light_signal(light_id, TrafficLightElement::RED);
+
+  validator::Params params;
+  params.traffic_light.delay_response_time = delay_response_time;
+  params.traffic_light.stop_overshoot_margin = stop_overshoot_margin;
+  params.traffic_light.allow_if_cannot_stop_distance = 10.0;
+  params.traffic_light.stable_duration_threshold_red = 0.0;
+  params.traffic_light.stable_duration_threshold_amber = 0.0;
+  params.traffic_light.stable_duration_threshold_unknown = 0.0;
+  params.traffic_light.ego_stopped_velocity_threshold = 0.01;
+  params.traffic_light.checked_trajectory_length.deceleration_limit = deceleration_limit;
+  params.traffic_light.checked_trajectory_length.jerk_limit = jerk_limit;
+  filter_->update_parameters(params);
+
+  set_ego_motion(velocity, acceleration);
+  const auto points = create_trajectory(0.0, 1.0, velocity);
+  expect_feasibility(
+    points, false, "Should reject crossing exactly at the stopping-distance boundary");
+}
+
+TEST_F(TrafficLightFilterTest, RejectsWhenStoppingDistanceIsUnavailable)
+{
+  const lanelet::Id light_id = 107;
+  constexpr double stop_x = 0.25;
+
+  create_and_set_map(light_id, stop_x);
+  set_traffic_light_signal(light_id, TrafficLightElement::RED);
+
+  validator::Params params;
+  params.traffic_light.delay_response_time = 0.0;
+  params.traffic_light.stop_overshoot_margin = 0.5;
+  params.traffic_light.allow_if_cannot_stop_distance = 10.0;
+  params.traffic_light.stable_duration_threshold_red = 0.0;
+  params.traffic_light.stable_duration_threshold_amber = 0.0;
+  params.traffic_light.stable_duration_threshold_unknown = 0.0;
+  params.traffic_light.ego_stopped_velocity_threshold = 0.01;
+  params.traffic_light.checked_trajectory_length.deceleration_limit = 0.0;
+  params.traffic_light.checked_trajectory_length.jerk_limit = 2.0;
+  filter_->update_parameters(params);
+
+  set_ego_motion(1.0, 0.0);
+  const auto points = create_trajectory(0.0, 1.0, 1.0);
+  expect_feasibility(
+    points, false, "Should retain the violation when stopping distance is unavailable");
+}
+
+TEST_F(TrafficLightFilterTest, RejectsWithZeroCannotStopAllowance)
+{
+  const lanelet::Id light_id = 108;
+  constexpr double stop_x = 1.0;
+
+  create_and_set_map(light_id, stop_x);
+  set_traffic_light_signal(light_id, TrafficLightElement::RED);
+
+  validator::Params params;
+  params.traffic_light.delay_response_time = 1.0;
+  params.traffic_light.stop_overshoot_margin = 0.5;
+  params.traffic_light.allow_if_cannot_stop_distance = 0.0;
+  params.traffic_light.stable_duration_threshold_red = 0.0;
+  params.traffic_light.stable_duration_threshold_amber = 0.0;
+  params.traffic_light.stable_duration_threshold_unknown = 0.0;
+  params.traffic_light.ego_stopped_velocity_threshold = 0.01;
+  params.traffic_light.checked_trajectory_length.deceleration_limit = 2.0;
+  params.traffic_light.checked_trajectory_length.jerk_limit = 2.0;
+  filter_->update_parameters(params);
+
+  set_ego_motion(10.0, 0.0);
+  const auto points = create_trajectory(0.0, 2.0, 10.0);
+  expect_feasibility(
+    points, false, "Should preserve the old rejection behavior when allowance is disabled");
 }
 
 TEST_F(TrafficLightFilterTest, IsInfeasibleWithAmberLightCanStop)


### PR DESCRIPTION
## Description

Add a feature to the `traffic_light_compliance_checker` to allow violations that occur close to a stop line when ego cannot stop comfortably.
This prevents false positives with the `traffic_light_filter` when the traffic signal switches to `RED` or `UNKNOWN` while the ego vehicle is about to cross the stop line.

## Related links

- https://tier4.atlassian.net/browse/T4DEV-55774

## How was this PR tested?

Psim
DLR

## Notes for reviewers

None.

## Interface changes

### ROS Parameter Changes

#### Additions and removals

| Change type   | Parameter Name | Type     | Default Value | Description       |
|:--------------|:---------------|:---------|:--------------|:------------------|
| Added | `allow_if_cannot_stop_distance`   | `double` | `0.0`         | allow crossing a stop line within this distance if ego cannot stop before the line plus its margin [m] |

## Effects on system behavior

Less FP with the `traffic_light_filter`.
