### PR TITLE
feat(autoware_mppi_optimizer): remove boundary checks and fix indexing

### DIFF
--- a/planning/autoware_mppi_optimizer/include/mppi/cost_functions/dubins/first_order_dubins_bicycle_cost.cu
+++ b/planning/autoware_mppi_optimizer/include/mppi/cost_functions/dubins/first_order_dubins_bicycle_cost.cu
@@ -357,18 +357,11 @@ __host__ __device__ bool FirstOrderDubinsBicycleCostImpl<
   CLASS_T, NUM_TIMESTEPS, PARAMS_T,
   DYN_PARAMS_T>::isEgoOutsideDrivableArea(const float x, const float y, const float yaw) const
 {
+  (void)x;
+  (void)y;
   (void)yaw;
-  if (num_drivable_vertices_ < 3) {
-    return isOffRoad(x, y);
-  }
-
-  // Rear-axle containment in the drivable polygon. Corner checks are too strict on tight curves.
-  if (pointInPolygon(x, y, drivable_poly_x_, drivable_poly_y_, num_drivable_vertices_)) {
-    return false;
-  }
-
-  // Polygon boundary is piecewise-linear; defer to ref lateral offset near the corridor edge.
-  return isOffRoad(x, y);
+  // Boundary / polygonal / left-right corridor crash disabled.
+  return false;
 }
 
 template <class CLASS_T, int NUM_TIMESTEPS, class PARAMS_T, class DYN_PARAMS_T>

--- a/planning/autoware_mppi_optimizer/include/mppi/cost_functions/dubins/first_order_dubins_bicycle_cost.cu
+++ b/planning/autoware_mppi_optimizer/include/mppi/cost_functions/dubins/first_order_dubins_bicycle_cost.cu
@@ -332,9 +332,9 @@ __host__ __device__ float FirstOrderDubinsBicycleCostImpl<
 }
 
 template <class CLASS_T, int NUM_TIMESTEPS, class PARAMS_T, class DYN_PARAMS_T>
-__host__ __device__ bool
-FirstOrderDubinsBicycleCostImpl<CLASS_T, NUM_TIMESTEPS, PARAMS_T, DYN_PARAMS_T>::isOffRoad(
-  const float x, const float y) const
+__host__ __device__ bool FirstOrderDubinsBicycleCostImpl<
+  CLASS_T, NUM_TIMESTEPS, PARAMS_T,
+  DYN_PARAMS_T>::exceedsLateralBoundary(const float x, const float y) const
 {
   const bool asymmetric =
     this->params_.boundary_threshold_left >= 0.0F || this->params_.boundary_threshold_right >= 0.0F;
@@ -350,18 +350,6 @@ FirstOrderDubinsBicycleCostImpl<CLASS_T, NUM_TIMESTEPS, PARAMS_T, DYN_PARAMS_T>:
                               : this->params_.boundary_threshold;
   const float signed_lat = computeSignedLateralOffset(x, y);
   return signed_lat > left_limit || signed_lat < -right_limit;
-}
-
-template <class CLASS_T, int NUM_TIMESTEPS, class PARAMS_T, class DYN_PARAMS_T>
-__host__ __device__ bool FirstOrderDubinsBicycleCostImpl<
-  CLASS_T, NUM_TIMESTEPS, PARAMS_T,
-  DYN_PARAMS_T>::isEgoOutsideDrivableArea(const float x, const float y, const float yaw) const
-{
-  (void)x;
-  (void)y;
-  (void)yaw;
-// Polygon boundary is piecewise-linear; defer to ref lateral offset near the corridor edge.
-return isOffRoad(x, y);
 }
 
 template <class CLASS_T, int NUM_TIMESTEPS, class PARAMS_T, class DYN_PARAMS_T>
