### PR TITLE
fix(static_obstacle_avoidance): prevent crash on empty path in planCa…

### DIFF
--- a/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/src/scene.cpp
+++ b/planning/behavior_path_planner/autoware_behavior_path_static_obstacle_avoidance_module/src/scene.cpp
@@ -1315,6 +1315,17 @@ CandidateOutput StaticObstacleAvoidanceModule::planCandidate() const
 
   auto shifted_path = data.candidate_path;
 
+  // In rare cases, updateData() returns early (e.g. after a modified goal),
+  // so fillShiftLine() is skipped and shifted_path remains empty.
+  // planWaitingApproval() may still call planCandidate(). Without this guard,
+  // findEgoIndex(shifted_path) would call validateNonEmpty() and throw
+  // std::invalid_argument.
+  if (shifted_path.path.points.empty()) {
+    RCLCPP_WARN_THROTTLE(
+      getLogger(), *clock_, 5000, "Candidate path is empty. Skip planning candidate.");
+    return output;
+  }
+
   if (data.safe_shift_line.empty()) {
     const size_t ego_idx = planner_data_->findEgoIndex(shifted_path.path.points);
     utils::clipPathLength(


### PR DESCRIPTION
## Description

- backport https://github.com/autowarefoundation/autoware_universe/pull/13008

### Original PR description

> ## Description
> 
> Added a guard for empty candidate_path before calling findEgoIndex() / findNearestIndex(), which throw via `validateNonEmpty()`  when the candidate path is empty after a route update (e.g. modified goal).
> 
> Please note that this issue is rare. An empty candidate path is not normally generated under typical conditions.
> 
> ### Problem
> When routes are updated, empty reference route is rarely referred during route transition, which then lead to exceptions in `validateNonEmpty()`.
> Most of these cases were already handled by:
> - https://github.com/autowarefoundation/autoware_universe/pull/10205
> 
> However, `planCandidate()` still had the same unprotected empty-path path.  In practice, this led to the following crash:
> ```
> terminate called after throwing an instance of 'std::invalid_argument'
>   what():  [autoware_motion_utils] validateNonEmpty(): Points is empty.
> ```
