### PR TITLE
feat(map_based_prediction): consider arrow signals in priority stop prediction

### DIFF
--- a/perception/autoware_map_based_prediction/include/autoware/map_based_prediction/priority_predictor/traffic_signal_stop_predictor.hpp
+++ b/perception/autoware_map_based_prediction/include/autoware/map_based_prediction/priority_predictor/traffic_signal_stop_predictor.hpp
@@ -75,6 +75,22 @@ bool findTrafficLightLaneletOnPredictedPath(
   const autoware::experimental::lanelet2_utils::LaneletRTree & road_lanelet_rtree,
   lanelet::ConstLanelet & signal_lanelet);
 
+// The lanelet that carries the traffic-light regulatory element (used for the signal lookup and the
+// stop line) and the lanelet whose turn_direction governs whether the signal requires a stop.
+struct SignalLanelets
+{
+  lanelet::ConstLanelet traffic_light_lanelet;
+  lanelet::ConstLanelet maneuver_lanelet;
+};
+
+// Resolve both lanelets for a lanelet path. The traffic-light lanelet is the first lanelet on the
+// path carrying a traffic light. Its turn_direction is used when present; otherwise (e.g. a shared
+// approach lanelet with no turn_direction) the turn_direction is taken from the first downstream
+// lanelet that has one, so that arrow signals are evaluated against the direction the path actually
+// takes through the intersection (right arrow -> keep the right-turn path, stop straight/left).
+std::optional<SignalLanelets> resolveSignalLanelets(
+  const lanelet::routing::LaneletPath & lanelet_path);
+
 bool evaluateSignalStopRequirement(
   const lanelet::ConstLanelet & lanelet, const std::optional<TrafficLightGroup> & signal);
 

--- a/perception/autoware_map_based_prediction/lib/priority_predictor/traffic_signal_stop_predictor.cpp
+++ b/perception/autoware_map_based_prediction/lib/priority_predictor/traffic_signal_stop_predictor.cpp
@@ -309,6 +309,31 @@ double weakenConfidenceInLaneChange(const Maneuver & maneuver, const double stop
   return maneuver == Maneuver::LANE_FOLLOW ? stop_weight : stop_weight * lane_change_penalty;
 }
 
