### PR TITLE
feat(mppi): add steer-rate cost and retune comfort params

### DIFF
--- a/planning/autoware_mppi_optimizer/config/mppi_optimizer.param.yaml
+++ b/planning/autoware_mppi_optimizer/config/mppi_optimizer.param.yaml
@@ -2,7 +2,9 @@
   ros__parameters:
     # Vehicle actuation dynamics are loaded from $(vehicle_model)_description/config/simulator_model.param.yaml
 
-    # FirstOrderDubinsBicycleCostParams (see first_order_dubins_bicycle_cost.cuh)
+    # MPPI controller / FirstOrderDubinsBicycleCostParams
+    # (see first_order_dubins_mppi_interface.cu, first_order_dubins_bicycle_cost.cuh)
+    lambda: 3000.0
     desired_speed: 2.5
     speed_coeff: 500.0
     track_coeff: 1000.0
@@ -11,11 +13,12 @@
     boundary_threshold: 0.8
     boundary_threshold_left: -1.0
     boundary_threshold_right: -1.0
-    lateral_acceleration_coeff: 300.0
+    lateral_acceleration_coeff: 500.0
     lateral_jerk_coeff: 3000.0
-    longitudinal_jerk_coeff: 10.0
-    accel_cmd_coeff: 0.0
+    longitudinal_jerk_coeff: 1000.0
+    accel_cmd_coeff: 200.0
     steer_cmd_coeff: 1000.0
+    steer_rate_coeff: 5000.0
     goal_pos_coeff: 1000.0
     goal_speed_coeff: 200.0
     goal_yaw_coeff: 500.0

