### PR TITLE
feat(collision_check_filter): add mutual yield arbitration

### DIFF
--- a/planning/autoware_trajectory_validator/CMakeLists.txt
+++ b/planning/autoware_trajectory_validator/CMakeLists.txt
@@ -38,7 +38,7 @@ ament_auto_add_library(autoware_trajectory_validator_plugins SHARED
   src/filters/safety/collision_check_filter/collision_check_filter.cpp
   src/filters/safety/collision_check_filter/reporter.cpp
   src/filters/safety/collision_check_filter/assessment.cpp
-  src/filters/safety/collision_check_filter/stopped_object_tracker.cpp
+  src/filters/safety/collision_check_filter/stop_tracker.cpp
   src/filters/safety/collision_check_filter/trajectory_utils.cpp
   src/filters/traffic_rule/traffic_light_filter.cpp
 )
@@ -110,10 +110,10 @@ if(BUILD_TESTING)
     autoware_trajectory_validator_plugins
   )
 
-  ament_add_gtest(test_stopped_object_tracker
-    test/plugins/collision_check_filter/test_stopped_object_tracker.cpp
+  ament_add_gtest(test_stop_tracker
+    test/plugins/collision_check_filter/test_stop_tracker.cpp
   )
-  target_link_libraries(test_stopped_object_tracker
+  target_link_libraries(test_stop_tracker
     autoware_trajectory_validator_plugins
   )
 

--- a/planning/autoware_trajectory_validator/CMakeLists.txt
+++ b/planning/autoware_trajectory_validator/CMakeLists.txt
@@ -35,9 +35,10 @@ target_compile_options(${trajectory_validator_lib_target} PUBLIC
 ament_auto_add_library(autoware_trajectory_validator_plugins SHARED
   src/filters/safety/uncrossable_boundary_departure.cpp
   src/filters/safety/vehicle_constraint_filter.cpp
-    src/filters/safety/collision_check_filter/collision_check_filter.cpp
+  src/filters/safety/collision_check_filter/collision_check_filter.cpp
   src/filters/safety/collision_check_filter/reporter.cpp
   src/filters/safety/collision_check_filter/assessment.cpp
+  src/filters/safety/collision_check_filter/stopped_object_tracker.cpp
   src/filters/safety/collision_check_filter/trajectory_utils.cpp
   src/filters/traffic_rule/traffic_light_filter.cpp
 )
@@ -106,6 +107,13 @@ if(BUILD_TESTING)
     test/plugins/collision_check_filter/test_geometry.cpp
   )
   target_link_libraries(test_geometry
+    autoware_trajectory_validator_plugins
+  )
+
+  ament_add_gtest(test_stopped_object_tracker
+    test/plugins/collision_check_filter/test_stopped_object_tracker.cpp
+  )
+  target_link_libraries(test_stopped_object_tracker
     autoware_trajectory_validator_plugins
   )
 

--- a/planning/autoware_trajectory_validator/config/trajectory_validator.param.yaml
+++ b/planning/autoware_trajectory_validator/config/trajectory_validator.param.yaml
@@ -13,11 +13,14 @@
     collision_check:
       global_setting:
         time_resolution: 0.1
-      stopped_object_tracking:
-        stopped_velocity_threshold: 0.1  # [m/s]
-        stopped_duration_threshold: 3.0  # [s]
-        history_timeout: 1.0  # [s]
       drac:
+        stop_tracking:
+          ego:
+            stopped_velocity_threshold: 0.01
+            history_timeout: 0.3
+          object:
+            stopped_velocity_threshold: 0.3
+            history_timeout: 0.3
         enable_assessment:
           # default value is true.
           unknown: false
@@ -55,6 +58,12 @@
               enable_abandon: false
         map_based:
           enable_assessment: true
+          mutual_yield_timeout_resolution:
+            enabled: true
+            min_wait_time:
+              base: 1.0
+              pedestrian: 3.0
+              bicycle: 3.0
           ego_prioritized_ego_earlier:
             enable_assessment: false # Not evaluated. Must be false
           ego_prioritized_object_earlier:

--- a/planning/autoware_trajectory_validator/config/trajectory_validator.param.yaml
+++ b/planning/autoware_trajectory_validator/config/trajectory_validator.param.yaml
@@ -13,6 +13,10 @@
     collision_check:
       global_setting:
         time_resolution: 0.1
+      stopped_object_tracking:
+        stopped_velocity_threshold: 0.1  # [m/s]
+        stopped_duration_threshold: 3.0  # [s]
+        history_timeout: 1.0  # [s]
       drac:
         enable_assessment:
           # default value is true.

--- a/planning/autoware_trajectory_validator/config/trajectory_validator.param.yaml
+++ b/planning/autoware_trajectory_validator/config/trajectory_validator.param.yaml
@@ -58,12 +58,12 @@
               enable_abandon: false
         map_based:
           enable_assessment: true
-          mutual_yield_timeout_resolution:
-            enabled: true
-            min_wait_time:
-              base: 1.0
-              pedestrian: 3.0
-              bicycle: 3.0
+          mutual_yield_timeout_arbitration:
+            enabled:
+              base: false
+              pedestrian: true
+              bicycle: true
+            min_wait_time: 3.0
           ego_prioritized_ego_earlier:
             enable_assessment: false # Not evaluated. Must be false
           ego_prioritized_object_earlier:

--- a/planning/autoware_trajectory_validator/param/parameter_struct.yaml
+++ b/planning/autoware_trajectory_validator/param/parameter_struct.yaml
@@ -45,6 +45,28 @@ validator:
         default_value: .NAN
         description: sampling interval used in collision check trajectory generation
         read_only: false
+    stopped_object_tracking:
+      stopped_velocity_threshold:
+        type: double
+        default_value: 0.1
+        description: planar speed below which an object is considered stopped (m/s)
+        read_only: false
+        validation:
+          gt<>: [0.0]
+      stopped_duration_threshold:
+        type: double
+        default_value: 3.0
+        description: continuous stop duration required to consider an object stopped long enough (s)
+        read_only: false
+        validation:
+          gt_eq<>: [0.0]
+      history_timeout:
+        type: double
+        default_value: 1.0
+        description: time after the last observation before a stopped-object record is removed (s)
+        read_only: false
+        validation:
+          gt_eq<>: [0.0]
     drac:
       enable_assessment:
         base:

--- a/planning/autoware_trajectory_validator/param/parameter_struct.yaml
+++ b/planning/autoware_trajectory_validator/param/parameter_struct.yaml
@@ -218,36 +218,32 @@ validator:
           default_value: false
           description: Use map based predicted path trajectories for DRAC assessment
           read_only: false
-        mutual_yield_timeout_resolution:
+        mutual_yield_timeout_arbitration:
           enabled:
-            type: bool
-            default_value: false
-            description: Resolve mutual-yield deadlocks after both participants have waited long enough
-            read_only: false
-          min_wait_time:
             base:
-              type: double
-              default_value: .NAN
-              description: Default minimum wait time before resolving a mutual-yield deadlock (s)
-              read_only: false
-            unknown:
-              &drac_labeled_wait_time_override {
-                type: double,
-                default_value: .NAN,
-                description: Per-class override. NaN uses the base value.,
+              &drac_labeled_mutual_yield_enabled {
+                type: bool,
+                default_value: false,
+                description: Enable mutual-yield arbitration for this object class,
                 read_only: false,
               }
-            car: *drac_labeled_wait_time_override
-            truck: *drac_labeled_wait_time_override
-            bus: *drac_labeled_wait_time_override
-            trailer: *drac_labeled_wait_time_override
-            motorcycle: *drac_labeled_wait_time_override
-            bicycle: *drac_labeled_wait_time_override
-            pedestrian: *drac_labeled_wait_time_override
-            animal: *drac_labeled_wait_time_override
-            hazard: *drac_labeled_wait_time_override
-            over_drivable: *drac_labeled_wait_time_override
-            under_drivable: *drac_labeled_wait_time_override
+            unknown: *drac_labeled_mutual_yield_enabled
+            car: *drac_labeled_mutual_yield_enabled
+            truck: *drac_labeled_mutual_yield_enabled
+            bus: *drac_labeled_mutual_yield_enabled
+            trailer: *drac_labeled_mutual_yield_enabled
+            motorcycle: *drac_labeled_mutual_yield_enabled
+            bicycle: *drac_labeled_mutual_yield_enabled
+            pedestrian: *drac_labeled_mutual_yield_enabled
+            animal: *drac_labeled_mutual_yield_enabled
+            hazard: *drac_labeled_mutual_yield_enabled
+            over_drivable: *drac_labeled_mutual_yield_enabled
+            under_drivable: *drac_labeled_mutual_yield_enabled
+          min_wait_time:
+            type: double
+            default_value: .NAN
+            description: Minimum wait time before resolving a mutual-yield deadlock (s)
+            read_only: false
         ego_prioritized_ego_earlier: *drac_assessment
         ego_prioritized_object_earlier: *drac_assessment
         object_prioritized_ego_earlier: *drac_assessment

--- a/planning/autoware_trajectory_validator/param/parameter_struct.yaml
+++ b/planning/autoware_trajectory_validator/param/parameter_struct.yaml
@@ -45,29 +45,38 @@ validator:
         default_value: .NAN
         description: sampling interval used in collision check trajectory generation
         read_only: false
-    stopped_object_tracking:
-      stopped_velocity_threshold:
-        type: double
-        default_value: 0.1
-        description: planar speed below which an object is considered stopped (m/s)
-        read_only: false
-        validation:
-          gt<>: [0.0]
-      stopped_duration_threshold:
-        type: double
-        default_value: 3.0
-        description: continuous stop duration required to consider an object stopped long enough (s)
-        read_only: false
-        validation:
-          gt_eq<>: [0.0]
-      history_timeout:
-        type: double
-        default_value: 1.0
-        description: time after the last observation before a stopped-object record is removed (s)
-        read_only: false
-        validation:
-          gt_eq<>: [0.0]
     drac:
+      stop_tracking:
+        ego:
+          stopped_velocity_threshold:
+            type: double
+            default_value: 0.01
+            description: planar speed below which the ego vehicle is considered stopped (m/s)
+            read_only: false
+            validation:
+              gt<>: [0.0]
+          history_timeout:
+            type: double
+            default_value: 0.3
+            description: maximum observation gap retained in the ego stop history (s)
+            read_only: false
+            validation:
+              gt_eq<>: [0.0]
+        object:
+          stopped_velocity_threshold:
+            type: double
+            default_value: 0.3
+            description: planar speed below which an object is considered stopped (m/s)
+            read_only: false
+            validation:
+              gt<>: [0.0]
+          history_timeout:
+            type: double
+            default_value: 0.3
+            description: time after the last observation before an object stop record is removed (s)
+            read_only: false
+            validation:
+              gt_eq<>: [0.0]
       enable_assessment:
         base:
           &drac_ea {
@@ -217,6 +226,36 @@ validator:
           default_value: false
           description: Use map based predicted path trajectories for DRAC assessment
           read_only: false
+        mutual_yield_timeout_resolution:
+          enabled:
+            type: bool
+            default_value: false
+            description: Resolve mutual-yield deadlocks after both participants have waited long enough
+            read_only: false
+          min_wait_time:
+            base:
+              type: double
+              default_value: .NAN
+              description: Default minimum wait time before resolving a mutual-yield deadlock (s)
+              read_only: false
+            unknown:
+              &drac_labeled_wait_time_override {
+                type: double,
+                default_value: .NAN,
+                description: Per-class override. NaN uses the base value.,
+                read_only: false,
+              }
+            car: *drac_labeled_wait_time_override
+            truck: *drac_labeled_wait_time_override
+            bus: *drac_labeled_wait_time_override
+            trailer: *drac_labeled_wait_time_override
+            motorcycle: *drac_labeled_wait_time_override
+            bicycle: *drac_labeled_wait_time_override
+            pedestrian: *drac_labeled_wait_time_override
+            animal: *drac_labeled_wait_time_override
+            hazard: *drac_labeled_wait_time_override
+            over_drivable: *drac_labeled_wait_time_override
+            under_drivable: *drac_labeled_wait_time_override
         ego_prioritized_ego_earlier: *drac_assessment
         ego_prioritized_object_earlier: *drac_assessment
         object_prioritized_ego_earlier: *drac_assessment

--- a/planning/autoware_trajectory_validator/param/parameter_struct.yaml
+++ b/planning/autoware_trajectory_validator/param/parameter_struct.yaml
@@ -50,33 +50,25 @@ validator:
         ego:
           stopped_velocity_threshold:
             type: double
-            default_value: 0.01
+            default_value: .NAN
             description: planar speed below which the ego vehicle is considered stopped (m/s)
             read_only: false
-            validation:
-              gt<>: [0.0]
           history_timeout:
             type: double
-            default_value: 0.3
+            default_value: .NAN
             description: maximum observation gap retained in the ego stop history (s)
             read_only: false
-            validation:
-              gt_eq<>: [0.0]
         object:
           stopped_velocity_threshold:
             type: double
-            default_value: 0.3
+            default_value: .NAN
             description: planar speed below which an object is considered stopped (m/s)
             read_only: false
-            validation:
-              gt<>: [0.0]
           history_timeout:
             type: double
-            default_value: 0.3
+            default_value: .NAN
             description: time after the last observation before an object stop record is removed (s)
             read_only: false
-            validation:
-              gt_eq<>: [0.0]
       enable_assessment:
         base:
           &drac_ea {

--- a/planning/autoware_trajectory_validator/schema/trajectory_validator.schema.json
+++ b/planning/autoware_trajectory_validator/schema/trajectory_validator.schema.json
@@ -43,6 +43,26 @@
       "required": [],
       "additionalProperties": false
     },
+    "mutual_yield_enabled_per_class": {
+      "type": "object",
+      "properties": {
+        "base": { "type": "boolean", "default": false },
+        "unknown": { "type": "boolean", "default": false },
+        "car": { "type": "boolean", "default": false },
+        "truck": { "type": "boolean", "default": false },
+        "bus": { "type": "boolean", "default": false },
+        "trailer": { "type": "boolean", "default": false },
+        "motorcycle": { "type": "boolean", "default": false },
+        "bicycle": { "type": "boolean", "default": false },
+        "pedestrian": { "type": "boolean", "default": false },
+        "animal": { "type": "boolean", "default": false },
+        "hazard": { "type": "boolean", "default": false },
+        "over_drivable": { "type": "boolean", "default": false },
+        "under_drivable": { "type": "boolean", "default": false }
+      },
+      "required": [],
+      "additionalProperties": false
+    },
     "labeled_double": {
       "type": "object",
       "properties": {
@@ -225,6 +245,21 @@
                       "type": "boolean",
                       "default": false,
                       "description": "Use map-based predicted path trajectories for DRAC assessment."
+                    },
+                    "mutual_yield_timeout_arbitration": {
+                      "type": "object",
+                      "properties": {
+                        "enabled": {
+                          "$ref": "#/definitions/mutual_yield_enabled_per_class"
+                        },
+                        "min_wait_time": {
+                          "type": "number",
+                          "minimum": 0.0,
+                          "description": "Minimum wait time before resolving a mutual-yield deadlock [s]."
+                        }
+                      },
+                      "required": [],
+                      "additionalProperties": false
                     },
                     "ego_prioritized_ego_earlier": {
                       "$ref": "#/definitions/drac_assessment"

--- a/planning/autoware_trajectory_validator/schema/trajectory_validator.schema.json
+++ b/planning/autoware_trajectory_validator/schema/trajectory_validator.schema.json
@@ -83,6 +83,23 @@
       "required": [],
       "additionalProperties": false
     },
+    "stop_tracking_params": {
+      "type": "object",
+      "properties": {
+        "stopped_velocity_threshold": {
+          "type": "number",
+          "description": "Planar speed below which the vehicle or object is considered stopped [m/s].",
+          "exclusiveMinimum": 0.0
+        },
+        "history_timeout": {
+          "type": "number",
+          "description": "Maximum observation gap retained in the stop history [s].",
+          "minimum": 0.0
+        }
+      },
+      "required": [],
+      "additionalProperties": false
+    },
     "drac_assessment": {
       "type": "object",
       "properties": {
@@ -176,6 +193,15 @@
               "type": "object",
               "description": "Deceleration Rate to Avoid Collision (DRAC) assessment settings.",
               "properties": {
+                "stop_tracking": {
+                  "type": "object",
+                  "properties": {
+                    "ego": { "$ref": "#/definitions/stop_tracking_params" },
+                    "object": { "$ref": "#/definitions/stop_tracking_params" }
+                  },
+                  "required": [],
+                  "additionalProperties": false
+                },
                 "enable_assessment": { "$ref": "#/definitions/enable_assessment_per_class" },
                 "pet_margin": {
                   "type": "object",

--- a/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/assessment.cpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/assessment.cpp
@@ -365,9 +365,10 @@ DracArtifact assess_map_based(
   }
 
   if (
+    drac_params.map_based.mutual_yield_timeout_arbitration.enabled &&
     stop_trackers.get_stopped_duration(object.object_id) >
-    rclcpp::Duration::from_seconds(
-      drac_params.map_based.mutual_yield_timeout_resolution.min_wait_time)) {
+      rclcpp::Duration::from_seconds(
+        drac_params.map_based.mutual_yield_timeout_arbitration.min_wait_time)) {
     for (auto evaluation : drac_artifact.evaluations) {
       evaluation.risk = RiskLevel::SAFE;
     }

--- a/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/assessment.cpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/assessment.cpp
@@ -385,13 +385,13 @@ DracArtifact assess(
   const autoware_vehicle_msgs::msg::TurnIndicatorsCommand & ego_turn_indicator,
   const nav_msgs::msg::Odometry & odometry,
   const autoware_perception_msgs::msg::PredictedObjects & predicted_objects,
-  StopTrackers & stop_tracker, const DracParamMap & drac_param_map,
+  StopTrackers & stop_trackers, const DracParamMap & drac_param_map,
   const GlobalParams & global_params)
 {
   DracArtifact drac_artifact{};
 
-  stop_tracker.ego_.update(odometry);
-  stop_tracker.object_.update(predicted_objects);
+  stop_trackers.ego.update(odometry);
+  stop_trackers.object.update(predicted_objects);
 
   for (const auto & predicted_object : predicted_objects.objects) {
     const auto & drac_params = drac_param_map.at(to_type_string(predicted_object.classification));
@@ -406,7 +406,7 @@ DracArtifact assess(
 
     if (drac_params.map_based.enable_assessment) {
       drac_artifact.merge(assess_map_based(
-        ego_trajectory_cache, ego_turn_indicator, predicted_object, stop_tracker, drac_params,
+        ego_trajectory_cache, ego_turn_indicator, predicted_object, stop_trackers, drac_params,
         global_params));
     }
   }

--- a/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/assessment.cpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/assessment.cpp
@@ -364,17 +364,19 @@ DracArtifact assess_map_based(
     }
   }
 
-  if (
-    drac_params.map_based.mutual_yield_timeout_arbitration.enabled &&
-    stop_trackers.get_stopped_duration(object.object_id) >
-      rclcpp::Duration::from_seconds(
-        drac_params.map_based.mutual_yield_timeout_arbitration.min_wait_time)) {
-    for (auto evaluation : drac_artifact.evaluations) {
-      evaluation.risk = RiskLevel::SAFE;
+  if (drac_params.map_based.mutual_yield_timeout_arbitration.enabled) {
+    const auto stopped_duration = stop_trackers.get_stopped_duration(object.object_id);
+    if (
+      stopped_duration.has_value() &&
+      stopped_duration.value() >
+        rclcpp::Duration::from_seconds(
+          drac_params.map_based.mutual_yield_timeout_arbitration.min_wait_time)) {
+      for (auto & evaluation : drac_artifact.evaluations) {
+        evaluation.risk = RiskLevel::SAFE;
+      }
+      drac_artifact.risk = RiskLevel::SAFE;
     }
-    drac_artifact.risk = RiskLevel::SAFE;
   }
-
   return drac_artifact;
 }
 

--- a/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/assessment.cpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/assessment.cpp
@@ -308,13 +308,12 @@ DracEvaluation assess_drac_object_prioritized_object_earlier(
 DracArtifact assess_map_based(
   const trajectory::EgoTrajectoryCache & ego_trajectory_cache,
   const autoware_vehicle_msgs::msg::TurnIndicatorsCommand & ego_turn_indicator,
-  const autoware_perception_msgs::msg::PredictedObject & object, const DracParams & drac_params,
-  const GlobalParams & global_params)
+  const autoware_perception_msgs::msg::PredictedObject & object, const StopTrackers & stop_trackers,
+  const DracParams & drac_params, const GlobalParams & global_params)
 {
   DracArtifact drac_artifact{};
 
   const double braking_delay = drac_params.ego_reaction_braking_delay.nominal;
-
   trajectory::EgoTrajectoryGenerationParams ego_traj_params{
     braking_delay, 0.0, drac_params.ego_footprint_margin};
 
@@ -364,18 +363,34 @@ DracArtifact assess_map_based(
       }
     }
   }
+
+  if (
+    stop_trackers.get_stopped_duration(object.object_id) >
+    rclcpp::Duration::from_seconds(
+      drac_params.map_based.mutual_yield_timeout_resolution.min_wait_time)) {
+    for (auto evaluation : drac_artifact.evaluations) {
+      evaluation.risk = RiskLevel::SAFE;
+    }
+    drac_artifact.risk = RiskLevel::SAFE;
+  }
+
   return drac_artifact;
 }
 
 DracArtifact assess(
   const trajectory::EgoTrajectoryCache & ego_trajectory_cache,
   const autoware_vehicle_msgs::msg::TurnIndicatorsCommand & ego_turn_indicator,
-  const FilterContext & context, const DracParamMap & drac_param_map,
+  const nav_msgs::msg::Odometry & odometry,
+  const autoware_perception_msgs::msg::PredictedObjects & predicted_objects,
+  StopTrackers & stop_tracker, const DracParamMap & drac_param_map,
   const GlobalParams & global_params)
 {
   DracArtifact drac_artifact{};
 
-  for (const auto & predicted_object : context.predicted_objects->objects) {
+  stop_tracker.ego_.update(odometry);
+  stop_tracker.object_.update(predicted_objects);
+
+  for (const auto & predicted_object : predicted_objects.objects) {
     const auto & drac_params = drac_param_map.at(to_type_string(predicted_object.classification));
     if (!drac_params.enable_assessment) {
       continue;
@@ -388,7 +403,8 @@ DracArtifact assess(
 
     if (drac_params.map_based.enable_assessment) {
       drac_artifact.merge(assess_map_based(
-        ego_trajectory_cache, ego_turn_indicator, predicted_object, drac_params, global_params));
+        ego_trajectory_cache, ego_turn_indicator, predicted_object, stop_tracker, drac_params,
+        global_params));
     }
   }
   return drac_artifact;

--- a/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/assessment.hpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/assessment.hpp
@@ -30,11 +30,6 @@
 #include <utility>
 #include <vector>
 
-namespace autoware::trajectory_validator::plugin::safety
-{
-
-}
-
 namespace autoware::trajectory_validator::plugin::safety::collision_timing_assessment
 {
 DracArtifact assess(

--- a/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/assessment.hpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/assessment.hpp
@@ -17,6 +17,7 @@
 
 #include "autoware/trajectory_validator/validator_interface.hpp"
 #include "parameter.hpp"
+#include "stop_tracker.hpp"
 #include "trajectory_utils.hpp"
 #include "types.hpp"
 
@@ -39,7 +40,9 @@ namespace autoware::trajectory_validator::plugin::safety::collision_timing_asses
 DracArtifact assess(
   const trajectory::EgoTrajectoryCache & ego_trajectory_cache,
   const autoware_vehicle_msgs::msg::TurnIndicatorsCommand & ego_turn_indicator,
-  const FilterContext & context, const DracParamMap & drac_param_map,
+  const nav_msgs::msg::Odometry & odometry,
+  const autoware_perception_msgs::msg::PredictedObjects & predicted_objects,
+  StopTrackers & stop_tracker, const DracParamMap & drac_param_map,
   const GlobalParams & global_params);
 }  // namespace autoware::trajectory_validator::plugin::safety::collision_timing_assessment
 

--- a/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/assessment.hpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/assessment.hpp
@@ -37,7 +37,7 @@ DracArtifact assess(
   const autoware_vehicle_msgs::msg::TurnIndicatorsCommand & ego_turn_indicator,
   const nav_msgs::msg::Odometry & odometry,
   const autoware_perception_msgs::msg::PredictedObjects & predicted_objects,
-  StopTrackers & stop_tracker, const DracParamMap & drac_param_map,
+  StopTrackers & stop_trackers, const DracParamMap & drac_param_map,
   const GlobalParams & global_params);
 }  // namespace autoware::trajectory_validator::plugin::safety::collision_timing_assessment
 

--- a/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/assessment.hpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/assessment.hpp
@@ -29,6 +29,11 @@
 #include <utility>
 #include <vector>
 
+namespace autoware::trajectory_validator::plugin::safety
+{
+
+}
+
 namespace autoware::trajectory_validator::plugin::safety::collision_timing_assessment
 {
 DracArtifact assess(

--- a/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/collision_check_filter.cpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/collision_check_filter.cpp
@@ -33,6 +33,8 @@ namespace autoware::trajectory_validator::plugin::safety
 void CollisionCheckFilter::update_parameters(const validator::Params & node_params)
 {
   global_params_ = GlobalParams(node_params.collision_check.global_setting);
+  stopped_object_tracker_.set_parameters(
+    StoppedObjectTrackingParams(node_params.collision_check.stopped_object_tracking));
 
   drac_param_map_ = create_param_map_per_object<DracParams>(node_params);
   rss_param_map_ = create_param_map_per_object<RssParams>(node_params);
@@ -100,7 +102,14 @@ CollisionCheckFilter::result_t CollisionCheckFilter::is_feasible(
   const CandidateTrajectory & candidate_trajectory, const FilterContext & context)
 {
   const auto & traj_points = candidate_trajectory.points;
-  if (!context.predicted_objects || context.predicted_objects->objects.empty()) {
+  if (!context.predicted_objects) {
+    clear_detection_times();
+    return {};  // No objects to check collision with
+  }
+
+  stopped_object_tracker_.update(*context.predicted_objects);
+
+  if (context.predicted_objects->objects.empty()) {
     clear_detection_times();
     return {};  // No objects to check collision with
   }

--- a/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/collision_check_filter.cpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/collision_check_filter.cpp
@@ -34,8 +34,8 @@ void CollisionCheckFilter::update_parameters(const validator::Params & node_para
 {
   global_params_ = GlobalParams(node_params.collision_check.global_setting);
   const auto & stop_tracking_params = node_params.collision_check.drac.stop_tracking;
-  stop_tracker_.ego_.set_parameters(StopTrackingParams(stop_tracking_params.ego));
-  stop_tracker_.object_.set_parameters(StopTrackingParams(stop_tracking_params.object));
+  stop_tracker_.ego.set_parameters(StopTrackingParams(stop_tracking_params.ego));
+  stop_tracker_.object.set_parameters(StopTrackingParams(stop_tracking_params.object));
 
   drac_param_map_ = create_param_map_per_object<DracParams>(node_params);
   rss_param_map_ = create_param_map_per_object<RssParams>(node_params);

--- a/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/collision_check_filter.cpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/collision_check_filter.cpp
@@ -33,8 +33,9 @@ namespace autoware::trajectory_validator::plugin::safety
 void CollisionCheckFilter::update_parameters(const validator::Params & node_params)
 {
   global_params_ = GlobalParams(node_params.collision_check.global_setting);
-  stopped_object_tracker_.set_parameters(
-    StoppedObjectTrackingParams(node_params.collision_check.stopped_object_tracking));
+  const auto & stop_tracking_params = node_params.collision_check.drac.stop_tracking;
+  stop_tracker_.ego_.set_parameters(StopTrackingParams(stop_tracking_params.ego));
+  stop_tracker_.object_.set_parameters(StopTrackingParams(stop_tracking_params.object));
 
   drac_param_map_ = create_param_map_per_object<DracParams>(node_params);
   rss_param_map_ = create_param_map_per_object<RssParams>(node_params);
@@ -102,14 +103,8 @@ CollisionCheckFilter::result_t CollisionCheckFilter::is_feasible(
   const CandidateTrajectory & candidate_trajectory, const FilterContext & context)
 {
   const auto & traj_points = candidate_trajectory.points;
-  if (!context.predicted_objects) {
-    clear_detection_times();
-    return {};  // No objects to check collision with
-  }
 
-  stopped_object_tracker_.update(*context.predicted_objects);
-
-  if (context.predicted_objects->objects.empty()) {
+  if (!context.odometry || !context.predicted_objects) {
     clear_detection_times();
     return {};  // No objects to check collision with
   }
@@ -125,8 +120,8 @@ CollisionCheckFilter::result_t CollisionCheckFilter::is_feasible(
     *vehicle_info_ptr_);
 
   const auto drac_artifact = collision_timing_assessment::assess(
-    ego_trajectory_cache, candidate_trajectory.turn_indicators_command, context, drac_param_map_,
-    global_params_);
+    ego_trajectory_cache, candidate_trajectory.turn_indicators_command, *context.odometry,
+    *context.predicted_objects, stop_tracker_, drac_param_map_, global_params_);
   const auto rss_artifact = rss_deceleration::assess(ego_trajectory_cache, context, rss_param_map_);
 
   auto planning_factors = reporter::process_collision_artifacts(

--- a/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/collision_check_filter.hpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/collision_check_filter.hpp
@@ -18,6 +18,7 @@
 #include "autoware/trajectory_validator/validator_interface.hpp"
 #include "parameter.hpp"
 #include "reporter.hpp"
+#include "stopped_object_tracker.hpp"
 #include "types.hpp"
 
 #include <vector>
@@ -38,6 +39,7 @@ private:
   GlobalParams global_params_;
   DracParamMap drac_param_map_;
   RssParamMap rss_param_map_;
+  StoppedObjectTracker stopped_object_tracker_;
 
   reporter::ContinuousDetectionTimes rss_continuous_times_;
   reporter::ContinuousDetectionTimes drac_continuous_times_;

--- a/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/collision_check_filter.hpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/collision_check_filter.hpp
@@ -18,7 +18,7 @@
 #include "autoware/trajectory_validator/validator_interface.hpp"
 #include "parameter.hpp"
 #include "reporter.hpp"
-#include "stopped_object_tracker.hpp"
+#include "stop_tracker.hpp"
 #include "types.hpp"
 
 #include <vector>
@@ -39,7 +39,7 @@ private:
   GlobalParams global_params_;
   DracParamMap drac_param_map_;
   RssParamMap rss_param_map_;
-  StoppedObjectTracker stopped_object_tracker_;
+  StopTrackers stop_tracker_;
 
   reporter::ContinuousDetectionTimes rss_continuous_times_;
   reporter::ContinuousDetectionTimes drac_continuous_times_;

--- a/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/parameter.hpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/parameter.hpp
@@ -192,14 +192,14 @@ struct DracParams
 
   struct MapBased
   {
-    struct MutualYieldTimeoutResolution
+    struct MutualYieldArbitration
     {
       bool enabled{false};
       double min_wait_time{1.0};
     };
 
     bool enable_assessment{};
-    MutualYieldTimeoutResolution mutual_yield_timeout_resolution{};
+    MutualYieldArbitration mutual_yield_timeout_arbitration{};
     DracAssessment ego_prioritized_ego_earlier{};
     DracAssessment ego_prioritized_object_earlier{};
     DracAssessment object_prioritized_ego_earlier{};
@@ -248,11 +248,11 @@ struct DracParams
 
     map_based.enable_assessment =
       extract_labeled_param<bool>(drac.map_based.enable_assessment, key);
-    const auto & mutual_yield_timeout_resolution = drac.map_based.mutual_yield_timeout_resolution;
-    map_based.mutual_yield_timeout_resolution.enabled =
-      extract_labeled_param<bool>(mutual_yield_timeout_resolution.enabled, key);
-    map_based.mutual_yield_timeout_resolution.min_wait_time =
-      extract_labeled_param<double>(mutual_yield_timeout_resolution.min_wait_time, key);
+    const auto & mutual_yield_timeout_arbitration = drac.map_based.mutual_yield_timeout_arbitration;
+    map_based.mutual_yield_timeout_arbitration.enabled =
+      extract_labeled_param<bool>(mutual_yield_timeout_arbitration.enabled, key);
+    map_based.mutual_yield_timeout_arbitration.min_wait_time =
+      extract_labeled_param<double>(mutual_yield_timeout_arbitration.min_wait_time, key);
     parse_assessment(
       drac.map_based.ego_prioritized_ego_earlier, map_based.ego_prioritized_ego_earlier);
     parse_assessment(

--- a/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/parameter.hpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/parameter.hpp
@@ -130,6 +130,22 @@ struct GlobalParams
   }
 };
 
+struct StoppedObjectTrackingParams
+{
+  double stopped_velocity_threshold{0.1};
+  double stopped_duration_threshold{3.0};
+  double history_timeout{1.0};
+
+  StoppedObjectTrackingParams() = default;
+  explicit StoppedObjectTrackingParams(
+    const validator::Params::CollisionCheck::StoppedObjectTracking & params)
+  : stopped_velocity_threshold(params.stopped_velocity_threshold),
+    stopped_duration_threshold(params.stopped_duration_threshold),
+    history_timeout(params.history_timeout)
+  {
+  }
+};
+
 struct DracParams
 {
   struct PetMargin

--- a/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/parameter.hpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/parameter.hpp
@@ -130,18 +130,26 @@ struct GlobalParams
   }
 };
 
-struct StoppedObjectTrackingParams
+struct StopTrackingParams
 {
-  double stopped_velocity_threshold{0.1};
-  double stopped_duration_threshold{3.0};
-  double history_timeout{1.0};
+  double stopped_velocity_threshold{0.3};
+  double history_timeout{0.5};
 
-  StoppedObjectTrackingParams() = default;
-  explicit StoppedObjectTrackingParams(
-    const validator::Params::CollisionCheck::StoppedObjectTracking & params)
+  StopTrackingParams() = default;
+  explicit StopTrackingParams(
+    const validator::Params::CollisionCheck::Drac::StopTracking::Ego & params)
   : stopped_velocity_threshold(params.stopped_velocity_threshold),
-    stopped_duration_threshold(params.stopped_duration_threshold),
     history_timeout(params.history_timeout)
+  {
+  }
+
+  explicit StopTrackingParams(
+    const validator::Params::CollisionCheck::Drac::StopTracking::Object & params)
+  : stopped_velocity_threshold(
+      extract_labeled_param<double>(
+        params.stopped_velocity_threshold, kCollisionCheckParamBaseKey)),
+    history_timeout(
+      extract_labeled_param<double>(params.history_timeout, kCollisionCheckParamBaseKey))
   {
   }
 };
@@ -184,7 +192,14 @@ struct DracParams
 
   struct MapBased
   {
+    struct MutualYieldTimeoutResolution
+    {
+      bool enabled{false};
+      double min_wait_time{1.0};
+    };
+
     bool enable_assessment{};
+    MutualYieldTimeoutResolution mutual_yield_timeout_resolution{};
     DracAssessment ego_prioritized_ego_earlier{};
     DracAssessment ego_prioritized_object_earlier{};
     DracAssessment object_prioritized_ego_earlier{};
@@ -233,6 +248,11 @@ struct DracParams
 
     map_based.enable_assessment =
       extract_labeled_param<bool>(drac.map_based.enable_assessment, key);
+    const auto & mutual_yield_timeout_resolution = drac.map_based.mutual_yield_timeout_resolution;
+    map_based.mutual_yield_timeout_resolution.enabled =
+      extract_labeled_param<bool>(mutual_yield_timeout_resolution.enabled, key);
+    map_based.mutual_yield_timeout_resolution.min_wait_time =
+      extract_labeled_param<double>(mutual_yield_timeout_resolution.min_wait_time, key);
     parse_assessment(
       drac.map_based.ego_prioritized_ego_earlier, map_based.ego_prioritized_ego_earlier);
     parse_assessment(

--- a/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/parameter.hpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/parameter.hpp
@@ -145,11 +145,8 @@ struct StopTrackingParams
 
   explicit StopTrackingParams(
     const validator::Params::CollisionCheck::Drac::StopTracking::Object & params)
-  : stopped_velocity_threshold(
-      extract_labeled_param<double>(
-        params.stopped_velocity_threshold, kCollisionCheckParamBaseKey)),
-    history_timeout(
-      extract_labeled_param<double>(params.history_timeout, kCollisionCheckParamBaseKey))
+  : stopped_velocity_threshold(params.stopped_velocity_threshold),
+    history_timeout(params.history_timeout)
   {
   }
 };

--- a/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/stop_tracker.cpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/stop_tracker.cpp
@@ -46,15 +46,6 @@ bool is_history_expired(
 {
   return (observation_time - record.last_seen).seconds() > params.history_timeout;
 }
-
-std::optional<rclcpp::Duration> calculate_stopped_duration(
-  const detail::StopTimeRecord * record, const std::optional<rclcpp::Time> & last_update_time)
-{
-  if (record == nullptr || !last_update_time.has_value()) {
-    return std::nullopt;
-  }
-  return last_update_time.value() - record->stopped_since;
-}
 }  // namespace
 
 ObjectStopTracker::ObjectStopTracker(const StopTrackingParams & params)
@@ -112,8 +103,10 @@ std::optional<rclcpp::Duration> ObjectStopTracker::get_stopped_duration(
   const unique_identifier_msgs::msg::UUID & object_id) const
 {
   const auto iter = stop_times_.find(object_id.uuid);
-  const auto * record = iter != stop_times_.end() ? &iter->second : nullptr;
-  return calculate_stopped_duration(record, last_update_time_);
+  if (iter == stop_times_.end() || !last_update_time_.has_value()) {
+    return std::nullopt;
+  }
+  return last_update_time_.value() - iter->second.stopped_since;
 }
 
 EgoStopTracker::EgoStopTracker(const StopTrackingParams & params)
@@ -159,15 +152,17 @@ void EgoStopTracker::update(const nav_msgs::msg::Odometry & odometry)
 
 std::optional<rclcpp::Duration> EgoStopTracker::get_stopped_duration() const
 {
-  const auto * record = stop_time_.has_value() ? &stop_time_.value() : nullptr;
-  return calculate_stopped_duration(record, last_update_time_);
+  if (!stop_time_.has_value() || !last_update_time_.has_value()) {
+    return std::nullopt;
+  }
+  return last_update_time_.value() - stop_time_->stopped_since;
 }
 
 std::optional<rclcpp::Duration> StopTrackers::get_stopped_duration(
   const unique_identifier_msgs::msg::UUID & object_id) const
 {
-  const auto ego_duration = ego_.get_stopped_duration();
-  const auto object_duration = object_.get_stopped_duration(object_id);
+  const auto ego_duration = ego.get_stopped_duration();
+  const auto object_duration = object.get_stopped_duration(object_id);
 
   if (!ego_duration.has_value() || !object_duration.has_value()) {
     return std::nullopt;

--- a/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/stop_tracker.cpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/stop_tracker.cpp
@@ -1,0 +1,169 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "stop_tracker.hpp"
+
+#include <algorithm>
+#include <stdexcept>
+
+namespace autoware::trajectory_validator::plugin::safety
+{
+namespace
+{
+void validate(const StopTrackingParams & params)
+{
+  if (!(params.stopped_velocity_threshold > 0.0)) {
+    throw std::invalid_argument("stopped_velocity_threshold must be greater than zero");
+  }
+  if (!(params.history_timeout >= 0.0)) {
+    throw std::invalid_argument("history_timeout must be non-negative");
+  }
+}
+
+bool is_stopped(const geometry_msgs::msg::Twist & twist, const StopTrackingParams & params)
+{
+  const auto & vel = twist.linear;
+  const double speed_sq = vel.x * vel.x + vel.y * vel.y;
+  const double speed_threshold_sq =
+    params.stopped_velocity_threshold * params.stopped_velocity_threshold;
+  return speed_sq < speed_threshold_sq;
+}
+
+bool is_history_expired(
+  const detail::StopTimeRecord & record, const rclcpp::Time & observation_time,
+  const StopTrackingParams & params)
+{
+  return (observation_time - record.last_seen).seconds() > params.history_timeout;
+}
+
+std::optional<rclcpp::Duration> calculate_stopped_duration(
+  const detail::StopTimeRecord * record, const std::optional<rclcpp::Time> & last_update_time)
+{
+  if (record == nullptr || !last_update_time.has_value()) {
+    return std::nullopt;
+  }
+  return last_update_time.value() - record->stopped_since;
+}
+}  // namespace
+
+ObjectStopTracker::ObjectStopTracker(const StopTrackingParams & params)
+{
+  stop_times_.reserve(kExpectedMaxObjectCount);
+  set_parameters(params);
+}
+
+void ObjectStopTracker::set_parameters(const StopTrackingParams & params)
+{
+  validate(params);
+  params_ = params;
+}
+
+void ObjectStopTracker::update(const autoware_perception_msgs::msg::PredictedObjects & objects)
+{
+  const rclcpp::Time observation_time(objects.header.stamp);
+
+  if (last_update_time_.has_value() && observation_time < last_update_time_.value()) {
+    stop_times_.clear();
+  }
+  last_update_time_ = observation_time;
+
+  for (auto iter = stop_times_.begin(); iter != stop_times_.end();) {
+    if (is_history_expired(iter->second, observation_time, params_)) {
+      iter = stop_times_.erase(iter);
+    } else {
+      ++iter;
+    }
+  }
+
+  for (const auto & object : objects.objects) {
+    const bool stopped = is_stopped(object.kinematics.initial_twist_with_covariance.twist, params_);
+    const auto & object_id = object.object_id.uuid;
+
+    if (!stopped) {
+      stop_times_.erase(object_id);
+      continue;
+    }
+
+    const auto [iter, inserted] = stop_times_.try_emplace(
+      object_id, detail::StopTimeRecord{observation_time, observation_time});
+    if (!inserted) {
+      iter->second.last_seen = observation_time;
+    }
+  }
+}
+
+std::optional<rclcpp::Duration> ObjectStopTracker::get_stopped_duration(
+  const unique_identifier_msgs::msg::UUID & object_id) const
+{
+  const auto iter = stop_times_.find(object_id.uuid);
+  const auto * record = iter != stop_times_.end() ? &iter->second : nullptr;
+  return calculate_stopped_duration(record, last_update_time_);
+}
+
+EgoStopTracker::EgoStopTracker(const StopTrackingParams & params)
+{
+  set_parameters(params);
+}
+
+void EgoStopTracker::set_parameters(const StopTrackingParams & params)
+{
+  validate(params);
+  params_ = params;
+}
+
+void EgoStopTracker::update(const nav_msgs::msg::Odometry & odometry)
+{
+  const rclcpp::Time observation_time(odometry.header.stamp);
+
+  if (last_update_time_.has_value() && observation_time < last_update_time_.value()) {
+    stop_time_.reset();
+  }
+  last_update_time_ = observation_time;
+
+  if (stop_time_.has_value() && is_history_expired(stop_time_.value(), observation_time, params_)) {
+    stop_time_.reset();
+  }
+
+  if (!is_stopped(odometry.twist.twist, params_)) {
+    stop_time_.reset();
+    return;
+  }
+
+  if (!stop_time_.has_value()) {
+    stop_time_.emplace(detail::StopTimeRecord{observation_time, observation_time});
+  } else {
+    stop_time_->last_seen = observation_time;
+  }
+}
+
+std::optional<rclcpp::Duration> EgoStopTracker::get_stopped_duration() const
+{
+  const auto * record = stop_time_.has_value() ? &stop_time_.value() : nullptr;
+  return calculate_stopped_duration(record, last_update_time_);
+}
+
+std::optional<rclcpp::Duration> StopTrackers::get_stopped_duration(
+  const unique_identifier_msgs::msg::UUID & object_id) const
+{
+  const auto ego_duration = ego_.get_stopped_duration();
+  const auto object_duration = object_.get_stopped_duration(object_id);
+
+  if (!ego_duration.has_value() || !object_duration.has_value()) {
+    return std::nullopt;
+  }
+
+  return std::min(ego_duration.value(), object_duration.value());
+}
+
+}  // namespace autoware::trajectory_validator::plugin::safety

--- a/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/stop_tracker.cpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/stop_tracker.cpp
@@ -73,8 +73,13 @@ void ObjectStopTracker::update(const autoware_perception_msgs::msg::PredictedObj
 {
   const rclcpp::Time observation_time(objects.header.stamp);
 
-  if (last_update_time_.has_value() && observation_time < last_update_time_.value()) {
-    stop_times_.clear();
+  if (last_update_time_.has_value()) {
+    if (observation_time == last_update_time_.value()) {
+      return;  // Same observation already processed (e.g. repeated within one planning cycle).
+    }
+    if (observation_time < last_update_time_.value()) {
+      stop_times_.clear();
+    }
   }
   last_update_time_ = observation_time;
 
@@ -126,8 +131,13 @@ void EgoStopTracker::update(const nav_msgs::msg::Odometry & odometry)
 {
   const rclcpp::Time observation_time(odometry.header.stamp);
 
-  if (last_update_time_.has_value() && observation_time < last_update_time_.value()) {
-    stop_time_.reset();
+  if (last_update_time_.has_value()) {
+    if (observation_time == last_update_time_.value()) {
+      return;  // Same observation already processed (e.g. repeated within one planning cycle).
+    }
+    if (observation_time < last_update_time_.value()) {
+      stop_time_.reset();
+    }
   }
   last_update_time_ = observation_time;
 

--- a/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/stop_tracker.hpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/stop_tracker.hpp
@@ -54,7 +54,12 @@ public:
 
   void set_parameters(const StopTrackingParams & params);
 
-  /** @brief Updates stop histories using PredictedObjects.header.stamp as the observation time. */
+  /**
+   * @brief Updates stop histories using PredictedObjects.header.stamp as the observation time.
+   *
+   * Calls that repeat the previous observation timestamp are ignored, so invoking this multiple
+   * times per planning cycle (once per candidate trajectory) is safe and does not accumulate.
+   */
   void update(const autoware_perception_msgs::msg::PredictedObjects & objects);
 
   /** @brief Returns the continuous stop duration, or nullopt if the object is not tracked. */
@@ -84,7 +89,12 @@ public:
 
   void set_parameters(const StopTrackingParams & params);
 
-  /** @brief Updates the ego stop history using Odometry.header.stamp as the observation time. */
+  /**
+   * @brief Updates the ego stop history using Odometry.header.stamp as the observation time.
+   *
+   * Calls that repeat the previous observation timestamp are ignored, so invoking this multiple
+   * times per planning cycle (once per candidate trajectory) is safe and does not accumulate.
+   */
   void update(const nav_msgs::msg::Odometry & odometry);
 
   /** @brief Returns the continuous ego stop duration, or nullopt if the ego is moving. */
@@ -102,8 +112,8 @@ private:
 class StopTrackers
 {
 public:
-  EgoStopTracker ego_;
-  ObjectStopTracker object_;
+  EgoStopTracker ego;
+  ObjectStopTracker object;
   [[nodiscard]] std::optional<rclcpp::Duration> get_stopped_duration(
     const unique_identifier_msgs::msg::UUID & object_id) const;
 };

--- a/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/stop_tracker.hpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/stop_tracker.hpp
@@ -1,0 +1,112 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#ifndef FILTERS__SAFETY__COLLISION_CHECK_FILTER__STOP_TRACKER_HPP_
+#define FILTERS__SAFETY__COLLISION_CHECK_FILTER__STOP_TRACKER_HPP_
+
+#include "autoware/trajectory_validator/detail/uuid_hash.hpp"
+#include "parameter.hpp"
+
+#include <rclcpp/time.hpp>
+
+#include <autoware_perception_msgs/msg/predicted_objects.hpp>
+#include <nav_msgs/msg/odometry.hpp>
+#include <unique_identifier_msgs/msg/uuid.hpp>
+
+#include <array>
+#include <cstdint>
+#include <optional>
+#include <unordered_map>
+
+namespace autoware::trajectory_validator::plugin::safety
+{
+namespace detail
+{
+struct StopTimeRecord
+{
+  rclcpp::Time stopped_since;
+  rclcpp::Time last_seen;
+};
+}  // namespace detail
+
+/**
+ * @brief Tracks how long each currently stopped object has remained stopped.
+ *
+ * Only stopped objects are retained. A moving object is removed immediately, and a stopped object
+ * that is no longer observed is removed after the configured history timeout. All observation
+ * timestamps are stored as absolute rclcpp::Time values.
+ */
+class ObjectStopTracker
+{
+public:
+  explicit ObjectStopTracker(const StopTrackingParams & params = {});
+
+  void set_parameters(const StopTrackingParams & params);
+
+  /** @brief Updates stop histories using PredictedObjects.header.stamp as the observation time. */
+  void update(const autoware_perception_msgs::msg::PredictedObjects & objects);
+
+  /** @brief Returns the continuous stop duration, or nullopt if the object is not tracked. */
+  [[nodiscard]] std::optional<rclcpp::Duration> get_stopped_duration(
+    const unique_identifier_msgs::msg::UUID & object_id) const;
+
+private:
+  using ObjectId = std::array<uint8_t, 16>;
+
+  static constexpr std::size_t kExpectedMaxObjectCount = 1024;
+
+  StopTrackingParams params_;
+  std::unordered_map<ObjectId, detail::StopTimeRecord, UuidHash> stop_times_;
+  std::optional<rclcpp::Time> last_update_time_;
+};
+
+/**
+ * @brief Tracks how long the ego vehicle has continuously remained stopped.
+ *
+ * The tracker stores a single stop record. Odometry.header.stamp is used as the observation time,
+ * and a gap longer than the configured history timeout starts a new stop history.
+ */
+class EgoStopTracker
+{
+public:
+  explicit EgoStopTracker(const StopTrackingParams & params = {});
+
+  void set_parameters(const StopTrackingParams & params);
+
+  /** @brief Updates the ego stop history using Odometry.header.stamp as the observation time. */
+  void update(const nav_msgs::msg::Odometry & odometry);
+
+  /** @brief Returns the continuous ego stop duration, or nullopt if the ego is moving. */
+  [[nodiscard]] std::optional<rclcpp::Duration> get_stopped_duration() const;
+
+private:
+  StopTrackingParams params_;
+  std::optional<detail::StopTimeRecord> stop_time_;
+  std::optional<rclcpp::Time> last_update_time_;
+};
+
+/**
+ * @brief Stop-history trackers used during collision assessment.
+ */
+class StopTrackers
+{
+public:
+  EgoStopTracker ego_;
+  ObjectStopTracker object_;
+  [[nodiscard]] std::optional<rclcpp::Duration> get_stopped_duration(
+    const unique_identifier_msgs::msg::UUID & object_id) const;
+};
+}  // namespace autoware::trajectory_validator::plugin::safety
+
+#endif  // FILTERS__SAFETY__COLLISION_CHECK_FILTER__STOP_TRACKER_HPP_

--- a/planning/autoware_trajectory_validator/test/plugins/collision_check_filter/test_stop_tracker.cpp
+++ b/planning/autoware_trajectory_validator/test/plugins/collision_check_filter/test_stop_tracker.cpp
@@ -100,24 +100,26 @@ TEST(StopTrackingParams, ConvertsEgoAndObjectParametersIndependently)
   EXPECT_DOUBLE_EQ(object_params.history_timeout, 0.4);
 }
 
-TEST(DracParams, ExtractsMutualYieldTimeoutResolutionPerObjectLabel)
+TEST(DracParams, ExtractsMutualYieldArbitrationPerObjectLabel)
 {
   validator::Params node_params;
-  auto & mutual_yield = node_params.collision_check.drac.map_based.mutual_yield_timeout_resolution;
-  mutual_yield.enabled = true;
-  mutual_yield.min_wait_time.base = 1.0;
-  mutual_yield.min_wait_time.pedestrian = 3.0;
-  mutual_yield.min_wait_time.bicycle = 4.0;
+  auto & mutual_yield = node_params.collision_check.drac.map_based.mutual_yield_timeout_arbitration;
+  mutual_yield.enabled.base = false;
+  mutual_yield.enabled.pedestrian = true;
+  mutual_yield.enabled.bicycle = true;
+  mutual_yield.min_wait_time = 3.0;
 
   const DracParams car_params(node_params, "car");
-  EXPECT_TRUE(car_params.map_based.mutual_yield_timeout_resolution.enabled);
-  EXPECT_DOUBLE_EQ(car_params.map_based.mutual_yield_timeout_resolution.min_wait_time, 1.0);
+  EXPECT_FALSE(car_params.map_based.mutual_yield_timeout_arbitration.enabled);
+  EXPECT_DOUBLE_EQ(car_params.map_based.mutual_yield_timeout_arbitration.min_wait_time, 3.0);
 
   const DracParams pedestrian_params(node_params, "pedestrian");
-  EXPECT_DOUBLE_EQ(pedestrian_params.map_based.mutual_yield_timeout_resolution.min_wait_time, 3.0);
+  EXPECT_TRUE(pedestrian_params.map_based.mutual_yield_timeout_arbitration.enabled);
+  EXPECT_DOUBLE_EQ(pedestrian_params.map_based.mutual_yield_timeout_arbitration.min_wait_time, 3.0);
 
   const DracParams bicycle_params(node_params, "bicycle");
-  EXPECT_DOUBLE_EQ(bicycle_params.map_based.mutual_yield_timeout_resolution.min_wait_time, 4.0);
+  EXPECT_TRUE(bicycle_params.map_based.mutual_yield_timeout_arbitration.enabled);
+  EXPECT_DOUBLE_EQ(bicycle_params.map_based.mutual_yield_timeout_arbitration.min_wait_time, 3.0);
 }
 
 TEST(ObjectStopTracker, ReportsContinuousStopDuration)

--- a/planning/autoware_trajectory_validator/test/plugins/collision_check_filter/test_stop_tracker.cpp
+++ b/planning/autoware_trajectory_validator/test/plugins/collision_check_filter/test_stop_tracker.cpp
@@ -142,6 +142,26 @@ TEST(ObjectStopTracker, ReportsContinuousStopDuration)
   EXPECT_DOUBLE_EQ(duration_at_three_seconds.value().seconds(), 3.0);
 }
 
+TEST(ObjectStopTracker, RepeatedObservationTimestampIsANoOp)
+{
+  StopTrackingParams params;
+  params.history_timeout = 10.0;
+  ObjectStopTracker tracker(params);
+  const auto id = make_uuid(7);
+  const auto stopped_object = make_object(id, 0.0);
+
+  update_with_object(tracker, make_time(10'000'000'000LL), stopped_object);
+  update_with_object(tracker, make_time(13'000'000'000LL), stopped_object);
+  ASSERT_TRUE(tracker.get_stopped_duration(id).has_value());
+  EXPECT_DOUBLE_EQ(tracker.get_stopped_duration(id).value().seconds(), 3.0);
+
+  // Re-observing the same timestamp (e.g. another candidate trajectory in the same planning
+  // cycle) must not alter the tracked duration.
+  update_with_object(tracker, make_time(13'000'000'000LL), stopped_object);
+  ASSERT_TRUE(tracker.get_stopped_duration(id).has_value());
+  EXPECT_DOUBLE_EQ(tracker.get_stopped_duration(id).value().seconds(), 3.0);
+}
+
 TEST(ObjectStopTracker, MovingObjectRemovesAndResetsItsStopHistory)
 {
   StopTrackingParams params;
@@ -236,6 +256,24 @@ TEST(EgoStopTracker, ReportsContinuousStopDuration)
   const auto duration_at_three_seconds = tracker.get_stopped_duration();
   ASSERT_TRUE(duration_at_three_seconds.has_value());
   EXPECT_DOUBLE_EQ(duration_at_three_seconds.value().seconds(), 3.0);
+}
+
+TEST(EgoStopTracker, RepeatedObservationTimestampIsANoOp)
+{
+  StopTrackingParams params;
+  params.history_timeout = 10.0;
+  EgoStopTracker tracker(params);
+
+  tracker.update(make_odometry(make_time(10'000'000'000LL), 0.0));
+  tracker.update(make_odometry(make_time(13'000'000'000LL), 0.0));
+  ASSERT_TRUE(tracker.get_stopped_duration().has_value());
+  EXPECT_DOUBLE_EQ(tracker.get_stopped_duration().value().seconds(), 3.0);
+
+  // Re-observing the same timestamp (e.g. another candidate trajectory in the same planning
+  // cycle) must not alter the tracked duration.
+  tracker.update(make_odometry(make_time(13'000'000'000LL), 0.0));
+  ASSERT_TRUE(tracker.get_stopped_duration().has_value());
+  EXPECT_DOUBLE_EQ(tracker.get_stopped_duration().value().seconds(), 3.0);
 }
 
 TEST(EgoStopTracker, MovingEgoRemovesAndResetsStopHistory)

--- a/planning/autoware_trajectory_validator/test/plugins/collision_check_filter/test_stop_tracker.cpp
+++ b/planning/autoware_trajectory_validator/test/plugins/collision_check_filter/test_stop_tracker.cpp
@@ -1,0 +1,324 @@
+// Copyright 2026 TIER IV, Inc.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "../../../src/filters/safety/collision_check_filter/stop_tracker.hpp"
+
+#include <rclcpp/time.hpp>
+
+#include <autoware_perception_msgs/msg/predicted_object.hpp>
+#include <autoware_perception_msgs/msg/predicted_objects.hpp>
+#include <nav_msgs/msg/odometry.hpp>
+#include <unique_identifier_msgs/msg/uuid.hpp>
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+
+namespace autoware::trajectory_validator::plugin::safety
+{
+namespace
+{
+using autoware_perception_msgs::msg::PredictedObject;
+using autoware_perception_msgs::msg::PredictedObjects;
+using nav_msgs::msg::Odometry;
+using unique_identifier_msgs::msg::UUID;
+
+rclcpp::Time make_time(const int64_t nanoseconds)
+{
+  return rclcpp::Time(nanoseconds, RCL_ROS_TIME);
+}
+
+UUID make_uuid(const uint8_t value)
+{
+  UUID id;
+  id.uuid.fill(value);
+  return id;
+}
+
+PredictedObject make_object(const UUID & id, const double velocity_x, const double velocity_y = 0.0)
+{
+  PredictedObject object;
+  object.object_id = id;
+  auto & linear_velocity = object.kinematics.initial_twist_with_covariance.twist.linear;
+  linear_velocity.x = velocity_x;
+  linear_velocity.y = velocity_y;
+  return object;
+}
+
+PredictedObjects make_objects(const rclcpp::Time & stamp)
+{
+  PredictedObjects objects;
+  objects.header.stamp = stamp;
+  return objects;
+}
+
+Odometry make_odometry(
+  const rclcpp::Time & stamp, const double velocity_x, const double velocity_y = 0.0)
+{
+  Odometry odometry;
+  odometry.header.stamp = stamp;
+  odometry.twist.twist.linear.x = velocity_x;
+  odometry.twist.twist.linear.y = velocity_y;
+  return odometry;
+}
+
+void update_with_object(
+  ObjectStopTracker & tracker, const rclcpp::Time & stamp, const PredictedObject & object)
+{
+  auto objects = make_objects(stamp);
+  objects.objects.push_back(object);
+  tracker.update(objects);
+}
+}  // namespace
+
+TEST(StopTrackingParams, ConvertsEgoAndObjectParametersIndependently)
+{
+  validator::Params node_params;
+  auto & stop_tracking = node_params.collision_check.drac.stop_tracking;
+  stop_tracking.ego.stopped_velocity_threshold = 0.01;
+  stop_tracking.ego.history_timeout = 0.2;
+  stop_tracking.object.stopped_velocity_threshold = 0.3;
+  stop_tracking.object.history_timeout = 0.4;
+
+  const StopTrackingParams ego_params(stop_tracking.ego);
+  EXPECT_DOUBLE_EQ(ego_params.stopped_velocity_threshold, 0.01);
+  EXPECT_DOUBLE_EQ(ego_params.history_timeout, 0.2);
+
+  const StopTrackingParams object_params(stop_tracking.object);
+  EXPECT_DOUBLE_EQ(object_params.stopped_velocity_threshold, 0.3);
+  EXPECT_DOUBLE_EQ(object_params.history_timeout, 0.4);
+}
+
+TEST(DracParams, ExtractsMutualYieldTimeoutResolutionPerObjectLabel)
+{
+  validator::Params node_params;
+  auto & mutual_yield = node_params.collision_check.drac.map_based.mutual_yield_timeout_resolution;
+  mutual_yield.enabled = true;
+  mutual_yield.min_wait_time.base = 1.0;
+  mutual_yield.min_wait_time.pedestrian = 3.0;
+  mutual_yield.min_wait_time.bicycle = 4.0;
+
+  const DracParams car_params(node_params, "car");
+  EXPECT_TRUE(car_params.map_based.mutual_yield_timeout_resolution.enabled);
+  EXPECT_DOUBLE_EQ(car_params.map_based.mutual_yield_timeout_resolution.min_wait_time, 1.0);
+
+  const DracParams pedestrian_params(node_params, "pedestrian");
+  EXPECT_DOUBLE_EQ(pedestrian_params.map_based.mutual_yield_timeout_resolution.min_wait_time, 3.0);
+
+  const DracParams bicycle_params(node_params, "bicycle");
+  EXPECT_DOUBLE_EQ(bicycle_params.map_based.mutual_yield_timeout_resolution.min_wait_time, 4.0);
+}
+
+TEST(ObjectStopTracker, ReportsContinuousStopDuration)
+{
+  StopTrackingParams params;
+  params.history_timeout = 10.0;
+  ObjectStopTracker tracker(params);
+  const auto id = make_uuid(1);
+  const auto stopped_object = make_object(id, 0.0);
+
+  update_with_object(tracker, make_time(10'000'000'000LL), stopped_object);
+  update_with_object(tracker, make_time(12'999'999'999LL), stopped_object);
+  const auto duration_before_three_seconds = tracker.get_stopped_duration(id);
+  ASSERT_TRUE(duration_before_three_seconds.has_value());
+  EXPECT_NEAR(duration_before_three_seconds.value().seconds(), 2.999999999, 1e-9);
+
+  update_with_object(tracker, make_time(13'000'000'000LL), stopped_object);
+  const auto duration_at_three_seconds = tracker.get_stopped_duration(id);
+  ASSERT_TRUE(duration_at_three_seconds.has_value());
+  EXPECT_DOUBLE_EQ(duration_at_three_seconds.value().seconds(), 3.0);
+}
+
+TEST(ObjectStopTracker, MovingObjectRemovesAndResetsItsStopHistory)
+{
+  StopTrackingParams params;
+  params.stopped_velocity_threshold = 0.1;
+  params.history_timeout = 10.0;
+  ObjectStopTracker tracker(params);
+  const auto id = make_uuid(2);
+
+  update_with_object(tracker, make_time(10'000'000'000LL), make_object(id, 0.0));
+  update_with_object(tracker, make_time(13'000'000'000LL), make_object(id, 0.0));
+  ASSERT_TRUE(tracker.get_stopped_duration(id).has_value());
+  EXPECT_DOUBLE_EQ(tracker.get_stopped_duration(id).value().seconds(), 3.0);
+
+  update_with_object(tracker, make_time(14'000'000'000LL), make_object(id, 0.1));
+  EXPECT_FALSE(tracker.get_stopped_duration(id).has_value());
+
+  update_with_object(tracker, make_time(15'000'000'000LL), make_object(id, 0.0));
+  update_with_object(tracker, make_time(17'999'999'999LL), make_object(id, 0.0));
+  const auto duration_after_restart = tracker.get_stopped_duration(id);
+  ASSERT_TRUE(duration_after_restart.has_value());
+  EXPECT_NEAR(duration_after_restart.value().seconds(), 2.999999999, 1e-9);
+
+  update_with_object(tracker, make_time(18'000'000'000LL), make_object(id, 0.0));
+  ASSERT_TRUE(tracker.get_stopped_duration(id).has_value());
+  EXPECT_DOUBLE_EQ(tracker.get_stopped_duration(id).value().seconds(), 3.0);
+}
+
+TEST(ObjectStopTracker, RemovesUnobservedObjectAfterHistoryTimeout)
+{
+  StopTrackingParams params;
+  params.history_timeout = 1.0;
+  ObjectStopTracker tracker(params);
+  const auto id = make_uuid(3);
+
+  update_with_object(tracker, make_time(10'000'000'000LL), make_object(id, 0.0));
+
+  auto empty_objects = make_objects(make_time(11'000'000'000LL));
+  tracker.update(empty_objects);
+  ASSERT_TRUE(tracker.get_stopped_duration(id).has_value());
+  EXPECT_DOUBLE_EQ(tracker.get_stopped_duration(id).value().seconds(), 1.0);
+
+  empty_objects.header.stamp = make_time(11'000'000'001LL);
+  tracker.update(empty_objects);
+  EXPECT_FALSE(tracker.get_stopped_duration(id).has_value());
+}
+
+TEST(ObjectStopTracker, UsesPlanarSpeedForStopClassification)
+{
+  StopTrackingParams params;
+  params.stopped_velocity_threshold = 0.1;
+  ObjectStopTracker tracker(params);
+  const auto id = make_uuid(4);
+
+  update_with_object(tracker, make_time(10'000'000'000LL), make_object(id, 0.06, 0.06));
+  EXPECT_TRUE(tracker.get_stopped_duration(id).has_value());
+
+  update_with_object(tracker, make_time(11'000'000'000LL), make_object(id, 0.08, 0.08));
+  EXPECT_FALSE(tracker.get_stopped_duration(id).has_value());
+}
+
+TEST(ObjectStopTracker, ResetsHistoryWhenObservationTimeMovesBackward)
+{
+  StopTrackingParams params;
+  params.history_timeout = 10.0;
+  ObjectStopTracker tracker(params);
+  const auto id = make_uuid(5);
+  const auto stopped_object = make_object(id, 0.0);
+
+  update_with_object(tracker, make_time(10'000'000'000LL), stopped_object);
+  update_with_object(tracker, make_time(13'000'000'000LL), stopped_object);
+  ASSERT_TRUE(tracker.get_stopped_duration(id).has_value());
+  EXPECT_DOUBLE_EQ(tracker.get_stopped_duration(id).value().seconds(), 3.0);
+
+  update_with_object(tracker, make_time(5'000'000'000LL), stopped_object);
+  ASSERT_TRUE(tracker.get_stopped_duration(id).has_value());
+  EXPECT_DOUBLE_EQ(tracker.get_stopped_duration(id).value().seconds(), 0.0);
+}
+
+TEST(EgoStopTracker, ReportsContinuousStopDuration)
+{
+  StopTrackingParams params;
+  params.history_timeout = 10.0;
+  EgoStopTracker tracker(params);
+
+  tracker.update(make_odometry(make_time(10'000'000'000LL), 0.0));
+  tracker.update(make_odometry(make_time(12'999'999'999LL), 0.0));
+  const auto duration_before_three_seconds = tracker.get_stopped_duration();
+  ASSERT_TRUE(duration_before_three_seconds.has_value());
+  EXPECT_NEAR(duration_before_three_seconds.value().seconds(), 2.999999999, 1e-9);
+
+  tracker.update(make_odometry(make_time(13'000'000'000LL), 0.0));
+  const auto duration_at_three_seconds = tracker.get_stopped_duration();
+  ASSERT_TRUE(duration_at_three_seconds.has_value());
+  EXPECT_DOUBLE_EQ(duration_at_three_seconds.value().seconds(), 3.0);
+}
+
+TEST(EgoStopTracker, MovingEgoRemovesAndResetsStopHistory)
+{
+  StopTrackingParams params;
+  params.stopped_velocity_threshold = 0.1;
+  params.history_timeout = 10.0;
+  EgoStopTracker tracker(params);
+
+  tracker.update(make_odometry(make_time(10'000'000'000LL), 0.0));
+  tracker.update(make_odometry(make_time(13'000'000'000LL), 0.0));
+  ASSERT_TRUE(tracker.get_stopped_duration().has_value());
+  EXPECT_DOUBLE_EQ(tracker.get_stopped_duration().value().seconds(), 3.0);
+
+  tracker.update(make_odometry(make_time(14'000'000'000LL), 0.1));
+  EXPECT_FALSE(tracker.get_stopped_duration().has_value());
+
+  tracker.update(make_odometry(make_time(15'000'000'000LL), 0.0));
+  tracker.update(make_odometry(make_time(18'000'000'000LL), 0.0));
+  ASSERT_TRUE(tracker.get_stopped_duration().has_value());
+  EXPECT_DOUBLE_EQ(tracker.get_stopped_duration().value().seconds(), 3.0);
+}
+
+TEST(EgoStopTracker, ResetsStopHistoryAfterHistoryTimeout)
+{
+  StopTrackingParams params;
+  params.history_timeout = 1.0;
+  EgoStopTracker tracker(params);
+
+  tracker.update(make_odometry(make_time(10'000'000'000LL), 0.0));
+  tracker.update(make_odometry(make_time(11'000'000'000LL), 0.0));
+  ASSERT_TRUE(tracker.get_stopped_duration().has_value());
+  EXPECT_DOUBLE_EQ(tracker.get_stopped_duration().value().seconds(), 1.0);
+
+  tracker.update(make_odometry(make_time(12'000'000'001LL), 0.0));
+  ASSERT_TRUE(tracker.get_stopped_duration().has_value());
+  EXPECT_DOUBLE_EQ(tracker.get_stopped_duration().value().seconds(), 0.0);
+}
+
+TEST(EgoStopTracker, UsesPlanarSpeedForStopClassification)
+{
+  StopTrackingParams params;
+  params.stopped_velocity_threshold = 0.1;
+  EgoStopTracker tracker(params);
+
+  tracker.update(make_odometry(make_time(10'000'000'000LL), 0.06, 0.06));
+  EXPECT_TRUE(tracker.get_stopped_duration().has_value());
+
+  tracker.update(make_odometry(make_time(11'000'000'000LL), 0.08, 0.08));
+  EXPECT_FALSE(tracker.get_stopped_duration().has_value());
+}
+
+TEST(EgoStopTracker, ResetsHistoryWhenObservationTimeMovesBackward)
+{
+  StopTrackingParams params;
+  params.history_timeout = 10.0;
+  EgoStopTracker tracker(params);
+
+  tracker.update(make_odometry(make_time(10'000'000'000LL), 0.0));
+  tracker.update(make_odometry(make_time(13'000'000'000LL), 0.0));
+  ASSERT_TRUE(tracker.get_stopped_duration().has_value());
+  EXPECT_DOUBLE_EQ(tracker.get_stopped_duration().value().seconds(), 3.0);
+
+  tracker.update(make_odometry(make_time(5'000'000'000LL), 0.0));
+  ASSERT_TRUE(tracker.get_stopped_duration().has_value());
+  EXPECT_DOUBLE_EQ(tracker.get_stopped_duration().value().seconds(), 0.0);
+}
+
+TEST(StopTrackers, KeepUpdateTimesIndependent)
+{
+  StopTrackingParams params;
+  params.history_timeout = 100.0;
+  ObjectStopTracker object_tracker(params);
+  EgoStopTracker ego_tracker(params);
+  const auto object_id = make_uuid(6);
+
+  update_with_object(object_tracker, make_time(10'000'000'000LL), make_object(object_id, 0.0));
+  update_with_object(object_tracker, make_time(13'000'000'000LL), make_object(object_id, 0.0));
+
+  ego_tracker.update(make_odometry(make_time(100'000'000'000LL), 0.0));
+  ego_tracker.update(make_odometry(make_time(102'000'000'000LL), 0.0));
+
+  ASSERT_TRUE(object_tracker.get_stopped_duration(object_id).has_value());
+  EXPECT_DOUBLE_EQ(object_tracker.get_stopped_duration(object_id).value().seconds(), 3.0);
+  ASSERT_TRUE(ego_tracker.get_stopped_duration().has_value());
+  EXPECT_DOUBLE_EQ(ego_tracker.get_stopped_duration().value().seconds(), 2.0);
+}
+}  // namespace autoware::trajectory_validator::plugin::safety


### PR DESCRIPTION
互いに停止した際のお見合いに対して進行をする機能を追加します。
考え方はbehavior_velocityのcrosswalkからの移植です。
