### PR TITLE
feat(trajectory_modifier, backup_planner): enable filtering objects by type and shape

### DIFF
--- a/common/autoware_obstacle_proximity_checker/include/autoware/obstacle_proximity_checker/structs.hpp
+++ b/common/autoware_obstacle_proximity_checker/include/autoware/obstacle_proximity_checker/structs.hpp
@@ -37,6 +37,8 @@ struct ObstacleTypeParameters
   double surround_check_front_distance{0.0};
   double surround_check_side_distance{0.0};
   double surround_check_back_distance{0.0};
+  bool enable_bbox_check{true};
+  bool enable_polygon_check{true};
 };
 
 struct Parameters

--- a/common/autoware_obstacle_proximity_checker/src/obstacle_proximity_checker.cpp
+++ b/common/autoware_obstacle_proximity_checker/src/obstacle_proximity_checker.cpp
@@ -195,8 +195,10 @@ std::optional<ProximityObstacle> ProximityChecker::getNearestObstacleByDynamicOb
       return false;
     }
     const auto & object_param = parameters_.obstacle_types_map.at(label);
-    if (object.shape.type == autoware_perception_msgs::msg::Shape::BOUNDING_BOX) return object_param.enable_bbox_check;
-    if (object.shape.type == autoware_perception_msgs::msg::Shape::POLYGON) return object_param.enable_polygon_check;
+    if (object.shape.type == autoware_perception_msgs::msg::Shape::BOUNDING_BOX)
+      return object_param.enable_bbox_check;
+    if (object.shape.type == autoware_perception_msgs::msg::Shape::POLYGON)
+      return object_param.enable_polygon_check;
     return false;
   };
 

--- a/common/autoware_obstacle_proximity_checker/src/obstacle_proximity_checker.cpp
+++ b/common/autoware_obstacle_proximity_checker/src/obstacle_proximity_checker.cpp
@@ -187,6 +187,19 @@ std::optional<ProximityObstacle> ProximityChecker::getNearestObstacleByDynamicOb
     return std::nullopt;
   }
 
+  auto is_enabled = [&](const auto & object, const std::string & label) {
+    const auto enable_check_iter = parameters_.object_type_enable_check.find(label);
+    if (
+      enable_check_iter == parameters_.object_type_enable_check.end() ||
+      !enable_check_iter->second) {
+      return false;
+    }
+    const auto & object_param = parameters_.obstacle_types_map.at(label);
+    if (object.shape.type == autoware_perception_msgs::msg::Shape::BOUNDING_BOX) return object_param.enable_bbox_check;
+    if (object.shape.type == autoware_perception_msgs::msg::Shape::POLYGON) return object_param.enable_polygon_check;
+    return false;
+  };
+
   autoware_perception_msgs::msg::PredictedObject nearest_object;
   double minimum_distance = std::numeric_limits<double>::max();
   bool was_minimum_distance_updated = false;
@@ -199,12 +212,7 @@ std::optional<ProximityObstacle> ProximityChecker::getNearestObstacleByDynamicOb
     }
 
     const auto & str_label = label_iter->second;
-    const auto enable_check_iter = parameters_.object_type_enable_check.find(str_label);
-    if (
-      enable_check_iter == parameters_.object_type_enable_check.end() ||
-      !enable_check_iter->second) {
-      continue;
-    }
+    if (!is_enabled(object, str_label)) continue;
 
     const auto & object_param = parameters_.obstacle_types_map.at(str_label);
     const double front_margin = object_param.surround_check_front_distance;

--- a/planning/autoware_minimum_rule_based_planner/config/minimum_rule_based_planner.param.yaml
+++ b/planning/autoware_minimum_rule_based_planner/config/minimum_rule_based_planner.param.yaml
@@ -63,7 +63,9 @@
       arrived_distance_threshold: 0.5 # threshold to check if the ego vehicle has arrived at the stop point [m]
 
       objects:
-        object_types: ["car", "truck", "bus", "trailer", "motorcycle", "bicycle", "pedestrian", "hazard"] # object types to consider for obstacle stop
+        target_objects:
+          bbox: ["car", "truck", "bus", "trailer", "motorcycle", "bicycle", "pedestrian", "hazard", "unknown"]
+          polygon: ["car", "truck", "bus", "trailer", "pedestrian", "hazard", "unknown"]
         stopped_velocity_th: 0.3 # velocity threshold for target object to be considered as stopped [m/s]
         max_lateral_velocity_th: 1.0 # maximum lateral velocity threshold for target object [m/s]
         safety_buffer: 0.1       # safety buffer to expand object shape [m]
@@ -101,7 +103,9 @@
       enable: true
       use_objects: true
       use_pointcloud: false
-      object_types: ["car", "truck", "bus", "trailer", "motorcycle", "bicycle", "pedestrian", "hazard", "animal", "unknown"] # object types to consider for surround obstacle stop
+      target_objects:
+        bbox: ["car", "truck", "bus", "trailer", "motorcycle", "bicycle", "pedestrian", "hazard", "animal", "unknown"]
+        polygon: ["car", "truck", "bus", "trailer", "pedestrian", "hazard", "animal", "unknown"]
       front_distance_th:
         car: 0.5
         truck: 0.5

--- a/planning/autoware_minimum_rule_based_planner/param/minimum_rule_based_planner_parameters.yaml
+++ b/planning/autoware_minimum_rule_based_planner/param/minimum_rule_based_planner_parameters.yaml
@@ -231,7 +231,8 @@ minimum_rule_based_planner:
       target_objects:
         bbox:
           type: string_array
-          default_value: [car, truck, bus, trailer, motorcycle, bicycle, pedestrian, hazard, unknown]
+          default_value:
+            [car, truck, bus, trailer, motorcycle, bicycle, pedestrian, hazard, unknown]
           description: types of bounding box shaped objects to consider for obstacle stop
           read_only: false
         polygon:
@@ -410,7 +411,8 @@ minimum_rule_based_planner:
     target_objects:
       bbox:
         type: string_array
-        default_value: [car, truck, bus, trailer, motorcycle, bicycle, pedestrian, hazard, animal, unknown]
+        default_value:
+          [car, truck, bus, trailer, motorcycle, bicycle, pedestrian, hazard, animal, unknown]
         description: types of bounding box shaped objects to consider for surround obstacle stop
         read_only: false
       polygon:

--- a/planning/autoware_minimum_rule_based_planner/param/minimum_rule_based_planner_parameters.yaml
+++ b/planning/autoware_minimum_rule_based_planner/param/minimum_rule_based_planner_parameters.yaml
@@ -228,10 +228,17 @@ minimum_rule_based_planner:
       validation:
         bounds<>: [0.0, 10.0]
     objects:
-      object_types:
-        type: string_array
-        default_value: [car, truck, bus, trailer, motorcycle, bicycle, pedestrian, hazard]
-        description: object types to consider for obstacle stop
+      target_objects:
+        bbox:
+          type: string_array
+          default_value: [car, truck, bus, trailer, motorcycle, bicycle, pedestrian, hazard, unknown]
+          description: types of bounding box shaped objects to consider for obstacle stop
+          read_only: false
+        polygon:
+          type: string_array
+          default_value: [car, truck, bus, trailer, pedestrian, hazard, unknown]
+          description: types of polygon shaped objects to consider for obstacle stop
+          read_only: false
       stopped_velocity_th:
         type: double
         default_value: 0.3