+std::optional<SignalLanelets> resolveSignalLanelets(
+  const lanelet::routing::LaneletPath & lanelet_path)
+{
+  std::optional<lanelet::ConstLanelet> traffic_light_lanelet;
+  for (const auto & way_lanelet : lanelet_path) {
+    if (!traffic_light_lanelet) {
+      if (!hasTrafficLight(way_lanelet)) {
+        continue;
+      }
+      traffic_light_lanelet = way_lanelet;
+      if (way_lanelet.hasAttribute("turn_direction")) {
+        return SignalLanelets{*traffic_light_lanelet, way_lanelet};
+      }
+      continue;
+    }
+    if (way_lanelet.hasAttribute("turn_direction")) {
+      return SignalLanelets{*traffic_light_lanelet, way_lanelet};
+    }
+  }
+  if (traffic_light_lanelet) {
+    return SignalLanelets{*traffic_light_lanelet, *traffic_light_lanelet};
+  }
+  return std::nullopt;
+}
+
 namespace
 {
 
@@ -353,18 +378,24 @@ std::vector<PredictedPath> addTrafficSignalStopHypotheses(
       continue;
     }
 
-    lanelet::ConstLanelet target_lanelet_signal_object;
-    if (!findTrafficLightLaneletOnPredictedPath(
-          predicted_path, road_lanelet_rtree, target_lanelet_signal_object)) {
+    constexpr double sample_interval_m = 3.0;
+    const auto lanelet_path =
+      buildLaneletPathFromPredictedPath(predicted_path, road_lanelet_rtree, sample_interval_m);
+    const auto signal_lanelets = resolveSignalLanelets(lanelet_path);
+    if (!signal_lanelets) {
       continue;
     }
+    const lanelet::ConstLanelet & target_lanelet_signal_object =
+      signal_lanelets->traffic_light_lanelet;
     const std::optional<TrafficLightGroup> signal_status =
       getSignalForLanelet(traffic_signal_id_map, target_lanelet_signal_object);
     const std::optional<lanelet::ConstLineString3d> related_stop_line =
       getStopLineOrEntryEdge(target_lanelet_signal_object);
 
+    // Evaluate the arrow/turn logic against the lanelet the path actually turns through, so that a
+    // right arrow keeps the right-turn path while still stopping straight/left paths.
     const bool signal_requires_stop =
-      evaluateSignalStopRequirement(target_lanelet_signal_object, signal_status);
+      evaluateSignalStopRequirement(signal_lanelets->maneuver_lanelet, signal_status);
     const bool stop_line_ahead =
       related_stop_line && hasStopLineAhead(
                              object.kinematics.pose_with_covariance.pose.position,

--- a/perception/autoware_map_based_prediction/test/map_based_prediction/test_trafficlight_priority.cpp
+++ b/perception/autoware_map_based_prediction/test/map_based_prediction/test_trafficlight_priority.cpp
@@ -309,6 +309,37 @@ TEST(PriorityUtils, SignalStopNotRequiredForMatchingArrow)
   EXPECT_TRUE(evaluateSignalStopRequirement(right_lane, signal));
 }
 
+TEST(PriorityUtils, ManeuverLaneletTakenFromDownstreamTurnWhenApproachHasNoTurnDirection)
+{
+  lanelet::Id id = 5600;
+  auto approach = makeLanelet(id, 0.0);  // carries the traffic light, no turn_direction
+  auto right_turn = makeLanelet(id, 5.0);
+  right_turn.setAttribute("turn_direction", "right");
+  attachTrafficLight(approach, id, makeStopLine(id, 1.0));
+
+  const lanelet::routing::LaneletPath path(lanelet::ConstLanelets{approach, right_turn});
+  const auto resolved = resolveSignalLanelets(path);
+  ASSERT_TRUE(resolved.has_value());
+  // Stop line stays on the traffic-light lanelet, turn_direction comes from the turn lanelet.
+  EXPECT_EQ(resolved->traffic_light_lanelet.id(), approach.id());
+  EXPECT_EQ(resolved->maneuver_lanelet.id(), right_turn.id());
+}
+
+TEST(PriorityUtils, ManeuverLaneletIsTrafficLightLaneletWhenItHasTurnDirection)
+{
+  lanelet::Id id = 5700;
+  const auto approach = makeLanelet(id, 0.0);
+  auto junction = makeLanelet(id, 5.0);
+  junction.setAttribute("turn_direction", "straight");
+  attachTrafficLight(junction, id, makeStopLine(id, 6.0));
+
+  const lanelet::routing::LaneletPath path(lanelet::ConstLanelets{approach, junction});
+  const auto resolved = resolveSignalLanelets(path);
+  ASSERT_TRUE(resolved.has_value());
+  EXPECT_EQ(resolved->traffic_light_lanelet.id(), junction.id());
+  EXPECT_EQ(resolved->maneuver_lanelet.id(), junction.id());
+}
+
 TEST(PriorityUtils, GetStopLineFromTrafficLight)
 {
   lanelet::Id id = 6100;


### PR DESCRIPTION
## Description

Makes the priority (traffic-signal stop) prediction consider **arrow signals**.

Previously the stop requirement was evaluated using the `turn_direction` of the lanelet that carries the traffic light. When the light is referenced by a shared approach lanelet with no `turn_direction`, the straight / left / right predicted paths all resolved to that same lanelet, so arrow signals were ignored and **every path was cut on red**.

Now, for each predicted path, two lanelets are resolved separately:

- **traffic_light_lanelet** — the first lanelet on the path carrying a traffic light; used for the signal lookup and the stop line (unchanged).
- **maneuver_lanelet** — the lanelet whose `turn_direction` drives the arrow decision: the traffic-light lanelet's own `turn_direction` when present, otherwise the first downstream lanelet on the path that has one.

The stop requirement (`isTrafficSignalStop`) is then evaluated against the maneuver lanelet. So, e.g., with a **right arrow**:

| Predicted path direction | Result |
| --- | --- |
| Right-turn lane | not cut (proceeds) |
| Straight lane | cut at stop line |
| Left lane | cut at stop line |

When the traffic-light lanelet itself carries a `turn_direction`, behavior is identical to before (backward compatible).

## Changes

- `resolveSignalLanelets()` returning `{traffic_light_lanelet, maneuver_lanelet}`
- Evaluate `isTrafficSignalStop` against the maneuver lanelet; stop line / signal lookup stay on the traffic-light lanelet
- Reuses the existing `autoware::traffic_light_utils::isTrafficSignalStop` arrow logic

## Tests

- Added unit tests for maneuver-lanelet resolution (downstream turn lanelet vs. traffic-light lanelet carrying the turn_direction)
- `colcon build` + `colcon test` pass on the base (`feat/v0.64/e2e`): 45 tests, 0 failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)
