### PR TITLE
feat(collision_check_filter): add object deceleration

### DIFF
--- a/planning/autoware_trajectory_validator/config/trajectory_validator.param.yaml
+++ b/planning/autoware_trajectory_validator/config/trajectory_validator.param.yaml
@@ -75,6 +75,9 @@
               danger_limit: -3.0
               fatal_limit: -6.0
               enable_abandon: true
+            object_drac_acceleration:
+              safe_limit: -0.5
+              low_caution_limit: -1.5
           object_prioritized_object_earlier:
             enable_assessment: true
             ego_drac_acceleration:

--- a/planning/autoware_trajectory_validator/param/parameter_struct.yaml
+++ b/planning/autoware_trajectory_validator/param/parameter_struct.yaml
@@ -251,7 +251,21 @@ validator:
             read_only: false
         ego_prioritized_ego_earlier: *drac_assessment
         ego_prioritized_object_earlier: *drac_assessment
-        object_prioritized_ego_earlier: *drac_assessment
+        # Same as the shared DRAC assessment, plus the object deceleration tiers that are only
+        # meaningful when the object has priority and can resolve the conflict by braking itself.
+        object_prioritized_ego_earlier:
+          <<: *drac_assessment
+          object_drac_acceleration:
+            safe_limit:
+              type: double
+              default_value: -0.5
+              description: Required object deceleration at or milder than this is classified as safe
+              read_only: false
+            low_caution_limit:
+              type: double
+              default_value: -1.5
+              description: Required object deceleration down to this is classified as low caution
+              read_only: false
         object_prioritized_object_earlier: *drac_assessment
     rss:
       enable_assessment:

--- a/planning/autoware_trajectory_validator/schema/trajectory_validator.schema.json
+++ b/planning/autoware_trajectory_validator/schema/trajectory_validator.schema.json
@@ -100,38 +100,66 @@
       "required": [],
       "additionalProperties": false
     },
+    "enable_drac_assessment": {
+      "type": "boolean",
+      "default": true,
+      "description": "Enable this DRAC assessment condition."
+    },
+    "ego_drac_acceleration": {
+      "type": "object",
+      "properties": {
+        "safe_limit": {
+          "type": "number",
+          "description": "Ego acceleration limit for a safe DRAC assessment [m/s²]."
+        },
+        "danger_limit": {
+          "type": "number",
+          "description": "Ego acceleration limit for a dangerous DRAC assessment [m/s²]."
+        },
+        "fatal_limit": {
+          "type": "number",
+          "description": "Ego acceleration limit for a fatal DRAC assessment [m/s²]."
+        },
+        "enable_abandon": {
+          "type": "boolean",
+          "default": false,
+          "description": "Treat an unavoidable collision as high caution instead of fatal."
+        }
+      },
+      "required": [],
+      "additionalProperties": false
+    },
+    "object_drac_acceleration": {
+      "type": "object",
+      "properties": {
+        "safe_limit": {
+          "type": "number",
+          "description": "Required object deceleration at or milder than this is classified as safe [m/s²]."
+        },
+        "low_caution_limit": {
+          "type": "number",
+          "description": "Required object deceleration down to this is classified as low caution [m/s²]."
+        }
+      },
+      "required": [],
+      "additionalProperties": false
+    },
     "drac_assessment": {
       "type": "object",
       "properties": {
-        "enable_assessment": {
-          "type": "boolean",
-          "default": true,
-          "description": "Enable this DRAC assessment condition."
-        },
-        "ego_drac_acceleration": {
-          "type": "object",
-          "properties": {
-            "safe_limit": {
-              "type": "number",
-              "description": "Ego acceleration limit for a safe DRAC assessment [m/s²]."
-            },
-            "danger_limit": {
-              "type": "number",
-              "description": "Ego acceleration limit for a dangerous DRAC assessment [m/s²]."
-            },
-            "fatal_limit": {
-              "type": "number",
-              "description": "Ego acceleration limit for a fatal DRAC assessment [m/s²]."
-            },
-            "enable_abandon": {
-              "type": "boolean",
-              "default": false,
-              "description": "Treat an unavoidable collision as high caution instead of fatal."
-            }
-          },
-          "required": [],
-          "additionalProperties": false
-        }
+        "enable_assessment": { "$ref": "#/definitions/enable_drac_assessment" },
+        "ego_drac_acceleration": { "$ref": "#/definitions/ego_drac_acceleration" }
+      },
+      "required": [],
+      "additionalProperties": false
+    },
+    "drac_assessment_with_object_braking": {
+      "type": "object",
+      "description": "DRAC assessment that also evaluates the object braking on its own.",
+      "properties": {
+        "enable_assessment": { "$ref": "#/definitions/enable_drac_assessment" },
+        "ego_drac_acceleration": { "$ref": "#/definitions/ego_drac_acceleration" },
+        "object_drac_acceleration": { "$ref": "#/definitions/object_drac_acceleration" }
       },
       "required": [],
       "additionalProperties": false
@@ -294,7 +322,7 @@
                       "$ref": "#/definitions/drac_assessment"
                     },
                     "object_prioritized_ego_earlier": {
-                      "$ref": "#/definitions/drac_assessment"
+                      "$ref": "#/definitions/drac_assessment_with_object_braking"
                     },
                     "object_prioritized_object_earlier": {
                       "$ref": "#/definitions/drac_assessment"

--- a/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/assessment.cpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/assessment.cpp
@@ -157,12 +157,31 @@ RiskLevel::_level_type identify_risk_level(
   }
 }
 