@@ -400,12 +407,17 @@ minimum_rule_based_planner:
       default_value: false
       description: enable the use of pointcloud for surround obstacle stop
       read_only: false
-    object_types:
-      type: string_array
-      default_value:
-        [car, truck, bus, trailer, motorcycle, bicycle, pedestrian, hazard, animal, unknown]
-      description: types of objects to consider for surround obstacle stop
-      read_only: false
+    target_objects:
+      bbox:
+        type: string_array
+        default_value: [car, truck, bus, trailer, motorcycle, bicycle, pedestrian, hazard, animal, unknown]
+        description: types of bounding box shaped objects to consider for surround obstacle stop
+        read_only: false
+      polygon:
+        type: string_array
+        default_value: [car, truck, bus, trailer, pedestrian, hazard, animal, unknown]
+        description: types of polygon shaped objects to consider for surround obstacle stop
+        read_only: false
     base_distance_th:
       &distance_th_template {
         type: double,

--- a/planning/autoware_minimum_rule_based_planner/plugins/obstacle_stop.cpp
+++ b/planning/autoware_minimum_rule_based_planner/plugins/obstacle_stop.cpp
@@ -55,7 +55,7 @@ void ObstacleStop::on_initialize(const MinimumRuleBasedPlannerParams & params)
       params_.pointcloud.clustering.max_size);
 
   object_filter_ = std::make_unique<trajectory_modifier::utils::obstacle_stop::ObjectFilter>(
-    params_.objects.object_types, params_.objects.stopped_velocity_th,
+    params_.objects.target_objects.bbox, params_.objects.target_objects.polygon, params_.objects.stopped_velocity_th,
     params_.objects.max_lateral_velocity_th, params_.objects.safety_buffer);
 
   pub_clustered_pointcloud_ =

--- a/planning/autoware_minimum_rule_based_planner/plugins/obstacle_stop.cpp
+++ b/planning/autoware_minimum_rule_based_planner/plugins/obstacle_stop.cpp
@@ -55,8 +55,9 @@ void ObstacleStop::on_initialize(const MinimumRuleBasedPlannerParams & params)
       params_.pointcloud.clustering.max_size);
 
   object_filter_ = std::make_unique<trajectory_modifier::utils::obstacle_stop::ObjectFilter>(
-    params_.objects.target_objects.bbox, params_.objects.target_objects.polygon, params_.objects.stopped_velocity_th,
-    params_.objects.max_lateral_velocity_th, params_.objects.safety_buffer);
+    params_.objects.target_objects.bbox, params_.objects.target_objects.polygon,
+    params_.objects.stopped_velocity_th, params_.objects.max_lateral_velocity_th,
+    params_.objects.safety_buffer);
 
   pub_clustered_pointcloud_ =
     get_node_ptr()->create_publisher<PointCloud2>("~/obstacle_stop/debug/cluster_points", 1);

--- a/planning/autoware_minimum_rule_based_planner/plugins/obstacle_stop.hpp
+++ b/planning/autoware_minimum_rule_based_planner/plugins/obstacle_stop.hpp
@@ -59,7 +59,7 @@ public:
     {
       const auto & p = params_.objects;
       object_filter_->set_params(
-        p.object_types, p.stopped_velocity_th, p.max_lateral_velocity_th, p.safety_buffer);
+        p.target_objects.bbox, p.target_objects.polygon, p.stopped_velocity_th, p.max_lateral_velocity_th, p.safety_buffer);
     }
 
     {

--- a/planning/autoware_minimum_rule_based_planner/plugins/obstacle_stop.hpp
+++ b/planning/autoware_minimum_rule_based_planner/plugins/obstacle_stop.hpp
@@ -59,7 +59,8 @@ public:
     {
       const auto & p = params_.objects;
       object_filter_->set_params(
-        p.target_objects.bbox, p.target_objects.polygon, p.stopped_velocity_th, p.max_lateral_velocity_th, p.safety_buffer);
+        p.target_objects.bbox, p.target_objects.polygon, p.stopped_velocity_th,
+        p.max_lateral_velocity_th, p.safety_buffer);
     }
 
     {

--- a/planning/autoware_minimum_rule_based_planner/plugins/surround_obstacle_stop.cpp
+++ b/planning/autoware_minimum_rule_based_planner/plugins/surround_obstacle_stop.cpp
@@ -37,12 +37,15 @@ using SurroundObstacleStopParams =
   autoware::minimum_rule_based_planner::plugin::MinimumRuleBasedPlannerParams::SurroundObstacleStop;
 
 ObstacleTypeParameters to_obstacle_type_parameters(
-  const double front_distance, const double side_distance, const double back_distance)
+  const double front_distance, const double side_distance, const double back_distance,
+  const bool enable_bbox_check = true, const bool enable_polygon_check = true)
 {
   ObstacleTypeParameters parameters;
   parameters.surround_check_front_distance = front_distance;
   parameters.surround_check_side_distance = side_distance;
   parameters.surround_check_back_distance = back_distance;
+  parameters.enable_bbox_check = enable_bbox_check;
+  parameters.enable_polygon_check = enable_polygon_check;
   return parameters;
 }
 
