### PR TITLE
feat(minimum_rule_based_planner): align stamp of trajectory with diffusion planner

### DIFF
--- a/planning/autoware_minimum_rule_based_planner/src/minimum_rule_based_planner.cpp
+++ b/planning/autoware_minimum_rule_based_planner/src/minimum_rule_based_planner.cpp
@@ -365,7 +365,8 @@ std::optional<PathWithLaneId> MinimumRuleBasedPlannerNode::plan_path(const Input
     return *input_data.test_path_with_lane_id_ptr;
   }
   return path_planner_->plan_path(
-    input_data.odometry_ptr->pose.pose, input_data.odometry_ptr->twist.twist.linear.x);
+    input_data.odometry_ptr->pose.pose, input_data.odometry_ptr->twist.twist.linear.x,
+    input_data.odometry_ptr->header.stamp);
 }
 
 Trajectory MinimumRuleBasedPlannerNode::shift_trajectory_to_ego(

--- a/planning/autoware_minimum_rule_based_planner/src/path_planner.cpp
+++ b/planning/autoware_minimum_rule_based_planner/src/path_planner.cpp
@@ -1336,7 +1336,8 @@ bool PathPlanner::update_current_lanelet(const geometry_msgs::msg::Pose & curren
 }
 
 std::optional<PathWithLaneId> PathPlanner::plan_path(
-  const geometry_msgs::msg::Pose & current_pose, const double ego_velocity)
+  const geometry_msgs::msg::Pose & current_pose, const double ego_velocity,
+  const builtin_interfaces::msg::Time & stamp)
 {
   const auto path_length_backward = params_.path_planning.path_length.backward;
   const auto path_length_forward = params_.path_planning.path_length.forward;
@@ -1382,12 +1383,12 @@ std::optional<PathWithLaneId> PathPlanner::plan_path(
     return std::nullopt;
   }
 
-  return generate_path(lanelet_sequence, s_start, s_end, ego_velocity);
+  return generate_path(lanelet_sequence, s_start, s_end, ego_velocity, stamp);
 }
 
 std::optional<PathWithLaneId> PathPlanner::generate_path(
   const lanelet::LaneletSequence & lanelet_sequence, const double s_start, const double s_end,
-  const double ego_velocity)
+  const double ego_velocity, const builtin_interfaces::msg::Time & stamp)
 {
   if (lanelet_sequence.empty()) {
     RCLCPP_ERROR(logger_, "Lanelet sequence is empty");
@@ -1539,7 +1540,7 @@ std::optional<PathWithLaneId> PathPlanner::generate_path(
 
   // Set header which is needed to engage
   finalized_path_with_lane_id.header.frame_id = route_context_.route_frame_id;
-  finalized_path_with_lane_id.header.stamp = clock_->now();
+  finalized_path_with_lane_id.header.stamp = stamp;
 
   const auto [left_bound, right_bound] = utils::get_path_bounds(
     extended_lanelet_sequence,

--- a/planning/autoware_minimum_rule_based_planner/src/path_planner.hpp
+++ b/planning/autoware_minimum_rule_based_planner/src/path_planner.hpp
@@ -18,10 +18,10 @@
 #include "type_alias.hpp"
 
 #include <autoware_utils_debug/time_keeper.hpp>
+#include <builtin_interfaces/msg/time.hpp>
 #include <rclcpp/clock.hpp>
 #include <rclcpp/logger.hpp>
 
-#include <builtin_interfaces/msg/time.hpp>
 #include <lanelet2_core/geometry/Lanelet.h>
 #include <lanelet2_routing/RoutingGraph.h>
 #include <lanelet2_traffic_rules/TrafficRules.h>

--- a/planning/autoware_minimum_rule_based_planner/src/path_planner.hpp
+++ b/planning/autoware_minimum_rule_based_planner/src/path_planner.hpp
@@ -21,6 +21,7 @@
 #include <rclcpp/clock.hpp>
 #include <rclcpp/logger.hpp>
 
+#include <builtin_interfaces/msg/time.hpp>
 #include <lanelet2_core/geometry/Lanelet.h>
 #include <lanelet2_routing/RoutingGraph.h>
 #include <lanelet2_traffic_rules/TrafficRules.h>
@@ -110,10 +111,11 @@ public:
 
   // Path planning
   std::optional<PathWithLaneId> plan_path(
-    const geometry_msgs::msg::Pose & current_pose, double ego_velocity);
+    const geometry_msgs::msg::Pose & current_pose, double ego_velocity,
+    const builtin_interfaces::msg::Time & stamp);
   std::optional<PathWithLaneId> generate_path(
     const lanelet::LaneletSequence & lanelet_sequence, double s_start, double s_end,
-    double ego_velocity);
+    double ego_velocity, const builtin_interfaces::msg::Time & stamp);
 
   // Trajectory shifting
   Trajectory shift_trajectory_to_ego(


### PR DESCRIPTION
# Description
stamp of trajectory is updated from "current clock" to "odometry.header.stamp" to align specification with diffusion planner. 

# How was this PR tested?
Only regression test is verified using psim and unit test because this PR don't intend effects to system behavior. 

# Interface changes
| Topic Type | Topic Name | Message Type | Description |
|:--|:--|:--|:--|
| Pub | `~/output/candidate_trajectories` | `autoware_internal_planning_msgs/msg/CandidateTrajectories` | `header.stamp` is now sourced from the input Odometry's `header.stamp` (data time) instead of `clock_->now()` (processing time). Value only; message structure unchanged. |
| Pub | `~/debug/path_with_lane_id` | `autoware_internal_planning_msgs/msg/PathWithLaneId` | same as above |
| Pub | `~/debug/trajectory` | `autoware_planning_msgs/msg/Trajectory` | same as above |
| Pub | `~/debug/stop_trajectory` | `autoware_planning_msgs/msg/Trajectory` | same as above |
| Pub | `~/debug/shifted_trajectory` | `autoware_planning_msgs/msg/Trajectory` | same as above |
| Pub | `~/debug/optimizer/<plugin_name>/trajectory` | `autoware_planning_msgs/msg/Trajectory` | same as above |
| Pub | `~/debug/modifier/<plugin_name>/trajectory` | `autoware_planning_msgs/msg/Trajectory` | same as above |


# ROS Parameter Changes
None. 

# Effects on system behavior
None. 