### PR TITLE
feat(trajectory_optimizer): switch runtime log from INFO to DEBUG

### DIFF
--- a/planning/autoware_trajectory_optimizer/src/trajectory_optimizer.cpp
+++ b/planning/autoware_trajectory_optimizer/src/trajectory_optimizer.cpp
@@ -221,7 +221,7 @@ void TrajectoryOptimizer::on_traj([[maybe_unused]] const CandidateTrajectories::
   const double elapsed_ms =
     std::chrono::duration<double, std::milli>(std::chrono::steady_clock::now() - t_opt_start)
       .count();
-  RCLCPP_INFO(
+  RCLCPP_DEBUG(
     get_logger(),
     "Trajectory optimizer: total execution time %.3f ms (%zu candidate trajectories, %zu plugins)",
     elapsed_ms, output_trajectories.candidate_trajectories.size(), plugins_.size());


### PR DESCRIPTION
Prevent the `autoware_trajectory_optimizer_node` runtime to be printed in the console (`INFO` -> `DEBUG`).
```
[autoware_trajectory_optimizer_node-25] [INFO] [1785118499.392719230] [planning.trajectory_generator.trajectory_optimizer_node]: Trajectory optimizer: total execution time 0.019 ms (1 candidate trajectories, 10 plugins)
```