@@ -51,48 +54,54 @@ Parameters to_proximity_checker_parameters(const SurroundObstacleStopParams & pa
   Parameters parameters;
   parameters.pointcloud_enable_check = params.use_pointcloud;
 
-  const std::unordered_set<std::string> enabled_object_types(
-    params.object_types.begin(), params.object_types.end());
+  const std::unordered_set<std::string> bbox_enabled_object_types(
+    params.target_objects.bbox.begin(), params.target_objects.bbox.end());
+  const std::unordered_set<std::string> polygon_enabled_object_types(
+    params.target_objects.polygon.begin(), params.target_objects.polygon.end());
 
-  const auto set_object_enable = [&](const std::string & label) {
-    parameters.object_type_enable_check[label] = enabled_object_types.count(label) > 0;
+  auto is_bbox_enabled = [&](const std::string & label) {
+    return bbox_enabled_object_types.count(label) > 0;
   };
-  set_object_enable("unknown");
-  set_object_enable("car");
-  set_object_enable("truck");
-  set_object_enable("bus");
-  set_object_enable("trailer");
-  set_object_enable("motorcycle");
-  set_object_enable("bicycle");
-  set_object_enable("pedestrian");
-  set_object_enable("hazard");
-  set_object_enable("animal");
-
+  auto is_polygon_enabled = [&](const std::string & label) {
+    return polygon_enabled_object_types.count(label) > 0;
+  };
+  
   const auto & front = params.front_distance_th;
   const auto & side = params.side_distance_th;
   const auto & back = params.back_distance_th;
-
+  auto get_object_distance_thresholds = [&](const std::string & label) {
+    if (label == "car") return std::make_tuple(front.car, side.car, back.car);
+    if (label == "truck") return std::make_tuple(front.truck, side.truck, back.truck);
+    if (label == "bus") return std::make_tuple(front.bus, side.bus, back.bus);
+    if (label == "trailer") return std::make_tuple(front.trailer, side.trailer, back.trailer);
+    if (label == "motorcycle") return std::make_tuple(front.motorcycle, side.motorcycle, back.motorcycle);
+    if (label == "bicycle") return std::make_tuple(front.bicycle, side.bicycle, back.bicycle);
+    if (label == "pedestrian") return std::make_tuple(front.pedestrian, side.pedestrian, back.pedestrian);
+    if (label == "hazard") return std::make_tuple(front.hazard, side.hazard, back.hazard);
+    if (label == "animal") return std::make_tuple(front.animal, side.animal, back.animal);
+    return std::make_tuple(front.unknown, side.unknown, back.unknown);
+  };
+  
+  const auto set_object_params = [&](const std::string & label) {
+    const auto bbox_enabled = is_bbox_enabled(label);
+    const auto polygon_enabled = is_polygon_enabled(label);
+    const auto [front, side, back] = get_object_distance_thresholds(label);
+    parameters.object_type_enable_check[label] = bbox_enabled || polygon_enabled;
+    parameters.obstacle_types_map[label] = to_obstacle_type_parameters(front, side, back, bbox_enabled, polygon_enabled);
+  };
+  set_object_params("unknown");
+  set_object_params("car");
+  set_object_params("truck");
+  set_object_params("bus");
+  set_object_params("trailer");
+  set_object_params("motorcycle");
+  set_object_params("bicycle");
+  set_object_params("pedestrian");
+  set_object_params("hazard");
+  set_object_params("animal");
+  
   parameters.obstacle_types_map["pointcloud"] =
     to_obstacle_type_parameters(front.pointcloud, side.pointcloud, back.pointcloud);
-  parameters.obstacle_types_map["unknown"] =
-    to_obstacle_type_parameters(front.unknown, side.unknown, back.unknown);
-  parameters.obstacle_types_map["car"] = to_obstacle_type_parameters(front.car, side.car, back.car);
-  parameters.obstacle_types_map["truck"] =
-    to_obstacle_type_parameters(front.truck, side.truck, back.truck);
-  parameters.obstacle_types_map["bus"] = to_obstacle_type_parameters(front.bus, side.bus, back.bus);
-  parameters.obstacle_types_map["trailer"] =
-    to_obstacle_type_parameters(front.trailer, side.trailer, back.trailer);
-  parameters.obstacle_types_map["motorcycle"] =
-    to_obstacle_type_parameters(front.motorcycle, side.motorcycle, back.motorcycle);
-  parameters.obstacle_types_map["bicycle"] =
-    to_obstacle_type_parameters(front.bicycle, side.bicycle, back.bicycle);
-  parameters.obstacle_types_map["pedestrian"] =
-    to_obstacle_type_parameters(front.pedestrian, side.pedestrian, back.pedestrian);
-  parameters.obstacle_types_map["hazard"] =
-    to_obstacle_type_parameters(front.hazard, side.hazard, back.hazard);
-  parameters.obstacle_types_map["animal"] =
-    to_obstacle_type_parameters(front.animal, side.animal, back.animal);
-
   return parameters;
 }
 }  // namespace

