### PR TITLE
feat(trajectory_modifier): remove max object velocity threshold for obstacle stop

### DIFF
--- a/common/autoware_traffic_light_compliance_checker/README.md
+++ b/common/autoware_traffic_light_compliance_checker/README.md
@@ -5,7 +5,6 @@ The `traffic_light_compliance_checker` package provides a deterministic validati
 ## Core Features
 
 1. **Signal State Tracking (`TrafficLightStatusTracker`)**
-
    - Eliminates perception jitter and signal flickering by maintaining a temporal state history for each traffic light group ID.
    - Leverages stable duration thresholds before validating a transition to `RED` or `AMBER`.
    - Utilizes a hysteresis buffer to sustain known states during transient object occlusions.

--- a/planning/autoware_minimum_rule_based_planner/config/minimum_rule_based_planner.param.yaml
+++ b/planning/autoware_minimum_rule_based_planner/config/minimum_rule_based_planner.param.yaml
@@ -64,7 +64,6 @@
 
       objects:
         object_types: ["car", "truck", "bus", "trailer", "motorcycle", "bicycle", "pedestrian", "hazard"] # object types to consider for obstacle stop
-        max_velocity_th: 3.0     # maximum velocity threshold for target object [m/s]
         stopped_velocity_th: 0.3 # velocity threshold for target object to be considered as stopped [m/s]
         max_lateral_velocity_th: 1.0 # maximum lateral velocity threshold for target object [m/s]
         safety_buffer: 0.1       # safety buffer to expand object shape [m]

--- a/planning/autoware_minimum_rule_based_planner/config/minimum_rule_based_planner.param.yaml
+++ b/planning/autoware_minimum_rule_based_planner/config/minimum_rule_based_planner.param.yaml
@@ -85,16 +85,16 @@
       rss_params:
         enable: true
         object_decel:
-          car: 1.5
-          truck: 1.5
-          bus: 1.5
-          trailer: 1.5
+          car: 1.6
+          truck: 1.6
+          bus: 1.6
+          trailer: 1.6
           motorcycle: 2.0
           bicycle: 3.0
           pedestrian: 5.0
-        ego_decel: 2.5           # [m/s^2]
-        reaction_time: 0.2       # [s]
-        safety_margin: 2.0       # [m]
+        ego_decel: 2.0           # [m/s^2]
+        reaction_time: 0.4       # [s]
+        safety_margin: 3.0       # [m]
         lookahead_horizon: 1.5   # [s]
 
     surround_obstacle_stop:

--- a/planning/autoware_minimum_rule_based_planner/param/minimum_rule_based_planner_parameters.yaml
+++ b/planning/autoware_minimum_rule_based_planner/param/minimum_rule_based_planner_parameters.yaml
@@ -232,10 +232,6 @@ minimum_rule_based_planner:
         type: string_array
         default_value: [car, truck, bus, trailer, motorcycle, bicycle, pedestrian, hazard]
         description: object types to consider for obstacle stop
-      max_velocity_th:
-        type: double
-        default_value: 3.0
-        description: maximum velocity threshold for target object [m/s]
       stopped_velocity_th:
         type: double
         default_value: 0.3

--- a/planning/autoware_minimum_rule_based_planner/param/minimum_rule_based_planner_parameters.yaml
+++ b/planning/autoware_minimum_rule_based_planner/param/minimum_rule_based_planner_parameters.yaml
@@ -319,25 +319,25 @@ minimum_rule_based_planner:
       object_decel:
         car:
           type: double
-          default_value: 1.5
+          default_value: 1.6
           description: deceleration for car type objects [m/s^2]
           validation:
             bounds<>: [0.0, 10.0]
         truck:
           type: double
-          default_value: 1.5
+          default_value: 1.6
           description: deceleration for truck type objects [m/s^2]
           validation:
             bounds<>: [0.0, 10.0]
         bus:
           type: double
-          default_value: 1.5
+          default_value: 1.6
           description: deceleration for bus type objects [m/s^2]
           validation:
             bounds<>: [0.0, 10.0]
         trailer:
           type: double