+// Object counterpart of identify_risk_level: classifies how hard the object must brake to avoid the
+// collision into a risk level, mirroring the ego DRAC acceleration tiers.
+RiskLevel::_level_type identify_object_risk_level(
+  const double required_object_acceleration,
+  const DracParams::ObjectDracAcceleration & object_acceleration_params)
+{
+  return (required_object_acceleration >= object_acceleration_params.safe_limit)
+           ? RiskLevel::SAFE
+           : RiskLevel::LOW_CAUTION;
+}
+
 struct EgoDracAssessmentParams
 {
   DracParams::PetMargin pet_margin{};
   EgoFootprintMargin ego_footprint_margin{};
   DracParams::EgoDracAcceleration acceleration{};
   double braking_delay{};
+};
+
+// Object counterpart of EgoDracAssessmentParams. Nothing about the ego motion is needed here: the
+// assessment runs against the nominal ego trajectory, which the caller supplies ready-made.
+struct ObjectDracAssessmentParams
+{
+  DracParams::PetMargin pet_margin{};
+  DracParams::ObjectDracAcceleration acceleration{};
 };
 
 std::pair<std::optional<double>, std::optional<CollisionDetail>> assess_ego_drac(
@@ -202,6 +221,33 @@ std::pair<std::optional<double>, std::optional<CollisionDetail>> assess_ego_drac
   return {std::nullopt, collision_result};
 }
 
