### PR TITLE
feat(traffic_light_filter): use empty traffic light message by default

### DIFF
--- a/planning/autoware_trajectory_selector/src/trajectory_selector_node.cpp
+++ b/planning/autoware_trajectory_selector/src/trajectory_selector_node.cpp
@@ -103,6 +103,10 @@ TrajectorySelectorNode::take_validator_data()
   }
 
   context.traffic_light_signals = sub_traffic_lights_.take_data();
+  if (!context.traffic_light_signals) {
+    context.traffic_light_signals =
+      std::make_shared<autoware_perception_msgs::msg::TrafficLightGroupArray>();
+  }
 
   context.route = sub_route_.take_data();
 


### PR DESCRIPTION
This PR fills the `traffic_light_signals` with an empty message if the `trajectory_selector_node` did not receive any message yet.
This prevents the `traffic_light_filter` from rejecting trajectories (and triggering MRM) when traffic light signals are not published (e.g., in Psim).