### PR TITLE
 feat(tier4_traffic_light_rviz_plugin): add route-based traffic light override panel for planning simulator

### DIFF
--- a/visualization/tier4_traffic_light_rviz_plugin/CMakeLists.txt
+++ b/visualization/tier4_traffic_light_rviz_plugin/CMakeLists.txt
@@ -12,6 +12,7 @@ add_definitions(-DQT_NO_KEYWORDS)
 
 ament_auto_add_library(${PROJECT_NAME} SHARED
   src/traffic_light_publish_panel.cpp
+  src/traffic_light_route_override_panel.cpp
 )
 
 target_link_libraries(${PROJECT_NAME}

--- a/visualization/tier4_traffic_light_rviz_plugin/README.md
+++ b/visualization/tier4_traffic_light_rviz_plugin/README.md
@@ -2,17 +2,47 @@
 
 ## Purpose
 
-This plugin panel publishes dummy traffic light signals.
+This package provides RViz panels to publish dummy traffic light signals for simulation.
+
+## Panels
+
+### TrafficLightPublishPanel
+
+Manually select traffic light IDs from the map and publish configured signals.
+
+### TrafficLightRouteOverridePanel
+
+Automatically extracts traffic lights on the current route (including conflicting crosswalk signals) and publishes override signals at 10 Hz. Intended for Planning Simulator where traffic light recognition is disabled by default.
 
 ## Inputs / Outputs
 
-### Output
+### TrafficLightPublishPanel
+
+#### Output
+
+| Name                                                    | Type                                                    | Description                   |
+| ------------------------------------------------------- | ------------------------------------------------------- | ----------------------------- |
+| `/perception/traffic_light_recognition/traffic_signals` | `autoware_perception_msgs::msg::TrafficLightGroupArray` | Publish traffic light signals |
+
+### TrafficLightRouteOverridePanel
+
+#### Input
+
+| Name                                                    | Type                                                    | Description                              |
+| ------------------------------------------------------- | ------------------------------------------------------- | ---------------------------------------- |
+| `/map/vector_map`                                       | `autoware_map_msgs::msg::LaneletMapBin`                 | Vector map for route traffic light query |
+| `/planning/mission_planning/route`                      | `autoware_planning_msgs::msg::LaneletRoute`             | Route to extract traffic lights          |
+| `/perception/traffic_light_recognition/traffic_signals` | `autoware_perception_msgs::msg::TrafficLightGroupArray` | Current traffic light states             |
+
+#### Output
 
 | Name                                                    | Type                                                    | Description                   |
 | ------------------------------------------------------- | ------------------------------------------------------- | ----------------------------- |
 | `/perception/traffic_light_recognition/traffic_signals` | `autoware_perception_msgs::msg::TrafficLightGroupArray` | Publish traffic light signals |
 
 ## HowToUse
+
+### TrafficLightPublishPanel
 
 <div align="center">
   <img src="images/select_panels.png" width=50%>
@@ -32,3 +62,13 @@ This plugin panel publishes dummy traffic light signals.
 <div align="center">
   <img src="images/traffic_light_publish_panel.gif">
 </div>
+
+### TrafficLightRouteOverridePanel
+
+1. Start Planning Simulator and open RViz.
+2. Select Panels / Add new panel / TrafficLightRouteOverridePanel.
+3. Set a route in RViz. Traffic lights on the route are listed automatically.
+4. Optionally change the override color for each signal (default: GREEN for vehicle signals, RED for pedestrian signals).
+5. Press the toggle button to switch to `ENABLED (10Hz)` and publish override signals.
+
+When a new route is set, the list is refreshed and override colors are reset to GREEN for vehicle signals and RED for pedestrian signals.

--- a/visualization/tier4_traffic_light_rviz_plugin/package.xml
+++ b/visualization/tier4_traffic_light_rviz_plugin/package.xml
@@ -14,6 +14,8 @@
   <depend>autoware_lanelet2_utils</depend>
   <depend>autoware_map_msgs</depend>
   <depend>autoware_perception_msgs</depend>
+  <depend>autoware_planning_msgs</depend>
+  <depend>unique_identifier_msgs</depend>
   <depend>libqt5-core</depend>
   <depend>libqt5-gui</depend>
   <depend>libqt5-widgets</depend>

--- a/visualization/tier4_traffic_light_rviz_plugin/plugins/plugin_description.xml
+++ b/visualization/tier4_traffic_light_rviz_plugin/plugins/plugin_description.xml
@@ -6,4 +6,10 @@
     <description>TrafficLightPublishPanel</description>
   </class>
 
+  <class
+    type="rviz_plugins::TrafficLightRouteOverridePanel"
+    base_class_type="rviz_common::Panel">
+    <description>TrafficLightRouteOverridePanel</description>
+  </class>
+
 </library>

--- a/visualization/tier4_traffic_light_rviz_plugin/src/traffic_light_route_override_panel.cpp
+++ b/visualization/tier4_traffic_light_rviz_plugin/src/traffic_light_route_override_panel.cpp
@@ -1,0 +1,413 @@
+//
+//  Copyright 2026 TIER IV, Inc. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+#include "traffic_light_route_override_panel.hpp"
+
+#include <QFont>
+#include <QHeaderView>
+#include <QVBoxLayout>
+#include <autoware/lanelet2_utils/conversion.hpp>
+#include <autoware_lanelet2_extension/utility/query.hpp>
+#include <rviz_common/display_context.hpp>
+
+#include <unique_identifier_msgs/msg/uuid.hpp>
+
+#include <lanelet2_routing/RoutingGraphContainer.h>
+#include <lanelet2_traffic_rules/TrafficRulesFactory.h>
+
+#include <algorithm>
+#include <set>
+#include <string>
+#include <utility>
+
+#undef signals
+namespace rviz_plugins
+{
+
+namespace
+{
+constexpr int kPublishRateHz = 10;
+constexpr int kPedestrianGraphId = 1;
+
+bool isSameUuid(
+  const std::array<uint8_t, 16> & a, const std::array<uint8_t, 16> & b)
+{
+  return a == b;
+}
+
+std::array<uint8_t, 16> toUuidArray(const unique_identifier_msgs::msg::UUID & uuid)
+{
+  std::array<uint8_t, 16> result{};
+  std::copy(uuid.uuid.begin(), uuid.uuid.end(), result.begin());
+  return result;
+}
+
+void appendUniqueTrafficLightIds(
+  const std::vector<lanelet::AutowareTrafficLightConstPtr> & traffic_lights,
+  std::set<int64_t> & ids)
+{
+  for (const auto & tl : traffic_lights) {
+    ids.insert(tl->id());
+  }
+}
+}  // namespace
+
+TrafficLightRouteOverridePanel::TrafficLightRouteOverridePanel(QWidget * parent)
+: rviz_common::Panel(parent)
+{
+  auto * vertical_header = new QHeaderView(Qt::Vertical);
+  vertical_header->hide();
+  auto * horizontal_header = new QHeaderView(Qt::Horizontal);
+  horizontal_header->setSectionResizeMode(QHeaderView::Stretch);
+
+  traffic_table_ = new QTableWidget();
+  traffic_table_->setColumnCount(3);
+  traffic_table_->setHorizontalHeaderLabels({"ID", "Current", "Override"});
+  traffic_table_->setVerticalHeader(vertical_header);
+  traffic_table_->setHorizontalHeader(horizontal_header);
+
+  toggle_button_ = new QPushButton("DISABLED");
+  toggle_button_->setMinimumHeight(50);
+  toggle_button_->setFont(QFont("Sans", 10, QFont::Bold));
+  connect(toggle_button_, SIGNAL(clicked()), this, SLOT(onToggleEnable()));
+
+  auto * layout = new QVBoxLayout();
+  layout->addWidget(traffic_table_);
+  layout->addWidget(toggle_button_);
+  setLayout(layout);
+
+  updateToggleButtonStyle();
+}
+
+void TrafficLightRouteOverridePanel::onInitialize()
+{
+  using std::placeholders::_1;
+  raw_node_ = getDisplayContext()->getRosNodeAbstraction().lock()->get_raw_node();
+
+  pub_traffic_signals_ = raw_node_->create_publisher<TrafficLightGroupArray>(
+    "/perception/traffic_light_recognition/traffic_signals", rclcpp::QoS(1));
+
+  sub_vector_map_ = raw_node_->create_subscription<LaneletMapBin>(
+    "/map/vector_map", rclcpp::QoS{1}.transient_local(),
+    std::bind(&TrafficLightRouteOverridePanel::onVectorMap, this, _1));
+
+  sub_route_ = raw_node_->create_subscription<LaneletRoute>(
+    "/planning/mission_planning/route", rclcpp::QoS{1}.transient_local(),
+    std::bind(&TrafficLightRouteOverridePanel::onRoute, this, _1));
+
+  sub_traffic_signals_ = raw_node_->create_subscription<TrafficLightGroupArray>(
+    "/perception/traffic_light_recognition/traffic_signals", rclcpp::QoS(1),
+    std::bind(&TrafficLightRouteOverridePanel::onTrafficSignals, this, _1));
+
+  const auto period = std::chrono::milliseconds(static_cast<int64_t>(1000 / kPublishRateHz));
+  pub_timer_ = raw_node_->create_wall_timer(
+    period, std::bind(&TrafficLightRouteOverridePanel::onTimer, this));
+}
+
+void TrafficLightRouteOverridePanel::onToggleEnable()
+{
+  enable_publish_ = !enable_publish_;
+  updateToggleButtonStyle();
+
+  if (enable_publish_ && !entries_.empty()) {
+    auto msg = buildTrafficLightGroupArray();
+    msg.stamp = raw_node_->get_clock()->now();
+    pub_traffic_signals_->publish(msg);
+  }
+}
+
+void TrafficLightRouteOverridePanel::updateToggleButtonStyle()
+{
+  if (enable_publish_) {
+    toggle_button_->setText("ENABLED (10Hz)");
+    toggle_button_->setStyleSheet(
+      "QPushButton { background-color: #336633; color: white; border-radius: 6px; }");
+  } else {
+    toggle_button_->setText("DISABLED");
+    toggle_button_->setStyleSheet(
+      "QPushButton { background-color: #808080; color: white; border-radius: 6px; }");
+  }
+}
+
+void TrafficLightRouteOverridePanel::onVectorMap(const LaneletMapBin::ConstSharedPtr msg)
+{
+  if (received_vector_map_) {
+    return;
+  }
+
+  lanelet_map_ptr_ = autoware::experimental::lanelet2_utils::remove_const(
+    autoware::experimental::lanelet2_utils::from_autoware_map_msgs(*msg));
+
+  const auto traffic_rules = lanelet::traffic_rules::TrafficRulesFactory::create(
+    lanelet::Locations::Germany, lanelet::Participants::Vehicle);
+  const auto pedestrian_rules = lanelet::traffic_rules::TrafficRulesFactory::create(
+    lanelet::Locations::Germany, lanelet::Participants::Pedestrian);
+  const lanelet::routing::RoutingGraphConstPtr vehicle_graph =
+    lanelet::routing::RoutingGraph::build(*lanelet_map_ptr_, *traffic_rules);
+  const lanelet::routing::RoutingGraphConstPtr pedestrian_graph =
+    lanelet::routing::RoutingGraph::build(*lanelet_map_ptr_, *pedestrian_rules);
+  lanelet::routing::RoutingGraphContainer overall_graphs({vehicle_graph, pedestrian_graph});
+  overall_graphs_ptr_ =
+    std::make_shared<const lanelet::routing::RoutingGraphContainer>(overall_graphs);
+
+  received_vector_map_ = true;
+  RCLCPP_INFO(raw_node_->get_logger(), "Received vector map for route traffic light override panel");
+}
+
+void TrafficLightRouteOverridePanel::onRoute(const LaneletRoute::ConstSharedPtr msg)
+{
+  if (!received_vector_map_ || lanelet_map_ptr_ == nullptr || overall_graphs_ptr_ == nullptr) {
+    RCLCPP_WARN(
+      raw_node_->get_logger(), "Cannot extract route traffic lights because vector map is not ready");
+    return;
+  }
+
+  const auto route_uuid = toUuidArray(msg->uuid);
+  if (last_route_uuid_.has_value() && isSameUuid(last_route_uuid_.value(), route_uuid)) {
+    return;
+  }
+  last_route_uuid_ = route_uuid;
+
+  const auto traffic_lights = extractTrafficLightIdsOnRoute(msg);
+  rebuildTable(traffic_lights);
+
+  RCLCPP_INFO(
+    raw_node_->get_logger(), "Updated route traffic lights: %zu signals found",
+    traffic_lights.size());
+}
+
+std::vector<RouteTrafficLightInfo> TrafficLightRouteOverridePanel::extractTrafficLightIdsOnRoute(
+  const LaneletRoute::ConstSharedPtr & route) const
+{
+  lanelet::ConstLanelets route_lanelets;
+  for (const auto & segment : route->segments) {
+    for (const auto & primitive : segment.primitives) {
+      try {
+        route_lanelets.push_back(lanelet_map_ptr_->laneletLayer.get(primitive.id));
+      } catch (const lanelet::NoSuchPrimitiveError & ex) {
+        RCLCPP_ERROR(raw_node_->get_logger(), "%s", ex.what());
+        return {};
+      }
+    }
+  }
+
+  std::set<int64_t> vehicle_traffic_light_ids;
+  appendUniqueTrafficLightIds(
+    lanelet::utils::query::autowareTrafficLights(route_lanelets), vehicle_traffic_light_ids);
+
+  std::set<int64_t> pedestrian_traffic_light_ids;
+  lanelet::ConstLanelets conflicting_crosswalks;
+  for (const auto & route_lanelet : route_lanelets) {
+    const auto conflict_lanelets =
+      overall_graphs_ptr_->conflictingInGraph(route_lanelet, kPedestrianGraphId);
+    for (const auto & lanelet : conflict_lanelets) {
+      conflicting_crosswalks.push_back(lanelet);
+    }
+  }
+  appendUniqueTrafficLightIds(
+    lanelet::utils::query::autowareTrafficLights(conflicting_crosswalks),
+    pedestrian_traffic_light_ids);
+
+  std::vector<RouteTrafficLightInfo> traffic_lights;
+  traffic_lights.reserve(vehicle_traffic_light_ids.size() + pedestrian_traffic_light_ids.size());
+
+  for (const auto id : vehicle_traffic_light_ids) {
+    traffic_lights.push_back(RouteTrafficLightInfo{id, false});
+  }
+  for (const auto id : pedestrian_traffic_light_ids) {
+    if (vehicle_traffic_light_ids.count(id) == 0) {
+      traffic_lights.push_back(RouteTrafficLightInfo{id, true});
+    }
+  }
+
+  std::sort(traffic_lights.begin(), traffic_lights.end(), [](const auto & a, const auto & b) {
+    return a.id < b.id;
+  });
+
+  return traffic_lights;
+}
+
+void TrafficLightRouteOverridePanel::rebuildTable(
+  const std::vector<RouteTrafficLightInfo> & traffic_lights)
+{
+  entries_.clear();
+  traffic_table_->setRowCount(static_cast<int>(traffic_lights.size()));
+
+  for (size_t i = 0; i < traffic_lights.size(); ++i) {
+    const auto & traffic_light = traffic_lights.at(i);
+
+    TrafficLightEntry entry;
+    entry.id = traffic_light.id;
+    entry.is_pedestrian = traffic_light.is_pedestrian;
+    entry.override_color =
+      traffic_light.is_pedestrian ? TrafficLightElement::RED : TrafficLightElement::GREEN;
+
+    auto * id_label = new QLabel(QString::number(traffic_light.id));
+    id_label->setAlignment(Qt::AlignCenter);
+
+    auto * current_label = new QLabel(colorToString(TrafficLightElement::UNKNOWN));
+    current_label->setAlignment(Qt::AlignCenter);
+    setColorLabelStyle(current_label, TrafficLightElement::UNKNOWN);
+
+    auto * override_combo = new QComboBox();
+    override_combo->addItems({"RED", "AMBER", "GREEN", "WHITE", "UNKNOWN"});
+    override_combo->setCurrentText(colorToString(entry.override_color));
+
+    const int row = static_cast<int>(i);
+    traffic_table_->setCellWidget(row, 0, id_label);
+    traffic_table_->setCellWidget(row, 1, current_label);
+    traffic_table_->setCellWidget(row, 2, override_combo);
+
+    entry.current_color_label = current_label;
+    entry.override_combo = override_combo;
+    entries_.push_back(entry);
+  }
+
+  updateCurrentColorLabels();
+  traffic_table_->update();
+}
+
+void TrafficLightRouteOverridePanel::onTrafficSignals(
+  const TrafficLightGroupArray::ConstSharedPtr msg)
+{
+  if (enable_publish_) {
+    return;
+  }
+
+  for (const auto & signal : msg->traffic_light_groups) {
+    if (signal.elements.empty()) {
+      current_colors_[signal.traffic_light_group_id] = TrafficLightElement::UNKNOWN;
+      continue;
+    }
+    current_colors_[signal.traffic_light_group_id] = signal.elements.front().color;
+  }
+
+  updateCurrentColorLabels();
+}
+
+void TrafficLightRouteOverridePanel::updateCurrentColorLabels()
+{
+  for (auto & entry : entries_) {
+    if (entry.current_color_label == nullptr) {
+      continue;
+    }
+
+    const auto it = current_colors_.find(entry.id);
+    const uint8_t color =
+      it != current_colors_.end() ? it->second : TrafficLightElement::UNKNOWN;
+    entry.current_color_label->setText(colorToString(color));
+    setColorLabelStyle(entry.current_color_label, color);
+  }
+}
+
+TrafficLightGroupArray TrafficLightRouteOverridePanel::buildTrafficLightGroupArray() const
+{
+  TrafficLightGroupArray msg;
+  msg.traffic_light_groups.reserve(entries_.size());
+
+  for (const auto & entry : entries_) {
+    TrafficLightElement element;
+    element.shape = TrafficLightElement::CIRCLE;
+    element.status = TrafficLightElement::SOLID_ON;
+    element.confidence = 1.0F;
+    element.color = entry.override_combo != nullptr
+                      ? colorFromComboText(entry.override_combo->currentText())
+                      : entry.override_color;
+
+    TrafficLightGroup group;
+    group.traffic_light_group_id = entry.id;
+    group.elements.push_back(element);
+    msg.traffic_light_groups.push_back(group);
+  }
+
+  return msg;
+}
+
+void TrafficLightRouteOverridePanel::onTimer()
+{
+  if (enable_publish_ && !entries_.empty()) {
+    auto msg = buildTrafficLightGroupArray();
+    msg.stamp = raw_node_->get_clock()->now();
+    pub_traffic_signals_->publish(msg);
+
+    for (const auto & group : msg.traffic_light_groups) {
+      if (group.elements.empty()) {
+        continue;
+      }
+      current_colors_[group.traffic_light_group_id] = group.elements.front().color;
+    }
+    updateCurrentColorLabels();
+  }
+}
+
+QString TrafficLightRouteOverridePanel::colorToString(const uint8_t color)
+{
+  switch (color) {
+    case TrafficLightElement::RED:
+      return "RED";
+    case TrafficLightElement::AMBER:
+      return "AMBER";
+    case TrafficLightElement::GREEN:
+      return "GREEN";
+    case TrafficLightElement::WHITE:
+      return "WHITE";
+    default:
+      return "UNKNOWN";
+  }
+}
+
+void TrafficLightRouteOverridePanel::setColorLabelStyle(QLabel * label, const uint8_t color)
+{
+  switch (color) {
+    case TrafficLightElement::RED:
+      label->setStyleSheet("background-color: #FF0000;");
+      break;
+    case TrafficLightElement::AMBER:
+      label->setStyleSheet("background-color: #FFBF00;");
+      break;
+    case TrafficLightElement::GREEN:
+      label->setStyleSheet("background-color: #7CFC00;");
+      break;
+    case TrafficLightElement::WHITE:
+      label->setStyleSheet("background-color: #FFFFFF;");
+      break;
+    default:
+      label->setStyleSheet("background-color: #808080;");
+      break;
+  }
+}
+
+uint8_t TrafficLightRouteOverridePanel::colorFromComboText(const QString & text)
+{
+  if (text == "RED") {
+    return TrafficLightElement::RED;
+  }
+  if (text == "AMBER") {
+    return TrafficLightElement::AMBER;
+  }
+  if (text == "GREEN") {
+    return TrafficLightElement::GREEN;
+  }
+  if (text == "WHITE") {
+    return TrafficLightElement::WHITE;
+  }
+  return TrafficLightElement::UNKNOWN;
+}
+
+}  // namespace rviz_plugins
+
+#include <pluginlib/class_list_macros.hpp>
+PLUGINLIB_EXPORT_CLASS(rviz_plugins::TrafficLightRouteOverridePanel, rviz_common::Panel)

--- a/visualization/tier4_traffic_light_rviz_plugin/src/traffic_light_route_override_panel.hpp
+++ b/visualization/tier4_traffic_light_rviz_plugin/src/traffic_light_route_override_panel.hpp
@@ -1,0 +1,119 @@
+//
+//  Copyright 2026 TIER IV, Inc. All rights reserved.
+//
+//  Licensed under the Apache License, Version 2.0 (the "License");
+//  you may not use this file except in compliance with the License.
+//  You may obtain a copy of the License at
+//
+//      http://www.apache.org/licenses/LICENSE-2.0
+//
+//  Unless required by applicable law or agreed to in writing, software
+//  distributed under the License is distributed on an "AS IS" BASIS,
+//  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  See the License for the specific language governing permissions and
+//  limitations under the License.
+//
+
+#ifndef TRAFFIC_LIGHT_ROUTE_OVERRIDE_PANEL_HPP_
+#define TRAFFIC_LIGHT_ROUTE_OVERRIDE_PANEL_HPP_
+
+#ifndef Q_MOC_RUN
+#include <qt5/QtWidgets/QComboBox>
+#include <qt5/QtWidgets/QLabel>
+#include <qt5/QtWidgets/QPushButton>
+#include <qt5/QtWidgets/QTableWidget>
+#include <rclcpp/rclcpp.hpp>
+#include <rviz_common/panel.hpp>
+
+#include <autoware_lanelet2_extension/regulatory_elements/autoware_traffic_light.hpp>
+#include <autoware_map_msgs/msg/lanelet_map_bin.hpp>
+#include <autoware_perception_msgs/msg/traffic_light_group_array.hpp>
+#include <autoware_planning_msgs/msg/lanelet_route.hpp>
+
+#include <lanelet2_core/LaneletMap.h>
+#include <lanelet2_routing/RoutingGraph.h>
+#endif
+
+#include <array>
+#include <cstdint>
+#include <memory>
+#include <optional>
+#include <unordered_map>
+#include <vector>
+
+namespace rviz_plugins
+{
+
+using autoware_map_msgs::msg::LaneletMapBin;
+using autoware_perception_msgs::msg::TrafficLightElement;
+using autoware_perception_msgs::msg::TrafficLightGroup;
+using autoware_perception_msgs::msg::TrafficLightGroupArray;
+using autoware_planning_msgs::msg::LaneletRoute;
+
+struct TrafficLightEntry
+{
+  int64_t id{};
+  bool is_pedestrian{false};
+  uint8_t override_color{TrafficLightElement::GREEN};
+  QComboBox * override_combo{nullptr};
+  QLabel * current_color_label{nullptr};
+};
+
+struct RouteTrafficLightInfo
+{
+  int64_t id{};
+  bool is_pedestrian{false};
+};
+
+class TrafficLightRouteOverridePanel : public rviz_common::Panel
+{
+  Q_OBJECT
+
+public:
+  explicit TrafficLightRouteOverridePanel(QWidget * parent = nullptr);
+  void onInitialize() override;
+
+public Q_SLOTS:
+  void onToggleEnable();
+
+protected:
+  void onVectorMap(const LaneletMapBin::ConstSharedPtr msg);
+  void onRoute(const LaneletRoute::ConstSharedPtr msg);
+  void onTrafficSignals(const TrafficLightGroupArray::ConstSharedPtr msg);
+  void onTimer();
+
+  void rebuildTable(const std::vector<RouteTrafficLightInfo> & traffic_lights);
+  void updateCurrentColorLabels();
+  TrafficLightGroupArray buildTrafficLightGroupArray() const;
+  std::vector<RouteTrafficLightInfo> extractTrafficLightIdsOnRoute(
+    const LaneletRoute::ConstSharedPtr & route) const;
+  void updateToggleButtonStyle();
+
+  static QString colorToString(uint8_t color);
+  static void setColorLabelStyle(QLabel * label, uint8_t color);
+  static uint8_t colorFromComboText(const QString & text);
+
+  rclcpp::Node::SharedPtr raw_node_;
+  rclcpp::TimerBase::SharedPtr pub_timer_;
+  rclcpp::Publisher<TrafficLightGroupArray>::SharedPtr pub_traffic_signals_;
+  rclcpp::Subscription<LaneletMapBin>::SharedPtr sub_vector_map_;
+  rclcpp::Subscription<LaneletRoute>::SharedPtr sub_route_;
+  rclcpp::Subscription<TrafficLightGroupArray>::SharedPtr sub_traffic_signals_;
+
+  QTableWidget * traffic_table_{nullptr};
+  QPushButton * toggle_button_{nullptr};
+
+  lanelet::LaneletMapPtr lanelet_map_ptr_;
+  std::shared_ptr<const lanelet::routing::RoutingGraphContainer> overall_graphs_ptr_;
+
+  std::vector<TrafficLightEntry> entries_;
+  std::unordered_map<int64_t, uint8_t> current_colors_;
+
+  std::optional<std::array<uint8_t, 16>> last_route_uuid_;
+  bool enable_publish_{false};
+  bool received_vector_map_{false};
+};
+
+}  // namespace rviz_plugins
+
+#endif  // TRAFFIC_LIGHT_ROUTE_OVERRIDE_PANEL_HPP_


### PR DESCRIPTION
# feat(tier4_traffic_light_rviz_plugin): add route-based traffic light override panel for planning simulator

## Summary

In Planning Simulator (closed-loop simulation), traffic light recognition is disabled by default (`perception/enable_traffic_light:=false`), so the traffic light recognition pipeline does not start and `/perception/traffic_light_recognition/traffic_signals` is not published. As a result, simulations that depend on traffic signals (e.g. stopping at stop lines) cannot be performed as intended.

This PR adds an RViz panel, **`TrafficLightRouteOverridePanel`**, to `tier4_traffic_light_rviz_plugin` that automatically extracts traffic lights along the current route and publishes override signal states.

## Changes

### New: `TrafficLightRouteOverridePanel`

- When a route is set, automatically extracts vehicle traffic lights on the route and pedestrian traffic lights on conflicting crosswalks from the map, and displays them in a list
- For each signal, the panel shows and allows configuration of:
  - **ID**: regulatory element ID (published as `traffic_light_group_id`)
  - **Current**: current lamp color (from `/perception/traffic_light_recognition/traffic_signals`; `UNKNOWN` if not yet received)
  - **Override**: lamp color to override (`RED` / `AMBER` / `GREEN` / `WHITE` / `UNKNOWN`)
- **Enable/Disable** toggle at the bottom of the panel; when enabled, publishes all signals at **10 Hz**

### Default override values

| Signal type | Source | Default override |
|---|---|---|
| Vehicle | Route lanelets | `GREEN` |
| Pedestrian | Conflicting crosswalks | `RED` |

If a signal ID appears on both the route and a conflicting crosswalk, it is treated as a vehicle signal with default `GREEN`.

### Signal extraction logic

Uses the same approach as `autoware_traffic_light_map_based_detector::routeCallback`:

1. Get route lanelets from `/planning/mission_planning/route`
2. Extract vehicle signals via `autowareTrafficLights(route_lanelets)`
3. Find conflicting crosswalks using RoutingGraph and extract pedestrian signals
4. Deduplicate by regulatory element ID

### Changed files

- `src/traffic_light_route_override_panel.hpp` (new)
- `src/traffic_light_route_override_panel.cpp` (new)
- `CMakeLists.txt`
- `plugins/plugin_description.xml`
- `package.xml` (adds `autoware_planning_msgs`, `unique_identifier_msgs` dependencies)
- `README.md`

## ROS I/F

| Direction | Topic | Type |
|---|---|---|
| Subscribe | `/map/vector_map` | `autoware_map_msgs/msg/LaneletMapBin` |
| Subscribe | `/planning/mission_planning/route` | `autoware_planning_msgs/msg/LaneletRoute` |
| Subscribe | `/perception/traffic_light_recognition/traffic_signals` | `autoware_perception_msgs/msg/TrafficLightGroupArray` |
| Publish | `/perception/traffic_light_recognition/traffic_signals` | `autoware_perception_msgs/msg/TrafficLightGroupArray` |

Published message format matches the existing `TrafficLightPublishPanel` (`shape=CIRCLE`, `status=SOLID_ON`, `confidence=1.0`).

## Test plan

- [x] `colcon build --packages-select tier4_traffic_light_rviz_plugin` succeeds
- [x] Planning Simulator starts and `TrafficLightRouteOverridePanel` can be added from RViz
- [x] After setting a route, traffic lights on the route appear automatically in the panel
- [x] Default override is `GREEN` for vehicle signals and `RED` for pedestrian signals
- [x] After enabling, `ros2 topic hz /perception/traffic_light_recognition/traffic_signals` shows ~10 Hz publishing
- [x] With a signal set to `RED` and enabled, the vehicle stops at the stop line
- [x] When the route changes, the list is refreshed and default values are reset

## Notes

- Intended for Planning Simulator with traffic light recognition disabled by default. If the traffic light recognition pipeline is enabled, this panel’s publishes may conflict with it
- Adding the panel to RViz config files (`.rviz`) is out of scope for this PR