+// Assesses whether the object decelerating (instead of ego braking) is enough to avoid the
+// collision. The object trajectory for each assumed deceleration is memoized in the object cache.
+std::pair<std::optional<double>, std::optional<CollisionDetail>> assess_object_drac(
+  const trajectory::ObjectTrajectoryCache & object_trajectory_cache,
+  const TrajectoryData & ego_nominal_trajectory,
+  const autoware_perception_msgs::msg::PredictedObject & object, const size_t predicted_path_index,
+  const ObjectDracAssessmentParams & params, const GlobalParams & global_params)
+{
+  const std::vector<double> object_acceleration_list{
+    params.acceleration.safe_limit, params.acceleration.low_caution_limit};
+
+  std::optional<CollisionDetail> last_detected_collision{};
+  for (const auto object_acceleration : object_acceleration_list) {
+    const auto & object_trajectory =
+      object_trajectory_cache.get_or_compute_predicted_path_trajectory(
+        object, predicted_path_index, 0.0, object_acceleration, 8.0);
+
+    auto detected_collision = find_collision_timing(
+      ego_nominal_trajectory, object_trajectory, params.pet_margin, global_params.time_resolution);
+    if (!detected_collision.has_value()) {
+      return {object_acceleration, last_detected_collision};
+    }
+    last_detected_collision = std::move(detected_collision);
+  }
+  return {std::nullopt, last_detected_collision};
+}
+
 DracEvaluation assess_drac_constant_curvature_object_first(
   const trajectory::EgoTrajectoryCache & ego_trajectory_cache,
   const TrajectoryData & object_constant_curvature_trajectory, const DracParams & drac_params,
@@ -224,6 +270,7 @@ DracEvaluation assess_drac_constant_curvature_object_first(
 
 DracArtifact assess_constant_curvature(
   const trajectory::EgoTrajectoryCache & ego_trajectory_cache,
+  const trajectory::ObjectTrajectoryCache & object_trajectory_cache,
   const autoware_perception_msgs::msg::PredictedObject & object, const DracParams & drac_params,
   const GlobalParams & global_params)
 {
@@ -237,11 +284,9 @@ DracArtifact assess_constant_curvature(
   const auto & ego_nominal_trajectory =
     ego_trajectory_cache.get_or_compute_trajectory_data(ego_traj_params);
 
-  const auto object_constant_curvature_trajectory =
-    trajectory::generate_constant_curvature_trajectory(
-      object, 0.0, 0.0, rclcpp::Duration::from_seconds(0.0),
-      drac_params.constant_curvature.object_time_horizon, rclcpp::Time{},
-      global_params.time_resolution);
+  const auto & object_constant_curvature_trajectory =
+    object_trajectory_cache.get_or_compute_constant_curvature_trajectory(
+      object, 0.0, 0.0, drac_params.constant_curvature.object_time_horizon);
 
   auto nominal_collision_result = find_collision_timing(
     ego_nominal_trajectory, object_constant_curvature_trajectory, drac_params.pet_margin,
@@ -266,19 +311,46 @@ DracArtifact assess_constant_curvature(
 
 DracEvaluation assess_drac_object_prioritized_ego_earlier(
   const trajectory::EgoTrajectoryCache & ego_trajectory_cache,
-  const TrajectoryData & object_map_based_trajectory, const DracParams & drac_params,
-  const GlobalParams & global_params, CollisionDetail && nominal_collision_result)
+  const trajectory::ObjectTrajectoryCache & object_trajectory_cache,
+  const TrajectoryData & ego_nominal_trajectory, const TrajectoryData & object_map_based_trajectory,
+  const autoware_perception_msgs::msg::PredictedObject & object, const size_t predicted_path_index,
+  const DracParams & drac_params, const GlobalParams & global_params,
+  CollisionDetail && nominal_collision_result)
 {
-  // todo(takagi): add object deceleration.
   const auto ego_drac_params = EgoDracAssessmentParams{
     drac_params.pet_margin, drac_params.ego_footprint_margin,
     drac_params.map_based.object_prioritized_ego_earlier.ego_drac_assessment,
     drac_params.ego_reaction_braking_delay.nominal};
-  auto [required_acceleration, last_collision] = assess_ego_drac(
-    ego_trajectory_cache, object_map_based_trajectory, ego_drac_params, global_params);
 
   DracEvaluation evaluation{};
   evaluation.method = "map_based, object prioritized, ego earlier";
+
+  // If the object decelerating on its own resolves the collision, ego need not brake. The assumed
+  // object decelerations are searched from mild to hard, mirroring the ego DRAC acceleration list,
+  // and the required object deceleration is mapped to a risk level.
+  const auto object_drac_params = ObjectDracAssessmentParams{
+    drac_params.pet_margin,
+    drac_params.map_based.object_prioritized_ego_earlier.object_drac_acceleration};
+
+  auto [object_required_acceleration, object_deceleration_last_collision] = assess_object_drac(
+    object_trajectory_cache, ego_nominal_trajectory, object, predicted_path_index,
+    object_drac_params, global_params);
+  if (object_required_acceleration.has_value()) {
+    evaluation.risk = identify_object_risk_level(
+      object_required_acceleration.value(), object_drac_params.acceleration);
+    evaluation.ego_drac_acceleration = 0.0;
+    // The mildest searched deceleration may avoid the collision without producing a collision
+    // detail of its own; fall back to the nominal (constant-velocity) collision for reporting in
+    // that case.
+    evaluation.detail = object_deceleration_last_collision.has_value()
+                          ? std::move(object_deceleration_last_collision.value())
+                          : std::move(nominal_collision_result);
+    return evaluation;
+  }
+
+  auto [required_acceleration, last_collision] = assess_ego_drac(
+    ego_trajectory_cache, object_map_based_trajectory, ego_drac_params, global_params);
+
   evaluation.risk = identify_risk_level(required_acceleration, ego_drac_params.acceleration);
   evaluation.ego_drac_acceleration = required_acceleration;
   evaluation.detail = std::move(last_collision).value_or(std::move(nominal_collision_result));
@@ -307,6 +379,7 @@ DracEvaluation assess_drac_object_prioritized_object_earlier(
 
 DracArtifact assess_map_based(
   const trajectory::EgoTrajectoryCache & ego_trajectory_cache,
+  const trajectory::ObjectTrajectoryCache & object_trajectory_cache,
   const autoware_vehicle_msgs::msg::TurnIndicatorsCommand & ego_turn_indicator,
   const autoware_perception_msgs::msg::PredictedObject & object, const StopTrackers & stop_trackers,
   const DracParams & drac_params, const GlobalParams & global_params)
@@ -317,10 +390,11 @@ DracArtifact assess_map_based(
   trajectory::EgoTrajectoryGenerationParams ego_traj_params{
     braking_delay, 0.0, drac_params.ego_footprint_margin};
 
-  for (const auto & obj_predicted_path : object.kinematics.predicted_paths) {
-    const auto predicted_path_nominal_trajectory = trajectory::generate_predicted_path_trajectory(
-      object, obj_predicted_path, 0.0, 0.0, rclcpp::Duration::from_seconds(0.0), 8.0,
-      rclcpp::Time(), global_params.time_resolution);
+  for (size_t predicted_path_index = 0;
+       predicted_path_index < object.kinematics.predicted_paths.size(); ++predicted_path_index) {
+    const auto & predicted_path_nominal_trajectory =
+      object_trajectory_cache.get_or_compute_predicted_path_trajectory(
+        object, predicted_path_index, 0.0, 0.0, 8.0);
 
     const auto & ego_nominal_trajectory =
       ego_trajectory_cache.get_or_compute_trajectory_data(ego_traj_params);
@@ -351,8 +425,9 @@ DracArtifact assess_map_based(
           continue;
         }
         drac_artifact.merge(assess_drac_object_prioritized_ego_earlier(
-          ego_trajectory_cache, predicted_path_nominal_trajectory, drac_params, global_params,
-          std::move(nominal_collision_result.value())));
+          ego_trajectory_cache, object_trajectory_cache, ego_nominal_trajectory,
+          predicted_path_nominal_trajectory, object, predicted_path_index, drac_params,
+          global_params, std::move(nominal_collision_result.value())));
       } else {
         if (!drac_params.map_based.object_prioritized_object_earlier.enable_assessment) {
           continue;
@@ -382,6 +457,7 @@ DracArtifact assess_map_based(
 
 DracArtifact assess(
   const trajectory::EgoTrajectoryCache & ego_trajectory_cache,
+  const trajectory::ObjectTrajectoryCache & object_trajectory_cache,
   const autoware_vehicle_msgs::msg::TurnIndicatorsCommand & ego_turn_indicator,
   const nav_msgs::msg::Odometry & odometry,
   const autoware_perception_msgs::msg::PredictedObjects & predicted_objects,
@@ -401,13 +477,14 @@ DracArtifact assess(
 
     if (drac_params.constant_curvature.enable_assessment) {
       drac_artifact.merge(assess_constant_curvature(
-        ego_trajectory_cache, predicted_object, drac_params, global_params));
+        ego_trajectory_cache, object_trajectory_cache, predicted_object, drac_params,
+        global_params));
     }
 
     if (drac_params.map_based.enable_assessment) {
       drac_artifact.merge(assess_map_based(
-        ego_trajectory_cache, ego_turn_indicator, predicted_object, stop_trackers, drac_params,
-        global_params));
+        ego_trajectory_cache, object_trajectory_cache, ego_turn_indicator, predicted_object,
+        stop_trackers, drac_params, global_params));
     }
   }
   return drac_artifact;
@@ -444,7 +521,7 @@ std::optional<double> compute_distance_to_collision(
 RssDetail assess_required_acceleration(
   const TrajectoryData & ego_trajectory, const geometry_msgs::msg::Twist & ego_twist,
   const autoware_perception_msgs::msg::PredictedObject & object, const RssParams & rss_params,
-  const builtin_interfaces::msg::Time & stamp)
+  const rclcpp::Time & stamp)
 {
   const auto ego_long_vel = ego_twist.linear.x;
   if (ego_long_vel <= 0.0) {

--- a/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/assessment.hpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/assessment.hpp
@@ -34,6 +34,7 @@ namespace autoware::trajectory_validator::plugin::safety::collision_timing_asses
 {
 DracArtifact assess(
   const trajectory::EgoTrajectoryCache & ego_trajectory_cache,
+  const trajectory::ObjectTrajectoryCache & object_trajectory_cache,
   const autoware_vehicle_msgs::msg::TurnIndicatorsCommand & ego_turn_indicator,
   const nav_msgs::msg::Odometry & odometry,
   const autoware_perception_msgs::msg::PredictedObjects & predicted_objects,

--- a/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/collision_check_filter.cpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/collision_check_filter.cpp
@@ -119,9 +119,15 @@ CollisionCheckFilter::result_t CollisionCheckFilter::is_feasible(
     rclcpp::Time(context.odometry->header.stamp), global_params_.time_resolution,
     *vehicle_info_ptr_);
 
+  // Object trajectories are independent of the ego candidate trajectory, so they are memoized per
+  // object and reused across the multiple is_feasible() calls of one perception frame; the cache
+  // is discarded when the PredictedObjects timestamp changes.
+  object_trajectory_cache_.update(
+    rclcpp::Time(context.predicted_objects->header.stamp), global_params_.time_resolution);
+
   const auto drac_artifact = collision_timing_assessment::assess(
-    ego_trajectory_cache, candidate_trajectory.turn_indicators_command, *context.odometry,
-    *context.predicted_objects, stop_tracker_, drac_param_map_, global_params_);
+    ego_trajectory_cache, object_trajectory_cache_, candidate_trajectory.turn_indicators_command,
+    *context.odometry, *context.predicted_objects, stop_tracker_, drac_param_map_, global_params_);
   const auto rss_artifact = rss_deceleration::assess(ego_trajectory_cache, context, rss_param_map_);
 
   auto planning_factors = reporter::process_collision_artifacts(

--- a/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/collision_check_filter.hpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/collision_check_filter.hpp
@@ -19,6 +19,7 @@
 #include "parameter.hpp"
 #include "reporter.hpp"
 #include "stop_tracker.hpp"
+#include "trajectory_utils.hpp"
 #include "types.hpp"
 
 #include <vector>
@@ -43,6 +44,10 @@ private:
 
   reporter::ContinuousDetectionTimes rss_continuous_times_;
   reporter::ContinuousDetectionTimes drac_continuous_times_;
+
+  // Retained across is_feasible() calls so object trajectories are reused within one perception
+  // frame; invalidated via update() when the PredictedObjects timestamp changes.
+  trajectory::ObjectTrajectoryCache object_trajectory_cache_;
 
   void clear_detection_times();
 

--- a/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/parameter.hpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/parameter.hpp
@@ -173,10 +173,23 @@ struct DracParams
     bool enable_abandon{false};
   };
 
+  struct ObjectDracAcceleration
+  {
+    double safe_limit{-0.5};
+    double low_caution_limit{-1.5};
+  };
+
   struct DracAssessment
   {
     bool enable_assessment{true};
     EgoDracAcceleration ego_drac_assessment{};
+  };
+
+  // DracAssessment that, on top of the ego braking, also evaluates whether the object braking on
+  // its own resolves the collision.
+  struct DracAssessmentWithObjectBraking : DracAssessment
+  {
+    ObjectDracAcceleration object_drac_acceleration{};
   };
 
   struct ConstantCurvature
@@ -199,7 +212,7 @@ struct DracParams
     MutualYieldArbitration mutual_yield_timeout_arbitration{};
     DracAssessment ego_prioritized_ego_earlier{};
     DracAssessment ego_prioritized_object_earlier{};
-    DracAssessment object_prioritized_ego_earlier{};
+    DracAssessmentWithObjectBraking object_prioritized_ego_earlier{};
     DracAssessment object_prioritized_object_earlier{};
   };
 
@@ -256,6 +269,14 @@ struct DracParams
       drac.map_based.ego_prioritized_object_earlier, map_based.ego_prioritized_object_earlier);
     parse_assessment(
       drac.map_based.object_prioritized_ego_earlier, map_based.object_prioritized_ego_earlier);
+    const auto & object_drac_acceleration =
+      drac.map_based.object_prioritized_ego_earlier.object_drac_acceleration;
+    auto & output_object_drac_acceleration =
+      map_based.object_prioritized_ego_earlier.object_drac_acceleration;
+    output_object_drac_acceleration.safe_limit =
+      extract_labeled_param<double>(object_drac_acceleration.safe_limit, key);
+    output_object_drac_acceleration.low_caution_limit =
+      extract_labeled_param<double>(object_drac_acceleration.low_caution_limit, key);
     parse_assessment(
       drac.map_based.object_prioritized_object_earlier,
       map_based.object_prioritized_object_earlier);

--- a/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/trajectory_utils.cpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/trajectory_utils.cpp
@@ -573,32 +573,42 @@ EgoTrajectoryCache::EgoTrajectoryCache(
   }
 }
 
+namespace
+{
+// Memoization body shared by every trajectory cache. `cache_key` is only used to look up and to
+// insert the entry; the values needed to build the trajectory are captured by `generate`, which is
+// invoked on a cache miss only.
+template <typename Cache, typename CacheKey, typename Generator>
+const TrajectoryData & get_or_emplace_trajectory(
+  Cache & cache, const CacheKey & cache_key, Generator && generate)
+{
+  const auto it = cache.find(cache_key);
+  if (it != cache.end()) {
+    return it->second;
+  }
+  return cache.emplace(cache_key, generate()).first->second;
+}
+}  // namespace
+
 const TrajectoryData & EgoTrajectoryCache::get_or_compute_trajectory_data(
   const EgoTrajectoryGenerationParams & params) const
 {
-  const auto it = trajectory_data_cache_.find(params);
-  if (it != trajectory_data_cache_.end()) {
-    return it->second;
-  }
-
-  const auto [inserted_it, inserted] = trajectory_data_cache_.emplace(
-    params, generate_ego_trajectory(
-              trajectory_interpolator_, sampling_reference_time_, current_time_, time_resolution_,
-              vehicle_info_, params));
-  static_cast<void>(inserted);
-  return inserted_it->second;
+  return get_or_emplace_trajectory(trajectory_data_cache_, params, [&]() {
+    return generate_ego_trajectory(
+      trajectory_interpolator_, sampling_reference_time_, current_time_, time_resolution_,
+      vehicle_info_, params);
+  });
 }
 
 TrajectoryData generate_predicted_path_trajectory(
   const autoware_perception_msgs::msg::PredictedObject & predicted_object,
   const autoware_perception_msgs::msg::PredictedPath & predicted_path, double braking_lag,
-  double assumed_acceleration, rclcpp::Duration start_time, double max_time,
-  const builtin_interfaces::msg::Time & stamp, double time_resolution)
+  double assumed_acceleration, double max_time, const rclcpp::Time & stamp, double time_resolution)
 
 {
   auto [times, distances] = time_distance::compute_motion_profile_1d(
     predicted_object.kinematics.initial_twist_with_covariance.twist, braking_lag,
-    assumed_acceleration, start_time.seconds(),
+    assumed_acceleration, 0.0,
     std::min(
       max_time, predicted_path.path.size() * rclcpp::Duration(predicted_path.time_step).seconds()),
     time_resolution);
@@ -614,12 +624,11 @@ TrajectoryData generate_predicted_path_trajectory(
 
 TrajectoryData generate_constant_curvature_trajectory(
   const autoware_perception_msgs::msg::PredictedObject & predicted_object, double braking_lag,
-  double assumed_acceleration, rclcpp::Duration start_time, double max_time,
-  const builtin_interfaces::msg::Time & stamp, double time_resolution)
+  double assumed_acceleration, double max_time, const rclcpp::Time & stamp, double time_resolution)
 {
   auto [times, distances] = time_distance::compute_motion_profile_1d(
     predicted_object.kinematics.initial_twist_with_covariance.twist, braking_lag,
-    assumed_acceleration, start_time.seconds(), max_time, time_resolution);
+    assumed_acceleration, 0.0, max_time, time_resolution);
 
   auto poses = pose::constant_curvature_predictor::compute(
     predicted_object.kinematics.initial_pose_with_covariance.pose,
@@ -630,6 +639,52 @@ TrajectoryData generate_constant_curvature_trajectory(
     TrajectoryIdentification{
       predicted_object, stamp, "constant_curvature_path", assumed_acceleration},
     std::move(times), std::move(distances), std::move(poses), std::move(footprints));
+}
+
+void ObjectTrajectoryCache::update(const rclcpp::Time & frame_stamp, const double time_resolution)
+{
+  if (time_resolution <= 0.0) {
+    throw std::invalid_argument("time_resolution must be positive");
+  }
+
+  // A new perception frame invalidates every memoized trajectory, so the whole cache is cleared.
+  // time_resolution is assumed fixed, hence it is not part of the invalidation condition.
+  const bool frame_changed = !frame_stamp_.has_value() || *frame_stamp_ != frame_stamp;
+  if (frame_changed) {
+    trajectory_data_cache_.clear();
+    frame_stamp_ = frame_stamp;
+  }
+  time_resolution_ = time_resolution;
+}
+
+const TrajectoryData & ObjectTrajectoryCache::get_or_compute_predicted_path_trajectory(
+  const autoware_perception_msgs::msg::PredictedObject & object, const size_t predicted_path_index,
+  const double braking_lag, const double assumed_acceleration, const double max_time) const
+{
+  const MapBasedTrajectoryParams params{
+    predicted_path_index, braking_lag, assumed_acceleration, max_time};
+
+  auto & cache = trajectory_data_cache_[object.object_id.uuid].map_based;
+  // The perception frame timestamp is forwarded as the trajectory stamp (used by the reporter).
+  return get_or_emplace_trajectory(cache, params, [&]() {
+    return generate_predicted_path_trajectory(
+      object, object.kinematics.predicted_paths.at(predicted_path_index), braking_lag,
+      assumed_acceleration, max_time, frame_stamp_.value(), time_resolution_);
+  });
+}
+
+const TrajectoryData & ObjectTrajectoryCache::get_or_compute_constant_curvature_trajectory(
+  const autoware_perception_msgs::msg::PredictedObject & object, const double braking_lag,
+  const double assumed_acceleration, const double max_time) const
+{
+  const ConstantCurvatureTrajectoryParams params{braking_lag, assumed_acceleration, max_time};
+
+  auto & cache = trajectory_data_cache_[object.object_id.uuid].constant_curvature;
+  // The perception frame timestamp is forwarded as the trajectory stamp (used by the reporter).
+  return get_or_emplace_trajectory(cache, params, [&]() {
+    return generate_constant_curvature_trajectory(
+      object, braking_lag, assumed_acceleration, max_time, frame_stamp_.value(), time_resolution_);
+  });
 }
 
 }  // namespace autoware::trajectory_validator::plugin::safety::trajectory

--- a/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/trajectory_utils.hpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/trajectory_utils.hpp
@@ -15,6 +15,7 @@
 #ifndef FILTERS__SAFETY__COLLISION_CHECK_FILTER__TRAJECTORY_UTILS_HPP_
 #define FILTERS__SAFETY__COLLISION_CHECK_FILTER__TRAJECTORY_UTILS_HPP_
 
+#include "autoware/trajectory_validator/detail/uuid_hash.hpp"
 #include "autoware/trajectory_validator/validator_interface.hpp"
 #include "types.hpp"
 
@@ -22,16 +23,20 @@
 #include <autoware/motion_utils/trajectory/trajectory.hpp>
 #include <autoware/universe_utils/geometry/geometry.hpp>
 #include <rclcpp/duration.hpp>
+#include <rclcpp/time.hpp>
 
 #include <geometry_msgs/msg/pose.hpp>
 
 #include <boost/geometry.hpp>
 
 #include <algorithm>
+#include <array>
+#include <cstdint>
 #include <iterator>
 #include <map>
 #include <optional>
 #include <string>
+#include <unordered_map>
 #include <utility>
 #include <vector>
 
@@ -407,7 +412,6 @@ double project_current_pose_on_trajectory(
 TravelDistanceTrajectory compute_cumulative_distances(const PoseTrajectory & pose_trajectory);
 }  // namespace detail
 
-// todo(takagi): reuse for object trajectory generation
 class EgoTrajectoryCache
 {
 private:
@@ -430,13 +434,83 @@ public:
 TrajectoryData generate_predicted_path_trajectory(
   const autoware_perception_msgs::msg::PredictedObject & predicted_object,
   const autoware_perception_msgs::msg::PredictedPath & predicted_path, double braking_lag,
-  double assumed_acceleration, rclcpp::Duration start_time, double max_time,
-  const builtin_interfaces::msg::Time & stamp, double time_resolution);
+  double assumed_acceleration, double max_time, const rclcpp::Time & stamp, double time_resolution);
 
 TrajectoryData generate_constant_curvature_trajectory(
   const autoware_perception_msgs::msg::PredictedObject & predicted_object, double braking_lag,
-  double assumed_acceleration, rclcpp::Duration start_time, double max_time,
-  const builtin_interfaces::msg::Time & stamp, double time_resolution);
+  double assumed_acceleration, double max_time, const rclcpp::Time & stamp, double time_resolution);
+
+// Parameters identifying one map-based predicted-path trajectory candidate of an object. Together
+// with the object UUID (the outer cache key) this uniquely determines the generated TrajectoryData
+// for a fixed time resolution.
+struct MapBasedTrajectoryParams
+{
+  size_t predicted_path_index{0};
+  double braking_lag{0.0};
+  double assumed_acceleration{0.0};
+  double max_time{0.0};
+
+  bool operator<(const MapBasedTrajectoryParams & rhs) const
+  {
+    return std::tie(predicted_path_index, braking_lag, assumed_acceleration, max_time) <
+           std::tie(
+             rhs.predicted_path_index, rhs.braking_lag, rhs.assumed_acceleration, rhs.max_time);
+  }
+};
+
+// Parameters identifying one constant-curvature trajectory candidate of an object.
+struct ConstantCurvatureTrajectoryParams
+{
+  double braking_lag{0.0};
+  double assumed_acceleration{0.0};
+  double max_time{0.0};
+
+  bool operator<(const ConstantCurvatureTrajectoryParams & rhs) const
+  {
+    return std::tie(braking_lag, assumed_acceleration, max_time) <
+           std::tie(rhs.braking_lag, rhs.assumed_acceleration, rhs.max_time);
+  }
+};
+
+// Lazily generates and memoizes object trajectories keyed by object UUID. Object trajectories are
+// independent of the ego candidate trajectory, so within one perception frame (identified by the
+// PredictedObjects timestamp) the same object trajectory is reused across the multiple
+// is_feasible() calls of that frame. update() must be called once per frame before the
+// get_or_compute_* methods; observing a new timestamp there discards every memoized trajectory.
+// Each generation method keeps its own map so that method-specific parameters stay separated, and
+// std::map keeps returned references valid across later insertions.
+class ObjectTrajectoryCache
+{
+public:
+  // Discards all memoized trajectories when a new PredictedObjects timestamp is observed. Called
+  // once per is_feasible(); repeated calls with the same timestamp are no-ops, so invoking it for
+  // each candidate trajectory of a frame is safe (same convention as ObjectStopTracker). The
+  // timestamp is only available on PredictedObjects (not on a single PredictedObject), so it is
+  // injected here rather than through the get_or_compute_* methods. time_resolution is assumed
+  // fixed and is only used for trajectory generation.
+  void update(const rclcpp::Time & frame_stamp, double time_resolution);
+
+  const TrajectoryData & get_or_compute_predicted_path_trajectory(
+    const autoware_perception_msgs::msg::PredictedObject & object, size_t predicted_path_index,
+    double braking_lag, double assumed_acceleration, double max_time) const;
+
+  const TrajectoryData & get_or_compute_constant_curvature_trajectory(
+    const autoware_perception_msgs::msg::PredictedObject & object, double braking_lag,
+    double assumed_acceleration, double max_time) const;
+
+private:
+  using ObjectId = std::array<uint8_t, 16>;
+
+  struct PerObjectCache
+  {
+    std::map<MapBasedTrajectoryParams, TrajectoryData> map_based;
+    std::map<ConstantCurvatureTrajectoryParams, TrajectoryData> constant_curvature;
+  };
+
+  double time_resolution_{0.0};
+  std::optional<rclcpp::Time> frame_stamp_;
+  mutable std::unordered_map<ObjectId, PerObjectCache, UuidHash> trajectory_data_cache_;
+};
 }  // namespace autoware::trajectory_validator::plugin::safety::trajectory
 
 #endif  // FILTERS__SAFETY__COLLISION_CHECK_FILTER__TRAJECTORY_UTILS_HPP_

--- a/planning/autoware_trajectory_validator/test/plugins/collision_check_filter/test_trajectory_utilities.cpp
+++ b/planning/autoware_trajectory_validator/test/plugins/collision_check_filter/test_trajectory_utilities.cpp
@@ -400,8 +400,7 @@ TEST(TrajectoryUtilitiesTest, GenerateConstantCurvaturePathTrajectoryMatchesPred
   const auto object = create_predicted_object(initial_pose, initial_twist, shape, {});
 
   const auto trajectory_data = trajectory::generate_constant_curvature_trajectory(
-    object, 0.0, 0.0, rclcpp::Duration::from_seconds(0.0), 0.25, builtin_interfaces::msg::Time{},
-    kDefaultTimeResolution);
+    object, 0.0, 0.0, 0.25, builtin_interfaces::msg::Time{}, kDefaultTimeResolution);
   const auto [expected_times, expected_distances] =
     trajectory::time_distance::compute_motion_profile_1d(
       initial_twist, 0.0, 0.0, 0.0, 0.25, kDefaultTimeResolution);


### PR DESCRIPTION
https://tier4.atlassian.net/wiki/spaces/CB/pages/4962386443/X2+v5.0.0+Collision+Check+Filter
に沿って、物体側にも減速するパターンを追加します。

あわせて、物体のTrajectoryDataをキャッシュとして保持するように変更しました。

以下にて、シナリオがpassし始めることと、計算時間課題がないことを確認しています。
http://10.0.12.96:3000/d/pc-metrics-e2e-arch/planning-control-metrics3a-e2e-architecture?orgId=1&from=2026-06-08T01:06:37.157Z&to=2026-06-08T13:06:37.157Z&timezone=browser&var-job_id=5ebe06fa-98c8-5dd2-9e61-bae78d349567&var-group_level=catalog&var-report_id=18b14d49-6830-409f-a2c1-6c78060499d9&var-tag=%5Bfail%5Dcollision_check_filter_FP&var-trajectory_generator=DiffusionPlanner_batch_0&var-processing_time=collision_check_filter&var-case_metric=obstacle_ttc%2Fmin&refresh=1h

なお、ノード死対応が未完了であるため、引き続き機能は無効化したままです。
launch PR: https://github.com/tier4/autoware_launch.x2/pull/2781