-          default_value: 1.5
+          default_value: 1.6
           description: deceleration for trailer type objects [m/s^2]
           validation:
             bounds<>: [0.0, 10.0]
@@ -361,19 +361,19 @@ minimum_rule_based_planner:
             bounds<>: [0.0, 10.0]
       ego_decel:
         type: double
-        default_value: 2.5
+        default_value: 2.0
         description: deceleration for ego vehicle used in RSS calculation [m/s^2]
         validation:
           bounds<>: [0.0, 10.0]
       reaction_time:
         type: double
-        default_value: 0.2
+        default_value: 0.4
         description: reaction time used in RSS calculation [s]
         validation:
           bounds<>: [0.0, 10.0]
       safety_margin:
         type: double
-        default_value: 2.0
+        default_value: 3.0
         description: safety margin used in RSS calculation [m]
         validation:
           bounds<>: [0.0, 10.0]

--- a/planning/autoware_minimum_rule_based_planner/plugins/obstacle_stop.cpp
+++ b/planning/autoware_minimum_rule_based_planner/plugins/obstacle_stop.cpp
@@ -55,9 +55,8 @@ void ObstacleStop::on_initialize(const MinimumRuleBasedPlannerParams & params)
       params_.pointcloud.clustering.max_size);
 
   object_filter_ = std::make_unique<trajectory_modifier::utils::obstacle_stop::ObjectFilter>(
-    params_.objects.object_types,
-    params_.objects.stopped_velocity_th, params_.objects.max_lateral_velocity_th,
-    params_.objects.safety_buffer);
+    params_.objects.object_types, params_.objects.stopped_velocity_th,
+    params_.objects.max_lateral_velocity_th, params_.objects.safety_buffer);
 
   pub_clustered_pointcloud_ =
     get_node_ptr()->create_publisher<PointCloud2>("~/obstacle_stop/debug/cluster_points", 1);

--- a/planning/autoware_minimum_rule_based_planner/plugins/obstacle_stop.cpp
+++ b/planning/autoware_minimum_rule_based_planner/plugins/obstacle_stop.cpp
@@ -55,7 +55,7 @@ void ObstacleStop::on_initialize(const MinimumRuleBasedPlannerParams & params)
       params_.pointcloud.clustering.max_size);
 
   object_filter_ = std::make_unique<trajectory_modifier::utils::obstacle_stop::ObjectFilter>(
-    params_.objects.object_types, params_.objects.max_velocity_th,
+    params_.objects.object_types,
     params_.objects.stopped_velocity_th, params_.objects.max_lateral_velocity_th,
     params_.objects.safety_buffer);
 

--- a/planning/autoware_minimum_rule_based_planner/plugins/obstacle_stop.hpp
+++ b/planning/autoware_minimum_rule_based_planner/plugins/obstacle_stop.hpp
@@ -59,8 +59,7 @@ public:
     {
       const auto & p = params_.objects;
       object_filter_->set_params(
-        p.object_types, p.stopped_velocity_th, p.max_lateral_velocity_th,
-        p.safety_buffer);
+        p.object_types, p.stopped_velocity_th, p.max_lateral_velocity_th, p.safety_buffer);
     }
 
     {

--- a/planning/autoware_minimum_rule_based_planner/plugins/obstacle_stop.hpp
+++ b/planning/autoware_minimum_rule_based_planner/plugins/obstacle_stop.hpp
@@ -59,7 +59,7 @@ public:
     {
       const auto & p = params_.objects;
       object_filter_->set_params(
-        p.object_types, p.max_velocity_th, p.stopped_velocity_th, p.max_lateral_velocity_th,
+        p.object_types, p.stopped_velocity_th, p.max_lateral_velocity_th,
         p.safety_buffer);
     }
 

--- a/planning/autoware_minimum_rule_based_planner/schema/minimum_rule_based_planner.schema.json
+++ b/planning/autoware_minimum_rule_based_planner/schema/minimum_rule_based_planner.schema.json
@@ -324,12 +324,6 @@
                     "type": "string"
                   }
                 },
