### PR TITLE
fix(traffic_light_stop): floor scan length with min_lookahead_distance and wire stop time step

### DIFF
--- a/common/autoware_traffic_light_compliance_checker/README.md
+++ b/common/autoware_traffic_light_compliance_checker/README.md
@@ -23,7 +23,7 @@ The `traffic_light_compliance_checker` package provides a deterministic validati
 The execution flow follows a sequential logical from signal processing & filtering down to stop line interaction evaluations:
 
 1. **Filter signals and update status tracker:** Feeds raw perception data into the status tracker to clean up transient noise and tracking dropouts.
-2. **Generate Geometric Trajectory Linestring:** Removes path points situated behind the ego vehicle, clamps the forward path length at the maximum required stop distance, and extends trajectory end to account for ego front offset.
+2. **Generate Geometric Trajectory Linestring:** Removes path points situated behind the ego vehicle, keeps the full forward path until the first planned stop (`v≈0`), and extends trajectory end to account for ego front offset.
 3. **Extract and group map stop lines:** Sorts overlapping intersection lines into separate evaluation queues for red and amber constraints.
 4. **Evaluate Stop Line Violations:** Checks the trajectory linesting against active stop lines, records detected violations and generate compliance result.
 
@@ -35,7 +35,7 @@ skinparam backgroundColor #WHITE
 start
 
 :Filter signals and update status tracker;<<#LightBlue>>
-:Generate Trajectory Linestring\n(Cull backward points & clamp at max stop distance);<<#LightBlue>>
+:Generate Trajectory Linestring\n(Cull backward points; keep until first planned stop);<<#LightBlue>>
 :Extend trajectory linestring\n(Add physical front bumper footprint offset);<<#LightBlue>>
 :Extract and group map stop lines\n(Categorize into RED vs. AMBER targets);<<#LightBlue>>
 

--- a/common/autoware_traffic_light_compliance_checker/README.md
+++ b/common/autoware_traffic_light_compliance_checker/README.md
@@ -23,7 +23,7 @@ The `traffic_light_compliance_checker` package provides a deterministic validati
 The execution flow follows a sequential logical from signal processing & filtering down to stop line interaction evaluations:
 
 1. **Filter signals and update status tracker:** Feeds raw perception data into the status tracker to clean up transient noise and tracking dropouts.
-2. **Generate Geometric Trajectory Linestring:** Removes path points situated behind the ego vehicle, keeps the full forward path until the first planned stop (`v≈0`), and extends trajectory end to account for ego front offset.
+2. **Generate Geometric Trajectory Linestring:** Removes path points situated behind the ego vehicle, clamps the forward path length at `max(min_lookahead_distance, comfortable_stop_distance + stop_overshoot_margin)` (or until the first planned stop), and extends trajectory end to account for ego front offset.
 3. **Extract and group map stop lines:** Sorts overlapping intersection lines into separate evaluation queues for red and amber constraints.
 4. **Evaluate Stop Line Violations:** Checks the trajectory linesting against active stop lines, records detected violations and generate compliance result.
 
@@ -35,7 +35,7 @@ skinparam backgroundColor #WHITE
 start
 
 :Filter signals and update status tracker;<<#LightBlue>>
-:Generate Trajectory Linestring\n(Cull backward points; keep until first planned stop);<<#LightBlue>>
+:Generate Trajectory Linestring\n(Cull backward points & clamp at max(min lookahead, stop distance));<<#LightBlue>>
 :Extend trajectory linestring\n(Add physical front bumper footprint offset);<<#LightBlue>>
 :Extract and group map stop lines\n(Categorize into RED vs. AMBER targets);<<#LightBlue>>
 
@@ -125,6 +125,7 @@ The interfaces pass inputs and output results through the following standard dat
 | `crossing_time_limit`                          | `double` | Maximum duration allowed for the vehicle to clear an amber light intersection (seconds).                   |
 | `stop_overshoot_margin`                        | `double` | Allowed physical distance buffer beyond a stop line for a stopped vehicle (meters).                        |
 | `allow_if_cannot_stop_distance`                | `double` | Distance within which a crossing trajectory is allowed when ego cannot stop before the stop line (meters). |
+| `min_lookahead_distance`                       | `double` | Minimum forward trajectory length to scan for stop lines, even at low ego speed (meters).                  |
 | `stable_duration_threshold_red`                | `double` | Required continuous duration for a `RED` state to be confirmed as valid (seconds).                         |
 | `stable_duration_threshold_amber`              | `double` | Required continuous duration for an `AMBER` state to be confirmed as valid (seconds).                      |
 | `stable_duration_threshold_unknown`            | `double` | Required continuous duration for an `UNKNOWN` state to be confirmed as valid (seconds).                    |

