### PR TITLE
feat(trajectory_validator): port the obstacle stop logic for the point cloud collision check filter

### DIFF
--- a/planning/autoware_trajectory_validator/src/filters/safety/point_cloud_collision_check/obstacle_stop.cpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/point_cloud_collision_check/obstacle_stop.cpp
@@ -14,19 +14,385 @@
 
 #include "obstacle_stop.hpp"
 
+#include <autoware/motion_utils/trajectory/trajectory.hpp>
+#include <autoware/motion_velocity_planner_common/polygon_utils.hpp>
+#include <autoware/motion_velocity_planner_common/utils.hpp>
+#include <autoware_utils_geometry/geometry.hpp>
+
+#include <boost/geometry.hpp>
+
+#include <algorithm>
+#include <cmath>
 #include <memory>
+#include <numeric>
+#include <optional>
+#include <utility>
 #include <vector>
 
 namespace autoware::trajectory_validator::plugin::safety::point_cloud_collision_check
 {
-void ObstacleStop::update_parameters([[maybe_unused]] const Params & params)
+namespace
 {
+namespace mvp = autoware::motion_velocity_planner;
+
+// motion_velocity_obstacle_stop_module/obstacle_stop_module.cpp:129-135
+double calc_x_offset_to_bumper(const bool is_driving_forward, const VehicleInfo & vehicle_info)
+{
+  if (is_driving_forward) {
+    return vehicle_info.max_longitudinal_offset_m;
+  }
+  return vehicle_info.min_longitudinal_offset_m;
 }
 
-std::vector<StopObstacle> ObstacleStop::calc_obstacle_stop(
-  [[maybe_unused]] const std::vector<TrajectoryPoint> & raw_trajectory_points,
-  [[maybe_unused]] const std::shared_ptr<const PlannerData> planner_data)
+// motion_velocity_obstacle_stop_module/obstacle_stop_module.cpp:157-180
+double calc_braking_dist_along_trajectory(
+  const StopObstacleClassification::Type label, const double lon_vel, const RSSParam & rss_params)
 {
-  return {};
+  const double braking_acc = [&]() {
+    if (label == StopObstacleClassification::Type::POINTCLOUD) {
+      return rss_params.pointcloud_deceleration;
+    }
+    if (
+      label == StopObstacleClassification::Type::UNKNOWN ||
+      label == StopObstacleClassification::Type::PEDESTRIAN) {
+      return rss_params.no_wheel_objects_deceleration;
+    }
+    if (
+      label == StopObstacleClassification::Type::BICYCLE ||
+      label == StopObstacleClassification::Type::MOTORCYCLE) {
+      return rss_params.two_wheel_objects_deceleration;
+    }
+    return rss_params.vehicle_objects_deceleration;
+  }();
+  const double error_considered_vel = std::max(lon_vel + rss_params.velocity_offset, 0.0);
+  return error_considered_vel * error_considered_vel * 0.5 / -braking_acc;
 }
+
+// motion_velocity_obstacle_stop_module/obstacle_stop_module.cpp:183-205
+PolygonParam create_polygon_param(
+  const ObstacleFilteringParam::TrimTrajectoryParam & trim_trajectory_param,
+  const std::optional<double> ego_braking_distance,
+  const ObstacleFilteringParam::LateralMarginParam & lateral_margin_param,
+  const std::optional<double> object_velocity)
+{
+  PolygonParam p;
+  if (!trim_trajectory_param.enable_trimming || !ego_braking_distance.has_value()) {
+    p.trimming_length = std::nullopt;
+  } else {
+    p.trimming_length =
+      trim_trajectory_param.min_trajectory_length +
+      trim_trajectory_param.braking_distance_scale_factor * ego_braking_distance.value();
+  }
+  p.lateral_margin = lateral_margin_param.nominal_margin +
+                     (object_velocity > lateral_margin_param.is_moving_threshold_velocity
+                        ? lateral_margin_param.additional_is_moving_margin
+                        : lateral_margin_param.additional_is_stop_margin);
+  p.off_track_scale = lateral_margin_param.additional_wheel_off_track_scale;
+  return p;
+}
+
+}  // namespace
+
+// motion_velocity_obstacle_stop_module/obstacle_stop_module.cpp:222-228
+// （init のうちパラメータ構築部）
+void ObstacleStop::update_parameters(const Params & params)
+{
+  common_param_ = params.common;
+  stop_planning_param_ = params.stop_planning;
+  obstacle_filtering_params_ = {
+    {StopObstacleClassification::Type::POINTCLOUD, params.obstacle_filtering}};
+  pointcloud_segmentation_param_ = params.pointcloud_segmentation;
+}
+
+// motion_velocity_obstacle_stop_module/obstacle_stop_module.cpp:280-341（plan）
+std::vector<StopObstacle> ObstacleStop::calc_obstacle_stop(
+  const std::vector<TrajectoryPoint> & raw_trajectory_points,
+  const std::shared_ptr<const PlannerData> planner_data)
+{
+  // autoware_utils_debug::ScopedTimeTrack st(__func__, *time_keeper_);
+  const double x_offset_to_bumper =
+    calc_x_offset_to_bumper(planner_data->is_driving_forward, planner_data->vehicle_info_);
+  trajectory_polygon_for_inside_map_.clear();
+
+  const auto decimated_traj_points = mvp::utils::decimate_trajectory_points_from_ego(
+    raw_trajectory_points, planner_data->current_odometry.pose.pose,
+    planner_data->ego_nearest_dist_threshold, planner_data->ego_nearest_yaw_threshold,
+    planner_data->trajectory_polygon_collision_check.decimate_trajectory_step_length,
+    stop_planning_param_.stop_margin);
+
+  auto stop_obstacles_for_point_cloud = filter_stop_obstacle_for_point_cloud(
+    planner_data->current_odometry, raw_trajectory_points, decimated_traj_points,
+    planner_data->no_ground_pointcloud, planner_data->vehicle_info_, x_offset_to_bumper,
+    planner_data->trajectory_polygon_collision_check);
+
+  return stop_obstacles_for_point_cloud;
+}
+
+// motion_velocity_obstacle_stop_module/obstacle_stop_module.cpp:344-353
+std::optional<double> ObstacleStop::calc_ego_forwarding_braking_distance(
+  const std::vector<TrajectoryPoint> & traj_points, const nav_msgs::msg::Odometry & odometry) const
+{
+  if (traj_points.empty() || autoware::motion_utils::isDrivingForward(traj_points) != true) {
+    return std::nullopt;
+  }
+  return autoware::motion_utils::calcDecelDistWithJerkAndAccConstraints(
+    odometry.twist.twist.linear.x, 0.0, common_param_.max_accel, common_param_.min_accel,
+    common_param_.max_jerk, common_param_.min_jerk);
+}
+
+// motion_velocity_obstacle_stop_module/obstacle_stop_module.cpp:356-431
+std::optional<CollisionPointWithDist> ObstacleStop::get_nearest_collision_point(
+  const std::vector<TrajectoryPoint> & traj_points, const std::vector<Polygon2d> & traj_polygons,
+  const Pointcloud & point_cloud, const double x_offset_to_bumper,
+  const VehicleInfo & vehicle_info) const
+{
+  // autoware_utils_debug::ScopedTimeTrack st(__func__, *time_keeper_);
+
+  if (traj_points.size() != traj_polygons.size()) {
+    RCLCPP_ERROR(
+      logger_, "The size of trajectory points and polygons do not match: %zu vs %zu",
+      traj_points.size(), traj_polygons.size());
+    return std::nullopt;
+  }
+
+  if (point_cloud.pointcloud.empty()) {
+    return std::nullopt;
+  }
+
+  const auto & clusters = point_cloud.get_cluster_indices();
+  const auto & pointcloud_ptr = point_cloud.get_filtered_pointcloud_ptr();
+
+  const auto & height_margin = pointcloud_segmentation_param_.height_margin;
+  std::vector<geometry_msgs::msg::Point> collision_geom_points{};
+  for (size_t traj_index = 0; traj_index < traj_points.size(); ++traj_index) {
+    const double rough_dist_th = boost::geometry::perimeter(traj_polygons.at(traj_index)) * 0.5;
+    const double traj_height = traj_points.at(traj_index).pose.position.z;
+
+    for (const auto & cluster : clusters) {
+      for (const auto & point_index : cluster.indices) {
+        const auto obstacle_point = mvp::utils::to_geometry_point(pointcloud_ptr->at(point_index));
+        if (
+          obstacle_point.z - traj_height < -height_margin.margin_from_bottom ||
+          obstacle_point.z - traj_height >
+            vehicle_info.max_height_offset_m + height_margin.margin_from_top) {
+          continue;
+        }
+        const double dist_from_base_link =
+          autoware_utils_geometry::calc_distance2d(traj_points.at(traj_index).pose, obstacle_point);
+        if (dist_from_base_link > rough_dist_th) {
+          continue;
+        }
+        Point2d obstacle_point_2d{obstacle_point.x, obstacle_point.y};
+        if (boost::geometry::within(obstacle_point_2d, traj_polygons.at(traj_index))) {
+          collision_geom_points.push_back(obstacle_point);
+        }
+      }
+    }
+    if (collision_geom_points.empty()) {
+      continue;
+    }
+
+    const auto bumper_pose = autoware_utils_geometry::calc_offset_pose(
+      traj_points.at(traj_index).pose, x_offset_to_bumper, 0.0, 0.0);
+    std::optional<double> max_collision_length = std::nullopt;
+    std::optional<geometry_msgs::msg::Point> max_collision_point = std::nullopt;
+    for (const auto & point : collision_geom_points) {
+      const double dist_from_bumper =
+        std::abs(autoware_utils_geometry::inverse_transform_point(point, bumper_pose).x);
+
+      if (!max_collision_length.has_value() || dist_from_bumper > *max_collision_length) {
+        max_collision_length = dist_from_bumper;
+        max_collision_point = point;
+      }
+    }
+    return CollisionPointWithDist{
+      *max_collision_point,
+      autoware::motion_utils::calcSignedArcLength(traj_points, 0, traj_index) -
+        *max_collision_length};
+  }
+  return std::nullopt;
+}
+
+// motion_velocity_obstacle_stop_module/obstacle_stop_module.cpp:520-578
+void ObstacleStop::upsert_pointcloud_stop_candidates(
+  const CollisionPointWithDist & nearest_collision_point,
+  const std::vector<TrajectoryPoint> & traj_points, rclcpp::Time latest_point_cloud_time)
+{
+  // autoware_utils_debug::ScopedTimeTrack st(__func__, *time_keeper_);
+  const auto & vel_params = pointcloud_segmentation_param_.velocity_estimation;
+  const auto & assoc_params = pointcloud_segmentation_param_.time_series_association;
+
+  for (auto stop_candidate = pointcloud_stop_candidates.rbegin();
+       stop_candidate != pointcloud_stop_candidates.rend(); ++stop_candidate) {
+    const double time_since_latest_collision =
+      (latest_point_cloud_time - stop_candidate->latest_collision_pointcloud_time).seconds();
+    if (time_since_latest_collision < 0.05) {
+      return;
+    }
+    const double longitudinal_displacement = autoware::motion_utils::calcSignedArcLength(
+      traj_points, stop_candidate->latest_collision_point.point, nearest_collision_point.point);
+
+    if (
+      time_since_latest_collision < assoc_params.max_time_diff &&
+      -assoc_params.position_diff + assoc_params.min_velocity * time_since_latest_collision <
+        longitudinal_displacement &&
+      longitudinal_displacement <
+        assoc_params.position_diff + assoc_params.max_velocity * time_since_latest_collision) {
+      const double clamped_vel = std::clamp(
+        longitudinal_displacement / time_since_latest_collision, vel_params.min_clamp_velocity,
+        vel_params.max_clamp_velocity);
+      if (!stop_candidate->vel_lpf.getValue().has_value()) {
+        auto & vel_vec = stop_candidate->initial_velocities;
+        vel_vec.push_back(clamped_vel);
+        if (vel_vec.size() >= vel_params.required_velocity_count) {
+          stop_candidate->vel_lpf.reset(
+            std::accumulate(vel_vec.begin(), vel_vec.end(), 0.0) / vel_vec.size());
+        }
+      } else {
+        stop_candidate->vel_lpf.filter(clamped_vel);
+      }
+      stop_candidate->latest_collision_point = nearest_collision_point;
+      stop_candidate->latest_collision_pointcloud_time = latest_point_cloud_time;
+
+      std::sort(
+        pointcloud_stop_candidates.begin(), pointcloud_stop_candidates.end(),
+        [](const PointcloudStopCandidate & a, const PointcloudStopCandidate & b) {
+          return a.latest_collision_pointcloud_time < b.latest_collision_pointcloud_time;
+        });
+
+      return;
+    }
+  }
+  PointcloudStopCandidate new_stop_candidate;
+  new_stop_candidate.latest_collision_point = nearest_collision_point;
+  new_stop_candidate.latest_collision_pointcloud_time = latest_point_cloud_time;
+  new_stop_candidate.vel_lpf.setGain(vel_params.lpf_gain);
+  pointcloud_stop_candidates.push_back(new_stop_candidate);
+}
+
+// motion_velocity_obstacle_stop_module/obstacle_stop_module.cpp:582-686
+std::vector<StopObstacle> ObstacleStop::filter_stop_obstacle_for_point_cloud(
+  const nav_msgs::msg::Odometry & odometry, const std::vector<TrajectoryPoint> & traj_points,
+  const std::vector<TrajectoryPoint> & decimated_traj_points, const Pointcloud & point_cloud,
+  const VehicleInfo & vehicle_info, const double x_offset_to_bumper,
+  const TrajectoryPolygonCollisionCheck & trajectory_polygon_collision_check)
+{
+  // autoware_utils_debug::ScopedTimeTrack st(__func__, *time_keeper_);
+  const auto & filtering_param =
+    obstacle_filtering_params_.at(StopObstacleClassification::Type::POINTCLOUD);
+
+  if (!filtering_param.check_inside) {
+    return std::vector<StopObstacle>{};
+  }
+
+  if (
+    point_cloud.preprocess_params_.filter_by_trajectory_polygon.lateral_margin <
+    filtering_param.lateral_margin.nominal_margin) {
+    RCLCPP_WARN_ONCE(
+      logger_,
+      "pointcloud preprocessing lateral margin in motion_velocity_planner_node (%f) is smaller "
+      "than obstacle_stop_module param (%f)",
+      point_cloud.preprocess_params_.filter_by_trajectory_polygon.lateral_margin,
+      filtering_param.lateral_margin.nominal_margin);
+  }
+
+  const auto & tp = trajectory_polygon_collision_check;
+  const auto polygon_param = create_polygon_param(
+    filtering_param.trim_trajectory, calc_ego_forwarding_braking_distance(traj_points, odometry),
+    filtering_param.lateral_margin, std::nullopt);
+  const auto detection_polygon_with_lat_margin = get_trajectory_polygon(
+    decimated_traj_points, vehicle_info, odometry.pose.pose, polygon_param,
+    tp.enable_to_consider_current_pose, tp.time_to_convergence, tp.decimate_trajectory_step_length);
+
+  const auto nearest_collision_point = get_nearest_collision_point(
+    detection_polygon_with_lat_margin.traj_points, detection_polygon_with_lat_margin.polygons,
+    point_cloud, x_offset_to_bumper, vehicle_info);
+
+  const auto latest_point_cloud_time =
+    rclcpp::Time(point_cloud.pointcloud.header.stamp * static_cast<uint32_t>(1e3), RCL_ROS_TIME);
+  if (nearest_collision_point) {
+    upsert_pointcloud_stop_candidates(
+      nearest_collision_point.value(), traj_points, latest_point_cloud_time);
+  }
+
+  while (
+    !pointcloud_stop_candidates.empty() &&
+    (latest_point_cloud_time - pointcloud_stop_candidates.front().latest_collision_pointcloud_time)
+        .seconds() > filtering_param.stop_obstacle_hold_time_threshold) {
+    pointcloud_stop_candidates.pop_front();
+  }
+
+  const rclcpp::Time now_stamp{odometry.header.stamp};
+  std::vector<StopObstacle> stop_obstacles;
+  for (const auto & stop_candidate : pointcloud_stop_candidates) {
+    if (!stop_candidate.vel_lpf.getValue().has_value()) {
+      continue;
+    }
+
+    // const double time_delay =
+    //   (clock_->now() - stop_candidate.latest_collision_pointcloud_time).seconds();
+    const double time_delay =
+      (now_stamp - stop_candidate.latest_collision_pointcloud_time).seconds();
+    const double time_compensated_dist_to_collide =
+      stop_candidate.latest_collision_point.dist_to_collide +
+      *stop_candidate.vel_lpf.getValue() * time_delay;
+
+    const bool use_estimated_velocity =
+      pointcloud_segmentation_param_.velocity_estimation.use_estimated_velocity;
+    if (
+      !use_estimated_velocity ||
+      *stop_candidate.vel_lpf.getValue() <
+        stop_planning_param_.obstacle_velocity_threshold_enter_fixed_stop) {
+      stop_obstacles.emplace_back(
+        stop_candidate.latest_collision_pointcloud_time,
+        StopObstacleClassification{StopObstacleClassification::Type::POINTCLOUD},
+        stop_candidate.vel_lpf.getValue().value(), stop_candidate.latest_collision_point.point,
+        time_compensated_dist_to_collide, polygon_param);
+    } else if (stop_planning_param_.rss_params.use_rss_stop) {
+      const auto braking_dist = calc_braking_dist_along_trajectory(
+        StopObstacleClassification::Type::POINTCLOUD, *stop_candidate.vel_lpf.getValue(),
+        stop_planning_param_.rss_params);
+      stop_obstacles.emplace_back(
+        stop_candidate.latest_collision_pointcloud_time,
+        StopObstacleClassification{StopObstacleClassification::Type::POINTCLOUD},
+        stop_candidate.vel_lpf.getValue().value(), stop_candidate.latest_collision_point.point,
+        time_compensated_dist_to_collide, polygon_param, braking_dist);
+      RCLCPP_DEBUG(
+        logger_,
+        "|_PC_| total_dist: %2.5f, raw_dist: %2.5f, time_compensated dist: %2.5f, "
+        "braking_dist: %2.5f",
+        (time_compensated_dist_to_collide + braking_dist),
+        (stop_candidate.latest_collision_point.dist_to_collide), time_compensated_dist_to_collide,
+        braking_dist);
+    }
+  }
+
+  return stop_obstacles;
+}
+
+// motion_velocity_obstacle_stop_module/obstacle_stop_module.cpp:1368-1391
+DetectionPolygon ObstacleStop::get_trajectory_polygon(
+  const std::vector<TrajectoryPoint> & decimated_traj_points, const VehicleInfo & vehicle_info,
+  const geometry_msgs::msg::Pose & current_ego_pose, const PolygonParam & polygon_param,
+  const bool enable_to_consider_current_pose, const double time_to_convergence,
+  const double decimate_trajectory_step_length) const
+{
+  if (trajectory_polygon_for_inside_map_.count(polygon_param) == 0) {
+    auto cropped_traj_points =
+      polygon_param.trimming_length.has_value()
+        ? autoware::motion_utils::cropForwardPoints(
+            decimated_traj_points, decimated_traj_points.front().pose.position, 0,
+            polygon_param.trimming_length.value())
+        : decimated_traj_points;
+
+    auto traj_polys = mvp::polygon_utils::create_one_step_polygons(
+      cropped_traj_points, vehicle_info, current_ego_pose, polygon_param.lateral_margin,
+      enable_to_consider_current_pose, time_to_convergence, decimate_trajectory_step_length,
+      polygon_param.off_track_scale);
+    trajectory_polygon_for_inside_map_.emplace(
+      polygon_param, DetectionPolygon{std::move(cropped_traj_points), std::move(traj_polys)});
+  }
+  return trajectory_polygon_for_inside_map_.at(polygon_param);
+}
+
 }  // namespace autoware::trajectory_validator::plugin::safety::point_cloud_collision_check

