### PR TITLE
feat(steer offset estimator): add initial offset publisher

### DIFF
--- a/vehicle/autoware_steer_offset_estimator/README.md
+++ b/vehicle/autoware_steer_offset_estimator/README.md
@@ -152,12 +152,14 @@ In addition to the Manual gates, Auto mode applies more restrictive temporal and
 
 #### Output
 
-| Name                                  | Type                                                | Description                   |
-| ------------------------------------- | --------------------------------------------------- | ----------------------------- |
-| `~/output/steering_offset`            | `autoware_internal_debug_msgs::msg::Float32Stamped` | steering offset               |
-| `~/output/steering_offset_covariance` | `autoware_internal_debug_msgs::msg::Float32Stamped` | covariance of steering offset |
-| `~/output/steering_offset_update`     | `autoware_internal_debug_msgs::msg::Float32Stamped` | updated steering offset value |
-| `~/output/debug_info`                 | `autoware_internal_debug_msgs::msg::StringStamped`  | debug info                    |
+| Name                                  | Type                                                | Description                                                        |
+| ------------------------------------- | --------------------------------------------------- | ------------------------------------------------------------------ |
+| `~/output/steering_offset`            | `autoware_internal_debug_msgs::msg::Float32Stamped` | steering offset                                                    |
+| `~/output/steering_offset_covariance` | `autoware_internal_debug_msgs::msg::Float32Stamped` | covariance of steering offset                                      |
+| `~/output/steering_offset_update`     | `autoware_internal_debug_msgs::msg::Float32Stamped` | updated steering offset value                                      |
+| `~/output/initial_calibration_offset` | `autoware_internal_debug_msgs::msg::Float32Stamped` | initial steering offset read from the calibration file at start-up |
+| `~/output/cumulative_steering_offset` | `autoware_internal_debug_msgs::msg::Float32Stamped` | initial calibration offset plus the estimated steering offset      |
+| `~/output/debug_info`                 | `autoware_internal_debug_msgs::msg::StringStamped`  | debug info                                                         |
 
 ### Services
 

--- a/vehicle/autoware_steer_offset_estimator/include/autoware/steer_offset_estimator/structs.hpp
+++ b/vehicle/autoware_steer_offset_estimator/include/autoware/steer_offset_estimator/structs.hpp
@@ -74,6 +74,7 @@ struct SteerOffsetCalibrationParameters
   std::string steer_offset_param_name;
   std::string calibration_file_path;
   std::string calibration_param_name;