--- a/common/autoware_traffic_light_compliance_checker/include/autoware/traffic_light_compliance_checker/structs.hpp
+++ b/common/autoware_traffic_light_compliance_checker/include/autoware/traffic_light_compliance_checker/structs.hpp
@@ -103,6 +103,7 @@ struct Parameters
   bool treat_unknown_light_as_red_light;
   double stop_overshoot_margin;
   double allow_if_cannot_stop_distance;
+  double min_lookahead_distance;
   double stable_duration_threshold_red;
   double stable_duration_threshold_amber;
   double stable_duration_threshold_unknown;

--- a/common/autoware_traffic_light_compliance_checker/src/traffic_light_compliance_checker.cpp
+++ b/common/autoware_traffic_light_compliance_checker/src/traffic_light_compliance_checker.cpp
@@ -281,13 +281,9 @@ TrafficLightComplianceChecker::check_with_filtered_signals(
 
   std::vector<autoware_planning_msgs::msg::TrajectoryPoint> trajectory;
   lanelet::BasicLineString2d trajectory_ls;
-  const auto ego_stopping_distance = autoware::motion_utils::calculate_stop_distance(
-    input.current_velocity, input.current_acceleration,
-    params_.checked_trajectory_length.deceleration_limit,
-    params_.checked_trajectory_length.jerk_limit, params_.delay_response_time);
-  // add the stop_overshoot_margin to not skip points beyond the stop line but within the margin
-  const auto max_trajectory_length =
-    ego_stopping_distance.value_or(0.0) + params_.stop_overshoot_margin;
+  // Check the full forward trajectory until the first planned stop (v≈0).
+  // Do not cap by comfortable ego stopping distance: at low ego_v that horizon
+  // shrinks to <1 m and misses red stop lines a few meters ahead.
   auto length = 0.0;
   auto backward_length = 0.0;
   std::optional<lanelet::BasicPoint2d> stop_point;
@@ -312,7 +308,6 @@ TrafficLightComplianceChecker::check_with_filtered_signals(
       stop_point = trajectory_ls.back();
       break;
     }
-    if (length > max_trajectory_length) break;
   }
 
   if (trajectory_ls.size() < 2) {

--- a/common/autoware_traffic_light_compliance_checker/src/traffic_light_compliance_checker.cpp
+++ b/common/autoware_traffic_light_compliance_checker/src/traffic_light_compliance_checker.cpp
@@ -281,9 +281,17 @@ TrafficLightComplianceChecker::check_with_filtered_signals(
 
   std::vector<autoware_planning_msgs::msg::TrajectoryPoint> trajectory;
   lanelet::BasicLineString2d trajectory_ls;
-  // Check the full forward trajectory until the first planned stop (v≈0).
-  // Do not cap by comfortable ego stopping distance: at low ego_v that horizon
-  // shrinks to <1 m and misses red stop lines a few meters ahead.
+  const auto ego_stopping_distance = autoware::motion_utils::calculate_stop_distance(
+    input.current_velocity, input.current_acceleration,
+    params_.checked_trajectory_length.deceleration_limit,
+    params_.checked_trajectory_length.jerk_limit, params_.delay_response_time);
+  // Floor by min_lookahead_distance so low ego speed still covers nearby stop lines,
+  // while keeping the comfortable-stop cap so far lights are not over-checked
+  // (important for traffic_light_filter which rejects trajectories).
+  // stop_overshoot_margin extends the scan so a stop just past the line is not truncated.
+  const auto max_trajectory_length = std::max(
+    params_.min_lookahead_distance,
+    ego_stopping_distance.value_or(0.0) + params_.stop_overshoot_margin);
   auto length = 0.0;
   auto backward_length = 0.0;
   std::optional<lanelet::BasicPoint2d> stop_point;
@@ -308,6 +316,7 @@ TrafficLightComplianceChecker::check_with_filtered_signals(
       stop_point = trajectory_ls.back();
       break;
     }
+    if (length > max_trajectory_length) break;
   }
 
   if (trajectory_ls.size() < 2) {

--- a/planning/autoware_trajectory_modifier/config/trajectory_modifier.param.yaml
+++ b/planning/autoware_trajectory_modifier/config/trajectory_modifier.param.yaml
@@ -92,6 +92,7 @@
       treat_unknown_light_as_red: false
       overshoot_tolerance: 0.0 # [m]
       allow_if_cannot_stop_distance: 0.0 # [m]
+      min_lookahead_distance: 20.0 # [m] minimum forward length to scan for stop lines even at low ego speed
       th_stable_duration_red: 0.2 # [s]
       th_stable_duration_amber: 0.2 # [s]
       th_amber_rejection_hysteresis: 0.5 # [s]

--- a/planning/autoware_trajectory_modifier/docs/TrafficLightStop.md
+++ b/planning/autoware_trajectory_modifier/docs/TrafficLightStop.md
@@ -80,6 +80,7 @@ The module parameters are grouped under `traffic_light_stop` section of `traject
 | `treat_unknown_light_as_red`    | bool   | false   | When true, unknown lights are treated identically to red lights (rejection on intersection).                      |
 | `overshoot_tolerance`           | double | 0.0     | [m] Maximum distance between the stop line and the trajectory stop point to consider the trajectory feasible.     |
 | `allow_if_cannot_stop_distance` | double | 0.0     | [m] Allow crossing when the ego front is within this distance and ego cannot stop before the stop line.           |
+| `min_lookahead_distance`        | double | 20.0    | [m] Minimum forward length to scan for stop lines even when comfortable stopping distance is shorter.             |
 | `th_stable_duration_red`        | double | 0.2     | [s] Minimum duration a RED light must be seen before it is considered active (only when ego is moving).           |
 | `th_stable_duration_amber`      | double | 0.2     | [s] Minimum duration an AMBER light must be seen before it is considered active (only when ego is moving).        |
 | `th_amber_rejection_hysteresis` | double | 0.5     | [s] Duration to persist an amber rejection state to prevent "flipping" due to minor velocity/distance changes.    |

--- a/planning/autoware_trajectory_modifier/param/trajectory_modifier_parameter_struct.yaml
+++ b/planning/autoware_trajectory_modifier/param/trajectory_modifier_parameter_struct.yaml
@@ -432,6 +432,13 @@ trajectory_modifier_params:
       validation:
         bounds<>: [0.0, 100.0]
       read_only: false
+    min_lookahead_distance:
+      type: double
+      default_value: 20.0
+      description: Minimum forward trajectory length to scan for traffic light stop lines even at low ego speed [m]
+      validation:
+        bounds<>: [0.0, 300.0]
+      read_only: false
     th_stable_duration_red:
       type: double
       default_value: 0.2

--- a/planning/autoware_trajectory_modifier/schema/trajectory_modifier.schema.json
+++ b/planning/autoware_trajectory_modifier/schema/trajectory_modifier.schema.json
@@ -471,6 +471,12 @@
               "default": 0.0,
               "minimum": 0.0
             },
+            "min_lookahead_distance": {
+              "type": "number",
+              "description": "Minimum forward trajectory length to scan for traffic light stop lines even at low ego speed [m]",
+              "default": 20.0,
+              "minimum": 0.0
+            },
             "th_stable_duration_red": {
               "type": "number",
               "description": "Threshold for stable duration of red light [s]",

--- a/planning/autoware_trajectory_modifier/src/trajectory_modifier_plugins/traffic_light_stop.cpp
+++ b/planning/autoware_trajectory_modifier/src/trajectory_modifier_plugins/traffic_light_stop.cpp
@@ -60,6 +60,7 @@ void TrafficLightStop::on_initialize([[maybe_unused]] const TrajectoryModifierPa
   enabled_ = params.use_traffic_light_stop;
   params_ = params.traffic_light_stop;
   stopping_params_ = params.stopping_constraints;
+  trajectory_time_step_ = params.trajectory_time_step;
 
   checker_ =
     std::make_unique<autoware::traffic_light_compliance_checker::TrafficLightComplianceChecker>(
@@ -71,6 +72,7 @@ void TrafficLightStop::update_params([[maybe_unused]] const TrajectoryModifierPa
   enabled_ = params.use_traffic_light_stop;
   params_ = params.traffic_light_stop;
   stopping_params_ = params.stopping_constraints;
+  trajectory_time_step_ = params.trajectory_time_step;
   checker_->update_parameters(to_checker_params(params));
 }
 

--- a/planning/autoware_trajectory_modifier/src/trajectory_modifier_plugins/traffic_light_stop.cpp
+++ b/planning/autoware_trajectory_modifier/src/trajectory_modifier_plugins/traffic_light_stop.cpp
@@ -36,6 +36,7 @@ autoware::traffic_light_compliance_checker::Parameters to_checker_params(
   p.treat_unknown_light_as_red_light = tl_stop_p.treat_unknown_light_as_red;
   p.stop_overshoot_margin = tl_stop_p.overshoot_tolerance;
   p.allow_if_cannot_stop_distance = tl_stop_p.allow_if_cannot_stop_distance;
+  p.min_lookahead_distance = tl_stop_p.min_lookahead_distance;
   p.stable_duration_threshold_red = tl_stop_p.th_stable_duration_red;
   p.stable_duration_threshold_amber = tl_stop_p.th_stable_duration_amber;
   p.amber_rejection_hysteresis_duration = tl_stop_p.th_amber_rejection_hysteresis;

--- a/planning/autoware_trajectory_modifier/tests/test_traffic_light_stop_integration.cpp
+++ b/planning/autoware_trajectory_modifier/tests/test_traffic_light_stop_integration.cpp
@@ -228,6 +228,7 @@ protected:
     tl.treat_amber_light_as_red = false;
     tl.treat_unknown_light_as_red = false;
     tl.overshoot_tolerance = 0.0;
+    tl.min_lookahead_distance = 20.0;
     tl.th_stable_duration_red = 0.0;
     tl.th_stable_duration_amber = 0.0;
     tl.th_amber_rejection_hysteresis = 0.0;

--- a/planning/autoware_trajectory_validator/config/trajectory_validator.param.yaml
+++ b/planning/autoware_trajectory_validator/config/trajectory_validator.param.yaml
@@ -103,6 +103,7 @@
       treat_unknown_light_as_red_light: false # [-] when true, unknown lights are handled like red lights
       stop_overshoot_margin: 0.5 # [m] maximum distance between the stop line and the trajectory stop point to consider the trajectory feasible
       allow_if_cannot_stop_distance: 0.0 # [m] allow crossing a stop line within this distance if ego cannot stop before the line plus its margin
+      min_lookahead_distance: 20.0 # [m] minimum forward length to scan for stop lines even at low ego speed
       stable_duration_threshold_red: 0.0 # [s] minimum duration a red light must be seen before it is considered active
       stable_duration_threshold_amber: 0.0 # [s] minimum duration an amber light must be seen before it is considered active
       stable_duration_threshold_unknown: 0.0 # [s] minimum duration an unknown light must be seen before it is considered active

--- a/planning/autoware_trajectory_validator/docs/TrafficLightFilter.md
+++ b/planning/autoware_trajectory_validator/docs/TrafficLightFilter.md
@@ -78,6 +78,7 @@ The filter utilizes the following data from the `FilterContext`:
 | `traffic_light.treat_unknown_light_as_red_light`             | bool   | false   | When true, unknown lights are treated identically to red lights (rejection on intersection).                      |
 | `traffic_light.stop_overshoot_margin`                        | double | 0.5     | [m] Maximum distance between the stop line and the trajectory stop point to consider the trajectory feasible.     |
 | `traffic_light.allow_if_cannot_stop_distance`                | double | 0.0     | [m] Allow crossing when the ego front is within this distance and ego cannot stop before the stop line.           |
+| `traffic_light.min_lookahead_distance`                       | double | 20.0    | [m] Minimum forward length to scan for stop lines even when comfortable stopping distance is shorter.             |
 | `traffic_light.stable_duration_threshold_red`                | double | 0.0     | [s] Minimum duration a RED light must be seen before it is considered active (only when ego is moving).           |
 | `traffic_light.stable_duration_threshold_amber`              | double | 0.0     | [s] Minimum duration an AMBER light must be seen before it is considered active (only when ego is moving).        |
 | `traffic_light.stable_duration_threshold_unknown`            | double | 0.0     | [s] Minimum duration an UNKNOWN light must be seen before it is considered active (only when ego is moving).      |

--- a/planning/autoware_trajectory_validator/param/parameter_struct.yaml
+++ b/planning/autoware_trajectory_validator/param/parameter_struct.yaml
@@ -301,6 +301,13 @@ validator:
       validation:
         bounds<>: [0.0, 100.0]
       read_only: false
+    min_lookahead_distance:
+      type: double
+      default_value: 20.0
+      description: Minimum forward trajectory length to scan for traffic light stop lines even at low ego speed (m)
+      validation:
+        bounds<>: [0.0, 300.0]
+      read_only: false
     stable_duration_threshold_red:
       type: double
       default_value: 0.0

--- a/planning/autoware_trajectory_validator/schema/trajectory_validator.schema.json
+++ b/planning/autoware_trajectory_validator/schema/trajectory_validator.schema.json
@@ -373,6 +373,12 @@
               "default": 0.0,
               "minimum": 0.0
             },
+            "min_lookahead_distance": {
+              "type": "number",
+              "description": "Minimum forward trajectory length to scan for traffic light stop lines even at low ego speed [m].",
+              "default": 20.0,
+              "minimum": 0.0
+            },
             "stable_duration_threshold_red": {
               "type": "number",
               "description": "Minimum duration a RED light must be seen before it is considered active (only when ego is moving) [s].",

--- a/planning/autoware_trajectory_validator/src/filters/traffic_rule/traffic_light_filter.cpp
+++ b/planning/autoware_trajectory_validator/src/filters/traffic_rule/traffic_light_filter.cpp
@@ -84,6 +84,7 @@ autoware::traffic_light_compliance_checker::Parameters to_checker_params(
   p.treat_unknown_light_as_red_light = params.treat_unknown_light_as_red_light;
   p.stop_overshoot_margin = params.stop_overshoot_margin;
   p.allow_if_cannot_stop_distance = params.allow_if_cannot_stop_distance;
+  p.min_lookahead_distance = params.min_lookahead_distance;
   p.stable_duration_threshold_red = params.stable_duration_threshold_red;
   p.stable_duration_threshold_amber = params.stable_duration_threshold_amber;
   p.stable_duration_threshold_unknown = params.stable_duration_threshold_unknown;

--- a/planning/autoware_trajectory_validator/test/plugins/test_traffic_light_filter.cpp
+++ b/planning/autoware_trajectory_validator/test/plugins/test_traffic_light_filter.cpp
@@ -63,6 +63,7 @@ protected:
     node_->declare_parameter("traffic_light.stable_duration_threshold_unknown", 0.0);
     node_->declare_parameter("traffic_light.amber_rejection_hysteresis_duration", 0.0);
     node_->declare_parameter("traffic_light.ego_stopped_velocity_threshold", 0.01);
+    node_->declare_parameter("traffic_light.min_lookahead_distance", 20.0);
     node_->declare_parameter("traffic_light.checked_trajectory_length.deceleration_limit", 999.9);
     node_->declare_parameter("traffic_light.checked_trajectory_length.jerk_limit", 999.9);
 
@@ -78,6 +79,7 @@ protected:
     params.traffic_light.stable_duration_threshold_unknown = 0.0;
     params.traffic_light.amber_rejection_hysteresis_duration = 0.0;
     params.traffic_light.ego_stopped_velocity_threshold = 0.01;
+    params.traffic_light.min_lookahead_distance = 20.0;
     params.traffic_light.checked_trajectory_length.deceleration_limit = 999.9;
     params.traffic_light.checked_trajectory_length.jerk_limit = 999.9;
     filter_->update_parameters(params);


### PR DESCRIPTION
## Summary
- Floor the traffic-light scan length at `min_lookahead_distance` (default 20 m) so red/amber stop lines further ahead are still checked at low ego speed (creeping ~0.5–1 m/s previously limited the scan to ~0.5 m via comfortable-stop distance alone).
- Keep the comfortable-stop + `stop_overshoot_margin` cap so far lights are not over-checked (important for `traffic_light_filter`, which rejects trajectories).
- Assign `trajectory_time_step_` in `TrafficLightStop` init/update so the existing 3-point `replace_trajectory_with_stop_point` fallback uses the configured step.
- Wire the same `min_lookahead_distance` through trajectory modifier (`TrafficLightStop`) and trajectory validator (`TrafficLightFilter`).

## Test plan
- [x] Logging sim: red light + creeping ego; previously `trunc_by_len` / `max_scan_len≈0.5` with `red_stop_lines=1` and `violations=0`; after fix expect violations and stop insertion
- [x] Logging sim: arrived / near-stop fallback path produces a Control-usable stop trajectory
- [ ] CI on this PR

https://github.com/user-attachments/assets/034fc7e2-9fe6-4518-8c07-80954bb728e5

## Notes for reviewers
- After merge, `pilot-auto.x2` `autoware.repos` pin for `autoware/universe` on `feat/v0.64/e2e` should be bumped in a follow-up monorepo PR.
- Launch-side param mirror (modifier + validator): [tier4/autoware_launch.x2#2757](https://github.com/tier4/autoware_launch.x2/pull/2757) (`feat/v4.4/e2e`).

## Related links
- https://github.com/tier4/autoware_launch.x2/pull/2757

Made with [Cursor](https://cursor.com)