--- a/planning/autoware_mppi_optimizer/include/autoware/mppi_optimizer/first_order_dubins_mppi_cost_params.hpp
+++ b/planning/autoware_mppi_optimizer/include/autoware/mppi_optimizer/first_order_dubins_mppi_cost_params.hpp
@@ -22,6 +22,8 @@ namespace autoware::mppi_optimizer
  * mppi_optimizer.param.yaml */
 struct FirstOrderDubinsMppiCostParams
 {
+  /** Softmax temperature for trajectory weighting (higher = softer weighting). */
+  float lambda{3000.0F};
   float desired_speed{3.0F};
   float speed_coeff{500.0F};
   float track_coeff{1000.0F};
@@ -32,6 +34,7 @@ struct FirstOrderDubinsMppiCostParams
   float boundary_threshold_right{-1.0F};
   float accel_cmd_coeff{0.0F};
   float steer_cmd_coeff{0.0F};
+  float steer_rate_coeff{0.0F};
   float lateral_acceleration_coeff{300.0F};
   float lateral_jerk_coeff{300.0F};
   float longitudinal_jerk_coeff{10.0F};

--- a/planning/autoware_mppi_optimizer/include/mppi/cost_functions/dubins/first_order_dubins_bicycle_cost.cu
+++ b/planning/autoware_mppi_optimizer/include/mppi/cost_functions/dubins/first_order_dubins_bicycle_cost.cu
@@ -12,7 +12,6 @@ using C = FirstOrderDubinsBicycleParams::ControlIndex;
 using mppi::cost::detail::distancePointToSegment;
 using mppi::cost::detail::orientedBoxCorners;
 using mppi::cost::detail::orientedBoxesOverlap;
-using mppi::cost::detail::pointInPolygon;
 using mppi::cost::detail::signedLateralOffsetPointToSegment;
 using mppi::cost::detail::vectorLength;
 
@@ -39,7 +38,7 @@ __host__ __device__ float referenceEndYaw(
 template <class PARAMS_T>
 __host__ __device__ void comfortTerms(
   const PARAMS_T & params, const float * u, const float * y, float & lateral_accel,
-  float & lateral_jerk, float & longitudinal_jerk)
+  float & lateral_jerk, float & longitudinal_jerk, float & steer_rate)
 {
   const float v = y[static_cast<int>(O::BASELINK_VEL_B_X)];
   const float steer = y[static_cast<int>(O::STEER_ANGLE)];
@@ -53,7 +52,7 @@ __host__ __device__ void comfortTerms(
 
   longitudinal_jerk = (accel_cmd - accel) / accel_tau;
 
-  const float steer_rate = (steer_cmd - steer) / steer_tau;
+  steer_rate = (steer_cmd - steer) / steer_tau;
   const float curvature = tanf(steer) / wheel_base;
 #ifdef __CUDA_ARCH__
   const float sec_sq = 1.0F / fmaxf(cosf(steer) * cosf(steer), 1.0E-6F);
@@ -358,17 +357,6 @@ __host__ __device__ bool FirstOrderDubinsBicycleCostImpl<
   DYN_PARAMS_T>::isEgoOutsideDrivableArea(const float x, const float y, const float yaw) const
 {
   (void)yaw;
-  if (num_drivable_vertices_ < 3) {
-    return isOffRoad(x, y);
-  }
-
-  // Rear-axle containment in the drivable polygon. Corner checks are too strict on tight curves.
-  if (pointInPolygon(x, y, drivable_poly_x_, drivable_poly_y_, num_drivable_vertices_)) {
-    return false;
-  }
-
-  // Polygon boundary is piecewise-linear; defer to ref lateral offset near the corridor edge.
-  return isOffRoad(x, y);
 }
 
 template <class CLASS_T, int NUM_TIMESTEPS, class PARAMS_T, class DYN_PARAMS_T>
@@ -557,10 +545,13 @@ float FirstOrderDubinsBicycleCostImpl<CLASS_T, NUM_TIMESTEPS, PARAMS_T, DYN_PARA
   float lateral_accel = 0.0F;
   float lateral_jerk = 0.0F;
   float longitudinal_jerk = 0.0F;
-  comfortTerms(this->params_, u.data(), y.data(), lateral_accel, lateral_jerk, longitudinal_jerk);
+  float steer_rate = 0.0F;
+  comfortTerms(
+    this->params_, u.data(), y.data(), lateral_accel, lateral_jerk, longitudinal_jerk, steer_rate);
   return this->params_.lateral_acceleration_coeff * std::abs(lateral_accel) +
          this->params_.lateral_jerk_coeff * std::abs(lateral_jerk) +
-         this->params_.longitudinal_jerk_coeff * std::abs(longitudinal_jerk);
+         this->params_.longitudinal_jerk_coeff * std::abs(longitudinal_jerk) +
+         this->params_.steer_rate_coeff * std::abs(steer_rate);
 }
 
 template <class CLASS_T, int NUM_TIMESTEPS, class PARAMS_T, class DYN_PARAMS_T>
@@ -572,10 +563,12 @@ FirstOrderDubinsBicycleCostImpl<CLASS_T, NUM_TIMESTEPS, PARAMS_T, DYN_PARAMS_T>:
   float lateral_accel = 0.0F;
   float lateral_jerk = 0.0F;
   float longitudinal_jerk = 0.0F;
-  comfortTerms(this->params_, u, y, lateral_accel, lateral_jerk, longitudinal_jerk);
+  float steer_rate = 0.0F;
+  comfortTerms(this->params_, u, y, lateral_accel, lateral_jerk, longitudinal_jerk, steer_rate);
   return this->params_.lateral_acceleration_coeff * fabsf(lateral_accel) +
          this->params_.lateral_jerk_coeff * fabsf(lateral_jerk) +
-         this->params_.longitudinal_jerk_coeff * fabsf(longitudinal_jerk);
+         this->params_.longitudinal_jerk_coeff * fabsf(longitudinal_jerk) +
+         this->params_.steer_rate_coeff * fabsf(steer_rate);
 }
 
 template <class CLASS_T, int NUM_TIMESTEPS, class PARAMS_T, class DYN_PARAMS_T>

--- a/planning/autoware_mppi_optimizer/include/mppi/cost_functions/dubins/first_order_dubins_bicycle_cost.cu
+++ b/planning/autoware_mppi_optimizer/include/mppi/cost_functions/dubins/first_order_dubins_bicycle_cost.cu
@@ -12,6 +12,7 @@ using C = FirstOrderDubinsBicycleParams::ControlIndex;
 using mppi::cost::detail::distancePointToSegment;
 using mppi::cost::detail::orientedBoxCorners;
 using mppi::cost::detail::orientedBoxesOverlap;
+using mppi::cost::detail::pointInPolygon;
 using mppi::cost::detail::signedLateralOffsetPointToSegment;
 using mppi::cost::detail::vectorLength;
 
@@ -357,6 +358,17 @@ __host__ __device__ bool FirstOrderDubinsBicycleCostImpl<
   DYN_PARAMS_T>::isEgoOutsideDrivableArea(const float x, const float y, const float yaw) const
 {
   (void)yaw;
+  if (num_drivable_vertices_ < 3) {
+    return isOffRoad(x, y);
+  }
+
+  // Rear-axle containment in the drivable polygon. Corner checks are too strict on tight curves.
+  if (pointInPolygon(x, y, drivable_poly_x_, drivable_poly_y_, num_drivable_vertices_)) {
+    return false;
+  }
+
+  // Polygon boundary is piecewise-linear; defer to ref lateral offset near the corridor edge.
+  return isOffRoad(x, y);
 }
 
 template <class CLASS_T, int NUM_TIMESTEPS, class PARAMS_T, class DYN_PARAMS_T>

--- a/planning/autoware_mppi_optimizer/include/mppi/cost_functions/dubins/first_order_dubins_bicycle_cost.cuh
+++ b/planning/autoware_mppi_optimizer/include/mppi/cost_functions/dubins/first_order_dubins_bicycle_cost.cuh
@@ -27,6 +27,8 @@ struct FirstOrderDubinsBicycleCostParams : public CostParams<2>
   float boundary_threshold_right = -1.0F;
   float accel_cmd_coeff = 0.0F;
   float steer_cmd_coeff = 0.0F;
+  /** Direct cost on steer rate [rad/s]: (steer_cmd - steer) / steer_time_constant. */
+  float steer_rate_coeff = 0.0F;
   float lateral_acceleration_coeff = 300.0F;
   float lateral_jerk_coeff = 300.0F;
   float longitudinal_jerk_coeff = 10.0F;

--- a/planning/autoware_mppi_optimizer/src/first_order_dubins/first_order_dubins_mppi_interface.cu
+++ b/planning/autoware_mppi_optimizer/src/first_order_dubins/first_order_dubins_mppi_interface.cu
@@ -418,10 +418,8 @@ struct FirstOrderDubinsMppiInterface::Impl
     // Steer exploration scales with wheelbase: larger vehicles need larger delta-steer to change
     // yaw.
     constexpr float kReferenceWheelBase = 0.32F;
-    constexpr float kReferenceSteerStd = 0.03F;
-    const float steer_std = std::clamp(
-      kReferenceSteerStd * (vehicle_params.wheel_base / kReferenceWheelBase), kReferenceSteerStd,
-      0.12F);
+    constexpr float kReferenceSteerStd = 0.001F;
+    const float steer_std = kReferenceSteerStd * (vehicle_params.wheel_base / kReferenceWheelBase);
 
     sp.std_dev[static_cast<int>(FirstOrderDubinsBicycleParams::ControlIndex::STEER_CMD)] =
       steer_std;

--- a/planning/autoware_mppi_optimizer/src/first_order_dubins/first_order_dubins_mppi_interface.cu
+++ b/planning/autoware_mppi_optimizer/src/first_order_dubins/first_order_dubins_mppi_interface.cu
@@ -53,7 +53,6 @@ constexpr int kMppiHorizon = 80;
 constexpr int kRefHorizon = kMppiHorizon;
 constexpr float kDt = 0.1F;
 constexpr int kNumRollouts = 32 * 1024;
-constexpr float kLambda = 1500.0F;
 constexpr float kInitArcLength = 1.5F;
 constexpr size_t kTrackingIndexResetThreshold = 15U;
 // constexpr int kMaxVizRollouts = 200;  // rollout viz disabled
@@ -84,6 +83,7 @@ void applyUserCostParams(
   cost_params.boundary_threshold_right = user.boundary_threshold_right;
   cost_params.accel_cmd_coeff = user.accel_cmd_coeff;
   cost_params.steer_cmd_coeff = user.steer_cmd_coeff;
+  cost_params.steer_rate_coeff = user.steer_rate_coeff;
   cost_params.lateral_acceleration_coeff = user.lateral_acceleration_coeff;
   cost_params.lateral_jerk_coeff = user.lateral_jerk_coeff;
   cost_params.longitudinal_jerk_coeff = user.longitudinal_jerk_coeff;
@@ -295,7 +295,7 @@ void selectTopRolloutIndices(
 
 void buildRolloutVisualization(
   Mppi & controller, SAMPLER & sampler, DYN & model, const DYN::state_array & x_at_optimization,
-  FirstOrderDubinsMppiDebug & debug)
+  const float lambda, FirstOrderDubinsMppiDebug & debug)
 {
   const Mppi::state_trajectory state_trajectory = controller.getActualStateSeq();
   fillOptimalHorizonPoints(state_trajectory, debug.optimal_horizon);
@@ -311,7 +311,7 @@ void buildRolloutVisualization(
   for (size_t i = 0; i < normalized_weights.size(); ++i) {
     const float w = static_cast<float>(importance(static_cast<int>(i)));
     normalized_weights[i] = (normalizer > 0.0F) ? w / normalizer : 0.0F;
-    raw_costs[i] = (w > 0.0F) ? (baseline - kLambda * std::log(w)) : (baseline + 1.0e30F);
+    raw_costs[i] = (w > 0.0F) ? (baseline - lambda * std::log(w)) : (baseline + 1.0e30F);
   }
 
   std::vector<int> rollout_indices;
@@ -429,7 +429,8 @@ struct FirstOrderDubinsMppiInterface::Impl
     sampler = SAMPLER(sp);
 
     controller = std::make_unique<Mppi>(
-      &model, &cost, &feedback, &sampler, kDt, 1, kLambda, 0.0F, kMppiHorizon, u_nom);
+      &model, &cost, &feedback, &sampler, kDt, 1, user_cost_params_.lambda, 0.0F, kMppiHorizon,
+      u_nom);
     auto cp = controller->getParams();
     cp.dynamics_rollout_dim_ = dim3(32, 2, 1);
     cp.cost_rollout_dim_ = dim3(32, 2, 1);
@@ -451,7 +452,7 @@ struct FirstOrderDubinsMppiInterface::Impl
       "wheel_base=%.2f, max_steer=%.2f, steer_std=%.3f, acc_tau=%.2f, steer_tau=%.2f, "
       "steer_rate_lim=%.2f, vel_rate_lim=%.2f, ego=%.2fx%.2f, axle_to_center=%.2f, "
       "desired_speed=%.2f, boundary_threshold=%.2f, obs_margin=%.2f)",
-      kMppiHorizon, kNumRollouts, kDt, kLambda, vehicle_params.wheel_base,
+      kMppiHorizon, kNumRollouts, kDt, user_cost_params_.lambda, vehicle_params.wheel_base,
       vehicle_params.max_steer_angle, steer_std, vehicle_params.acc_time_constant,
       vehicle_params.steer_time_constant, vehicle_params.steer_rate_lim,
       vehicle_params.vel_rate_lim, vehicle_params.ego_length, vehicle_params.ego_width,

--- a/planning/autoware_mppi_optimizer/src/first_order_dubins_mppi_cost_params_ros.cpp
+++ b/planning/autoware_mppi_optimizer/src/first_order_dubins_mppi_cost_params_ros.cpp
@@ -62,8 +62,7 @@ FirstOrderDubinsMppiCostParams get_first_order_dubins_mppi_cost_params(
   const rclcpp::Node & node, const std::string & prefix)
 {
   FirstOrderDubinsMppiCostParams params;
-  params.lambda =
-    static_cast<float>(node.get_parameter(param_name(prefix, "lambda")).as_double());
+  params.lambda = static_cast<float>(node.get_parameter(param_name(prefix, "lambda")).as_double());
   params.desired_speed =
     static_cast<float>(node.get_parameter(param_name(prefix, "desired_speed")).as_double());
   params.speed_coeff =

--- a/planning/autoware_mppi_optimizer/src/first_order_dubins_mppi_cost_params_ros.cpp
+++ b/planning/autoware_mppi_optimizer/src/first_order_dubins_mppi_cost_params_ros.cpp
@@ -31,6 +31,7 @@ std::string param_name(const std::string & prefix, const std::string & name)
 void declare_first_order_dubins_mppi_cost_params(rclcpp::Node & node, const std::string & prefix)
 {
   const FirstOrderDubinsMppiCostParams defaults;
+  node.declare_parameter(param_name(prefix, "lambda"), defaults.lambda);
   node.declare_parameter(param_name(prefix, "desired_speed"), defaults.desired_speed);
   node.declare_parameter(param_name(prefix, "speed_coeff"), defaults.speed_coeff);
   node.declare_parameter(param_name(prefix, "track_coeff"), defaults.track_coeff);
@@ -43,6 +44,7 @@ void declare_first_order_dubins_mppi_cost_params(rclcpp::Node & node, const std:
     param_name(prefix, "boundary_threshold_right"), defaults.boundary_threshold_right);
   node.declare_parameter(param_name(prefix, "accel_cmd_coeff"), defaults.accel_cmd_coeff);
   node.declare_parameter(param_name(prefix, "steer_cmd_coeff"), defaults.steer_cmd_coeff);
+  node.declare_parameter(param_name(prefix, "steer_rate_coeff"), defaults.steer_rate_coeff);
   node.declare_parameter(
     param_name(prefix, "lateral_acceleration_coeff"), defaults.lateral_acceleration_coeff);
   node.declare_parameter(param_name(prefix, "lateral_jerk_coeff"), defaults.lateral_jerk_coeff);
@@ -60,6 +62,8 @@ FirstOrderDubinsMppiCostParams get_first_order_dubins_mppi_cost_params(
   const rclcpp::Node & node, const std::string & prefix)
 {
   FirstOrderDubinsMppiCostParams params;
+  params.lambda =
+    static_cast<float>(node.get_parameter(param_name(prefix, "lambda")).as_double());
   params.desired_speed =
     static_cast<float>(node.get_parameter(param_name(prefix, "desired_speed")).as_double());
   params.speed_coeff =
@@ -80,6 +84,8 @@ FirstOrderDubinsMppiCostParams get_first_order_dubins_mppi_cost_params(
     static_cast<float>(node.get_parameter(param_name(prefix, "accel_cmd_coeff")).as_double());
   params.steer_cmd_coeff =
     static_cast<float>(node.get_parameter(param_name(prefix, "steer_cmd_coeff")).as_double());
+  params.steer_rate_coeff =
+    static_cast<float>(node.get_parameter(param_name(prefix, "steer_rate_coeff")).as_double());
   params.lateral_acceleration_coeff = static_cast<float>(
     node.get_parameter(param_name(prefix, "lateral_acceleration_coeff")).as_double());
   params.lateral_jerk_coeff =


### PR DESCRIPTION
Penalize instantaneous steer rate in comfort cost, expose lambda and steer_rate_coeff via ROS params, and raise default comfort weights to reduce control jitter.