-                "max_velocity_th": {
-                  "type": "number",
-                  "description": "Max velocity threshold [m/s]",
-                  "default": 1.0,
-                  "minimum": 0.0
-                },
                 "stopped_velocity_th": {
                   "type": "number",
                   "description": "Velocity threshold for target object to be considered as stopped [m/s]",

--- a/planning/autoware_trajectory_modifier/config/trajectory_modifier.param.yaml
+++ b/planning/autoware_trajectory_modifier/config/trajectory_modifier.param.yaml
@@ -48,7 +48,6 @@
 
       objects:
         object_types: ["car", "truck", "bus", "trailer", "motorcycle", "bicycle", "pedestrian", "hazard"] # object types to consider for obstacle stop
-        max_velocity_th: 3.0      # maximum velocity threshold for target object [m/s]
         stopped_velocity_th: 0.3 # [m/s]
         max_lateral_velocity_th: 1.0 # [m/s] max lateral velocity (w.r.t ego traj) to consider for obstacle stop
         safety_buffer: 0.1 # [m] safety buffer to expand object shape

--- a/planning/autoware_trajectory_modifier/config/trajectory_modifier.param.yaml
+++ b/planning/autoware_trajectory_modifier/config/trajectory_modifier.param.yaml
@@ -69,17 +69,17 @@
       rss_params:
         enable: true
         object_decel:
-          car: 1.5
-          truck: 1.5
-          bus: 1.5
-          trailer: 1.5
+          car: 1.6
+          truck: 1.6
+          bus: 1.6
+          trailer: 1.6
           motorcycle: 2.0
           bicycle: 3.0
           pedestrian: 5.0
           animal: 5.0
-        ego_decel: 2.5 # [m/s^2]
-        reaction_time: 0.2 # [s]
-        safety_margin: 2.0 # [m]
+        ego_decel: 2.0 # [m/s^2]
+        reaction_time: 0.4 # [s]
+        safety_margin: 3.0 # [m]
         lookahead_horizon: 1.5 # [s]
 
     # Traffic Light Stop Plugin Parameters

--- a/planning/autoware_trajectory_modifier/include/autoware/trajectory_modifier/trajectory_modifier_utils/obstacle_stop_utils.hpp
+++ b/planning/autoware_trajectory_modifier/include/autoware/trajectory_modifier/trajectory_modifier_utils/obstacle_stop_utils.hpp
@@ -251,11 +251,9 @@ struct ObjectFilter
    * @param safety_buffer Safety buffer to expand object shape [m].
    */
   ObjectFilter(
-    const std::vector<std::string> & object_type_strings, 
-    const double stopped_velocity_th, const double max_lateral_velocity_th,
-    const double safety_buffer)
-  : 
-    stopped_velocity_th_(stopped_velocity_th),
+    const std::vector<std::string> & object_type_strings, const double stopped_velocity_th,
+    const double max_lateral_velocity_th, const double safety_buffer)
+  : stopped_velocity_th_(stopped_velocity_th),
     max_lateral_velocity_th_(max_lateral_velocity_th),
     safety_buffer_(safety_buffer)
   {
@@ -304,9 +302,8 @@ struct ObjectFilter
    * @brief Update allow-listed types and velocity thresholds without reconstructing the filter.
    */
   void set_params(
-    const std::vector<std::string> & object_type_strings,
-    const double stopped_velocity_th, const double max_lateral_velocity_th,
-    const double safety_buffer)
+    const std::vector<std::string> & object_type_strings, const double stopped_velocity_th,
+    const double max_lateral_velocity_th, const double safety_buffer)
   {
     object_types_.clear();
     for (const auto & object_type_string : object_type_strings) {

--- a/planning/autoware_trajectory_modifier/include/autoware/trajectory_modifier/trajectory_modifier_utils/obstacle_stop_utils.hpp
+++ b/planning/autoware_trajectory_modifier/include/autoware/trajectory_modifier/trajectory_modifier_utils/obstacle_stop_utils.hpp
@@ -246,16 +246,15 @@ struct ObjectFilter
   /**
    * @brief Construct a filter from allowed type names and speed thresholds.
    * @param object_type_strings Allowed object classes (see string_to_object_type).
-   * @param max_velocity_th Remove objects with longitudinal twist.x above this [m/s].
    * @param stopped_velocity_th Used when filtering by target area for "moving" vs stopped.
    * @param max_lateral_velocity_th Lateral speed threshold for the exiting-object heuristic [m/s].
    * @param safety_buffer Safety buffer to expand object shape [m].
    */
   ObjectFilter(
-    const std::vector<std::string> & object_type_strings, const double max_velocity_th,
+    const std::vector<std::string> & object_type_strings, 
     const double stopped_velocity_th, const double max_lateral_velocity_th,
     const double safety_buffer)
-  : max_velocity_th_(max_velocity_th),
+  : 
     stopped_velocity_th_(stopped_velocity_th),
     max_lateral_velocity_th_(max_lateral_velocity_th),
     safety_buffer_(safety_buffer)
@@ -276,8 +275,6 @@ struct ObjectFilter
       std::remove_if(
         objects.objects.begin(), objects.objects.end(),
         [&](const auto & object) {
-          if (object.kinematics.initial_twist_with_covariance.twist.linear.x > max_velocity_th_)
-            return true;
           const auto label =
             object.classification.empty()
               ? ObjectClassification::UNKNOWN
@@ -307,7 +304,7 @@ struct ObjectFilter
    * @brief Update allow-listed types and velocity thresholds without reconstructing the filter.
    */
   void set_params(
-    const std::vector<std::string> & object_type_strings, const double max_velocity_th,
+    const std::vector<std::string> & object_type_strings,
     const double stopped_velocity_th, const double max_lateral_velocity_th,
     const double safety_buffer)
   {
@@ -316,7 +313,6 @@ struct ObjectFilter
       if (string_to_object_type.count(object_type_string) == 0) continue;
       object_types_.emplace(string_to_object_type.at(object_type_string));
     }
-    max_velocity_th_ = max_velocity_th;
     stopped_velocity_th_ = stopped_velocity_th;
     max_lateral_velocity_th_ = max_lateral_velocity_th;
     safety_buffer_ = safety_buffer;
@@ -324,7 +320,6 @@ struct ObjectFilter
 
 private:
   std::unordered_set<ObjectType> object_types_;
-  double max_velocity_th_;
   double stopped_velocity_th_;
   double max_lateral_velocity_th_;
   double safety_buffer_;

--- a/planning/autoware_trajectory_modifier/param/trajectory_modifier_parameter_struct.yaml
+++ b/planning/autoware_trajectory_modifier/param/trajectory_modifier_parameter_struct.yaml
@@ -300,28 +300,28 @@ trajectory_modifier_params:
       object_decel:
         car:
           type: double
-          default_value: 1.5
+          default_value: 1.6
           description: Deceleration for car type objects [m/s^2]
           validation:
             bounds<>: [0.0, 10.0]
           read_only: false
         truck:
           type: double
-          default_value: 1.5
+          default_value: 1.6
           description: Deceleration for truck type objects [m/s^2]
           validation:
             bounds<>: [0.0, 10.0]
           read_only: false
         bus:
           type: double
-          default_value: 1.5
+          default_value: 1.6
           description: Deceleration for bus type objects [m/s^2]
           validation:
             bounds<>: [0.0, 10.0]
           read_only: false
         trailer:
           type: double
-          default_value: 1.5
+          default_value: 1.6
           description: Deceleration for trailer type objects [m/s^2]
           validation:
             bounds<>: [0.0, 10.0]
@@ -356,21 +356,21 @@ trajectory_modifier_params:
           read_only: false
       ego_decel:
         type: double
-        default_value: 4.0
+        default_value: 2.0
         description: Deceleration for ego vehicle [m/s^2]
         validation:
           bounds<>: [0.0, 10.0]
         read_only: false
       reaction_time:
         type: double
-        default_value: 0.2
+        default_value: 0.4
         description: Reaction time to consider for RSS calculation [s]
         validation:
           bounds<>: [0.0, 10.0]
         read_only: false
       safety_margin:
         type: double
-        default_value: 2.0
+        default_value: 3.0
         description: Safety margin to consider for RSS calculation [m]
         validation:
           bounds<>: [0.0, 10.0]

--- a/planning/autoware_trajectory_modifier/param/trajectory_modifier_parameter_struct.yaml
+++ b/planning/autoware_trajectory_modifier/param/trajectory_modifier_parameter_struct.yaml
@@ -203,13 +203,6 @@ trajectory_modifier_params:
         default_value: [car, truck, bus, trailer, motorcycle, bicycle, pedestrian, hazard]
         description: Types of objects to consider for obstacle stop
         read_only: false
-      max_velocity_th:
-        type: double
-        default_value: 5.0
-        description: Maximum velocity threshold for target object to be considered for obstacle stop [m/s]
-        validation:
-          bounds<>: [0.0, 100.0]
-        read_only: false
       stopped_velocity_th:
         type: double
         default_value: 0.25

--- a/planning/autoware_trajectory_modifier/schema/trajectory_modifier.schema.json
+++ b/planning/autoware_trajectory_modifier/schema/trajectory_modifier.schema.json
@@ -226,12 +226,6 @@
                     "type": "string"
                   }
                 },
-                "max_velocity_th": {
-                  "type": "number",
-                  "description": "Maximum velocity threshold for target object [m/s]",
-                  "default": 5.0,
-                  "minimum": 0.0
-                },
                 "stopped_velocity_th": {
                   "type": "number",
                   "description": "Velocity threshold for target object to be considered as stopped [m/s]",

--- a/planning/autoware_trajectory_modifier/src/trajectory_modifier_plugins/obstacle_stop.cpp
+++ b/planning/autoware_trajectory_modifier/src/trajectory_modifier_plugins/obstacle_stop.cpp
@@ -78,8 +78,7 @@ void ObstacleStop::on_initialize(const TrajectoryModifierParams & params)
   {
     const auto & p = params_.objects;
     object_filter_ = std::make_unique<utils::obstacle_stop::ObjectFilter>(
-      p.object_types, p.stopped_velocity_th, p.max_lateral_velocity_th,
-      p.safety_buffer);
+      p.object_types, p.stopped_velocity_th, p.max_lateral_velocity_th, p.safety_buffer);
   }
 
   {
@@ -127,8 +126,7 @@ void ObstacleStop::update_params(const TrajectoryModifierParams & params)
   {
     const auto & p = params_.objects;
     object_filter_->set_params(
-      p.object_types, p.stopped_velocity_th, p.max_lateral_velocity_th,
-      p.safety_buffer);
+      p.object_types, p.stopped_velocity_th, p.max_lateral_velocity_th, p.safety_buffer);
   }
 
   {

--- a/planning/autoware_trajectory_modifier/src/trajectory_modifier_plugins/obstacle_stop.cpp
+++ b/planning/autoware_trajectory_modifier/src/trajectory_modifier_plugins/obstacle_stop.cpp
@@ -78,7 +78,7 @@ void ObstacleStop::on_initialize(const TrajectoryModifierParams & params)
   {
     const auto & p = params_.objects;
     object_filter_ = std::make_unique<utils::obstacle_stop::ObjectFilter>(
-      p.object_types, p.max_velocity_th, p.stopped_velocity_th, p.max_lateral_velocity_th,
+      p.object_types, p.stopped_velocity_th, p.max_lateral_velocity_th,
       p.safety_buffer);
   }
 
@@ -127,7 +127,7 @@ void ObstacleStop::update_params(const TrajectoryModifierParams & params)
   {
     const auto & p = params_.objects;
     object_filter_->set_params(
-      p.object_types, p.max_velocity_th, p.stopped_velocity_th, p.max_lateral_velocity_th,
+      p.object_types, p.stopped_velocity_th, p.max_lateral_velocity_th,
       p.safety_buffer);
   }
 

--- a/planning/autoware_trajectory_modifier/src/trajectory_modifier_utils/obstacle_stop_utils.cpp
+++ b/planning/autoware_trajectory_modifier/src/trajectory_modifier_utils/obstacle_stop_utils.cpp
@@ -334,13 +334,13 @@ ObjectState get_object_state_at_time(
     motion_utils::findNearestSegmentIndex(trajectory_points, predicted_obj_pose.position);
   const auto p1 = trajectory_points.at(nearest_seg).pose.position;
   const auto p2 = trajectory_points.at(nearest_seg + 1).pose.position;
-  auto lon_vel = std::invoke([&]() -> double {
+  auto lon_vel = [&](){
     const auto traj_dir = Eigen::Vector2d(p2.x - p1.x, p2.y - p1.y).normalized();
     const Eigen::Rotation2Dd obj_rot(tf2::getYaw(predicted_obj_pose.orientation));
     const auto obj_vel = object.kinematics.initial_twist_with_covariance.twist.linear;
     const auto obj_vel_vector = obj_rot * Eigen::Vector2d(obj_vel.x, obj_vel.y);
     return std::max(0.0, obj_vel_vector.dot(traj_dir));
-  });
+  }();
 
   const auto obj_polygon = autoware_utils::to_polygon2d(predicted_obj_pose, object.shape);
   auto min_arc_length = std::numeric_limits<double>::max();
@@ -412,14 +412,15 @@ std::optional<CollisionPoint> get_nearest_object_collision(
   geometry_msgs::msg::Point nearest_collision_point;
   bool found_collision = false;
   bool is_dynamic_collision = false;
-  auto curr_arc_length = 0.0;
 
   for (const auto & object : target_objects.objects) {
     auto last_p = trajectory_points.front().pose.position;
+    auto curr_arc_length = 0.0;
     for (const auto & traj_p : trajectory_points) {
       const auto t = rclcpp::Duration(traj_p.time_from_start).seconds();
       if (t > lookahead_horizon) break;
       curr_arc_length += autoware_utils::calc_distance2d(last_p, traj_p.pose.position);
+      last_p = traj_p.pose.position;
       const auto target_ego_vel = traj_p.longitudinal_velocity_mps;
       const auto obj_state = get_object_state_at_time(trajectory_points, object, t);
       const auto [safe, dynamic] =
@@ -432,7 +433,6 @@ std::optional<CollisionPoint> get_nearest_object_collision(
         nearest_collision_point = obj_state.nearest_point;
         is_dynamic_collision = dynamic;
       }
-      last_p = traj_p.pose.position;
       break;
     }
   }

--- a/planning/autoware_trajectory_modifier/src/trajectory_modifier_utils/obstacle_stop_utils.cpp
+++ b/planning/autoware_trajectory_modifier/src/trajectory_modifier_utils/obstacle_stop_utils.cpp
@@ -334,7 +334,7 @@ ObjectState get_object_state_at_time(
     motion_utils::findNearestSegmentIndex(trajectory_points, predicted_obj_pose.position);
   const auto p1 = trajectory_points.at(nearest_seg).pose.position;
   const auto p2 = trajectory_points.at(nearest_seg + 1).pose.position;
-  auto lon_vel = [&](){
+  auto lon_vel = [&]() {
     const auto traj_dir = Eigen::Vector2d(p2.x - p1.x, p2.y - p1.y).normalized();
     const Eigen::Rotation2Dd obj_rot(tf2::getYaw(predicted_obj_pose.orientation));
     const auto obj_vel = object.kinematics.initial_twist_with_covariance.twist.linear;

--- a/planning/autoware_trajectory_modifier/tests/test_obstacle_stop_integration.cpp
+++ b/planning/autoware_trajectory_modifier/tests/test_obstacle_stop_integration.cpp
@@ -239,7 +239,6 @@ protected:
     p.obstacle_tracking.grace_period = 0.5;
 
     p.objects.object_types = {"car"};
-    p.objects.max_velocity_th = 1.0;
 
     p.pointcloud.height_buffer = 0.5;
     p.pointcloud.min_height = 0.2;


### PR DESCRIPTION
This PR removes the max velocity threshold for `obstacle_stop` target objects, and fixes the collision check logic to:
- Properly update last_p when applying RSS check through trajectory points
- Reset accumulated arc_length for each object

It also tunes RSS params to avoid false activation and ensure proper stoppage for front moving targets.

requires https://github.com/tier4/autoware_launch.x2/pull/2755