--- a/planning/autoware_trajectory_validator/src/filters/safety/point_cloud_collision_check/obstacle_stop.hpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/point_cloud_collision_check/obstacle_stop.hpp
@@ -19,12 +19,19 @@
 #include "planner_data_lite.hpp"
 #include "types.hpp"
 
+#include <rclcpp/logger.hpp>
+#include <rclcpp/logging.hpp>
+
+#include <deque>
+#include <map>
 #include <memory>
+#include <optional>
+#include <unordered_map>
 #include <vector>
 
 namespace autoware::trajectory_validator::plugin::safety::point_cloud_collision_check
 {
-// 移植元 ObstacleStopModule の点群経路。中身は後続 PR で移植する。
+
 class ObstacleStop
 {
 public:
@@ -33,7 +40,45 @@ public:
   std::vector<StopObstacle> calc_obstacle_stop(
     const std::vector<TrajectoryPoint> & raw_trajectory_points,
     const std::shared_ptr<const PlannerData> planner_data);
+
+private:
+  DetectionPolygon get_trajectory_polygon(
+    const std::vector<TrajectoryPoint> & decimated_traj_points, const VehicleInfo & vehicle_info,
+    const geometry_msgs::msg::Pose & current_ego_pose, const PolygonParam & polygon_param,
+    const bool enable_to_consider_current_pose, const double time_to_convergence,
+    const double decimate_trajectory_step_length) const;
+
+  // 前提: is_feasible は1サイクルに1候補のみを処理する（単一候補前提）。
+  void upsert_pointcloud_stop_candidates(
+    const CollisionPointWithDist & nearest_collision_point,
+    const std::vector<TrajectoryPoint> & traj_points, rclcpp::Time latest_point_cloud_time);
+
+  std::vector<StopObstacle> filter_stop_obstacle_for_point_cloud(
+    const nav_msgs::msg::Odometry & odometry, const std::vector<TrajectoryPoint> & traj_points,
+    const std::vector<TrajectoryPoint> & decimated_traj_points, const Pointcloud & point_cloud,
+    const VehicleInfo & vehicle_info, const double x_offset_to_bumper,
+    const TrajectoryPolygonCollisionCheck & trajectory_polygon_collision_check);
+
+  std::optional<double> calc_ego_forwarding_braking_distance(
+    const std::vector<TrajectoryPoint> & traj_points,
+    const nav_msgs::msg::Odometry & odometry) const;
+
+  std::optional<CollisionPointWithDist> get_nearest_collision_point(
+    const std::vector<TrajectoryPoint> & traj_points, const std::vector<Polygon2d> & traj_polygons,
+    const Pointcloud & point_cloud, const double x_offset_to_bumper,
+    const VehicleInfo & vehicle_info) const;
+
+  CommonParam common_param_{};
+  StopPlanningParam stop_planning_param_{};
+  std::unordered_map<StopObstacleClassification::Type, ObstacleFilteringParam>
+    obstacle_filtering_params_{};
+  PointcloudSegmentationParam pointcloud_segmentation_param_;
+
+  std::deque<PointcloudStopCandidate> pointcloud_stop_candidates{};
+  mutable std::map<PolygonParam, DetectionPolygon> trajectory_polygon_for_inside_map_{};
+  rclcpp::Logger logger_{rclcpp::get_logger("point_cloud_collision_check_filter")};
 };
+
 }  // namespace autoware::trajectory_validator::plugin::safety::point_cloud_collision_check
 
 #endif  // FILTERS__SAFETY__POINT_CLOUD_COLLISION_CHECK__OBSTACLE_STOP_HPP_