+  std::string initial_calibration_param_name;
 
   static inline const std::unordered_map<std::string, CalibrationMode> mode_map{
     {"off", CalibrationMode::OFF},

--- a/vehicle/autoware_steer_offset_estimator/launch/steer_offset_estimator.launch.xml
+++ b/vehicle/autoware_steer_offset_estimator/launch/steer_offset_estimator.launch.xml
@@ -17,11 +17,14 @@
     <param name="steer_offset_param_name" value="$(var steer_offset_log_param_name)"/>
     <param name="calibration_file_path" value="$(var steer_offset_calibration_file_path)"/>
     <param name="calibration_param_name" value="$(var steer_offset_calibration_param_name)"/>
+    <param name="initial_calibration_param_name" value="$(var steer_offset_initial_calibration_param_name)"/>
     <remap from="~/input/pose" to="/localization/pose_estimator/pose"/>
     <remap from="~/input/steer" to="/vehicle/status/steering_status"/>
     <remap from="~/output/steering_offset" to="~/steering_offset"/>
     <remap from="~/output/steering_offset_covariance" to="~/steering_offset_covariance"/>
     <remap from="~/output/debug_info" to="~/debug_info"/>
     <remap from="~/output/steering_offset_update" to="~/steering_offset_update"/>
+    <remap from="~/output/initial_calibration_offset" to="~/initial_calibration_offset"/>
+    <remap from="~/output/cumulative_steering_offset" to="~/cumulative_steering_offset"/>
   </node>
 </launch>

--- a/vehicle/autoware_steer_offset_estimator/launch/steer_offset_estimator.launch.xml
+++ b/vehicle/autoware_steer_offset_estimator/launch/steer_offset_estimator.launch.xml
@@ -5,6 +5,7 @@
   <arg name="steer_offset_log_param_name" default="steer_offset"/>
   <arg name="steer_offset_calibration_file_path" default="$(find-pkg-share autoware_steer_offset_estimator)/config/steer_offset.param.yaml"/>
   <arg name="steer_offset_calibration_param_name" default="residual_steering_offset"/>
+  <arg name="steer_offset_initial_calibration_param_name" default="steering_angle_collection_offset"/>
   <!-- get wheel base from vehicle info -->
   <include file="$(find-pkg-share autoware_global_parameter_loader)/launch/global_params.launch.py"/>
 

--- a/vehicle/autoware_steer_offset_estimator/src/node.cpp
+++ b/vehicle/autoware_steer_offset_estimator/src/node.cpp
@@ -68,8 +68,28 @@ SteerOffsetEstimatorNode::SteerOffsetEstimatorNode(const rclcpp::NodeOptions & n
   pub_debug_info_ = this->create_publisher<StringStamped>("~/output/debug_info", 1);
   pub_steer_offset_update_ = this->create_publisher<Float32Stamped>(
     "~/output/steering_offset_update", rclcpp::QoS{1}.transient_local());
+  pub_initial_calibration_offset_ =
+    this->create_publisher<Float32Stamped>("~/output/initial_calibration_offset", 1);
+  pub_cumulative_steer_offset_ =
+    this->create_publisher<Float32Stamped>("~/output/cumulative_steering_offset", 1);
 
   set_calibration_parameters();
+
+  // The initial calibration offset is assumed to be constant, so the calibration file is read
+  // only once here and the value is cached in initial_calibration_offset_.
+  const auto initial_calibration_offset = read_from_yaml(
+    calibration_params_.calibration_file_path, calibration_params_.initial_calibration_param_name);
+  if (initial_calibration_offset) {
+    initial_calibration_offset_ = initial_calibration_offset.value();
+    RCLCPP_INFO(
+      this->get_logger(), "Loaded initial calibration offset %.4f from %s as '%s'",
+      initial_calibration_offset_.value(), calibration_params_.calibration_file_path.c_str(),
+      calibration_params_.initial_calibration_param_name.c_str());
+  } else {
+    RCLCPP_ERROR(
+      this->get_logger(), "Failed to read initial calibration offset: %s",
+      initial_calibration_offset.error().c_str());
+  }
 
   // Create timer
   auto update_hz = this->declare_parameter<double>("update_hz", 10.0);
@@ -128,6 +148,8 @@ void SteerOffsetEstimatorNode::set_calibration_parameters()
     this->declare_parameter<std::string>("calibration_file_path");
   calibration_params_.calibration_param_name =
     this->declare_parameter<std::string>("calibration_param_name");
+  calibration_params_.initial_calibration_param_name =
+    this->declare_parameter<std::string>("initial_calibration_param_name");
 }
 
 void SteerOffsetEstimatorNode::on_timer()
@@ -191,6 +213,12 @@ void SteerOffsetEstimatorNode::publish_data(const SteerOffsetEstimationUpdated &
 
   pub_float(pub_steer_offset_, result.offset);
   pub_float(pub_steer_offset_covariance_, result.covariance);
+
+  // Uses the value cached at start-up; the calibration file is never re-read.
+  if (initial_calibration_offset_) {
+    pub_float(pub_initial_calibration_offset_, initial_calibration_offset_.value());
+    pub_float(pub_cumulative_steer_offset_, initial_calibration_offset_.value() + result.offset);
+  }
 
   if (is_publish_update()) {
     pub_float(pub_steer_offset_update_, latest_reliable_result_->offset);
@@ -312,6 +340,28 @@ tl::expected<double, std::string> SteerOffsetEstimatorNode::execute_calibration_
   const auto & param_name = calibration_params_.calibration_param_name;
 
   return write_to_yaml(param_path, param_name, steer_offset, true);
+}
+
+tl::expected<double, std::string> SteerOffsetEstimatorNode::read_from_yaml(
+  const std::string & file_path, const std::string & param_name)
+{
+  try {
+    YAML::Node config = YAML::LoadFile(file_path);
+    auto node = config["/**"]["ros__parameters"];
+
+    if (!node) {
+      return tl::make_unexpected(
+        fmt::format("Could not find 'ros__parameters' key in YAML: {}", file_path));
+    }
+    if (!node[param_name]) {
+      return tl::make_unexpected(
+        fmt::format("Could not find '{}' key in YAML: {}", param_name, file_path));
+    }
+
+    return node[param_name].as<double>();
+  } catch (const std::exception & e) {
+    return tl::make_unexpected(fmt::format("YAML read exception: {}", e.what()));
+  }
 }
 
 tl::expected<double, std::string> SteerOffsetEstimatorNode::write_to_yaml(

--- a/vehicle/autoware_steer_offset_estimator/src/node.hpp
+++ b/vehicle/autoware_steer_offset_estimator/src/node.hpp
@@ -28,6 +28,7 @@
 #include <std_srvs/srv/trigger.hpp>
 
 #include <memory>
+#include <optional>
 #include <string>
 
 /**
@@ -86,6 +87,15 @@ private:
    */
   double last_offset_update_;
 
+  /**
+   * @brief Initial steering offset read once from the calibration YAML file at start-up
+   *
+   * The value is assumed to be constant for the lifetime of the node, so the file is read a
+   * single time in the constructor and the result cached here. Empty if the file or the
+   * parameter could not be read.
+   */
+  std::optional<double> initial_calibration_offset_;
+
   // Subscribers
   /**
    * @brief Subscriber for pose
@@ -117,6 +127,16 @@ private:
    * @brief Publisher for steering offset update
    */
   rclcpp::Publisher<Float32Stamped>::SharedPtr pub_steer_offset_update_;
+
+  /**
+   * @brief Publisher for the initial steering offset read from the calibration YAML file
+   */
+  rclcpp::Publisher<Float32Stamped>::SharedPtr pub_initial_calibration_offset_;
+
+  /**
+   * @brief Publisher for the initial calibration offset plus the estimated steering offset
+   */
+  rclcpp::Publisher<Float32Stamped>::SharedPtr pub_cumulative_steer_offset_;
 
   // Timer
   /**
@@ -173,6 +193,15 @@ private:
   tl::expected<double, std::string> write_to_yaml(
     const std::string & file_path, const std::string & param_name, double value,
     const bool accumulate = false) const;
+
+  /**
+   * @brief Read a single double parameter out of a ROS parameter YAML file
+   * @param file_path Path to the YAML file
+   * @param param_name Key to look up under the wildcard 'ros__parameters' node
+   * @return The value on success, or an error string on failure
+   */
+  static tl::expected<double, std::string> read_from_yaml(
+    const std::string & file_path, const std::string & param_name);
 
   /**
    * @brief Publish steering offset estimation results


### PR DESCRIPTION
## Description

Adds two new output topics to `autoware_steer_offset_estimator`:

- **`~/output/initial_calibration_offset`** — the steering offset that was already applied to the vehicle before this node started, read from the calibration YAML file at start-up.
- **`~/output/cumulative_steering_offset`** — that initial offset plus the currently estimated offset, i.e. the total offset that would be in effect if the current estimate were applied.

Until now the node only published the offset it estimated _itself_ (`~/output/steering_offset`). There was no way to see the absolute offset of the vehicle, because the already-applied portion lived only in the calibration file and was never exposed on the ROS graph. Consumers had to read the YAML file themselves to reconstruct it.

The value is taken from the calibration file pointed to by the existing `steer_offset_calibration_file_path` launch argument, under the key named by `steer_offset_initial_calibration_param_name` (default `steering_angle_collection_offset`). That launch argument already existed but was never forwarded to the node; this PR wires it through as the `initial_calibration_param_name` ROS parameter.

Since the initial offset is a start-up constant, the file is read **exactly once** in the constructor and the value is cached in `std::optional<double> initial_calibration_offset_`. `publish_data()` only ever reads the cached value — the file is never re-read, so no file I/O happens in the update loop. If the value ever needs to change, the node has to be restarted.

Both topics are published from `publish_data()` using the existing `pub_float` lambda, with the same `Float32Stamped` type and depth-1 QoS as `steering_offset` and `steering_offset_covariance`.

## Related links

**Parent Issue:**

- Link

## How was this PR tested?

### Build and lint

- `colcon build --packages-up-to autoware_steer_offset_estimator` — clean, no new warnings.
- `colcon test --packages-select autoware_steer_offset_estimator` — 5/5 passed (copyright, cppcheck, gtest, lint_cmake, xmllint).
- `pre-commit run --files <changed files>` — passed.

### Runtime, success path

Launched with a calibration file containing `steering_angle_collection_offset: 0.0123`, and fed synthetic pose + steering input to drive the estimator. To make the sum distinguishable from the initial value alone, the input reports a zero steering angle while actually yawing at 0.01 rad/s, so the estimator has to attribute the residual yaw rate to a steering offset and converges to a non-zero value.

A checker node subscribed to all three topics and compared them every second:

```text
initial=0.012300 offset=0.028540 cumulative=0.040840 expected=0.040840 err=1.9e-09 OK
initial=0.012300 offset=0.028692 cumulative=0.040992 expected=0.040992 err=1.9e-09 OK
...
initial=0.012300 offset=0.029673 cumulative=0.041973 expected=0.041973 err=0.0e+00 OK
```

Twelve consecutive samples matched to float32 rounding precision while `offset` was still converging, confirming the cumulative topic tracks the live estimate rather than a stale value.

Also confirmed:

- `Durability: VOLATILE` and a steady 10 Hz publish rate (matching `update_hz`), consistent with the neighbouring offset topics.
- The `Loaded initial calibration offset ...` log line appears **exactly once** per run, confirming the file is read a single time.

### Runtime, failure path

Launched against a calibration file that does _not_ contain the key. The node logs an error and starts normally; both new topics stay silent rather than publishing a misleading `0.0`:

```text
[ERROR] Failed to read initial calibration offset: Could not find
'steering_angle_collection_offset' key in YAML: .../config/steer_offset.param.yaml
```

## Notes for reviewers

**The two new topics are silent under the default launch arguments.** `steer_offset_calibration_file_path` defaults to this package's `config/steer_offset.param.yaml`, which only contains `steer_offset` — it has neither `steering_angle_collection_offset` nor the pre-existing `residual_steering_offset`. Deployments are expected to override that path with a vehicle-specific calibration file. This mismatch already existed for `steer_offset_calibration_param_name`, so I did not add placeholder keys to the default config rather than guess at their intended semantics. Happy to add `steering_angle_collection_offset: 0.0` to the default config if reviewers would prefer the defaults be self-consistent.

**Failure behaviour is deliberately silent.** If the calibration value cannot be read, `initial_calibration_offset_` stays empty and neither new topic publishes. Publishing `0.0` instead would be indistinguishable from a genuinely zero offset, which for `cumulative_steering_offset` would silently understate the vehicle's real total offset. If you would rather `cumulative_steering_offset` fall back to the raw estimate, it is a one-line change.

**Both new topics inherit the gating of `publish_data()`**, which is only called when `estimator_.update()` returns a result. They are therefore silent while stationary, below `min_velocity`, or when the steering/angular-velocity gates reject a sample — exactly like `steering_offset` and `steering_offset_covariance`. This is worth a thought for `initial_calibration_offset`, which is a start-up constant that a consumer might reasonably expect to always be available; a latched (`transient_local`) publisher would be an alternative, but consistency with the sibling topics was preferred here.

**`read_from_yaml()` deliberately mirrors the existing `write_to_yaml()`** — same `/**` → `ros__parameters` lookup and the same `tl::expected<double, std::string>` error style. It is `static` because it needs no node state.

## Interface changes

### Topic changes

#### Additions and removals

| Change type | Topic Type | Topic Name                            | Message Type                                        | Description                                                                                |
| :---------- | :--------- | :------------------------------------ | :-------------------------------------------------- | :----------------------------------------------------------------------------------------- |
| Added       | Pub        | `~/output/initial_calibration_offset` | `autoware_internal_debug_msgs::msg::Float32Stamped` | Steering offset already applied to the vehicle, read from the calibration file at start-up |
| Added       | Pub        | `~/output/cumulative_steering_offset` | `autoware_internal_debug_msgs::msg::Float32Stamped` | `initial_calibration_offset` + the estimated `steering_offset`                             |

Remapped in `steer_offset_estimator.launch.xml` to `~/initial_calibration_offset` and `~/cumulative_steering_offset`, following the existing remap convention.

### ROS Parameter Changes

#### Additions and removals

| Change type | Parameter Name                   | Type     | Default Value                      | Description                                                                      |
| :---------- | :------------------------------- | :------- | :--------------------------------- | :------------------------------------------------------------------------------- |
| Added       | `initial_calibration_param_name` | `string` | `steering_angle_collection_offset` | Key to read from the calibration YAML file to obtain the initial steering offset |

Set from the pre-existing `steer_offset_initial_calibration_param_name` launch argument, which was previously declared but never forwarded to the node.

## Effects on system behavior

Purely additive — two new debug output topics. No existing topic, parameter, service, or estimation logic is changed, and no behaviour is removed.

The calibration YAML file is read once more at node start-up (one extra file read, in the constructor). Nothing is added to the periodic update path: `publish_data()` reads only the cached value, so there is no per-cycle file I/O. The steady-state cost is two extra `Float32Stamped` publications per update cycle.

The node no longer aborts or changes behaviour if the calibration key is missing — it logs an error and continues with the new topics inactive.