@@ -424,9 +412,9 @@ FirstOrderDubinsBicycleCostImpl<CLASS_T, NUM_TIMESTEPS, PARAMS_T, DYN_PARAMS_T>:
   detectAndLatchCrash(
     const float x, const float y, const float yaw, const int timestep, int * crash_status) const
 {
-  const bool off_road = isEgoOutsideDrivableArea(x, y, yaw);
+  const bool beyond_lateral_bound = exceedsLateralBoundary(x, y);
   const bool hit_car = egoIntersectsObstacleAtStep(x, y, yaw, timestep);
-  const int violations = static_cast<int>(off_road) + static_cast<int>(hit_car);
+  const int violations = static_cast<int>(beyond_lateral_bound) + static_cast<int>(hit_car);
   if (violations > 0) {
     if (crash_status != nullptr) {
       crash_status[0] = violations;

--- a/planning/autoware_mppi_optimizer/include/mppi/cost_functions/dubins/first_order_dubins_bicycle_cost.cu
+++ b/planning/autoware_mppi_optimizer/include/mppi/cost_functions/dubins/first_order_dubins_bicycle_cost.cu
@@ -360,8 +360,8 @@ __host__ __device__ bool FirstOrderDubinsBicycleCostImpl<
   (void)x;
   (void)y;
   (void)yaw;
-  // Boundary / polygonal / left-right corridor crash disabled.
-  return false;
+// Polygon boundary is piecewise-linear; defer to ref lateral offset near the corridor edge.
+return isOffRoad(x, y);
 }
 
 template <class CLASS_T, int NUM_TIMESTEPS, class PARAMS_T, class DYN_PARAMS_T>

--- a/planning/autoware_mppi_optimizer/include/mppi/cost_functions/dubins/first_order_dubins_bicycle_cost.cuh
+++ b/planning/autoware_mppi_optimizer/include/mppi/cost_functions/dubins/first_order_dubins_bicycle_cost.cuh
@@ -96,8 +96,7 @@ public:
 
   __host__ __device__ bool isOffRoad(const float x, const float y) const;
 
-  /** True when outside drivable polygon (rear axle); falls back to ref lateral offset near the poly
-   * boundary. */
+  /** Disabled: always false (no polygon / lateral-bound / road-border crash). */
   __host__ __device__ bool isEgoOutsideDrivableArea(
     const float x, const float y, const float yaw) const;
 

--- a/planning/autoware_mppi_optimizer/include/mppi/cost_functions/dubins/first_order_dubins_bicycle_cost.cuh
+++ b/planning/autoware_mppi_optimizer/include/mppi/cost_functions/dubins/first_order_dubins_bicycle_cost.cuh
@@ -17,11 +17,11 @@ struct FirstOrderDubinsBicycleCostParams : public CostParams<2>
   float track_coeff = 1000.0F;
   /** Pull toward ref heading at each horizon step: coeff * (yaw - ref_yaw[t])^2; 0 disables. */
   float heading_coeff = 500.0F;
-  /** Per-violation crash penalty; latched crash_status counts violations (1=off-road or hit,
+  /** Per-violation crash penalty; latched crash_status counts violations (1=lateral bound or hit,
    * 2=both). */
   float crash_coeff = 100000.0F;
   float boundary_threshold = 0.8F;
-  /** Off-road if signed lateral offset exceeds these (path-left = +); <0 falls back to
+  /** Beyond bound if signed lateral offset exceeds these (path-left = +); <0 falls back to
    * boundary_threshold. */
   float boundary_threshold_left = -1.0F;
   float boundary_threshold_right = -1.0F;
@@ -94,11 +94,8 @@ public:
 
   __host__ __device__ float computeSignedLateralOffset(float x, float y) const;
 
-  __host__ __device__ bool isOffRoad(const float x, const float y) const;
-
-  /** Disabled: always false (no polygon / lateral-bound / road-border crash). */
-  __host__ __device__ bool isEgoOutsideDrivableArea(
-    const float x, const float y, const float yaw) const;
+  /** True if |signed lateral offset to ref| exceeds boundary_threshold(_left/_right). */
+  __host__ __device__ bool exceedsLateralBoundary(const float x, const float y) const;
 
   __host__ __device__ bool egoIntersectsObstacleAtStep(
     const float x, const float y, const float yaw, int timestep) const;

--- a/planning/autoware_mppi_optimizer/src/first_order_dubins/first_order_dubins_mppi_interface.cu
+++ b/planning/autoware_mppi_optimizer/src/first_order_dubins/first_order_dubins_mppi_interface.cu
@@ -745,7 +745,30 @@ FirstOrderDubinsMppiOptimizationResult FirstOrderDubinsMppiInterface::optimizeTr
   const int steer_cmd_idx =
     static_cast<int>(FirstOrderDubinsBicycleParams::ControlIndex::STEER_CMD);
 
-  const size_t num_points = std::min(output.points.size(), static_cast<size_t>(kMppiHorizon));
+  // GPU costs post-step state at timestep t against ref[t] (= DP[t] at time (t+1)*dt).
+  // Map: points[i] <- state[i+1], control[i].
+  //
+  // Vendor mismatch: GPU rollouts take H steps (mppi_common.cu: t = 0..H-1) and cost the
+  // final post-step state x[H], but host getActualStateSeq() only runs H-1 steps
+  // (controller.cuh: i < num_timesteps - 1) and stores x[0..H-1]. Reconstruct x[H] here
+  // with one dynamics step so the last DP point is not left as a duplicate of x[H-1].
+  const int n_state = static_cast<int>(state_trajectory.cols());
+  const int n_ctrl = static_cast<int>(u_opt_traj.cols());
+  const size_t num_points = std::min(
+    {output.points.size(), static_cast<size_t>(std::max(0, n_state)),
+     static_cast<size_t>(std::max(0, n_ctrl))});
+
+  DYN::state_array x_final = DYN::state_array::Zero();
+  DYN::state_array x_final_dot = DYN::state_array::Zero();
+  DYN::output_array y_final = DYN::output_array::Zero();
+  const bool have_final_state = n_state > 0 && n_ctrl > 0;
+  if (have_final_state) {
+    DYN::state_array x_tail = state_trajectory.col(n_state - 1);
+    DYN::control_array u_tail = u_opt_traj.col(n_ctrl - 1);
+    impl_->model.enforceConstraints(x_tail, u_tail);
+    impl_->model.step(
+      x_tail, x_final, x_final_dot, u_tail, y_final, static_cast<float>(n_state - 1), kDt);
+  }
 
   float max_pos_delta = 0.0F;
   float max_vel_delta = 0.0F;
@@ -755,11 +778,17 @@ FirstOrderDubinsMppiOptimizationResult FirstOrderDubinsMppiInterface::optimizeTr
       break;
     }
     const auto & in_point = input.points[i];
-    const int col = static_cast<int>(i);
-    const float tracked_x = state_trajectory(pos_x_idx, col);
-    const float tracked_y = state_trajectory(pos_y_idx, col);
-    const float tracked_yaw = state_trajectory(yaw_idx, col);
-    const float tracked_v = state_trajectory(vel_x_idx, col);
+    const int control_col = static_cast<int>(i);
+    const bool use_final = (control_col + 1 >= n_state) && have_final_state;
+
+    const float tracked_x =
+      use_final ? x_final(pos_x_idx) : state_trajectory(pos_x_idx, control_col + 1);
+    const float tracked_y =
+      use_final ? x_final(pos_y_idx) : state_trajectory(pos_y_idx, control_col + 1);
+    const float tracked_yaw =
+      use_final ? x_final(yaw_idx) : state_trajectory(yaw_idx, control_col + 1);
+    const float tracked_v =
+      use_final ? x_final(vel_x_idx) : state_trajectory(vel_x_idx, control_col + 1);
 
     const float ref_x = static_cast<float>(in_point.pose.position.x);
     const float ref_y = static_cast<float>(in_point.pose.position.y);
@@ -773,8 +802,8 @@ FirstOrderDubinsMppiOptimizationResult FirstOrderDubinsMppiInterface::optimizeTr
     out_point.pose.position.z = in_point.pose.position.z;
     out_point.pose.orientation = quaternionFromYaw(tracked_yaw);
     out_point.longitudinal_velocity_mps = tracked_v;
-    out_point.acceleration_mps2 = u_opt_traj(accel_cmd_idx, col);
-    out_point.front_wheel_angle_rad = u_opt_traj(steer_cmd_idx, col);
+    out_point.acceleration_mps2 = u_opt_traj(accel_cmd_idx, control_col);
+    out_point.front_wheel_angle_rad = u_opt_traj(steer_cmd_idx, control_col);
     ++i;
   }
 