--- a/planning/autoware_trajectory_validator/src/filters/safety/point_cloud_collision_check/types.hpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/point_cloud_collision_check/types.hpp
@@ -15,15 +15,204 @@
 #ifndef FILTERS__SAFETY__POINT_CLOUD_COLLISION_CHECK__TYPES_HPP_
 #define FILTERS__SAFETY__POINT_CLOUD_COLLISION_CHECK__TYPES_HPP_
 
+#include <autoware/signal_processing/lowpass_filter_1d.hpp>
 #include <autoware_utils_geometry/boost_geometry.hpp>
+#include <rclcpp/time.hpp>
 
+#include <autoware_perception_msgs/msg/object_classification.hpp>
+#include <autoware_perception_msgs/msg/shape.hpp>
 #include <autoware_planning_msgs/msg/trajectory_point.hpp>
+#include <geometry_msgs/msg/point.hpp>
+#include <geometry_msgs/msg/pose.hpp>
+#include <unique_identifier_msgs/msg/uuid.hpp>
+
+#include <optional>
+#include <stdexcept>
+#include <string>
+#include <tuple>
+#include <unordered_map>
+#include <utility>
+#include <vector>
 
 namespace autoware::trajectory_validator::plugin::safety::point_cloud_collision_check
 {
 using autoware_planning_msgs::msg::TrajectoryPoint;
+using ObjectClassification = autoware_perception_msgs::msg::ObjectClassification;
 using Point2d = autoware_utils_geometry::Point2d;
 using Polygon2d = autoware_utils_geometry::Polygon2d;
+using Shape = autoware_perception_msgs::msg::Shape;
+using UUID = unique_identifier_msgs::msg::UUID;
+
+struct StopObstacleClassification
+{
+  enum class Type {
+    UNKNOWN,
+    CAR,
+    TRUCK,
+    BUS,
+    TRAILER,
+    MOTORCYCLE,
+    BICYCLE,
+    PEDESTRIAN,
+    ANIMAL,
+    HAZARD,
+    POINTCLOUD
+  };
+
+  inline static const std::unordered_map<Type, std::string> to_string_map = {
+    {Type::UNKNOWN, "unknown"},      {Type::CAR, "car"},
+    {Type::TRUCK, "truck"},          {Type::BUS, "bus"},
+    {Type::TRAILER, "trailer"},      {Type::MOTORCYCLE, "motorcycle"},
+    {Type::BICYCLE, "bicycle"},      {Type::PEDESTRIAN, "pedestrian"},
+    {Type::ANIMAL, "animal"},        {Type::HAZARD, "hazard"},
+    {Type::POINTCLOUD, "pointcloud"}};
+
+  explicit StopObstacleClassification(const ObjectClassification object_classification)
+  {
+    switch (object_classification.label) {
+      case ObjectClassification::UNKNOWN:
+        label = Type::UNKNOWN;
+        break;
+      case ObjectClassification::CAR:
+        label = Type::CAR;
+        break;
+      case ObjectClassification::TRUCK:
+        label = Type::TRUCK;
+        break;
+      case ObjectClassification::BUS:
+        label = Type::BUS;
+        break;
+      case ObjectClassification::TRAILER:
+        label = Type::TRAILER;
+        break;
+      case ObjectClassification::MOTORCYCLE:
+        label = Type::MOTORCYCLE;
+        break;
+      case ObjectClassification::BICYCLE:
+        label = Type::BICYCLE;
+        break;
+      case ObjectClassification::PEDESTRIAN:
+        label = Type::PEDESTRIAN;
+        break;
+      case ObjectClassification::ANIMAL:
+        label = Type::ANIMAL;
+        break;
+      case ObjectClassification::HAZARD:
+        label = Type::HAZARD;
+        break;
+      default:
+        throw std::invalid_argument("Undefined ObjectClassification label");
+    }
+  }
+  explicit StopObstacleClassification(
+    const std::vector<ObjectClassification> & object_classifications)
+  : StopObstacleClassification(object_classifications.at(0))
+  {
+  }
+  explicit StopObstacleClassification(Type v) : label(v) {}
+  StopObstacleClassification() = default;
+
+  std::string to_string() const { return to_string_map.at(label); }
+
+  Type label{};
+
+  bool operator==(const StopObstacleClassification & other) const { return label == other.label; }
+  bool operator!=(const StopObstacleClassification & other) const { return !(*this == other); }
+};
+
+struct CollisionPointWithDist
+{
+  geometry_msgs::msg::Point point{};
+  double dist_to_collide{};
+};
+
+struct PointcloudStopCandidate
+{
+  std::vector<double> initial_velocities{};
+  autoware::signal_processing::LowpassFilter1d vel_lpf{0.0};
+  rclcpp::Time latest_collision_pointcloud_time;
+  CollisionPointWithDist latest_collision_point;
+};
+
+struct PolygonParam
+{
+  std::optional<double> trimming_length{};
+  double lateral_margin{};
+  double off_track_scale{};
+
+  bool operator<(const PolygonParam & other) const
+  {
+    return std::tie(trimming_length, lateral_margin, off_track_scale) <
+           std::tie(other.trimming_length, other.lateral_margin, other.off_track_scale);
+  }
+};
+
+struct StopObstacle
+{
+  StopObstacle(
+    const UUID & arg_uuid, const rclcpp::Time & arg_stamp,
+    const StopObstacleClassification & arg_object_classification,
+    const geometry_msgs::msg::Pose & arg_pose, const Shape & arg_shape,
+    const double arg_lon_velocity, const geometry_msgs::msg::Point & arg_collision_point,
+    const double arg_dist_to_collide_on_decimated_traj, const PolygonParam & arg_polygon_param,
+    const std::optional<double> arg_braking_dist = std::nullopt)
+  : uuid(arg_uuid),
+    stamp(arg_stamp),
+    pose(arg_pose),
+    velocity(arg_lon_velocity),
+    shape(arg_shape),
+    collision_point(arg_collision_point),
+    dist_to_collide_on_decimated_traj(arg_dist_to_collide_on_decimated_traj),
+    classification(arg_object_classification),
+    polygon_param(arg_polygon_param),
+    braking_dist(arg_braking_dist)
+  {
+  }
+  StopObstacle(
+    const rclcpp::Time & arg_stamp, const StopObstacleClassification & arg_object_classification,
+    const double arg_lon_velocity, const geometry_msgs::msg::Point & arg_collision_point,
+    const double arg_dist_to_collide_on_decimated_traj, const PolygonParam & arg_polygon_param,
+    const std::optional<double> arg_braking_dist = std::nullopt)
+  : stamp(arg_stamp),
+    velocity(arg_lon_velocity),
+    collision_point(arg_collision_point),
+    dist_to_collide_on_decimated_traj(arg_dist_to_collide_on_decimated_traj),
+    classification(arg_object_classification),
+    polygon_param(arg_polygon_param),
+    braking_dist(arg_braking_dist)
+  {
+    if (arg_object_classification.label != StopObstacleClassification::Type::POINTCLOUD) {
+      throw std::invalid_argument(
+        "Constructor for pointcloud StopObstacle must be called with POINTCLOUD label");
+    }
+    pose.position = arg_collision_point;
+    shape.type = autoware_perception_msgs::msg::Shape::BOUNDING_BOX;
+  }
+  UUID uuid{};
+  rclcpp::Time stamp;
+  geometry_msgs::msg::Pose pose;
+  double velocity;
+
+  Shape shape;
+  geometry_msgs::msg::Point collision_point;
+  double dist_to_collide_on_decimated_traj;
+  StopObstacleClassification classification;
+  PolygonParam polygon_param;
+  std::optional<double> braking_dist;
+};
+
+struct DetectionPolygon
+{
+  const std::vector<TrajectoryPoint> traj_points;
+  const std::vector<Polygon2d> polygons;
+  DetectionPolygon(std::vector<TrajectoryPoint> && points, std::vector<Polygon2d> && polys)
+  : traj_points(std::move(points)), polygons(std::move(polys))
+  {
+    if (traj_points.size() != polygons.size()) {
+      throw std::invalid_argument("Vector sizes must be identical for DetectionPolygon.");
+    }
+  }
+};
 
 }  // namespace autoware::trajectory_validator::plugin::safety::point_cloud_collision_check
 


### PR DESCRIPTION
Port the point cloud path of ObstacleStopModule, split out of #3242.

- types.hpp: StopObstacle, PointcloudStopCandidate, PolygonParam, DetectionPolygon
- obstacle_stop.{hpp,cpp}: trajectory polygon generation with caching, nearest
  collision point extraction, time series association of point cloud stop
  candidates with lowpass filtered velocity estimation, and stop obstacle creation