--- a/planning/autoware_minimum_rule_based_planner/plugins/surround_obstacle_stop.cpp
+++ b/planning/autoware_minimum_rule_based_planner/plugins/surround_obstacle_stop.cpp
@@ -65,7 +65,7 @@ Parameters to_proximity_checker_parameters(const SurroundObstacleStopParams & pa
   auto is_polygon_enabled = [&](const std::string & label) {
     return polygon_enabled_object_types.count(label) > 0;
   };
-  
+
   const auto & front = params.front_distance_th;
   const auto & side = params.side_distance_th;
   const auto & back = params.back_distance_th;
@@ -74,20 +74,23 @@ Parameters to_proximity_checker_parameters(const SurroundObstacleStopParams & pa
     if (label == "truck") return std::make_tuple(front.truck, side.truck, back.truck);
     if (label == "bus") return std::make_tuple(front.bus, side.bus, back.bus);
     if (label == "trailer") return std::make_tuple(front.trailer, side.trailer, back.trailer);
-    if (label == "motorcycle") return std::make_tuple(front.motorcycle, side.motorcycle, back.motorcycle);
+    if (label == "motorcycle")
+      return std::make_tuple(front.motorcycle, side.motorcycle, back.motorcycle);
     if (label == "bicycle") return std::make_tuple(front.bicycle, side.bicycle, back.bicycle);
-    if (label == "pedestrian") return std::make_tuple(front.pedestrian, side.pedestrian, back.pedestrian);
+    if (label == "pedestrian")
+      return std::make_tuple(front.pedestrian, side.pedestrian, back.pedestrian);
     if (label == "hazard") return std::make_tuple(front.hazard, side.hazard, back.hazard);
     if (label == "animal") return std::make_tuple(front.animal, side.animal, back.animal);
     return std::make_tuple(front.unknown, side.unknown, back.unknown);
   };
-  
+
   const auto set_object_params = [&](const std::string & label) {
     const auto bbox_enabled = is_bbox_enabled(label);
     const auto polygon_enabled = is_polygon_enabled(label);
     const auto [front, side, back] = get_object_distance_thresholds(label);
     parameters.object_type_enable_check[label] = bbox_enabled || polygon_enabled;
-    parameters.obstacle_types_map[label] = to_obstacle_type_parameters(front, side, back, bbox_enabled, polygon_enabled);
+    parameters.obstacle_types_map[label] =
+      to_obstacle_type_parameters(front, side, back, bbox_enabled, polygon_enabled);
   };
   set_object_params("unknown");
   set_object_params("car");
@@ -99,7 +102,7 @@ Parameters to_proximity_checker_parameters(const SurroundObstacleStopParams & pa
   set_object_params("pedestrian");
   set_object_params("hazard");
   set_object_params("animal");
-  
+
   parameters.obstacle_types_map["pointcloud"] =
     to_obstacle_type_parameters(front.pointcloud, side.pointcloud, back.pointcloud);
   return parameters;

--- a/planning/autoware_minimum_rule_based_planner/schema/minimum_rule_based_planner.schema.json
+++ b/planning/autoware_minimum_rule_based_planner/schema/minimum_rule_based_planner.schema.json
@@ -313,7 +313,17 @@
                     "bbox": {
                       "type": "array",
                       "description": "Types of bounding box shaped objects to consider for obstacle stop",
-                      "default": ["car", "truck", "bus", "trailer", "motorcycle", "bicycle", "pedestrian", "hazard", "unknown"],
+                      "default": [
+                        "car",
+                        "truck",
+                        "bus",
+                        "trailer",
+                        "motorcycle",
+                        "bicycle",
+                        "pedestrian",
+                        "hazard",
+                        "unknown"
+                      ],
                       "items": {
                         "type": "string"
                       }
@@ -321,7 +331,15 @@
                     "polygon": {
                       "type": "array",
                       "description": "Types of polygon shaped objects to consider for obstacle stop",
-                      "default": ["car", "truck", "bus", "trailer", "pedestrian", "hazard", "unknown"],
+                      "default": [
+                        "car",
+                        "truck",
+                        "bus",
+                        "trailer",
+                        "pedestrian",
+                        "hazard",
+                        "unknown"
+                      ],
                       "items": {
                         "type": "string"
                       }
@@ -554,7 +572,18 @@
                 "bbox": {
                   "type": "array",
                   "description": "Types of bounding box shaped objects to consider for surround obstacle stop",
-                  "default": ["car", "truck", "bus", "trailer", "motorcycle", "bicycle", "pedestrian", "hazard", "animal", "unknown"],
+                  "default": [
+                    "car",
+                    "truck",
+                    "bus",
+                    "trailer",
+                    "motorcycle",
+                    "bicycle",
+                    "pedestrian",
+                    "hazard",
+                    "animal",
+                    "unknown"
+                  ],
                   "items": {
                     "type": "string"
                   }
@@ -562,7 +591,16 @@
                 "polygon": {
                   "type": "array",
                   "description": "Types of polygon shaped objects to consider for surround obstacle stop",
-                  "default": ["car", "truck", "bus", "trailer", "pedestrian", "hazard", "animal", "unknown"],
+                  "default": [
+                    "car",
+                    "truck",
+                    "bus",
+                    "trailer",
+                    "pedestrian",
+                    "hazard",
+                    "animal",
+                    "unknown"
+                  ],
                   "items": {
                     "type": "string"
                   }

--- a/planning/autoware_minimum_rule_based_planner/schema/minimum_rule_based_planner.schema.json
+++ b/planning/autoware_minimum_rule_based_planner/schema/minimum_rule_based_planner.schema.json
@@ -307,22 +307,28 @@
             "objects": {
               "type": "object",
               "properties": {
-                "object_types": {
-                  "type": "array",
-                  "description": "Object types",
-                  "default": [
-                    "car",
-                    "truck",
-                    "bus",
-                    "trailer",
-                    "motorcycle",
-                    "bicycle",
-                    "pedestrian",
-                    "hazard"
-                  ],
-                  "items": {
-                    "type": "string"
-                  }
+                "target_objects": {
+                  "type": "object",
+                  "properties": {
+                    "bbox": {
+                      "type": "array",
+                      "description": "Types of bounding box shaped objects to consider for obstacle stop",
+                      "default": ["car", "truck", "bus", "trailer", "motorcycle", "bicycle", "pedestrian", "hazard", "unknown"],
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "polygon": {
+                      "type": "array",
+                      "description": "Types of polygon shaped objects to consider for obstacle stop",
+                      "default": ["car", "truck", "bus", "trailer", "pedestrian", "hazard", "unknown"],
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "required": [],
+                  "additionalProperties": false
                 },
                 "stopped_velocity_th": {
                   "type": "number",
@@ -542,24 +548,28 @@
               "description": "Enable the use of pointcloud for surround obstacle stop",
               "default": false
             },
-            "object_types": {
-              "type": "array",
-              "description": "Types of objects to consider for surround obstacle stop",
-              "default": [
-                "car",
-                "truck",
-                "bus",
-                "trailer",
-                "motorcycle",
-                "bicycle",
-                "pedestrian",
-                "hazard",
-                "animal",
-                "unknown"
-              ],
-              "items": {
-                "type": "string"
-              }
+            "target_objects": {
+              "type": "object",
+              "properties": {
+                "bbox": {
+                  "type": "array",
+                  "description": "Types of bounding box shaped objects to consider for surround obstacle stop",
+                  "default": ["car", "truck", "bus", "trailer", "motorcycle", "bicycle", "pedestrian", "hazard", "animal", "unknown"],
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "polygon": {
+                  "type": "array",
+                  "description": "Types of polygon shaped objects to consider for surround obstacle stop",
+                  "default": ["car", "truck", "bus", "trailer", "pedestrian", "hazard", "animal", "unknown"],
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              },
+              "required": [],
+              "additionalProperties": false
             },
             "front_distance_th": {
               "type": "object",

--- a/planning/autoware_trajectory_modifier/config/trajectory_modifier.param.yaml
+++ b/planning/autoware_trajectory_modifier/config/trajectory_modifier.param.yaml
@@ -47,7 +47,9 @@
         grace_period: 0.2 # [s]
 
       objects:
-        object_types: ["car", "truck", "bus", "trailer", "motorcycle", "bicycle", "pedestrian", "hazard"] # object types to consider for obstacle stop
+        target_objects:
+          bbox: ["car", "truck", "bus", "trailer", "motorcycle", "bicycle", "pedestrian", "hazard", "unknown"]
+          polygon: ["car", "truck", "bus", "trailer", "pedestrian", "hazard", "unknown"]
         stopped_velocity_th: 0.3 # [m/s]
         max_lateral_velocity_th: 1.0 # [m/s] max lateral velocity (w.r.t ego traj) to consider for obstacle stop
         safety_buffer: 0.1 # [m] safety buffer to expand object shape
@@ -101,7 +103,9 @@
     surround_obstacle_stop:
       use_objects: true
       use_pointcloud: false
-      object_types: ["car", "truck", "bus", "trailer", "motorcycle", "bicycle", "pedestrian", "hazard", "animal", "unknown"]
+      target_objects:
+        bbox: ["car", "truck", "bus", "trailer", "motorcycle", "bicycle", "pedestrian", "hazard", "animal", "unknown"]
+        polygon: ["car", "truck", "bus", "trailer", "pedestrian", "hazard", "animal", "unknown"]
       front_distance_th:
         car: 0.5
         truck: 0.5

--- a/planning/autoware_trajectory_modifier/include/autoware/trajectory_modifier/trajectory_modifier_utils/obstacle_stop_utils.hpp
+++ b/planning/autoware_trajectory_modifier/include/autoware/trajectory_modifier/trajectory_modifier_utils/obstacle_stop_utils.hpp
@@ -20,7 +20,7 @@
 #include <autoware_vehicle_info_utils/vehicle_info.hpp>
 #include <rclcpp/time.hpp>
 
-#include <autoware_perception_msgs/msg/detail/shape__struct.hpp>
+#include <autoware_perception_msgs/msg/shape.hpp>
 #include <autoware_perception_msgs/msg/predicted_objects.hpp>
 #include <autoware_planning_msgs/msg/trajectory.hpp>
 #include <autoware_planning_msgs/msg/trajectory_point.hpp>

--- a/planning/autoware_trajectory_modifier/include/autoware/trajectory_modifier/trajectory_modifier_utils/obstacle_stop_utils.hpp
+++ b/planning/autoware_trajectory_modifier/include/autoware/trajectory_modifier/trajectory_modifier_utils/obstacle_stop_utils.hpp
@@ -20,6 +20,7 @@
 #include <autoware_vehicle_info_utils/vehicle_info.hpp>
 #include <rclcpp/time.hpp>
 
+#include <autoware_perception_msgs/msg/detail/shape__struct.hpp>
 #include <autoware_perception_msgs/msg/predicted_objects.hpp>
 #include <autoware_planning_msgs/msg/trajectory.hpp>
 #include <autoware_planning_msgs/msg/trajectory_point.hpp>
@@ -55,6 +56,7 @@ using PointCloud = pcl::PointCloud<pcl::PointXYZ>;
 using autoware_perception_msgs::msg::ObjectClassification;
 using autoware_perception_msgs::msg::PredictedObject;
 using autoware_perception_msgs::msg::PredictedObjects;
+using autoware_perception_msgs::msg::Shape;
 using autoware_planning_msgs::msg::TrajectoryPoint;
 using TrajectoryPoints = std::vector<TrajectoryPoint>;
 using autoware_utils_geometry::MultiPolygon2d;
@@ -251,15 +253,20 @@ struct ObjectFilter
    * @param safety_buffer Safety buffer to expand object shape [m].
    */
   ObjectFilter(
-    const std::vector<std::string> & object_type_strings, const double stopped_velocity_th,
+    const std::vector<std::string> & bbox_object_type_strings,
+    const std::vector<std::string> & polygon_object_type_strings, const double stopped_velocity_th,
     const double max_lateral_velocity_th, const double safety_buffer)
   : stopped_velocity_th_(stopped_velocity_th),
     max_lateral_velocity_th_(max_lateral_velocity_th),
     safety_buffer_(safety_buffer)
   {
-    for (const auto & object_type_string : object_type_strings) {
+    for (const auto & object_type_string : bbox_object_type_strings) {
       if (string_to_object_type.count(object_type_string) == 0) continue;
-      object_types_.emplace(string_to_object_type.at(object_type_string));
+      bbox_object_types_.emplace(string_to_object_type.at(object_type_string));
+    }
+    for (const auto & object_type_string : polygon_object_type_strings) {
+      if (string_to_object_type.count(object_type_string) == 0) continue;
+      polygon_object_types_.emplace(string_to_object_type.at(object_type_string));
     }
   }
 
@@ -278,7 +285,9 @@ struct ObjectFilter
               ? ObjectClassification::UNKNOWN
               : autoware::object_recognition_utils::getHighestProbLabel(object.classification);
           if (classification_to_object_type.count(label) == 0) return true;
-          return object_types_.count(classification_to_object_type.at(label)) == 0;
+          if (object.shape.type == Shape::BOUNDING_BOX) return bbox_object_types_.count(classification_to_object_type.at(label)) == 0;
+          if (object.shape.type == Shape::POLYGON) return polygon_object_types_.count(classification_to_object_type.at(label)) == 0;
+          return true;
         }),
       objects.objects.end());
   }
@@ -302,13 +311,19 @@ struct ObjectFilter
    * @brief Update allow-listed types and velocity thresholds without reconstructing the filter.
    */
   void set_params(
-    const std::vector<std::string> & object_type_strings, const double stopped_velocity_th,
+    const std::vector<std::string> & bbox_object_type_strings,
+    const std::vector<std::string> & polygon_object_type_strings, const double stopped_velocity_th,
     const double max_lateral_velocity_th, const double safety_buffer)
   {
-    object_types_.clear();
-    for (const auto & object_type_string : object_type_strings) {
+    bbox_object_types_.clear();
+    polygon_object_types_.clear();
+    for (const auto & object_type_string : bbox_object_type_strings) {
       if (string_to_object_type.count(object_type_string) == 0) continue;
-      object_types_.emplace(string_to_object_type.at(object_type_string));
+      bbox_object_types_.emplace(string_to_object_type.at(object_type_string));
+    }
+    for (const auto & object_type_string : polygon_object_type_strings) {
+      if (string_to_object_type.count(object_type_string) == 0) continue;
+      polygon_object_types_.emplace(string_to_object_type.at(object_type_string));
     }
     stopped_velocity_th_ = stopped_velocity_th;
     max_lateral_velocity_th_ = max_lateral_velocity_th;
@@ -316,7 +331,8 @@ struct ObjectFilter
   }
 
 private:
-  std::unordered_set<ObjectType> object_types_;
+  std::unordered_set<ObjectType> bbox_object_types_;
+  std::unordered_set<ObjectType> polygon_object_types_;
   double stopped_velocity_th_;
   double max_lateral_velocity_th_;
   double safety_buffer_;

--- a/planning/autoware_trajectory_modifier/include/autoware/trajectory_modifier/trajectory_modifier_utils/obstacle_stop_utils.hpp
+++ b/planning/autoware_trajectory_modifier/include/autoware/trajectory_modifier/trajectory_modifier_utils/obstacle_stop_utils.hpp
@@ -20,8 +20,8 @@
 #include <autoware_vehicle_info_utils/vehicle_info.hpp>
 #include <rclcpp/time.hpp>
 
-#include <autoware_perception_msgs/msg/shape.hpp>
 #include <autoware_perception_msgs/msg/predicted_objects.hpp>
+#include <autoware_perception_msgs/msg/shape.hpp>
 #include <autoware_planning_msgs/msg/trajectory.hpp>
 #include <autoware_planning_msgs/msg/trajectory_point.hpp>
 #include <sensor_msgs/msg/point_cloud2.hpp>
@@ -285,8 +285,10 @@ struct ObjectFilter
               ? ObjectClassification::UNKNOWN
               : autoware::object_recognition_utils::getHighestProbLabel(object.classification);
           if (classification_to_object_type.count(label) == 0) return true;
-          if (object.shape.type == Shape::BOUNDING_BOX) return bbox_object_types_.count(classification_to_object_type.at(label)) == 0;
-          if (object.shape.type == Shape::POLYGON) return polygon_object_types_.count(classification_to_object_type.at(label)) == 0;
+          if (object.shape.type == Shape::BOUNDING_BOX)
+            return bbox_object_types_.count(classification_to_object_type.at(label)) == 0;
+          if (object.shape.type == Shape::POLYGON)
+            return polygon_object_types_.count(classification_to_object_type.at(label)) == 0;
           return true;
         }),
       objects.objects.end());

--- a/planning/autoware_trajectory_modifier/param/trajectory_modifier_parameter_struct.yaml
+++ b/planning/autoware_trajectory_modifier/param/trajectory_modifier_parameter_struct.yaml
@@ -198,11 +198,17 @@ trajectory_modifier_params:
         read_only: false
 
     objects:
-      object_types:
-        type: string_array
-        default_value: [car, truck, bus, trailer, motorcycle, bicycle, pedestrian, hazard]
-        description: Types of objects to consider for obstacle stop
-        read_only: false
+      target_objects:
+        bbox:
+          type: string_array
+          default_value: [car, truck, bus, trailer, motorcycle, bicycle, pedestrian, hazard, unknown]
+          description: Types of bounding box shaped objects to consider for obstacle stop
+          read_only: false
+        polygon:
+          type: string_array
+          default_value: [car, truck, bus, trailer, pedestrian, hazard, unknown]
+          description: Types of polygon shaped objects to consider for obstacle stop
+          read_only: false
       stopped_velocity_th:
         type: double
         default_value: 0.25
@@ -472,11 +478,17 @@ trajectory_modifier_params:
       default_value: true
       description: Enable the use of pointcloud for surround obstacle stop
       read_only: false
-    object_types:
-      type: string_array
-      default_value: [car, truck, bus, trailer, motorcycle, bicycle, pedestrian]
-      description: Types of objects to consider for surround obstacle stop
-      read_only: false
+    target_objects:
+      bbox:
+        type: string_array
+        default_value: [car, truck, bus, trailer, motorcycle, bicycle, pedestrian, hazard, animal, unknown]
+        description: Types of bounding box shaped objects to consider for surround obstacle stop
+        read_only: false
+      polygon:
+        type: string_array
+        default_value: [car, truck, bus, trailer, pedestrian, hazard, animal, unknown]
+        description: Types of polygon shaped objects to consider for surround obstacle stop
+        read_only: false
     base_distance_th:
       &distance_th_template {
         type: double,

--- a/planning/autoware_trajectory_modifier/param/trajectory_modifier_parameter_struct.yaml
+++ b/planning/autoware_trajectory_modifier/param/trajectory_modifier_parameter_struct.yaml
@@ -201,7 +201,8 @@ trajectory_modifier_params:
       target_objects:
         bbox:
           type: string_array
-          default_value: [car, truck, bus, trailer, motorcycle, bicycle, pedestrian, hazard, unknown]
+          default_value:
+            [car, truck, bus, trailer, motorcycle, bicycle, pedestrian, hazard, unknown]
           description: Types of bounding box shaped objects to consider for obstacle stop
           read_only: false
         polygon:
@@ -481,7 +482,8 @@ trajectory_modifier_params:
     target_objects:
       bbox:
         type: string_array
-        default_value: [car, truck, bus, trailer, motorcycle, bicycle, pedestrian, hazard, animal, unknown]
+        default_value:
+          [car, truck, bus, trailer, motorcycle, bicycle, pedestrian, hazard, animal, unknown]
         description: Types of bounding box shaped objects to consider for surround obstacle stop
         read_only: false
       polygon:

--- a/planning/autoware_trajectory_modifier/schema/trajectory_modifier.schema.json
+++ b/planning/autoware_trajectory_modifier/schema/trajectory_modifier.schema.json
@@ -209,22 +209,28 @@
             "objects": {
               "type": "object",
               "properties": {
-                "object_types": {
-                  "type": "array",
-                  "description": "Object types to consider for obstacle stop",
-                  "default": [
-                    "car",
-                    "truck",
-                    "bus",
-                    "trailer",
-                    "motorcycle",
-                    "bicycle",
-                    "pedestrian",
-                    "hazard"
-                  ],
-                  "items": {
-                    "type": "string"
-                  }
+                "target_objects": {
+                  "type": "object",
+                  "properties": {
+                    "bbox": {
+                      "type": "array",
+                      "description": "Types of bounding box shaped objects to consider for obstacle stop",
+                      "default": ["car", "truck", "bus", "trailer", "motorcycle", "bicycle", "pedestrian", "hazard", "unknown"],
+                      "items": {
+                        "type": "string"
+                      }
+                    },
+                    "polygon": {
+                      "type": "array",
+                      "description": "Types of polygon shaped objects to consider for obstacle stop",
+                      "default": ["car", "truck", "bus", "trailer", "pedestrian", "hazard", "unknown"],
+                      "items": {
+                        "type": "string"
+                      }
+                    }
+                  },
+                  "required": [],
+                  "additionalProperties": false
                 },
                 "stopped_velocity_th": {
                   "type": "number",
@@ -512,13 +518,28 @@
               "description": "Enable the use of pointcloud for surround obstacle stop",
               "default": true
             },
-            "object_types": {
-              "type": "array",
-              "description": "Types of objects to consider for surround obstacle stop",
-              "default": ["car", "truck", "bus", "trailer", "motorcycle", "bicycle", "pedestrian"],
-              "items": {
-                "type": "string"
-              }
+            "target_objects": {
+              "type": "object",
+              "properties": {
+                "bbox": {
+                  "type": "array",
+                  "description": "Types of bounding box shaped objects to consider for surround obstacle stop",
+                  "default": ["car", "truck", "bus", "trailer", "motorcycle", "bicycle", "pedestrian", "hazard", "animal", "unknown"],
+                  "items": {
+                    "type": "string"
+                  }
+                },
+                "polygon": {
+                  "type": "array",
+                  "description": "Types of polygon shaped objects to consider for surround obstacle stop",
+                  "default": ["car", "truck", "bus", "trailer", "pedestrian", "hazard", "animal", "unknown"],
+                  "items": {
+                    "type": "string"
+                  }
+                }
+              },
+              "required": [],
+              "additionalProperties": false
             },
             "front_distance_th": {
               "type": "object",

--- a/planning/autoware_trajectory_modifier/schema/trajectory_modifier.schema.json
+++ b/planning/autoware_trajectory_modifier/schema/trajectory_modifier.schema.json
@@ -215,7 +215,17 @@
                     "bbox": {
                       "type": "array",
                       "description": "Types of bounding box shaped objects to consider for obstacle stop",
-                      "default": ["car", "truck", "bus", "trailer", "motorcycle", "bicycle", "pedestrian", "hazard", "unknown"],
+                      "default": [
+                        "car",
+                        "truck",
+                        "bus",
+                        "trailer",
+                        "motorcycle",
+                        "bicycle",
+                        "pedestrian",
+                        "hazard",
+                        "unknown"
+                      ],
                       "items": {
                         "type": "string"
                       }
@@ -223,7 +233,15 @@
                     "polygon": {
                       "type": "array",
                       "description": "Types of polygon shaped objects to consider for obstacle stop",
-                      "default": ["car", "truck", "bus", "trailer", "pedestrian", "hazard", "unknown"],
+                      "default": [
+                        "car",
+                        "truck",
+                        "bus",
+                        "trailer",
+                        "pedestrian",
+                        "hazard",
+                        "unknown"
+                      ],
                       "items": {
                         "type": "string"
                       }
@@ -524,7 +542,18 @@
                 "bbox": {
                   "type": "array",
                   "description": "Types of bounding box shaped objects to consider for surround obstacle stop",
-                  "default": ["car", "truck", "bus", "trailer", "motorcycle", "bicycle", "pedestrian", "hazard", "animal", "unknown"],
+                  "default": [
+                    "car",
+                    "truck",
+                    "bus",
+                    "trailer",
+                    "motorcycle",
+                    "bicycle",
+                    "pedestrian",
+                    "hazard",
+                    "animal",
+                    "unknown"
+                  ],
                   "items": {
                     "type": "string"
                   }
@@ -532,7 +561,16 @@
                 "polygon": {
                   "type": "array",
                   "description": "Types of polygon shaped objects to consider for surround obstacle stop",
-                  "default": ["car", "truck", "bus", "trailer", "pedestrian", "hazard", "animal", "unknown"],
+                  "default": [
+                    "car",
+                    "truck",
+                    "bus",
+                    "trailer",
+                    "pedestrian",
+                    "hazard",
+                    "animal",
+                    "unknown"
+                  ],
                   "items": {
                     "type": "string"
                   }

--- a/planning/autoware_trajectory_modifier/src/trajectory_modifier_plugins/obstacle_stop.cpp
+++ b/planning/autoware_trajectory_modifier/src/trajectory_modifier_plugins/obstacle_stop.cpp
@@ -78,7 +78,8 @@ void ObstacleStop::on_initialize(const TrajectoryModifierParams & params)
   {
     const auto & p = params_.objects;
     object_filter_ = std::make_unique<utils::obstacle_stop::ObjectFilter>(
-      p.target_objects.bbox, p.target_objects.polygon, p.stopped_velocity_th, p.max_lateral_velocity_th, p.safety_buffer);
+      p.target_objects.bbox, p.target_objects.polygon, p.stopped_velocity_th,
+      p.max_lateral_velocity_th, p.safety_buffer);
   }
 
   {
@@ -126,7 +127,8 @@ void ObstacleStop::update_params(const TrajectoryModifierParams & params)
   {
     const auto & p = params_.objects;
     object_filter_->set_params(
-      p.target_objects.bbox, p.target_objects.polygon, p.stopped_velocity_th, p.max_lateral_velocity_th, p.safety_buffer);
+      p.target_objects.bbox, p.target_objects.polygon, p.stopped_velocity_th,
+      p.max_lateral_velocity_th, p.safety_buffer);
   }
 
   {

--- a/planning/autoware_trajectory_modifier/src/trajectory_modifier_plugins/obstacle_stop.cpp
+++ b/planning/autoware_trajectory_modifier/src/trajectory_modifier_plugins/obstacle_stop.cpp
@@ -78,7 +78,7 @@ void ObstacleStop::on_initialize(const TrajectoryModifierParams & params)
   {
     const auto & p = params_.objects;
     object_filter_ = std::make_unique<utils::obstacle_stop::ObjectFilter>(
-      p.object_types, p.stopped_velocity_th, p.max_lateral_velocity_th, p.safety_buffer);
+      p.target_objects.bbox, p.target_objects.polygon, p.stopped_velocity_th, p.max_lateral_velocity_th, p.safety_buffer);
   }
 
   {
@@ -126,7 +126,7 @@ void ObstacleStop::update_params(const TrajectoryModifierParams & params)
   {
     const auto & p = params_.objects;
     object_filter_->set_params(
-      p.object_types, p.stopped_velocity_th, p.max_lateral_velocity_th, p.safety_buffer);
+      p.target_objects.bbox, p.target_objects.polygon, p.stopped_velocity_th, p.max_lateral_velocity_th, p.safety_buffer);
   }
 
   {

--- a/planning/autoware_trajectory_modifier/src/trajectory_modifier_plugins/surround_obstacle_stop.cpp
+++ b/planning/autoware_trajectory_modifier/src/trajectory_modifier_plugins/surround_obstacle_stop.cpp
@@ -36,12 +36,15 @@ using autoware::obstacle_proximity_checker::ObstacleTypeParameters;
 using autoware::obstacle_proximity_checker::Parameters;
 
 ObstacleTypeParameters to_obstacle_type_parameters(
-  const double front_distance, const double side_distance, const double back_distance)
+  const double front_distance, const double side_distance, const double back_distance,
+  const bool enable_bbox_check = true, const bool enable_polygon_check = true)
 {
   ObstacleTypeParameters parameters;
   parameters.surround_check_front_distance = front_distance;
   parameters.surround_check_side_distance = side_distance;
   parameters.surround_check_back_distance = back_distance;
+  parameters.enable_bbox_check = enable_bbox_check;
+  parameters.enable_polygon_check = enable_polygon_check;
   return parameters;
 }
 
@@ -52,47 +55,54 @@ Parameters to_proximity_checker_parameters(
   Parameters parameters;
   parameters.pointcloud_enable_check = params.use_pointcloud;
 
-  const std::unordered_set<std::string> enabled_object_types(
-    params.object_types.begin(), params.object_types.end());
+  const std::unordered_set<std::string> bbox_enabled_object_types(
+    params.target_objects.bbox.begin(), params.target_objects.bbox.end());
+  const std::unordered_set<std::string> polygon_enabled_object_types(
+    params.target_objects.polygon.begin(), params.target_objects.polygon.end());
 
-  const auto set_object_enable = [&](const std::string & label) {
-    parameters.object_type_enable_check[label] = enabled_object_types.count(label) > 0;
+  auto is_bbox_enabled = [&](const std::string & label) {
+    return bbox_enabled_object_types.count(label) > 0;
   };
-  set_object_enable("unknown");
-  set_object_enable("car");
-  set_object_enable("truck");
-  set_object_enable("bus");
-  set_object_enable("trailer");
-  set_object_enable("motorcycle");
-  set_object_enable("bicycle");
-  set_object_enable("pedestrian");
-  set_object_enable("hazard");
-  set_object_enable("animal");
+  auto is_polygon_enabled = [&](const std::string & label) {
+    return polygon_enabled_object_types.count(label) > 0;
+  };
 
   const auto & front = params.front_distance_th;
   const auto & side = params.side_distance_th;
   const auto & back = params.back_distance_th;
+  auto get_object_distance_thresholds = [&](const std::string & label) {
+    if (label == "car") return std::make_tuple(front.car, side.car, back.car);
+    if (label == "truck") return std::make_tuple(front.truck, side.truck, back.truck);
+    if (label == "bus") return std::make_tuple(front.bus, side.bus, back.bus);
+    if (label == "trailer") return std::make_tuple(front.trailer, side.trailer, back.trailer);
+    if (label == "motorcycle") return std::make_tuple(front.motorcycle, side.motorcycle, back.motorcycle);
+    if (label == "bicycle") return std::make_tuple(front.bicycle, side.bicycle, back.bicycle);
+    if (label == "pedestrian") return std::make_tuple(front.pedestrian, side.pedestrian, back.pedestrian);
+    if (label == "hazard") return std::make_tuple(front.hazard, side.hazard, back.hazard);
+    if (label == "animal") return std::make_tuple(front.animal, side.animal, back.animal);
+    return std::make_tuple(front.unknown, side.unknown, back.unknown);
+  };
+
+  const auto set_object_params = [&](const std::string & label) {
+    const auto bbox_enabled = is_bbox_enabled(label);
+    const auto polygon_enabled = is_polygon_enabled(label);
+    const auto [front, side, back] = get_object_distance_thresholds(label);
+    parameters.object_type_enable_check[label] = bbox_enabled || polygon_enabled;
+    parameters.obstacle_types_map[label] = to_obstacle_type_parameters(front, side, back, bbox_enabled, polygon_enabled);
+  };
+  set_object_params("unknown");
+  set_object_params("car");
+  set_object_params("truck");
+  set_object_params("bus");
+  set_object_params("trailer");
+  set_object_params("motorcycle");
+  set_object_params("bicycle");
+  set_object_params("pedestrian");
+  set_object_params("hazard");
+  set_object_params("animal");
 
   parameters.obstacle_types_map["pointcloud"] =
     to_obstacle_type_parameters(front.pointcloud, side.pointcloud, back.pointcloud);
-  parameters.obstacle_types_map["unknown"] =
-    to_obstacle_type_parameters(front.unknown, side.unknown, back.unknown);
-  parameters.obstacle_types_map["car"] = to_obstacle_type_parameters(front.car, side.car, back.car);
-  parameters.obstacle_types_map["truck"] =
-    to_obstacle_type_parameters(front.truck, side.truck, back.truck);
-  parameters.obstacle_types_map["bus"] = to_obstacle_type_parameters(front.bus, side.bus, back.bus);
-  parameters.obstacle_types_map["trailer"] =
-    to_obstacle_type_parameters(front.trailer, side.trailer, back.trailer);
-  parameters.obstacle_types_map["motorcycle"] =
-    to_obstacle_type_parameters(front.motorcycle, side.motorcycle, back.motorcycle);
-  parameters.obstacle_types_map["bicycle"] =
-    to_obstacle_type_parameters(front.bicycle, side.bicycle, back.bicycle);
-  parameters.obstacle_types_map["pedestrian"] =
-    to_obstacle_type_parameters(front.pedestrian, side.pedestrian, back.pedestrian);
-  parameters.obstacle_types_map["hazard"] =
-    to_obstacle_type_parameters(front.hazard, side.hazard, back.hazard);
-  parameters.obstacle_types_map["animal"] =
-    to_obstacle_type_parameters(front.animal, side.animal, back.animal);
   return parameters;
 }
 }  // namespace

--- a/planning/autoware_trajectory_modifier/src/trajectory_modifier_plugins/surround_obstacle_stop.cpp
+++ b/planning/autoware_trajectory_modifier/src/trajectory_modifier_plugins/surround_obstacle_stop.cpp
@@ -75,9 +75,11 @@ Parameters to_proximity_checker_parameters(
     if (label == "truck") return std::make_tuple(front.truck, side.truck, back.truck);
     if (label == "bus") return std::make_tuple(front.bus, side.bus, back.bus);
     if (label == "trailer") return std::make_tuple(front.trailer, side.trailer, back.trailer);
-    if (label == "motorcycle") return std::make_tuple(front.motorcycle, side.motorcycle, back.motorcycle);
+    if (label == "motorcycle")
+      return std::make_tuple(front.motorcycle, side.motorcycle, back.motorcycle);
     if (label == "bicycle") return std::make_tuple(front.bicycle, side.bicycle, back.bicycle);
-    if (label == "pedestrian") return std::make_tuple(front.pedestrian, side.pedestrian, back.pedestrian);
+    if (label == "pedestrian")
+      return std::make_tuple(front.pedestrian, side.pedestrian, back.pedestrian);
     if (label == "hazard") return std::make_tuple(front.hazard, side.hazard, back.hazard);
     if (label == "animal") return std::make_tuple(front.animal, side.animal, back.animal);
     return std::make_tuple(front.unknown, side.unknown, back.unknown);
@@ -88,7 +90,8 @@ Parameters to_proximity_checker_parameters(
     const auto polygon_enabled = is_polygon_enabled(label);
     const auto [front, side, back] = get_object_distance_thresholds(label);
     parameters.object_type_enable_check[label] = bbox_enabled || polygon_enabled;
-    parameters.obstacle_types_map[label] = to_obstacle_type_parameters(front, side, back, bbox_enabled, polygon_enabled);
+    parameters.obstacle_types_map[label] =
+      to_obstacle_type_parameters(front, side, back, bbox_enabled, polygon_enabled);
   };
   set_object_params("unknown");
   set_object_params("car");

--- a/planning/autoware_trajectory_modifier/src/trajectory_modifier_utils/obstacle_stop_utils.cpp
+++ b/planning/autoware_trajectory_modifier/src/trajectory_modifier_utils/obstacle_stop_utils.cpp
@@ -618,8 +618,9 @@ void ObstacleTracker::update_objects(
         existing_object.object.kinematics.initial_pose_with_covariance.pose.position);
       if (distance > min_distance) continue;
       // ignore orientation difference for cylinder objects
+      const bool is_symmetric = std::abs(object.shape.dimensions.x - object.shape.dimensions.y) < 0.1;
       const auto yaw_diff =
-        object.shape.type == autoware_perception_msgs::msg::Shape::CYLINDER
+        is_symmetric
           ? 0.0
           : std::abs(
               autoware_utils_geometry::calc_yaw_deviation(

--- a/planning/autoware_trajectory_modifier/src/trajectory_modifier_utils/obstacle_stop_utils.cpp
+++ b/planning/autoware_trajectory_modifier/src/trajectory_modifier_utils/obstacle_stop_utils.cpp
@@ -618,14 +618,14 @@ void ObstacleTracker::update_objects(
         existing_object.object.kinematics.initial_pose_with_covariance.pose.position);
       if (distance > min_distance) continue;
       // ignore orientation difference for cylinder objects
-      const bool is_symmetric = std::abs(object.shape.dimensions.x - object.shape.dimensions.y) < 0.1;
+      const bool is_symmetric =
+        std::abs(object.shape.dimensions.x - object.shape.dimensions.y) < 0.1;
       const auto yaw_diff =
-        is_symmetric
-          ? 0.0
-          : std::abs(
-              autoware_utils_geometry::calc_yaw_deviation(
-                object.kinematics.initial_pose_with_covariance.pose,
-                existing_object.object.kinematics.initial_pose_with_covariance.pose));
+        is_symmetric ? 0.0
+                     : std::abs(
+                         autoware_utils_geometry::calc_yaw_deviation(
+                           object.kinematics.initial_pose_with_covariance.pose,
+                           existing_object.object.kinematics.initial_pose_with_covariance.pose));
       if (yaw_diff > object_yaw_th_) continue;
       min_distance = distance;
       closest_uuid = uuid;

--- a/planning/autoware_trajectory_modifier/tests/test_obstacle_stop_integration.cpp
+++ b/planning/autoware_trajectory_modifier/tests/test_obstacle_stop_integration.cpp
@@ -238,7 +238,8 @@ protected:
     p.obstacle_tracking.pcd_distance_th = 0.5;
     p.obstacle_tracking.grace_period = 0.5;
 
-    p.objects.object_types = {"car"};
+    p.objects.target_objects.bbox = {"car"};
+    p.objects.target_objects.polygon = {"car"};
 
     p.pointcloud.height_buffer = 0.5;
     p.pointcloud.min_height = 0.2;

--- a/planning/autoware_trajectory_modifier/tests/test_surround_obstacle_stop_integration.cpp
+++ b/planning/autoware_trajectory_modifier/tests/test_surround_obstacle_stop_integration.cpp
@@ -230,7 +230,8 @@ protected:
     auto & p = params_.surround_obstacle_stop;
     p.use_objects = true;
     p.use_pointcloud = true;
-    p.object_types = {"car"};
+    p.target_objects.bbox = {"car"};
+    p.target_objects.polygon = {"car"};
     p.hysteresis_distance = 0.5;
     p.hysteresis_time = 0.0;
     p.ego_stopped_vel_th = 0.1;


### PR DESCRIPTION
This PR applies the following changes for extending object filtering to consider shape:
- update `obstacle_stop` params in modifier and backup planner to specify enabled types per shape
- update `surround_obstacle_stop` params in modifier and backup planner to specify enabled types per shape
- update related parameter structs and schemas
- modify `ObjectFilter` code in `obstacle_stop_utils` to support filtering by type and shape
- modify `ObstacleProximityChecker` class to support filtering by type and shape
- fix `ObstacleTracker` logic for ignoring orientation change

requires https://github.com/tier4/autoware_launch.x2/pull/2778