--- a/planning/autoware_mppi_optimizer/src/first_order_dubins/first_order_dubins_mppi_interface.cu
+++ b/planning/autoware_mppi_optimizer/src/first_order_dubins/first_order_dubins_mppi_interface.cu
@@ -761,14 +761,11 @@ FirstOrderDubinsMppiOptimizationResult FirstOrderDubinsMppiInterface::optimizeTr
   DYN::state_array x_final = DYN::state_array::Zero();
   DYN::state_array x_final_dot = DYN::state_array::Zero();
   DYN::output_array y_final = DYN::output_array::Zero();
-  const bool have_final_state = n_state > 0 && n_ctrl > 0;
-  if (have_final_state) {
-    DYN::state_array x_tail = state_trajectory.col(n_state - 1);
-    DYN::control_array u_tail = u_opt_traj.col(n_ctrl - 1);
-    impl_->model.enforceConstraints(x_tail, u_tail);
-    impl_->model.step(
-      x_tail, x_final, x_final_dot, u_tail, y_final, static_cast<float>(n_state - 1), kDt);
-  }
+  DYN::state_array x_tail = state_trajectory.col(n_state - 1);
+  DYN::control_array u_tail = u_opt_traj.col(n_ctrl - 1);
+  impl_->model.enforceConstraints(x_tail, u_tail);
+  impl_->model.step(
+    x_tail, x_final, x_final_dot, u_tail, y_final, static_cast<float>(n_state - 1), kDt);
 
   float max_pos_delta = 0.0F;
   float max_vel_delta = 0.0F;
@@ -779,7 +776,7 @@ FirstOrderDubinsMppiOptimizationResult FirstOrderDubinsMppiInterface::optimizeTr
     }
     const auto & in_point = input.points[i];
     const int control_col = static_cast<int>(i);
-    const bool use_final = (control_col + 1 >= n_state) && have_final_state;
+    const bool use_final = control_col + 1 >= n_state;
 
     const float tracked_x =
       use_final ? x_final(pos_x_idx) : state_trajectory(pos_x_idx, control_col + 1);


### PR DESCRIPTION
Encode left/right route bounds as open border segments with OBB intersection instead of closed-polygon containment, and fix output horizon indexing (post-step state alignment).