### PR TITLE
feat(collision_check_filter): add exceptin guard

### DIFF
--- a/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/trajectory_utils.cpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/trajectory_utils.cpp
@@ -340,6 +340,14 @@ FootprintTrajectory compute_footprint_trajectory(
 std::tuple<size_t, size_t, double> resolve_interpolation(
   const std::vector<double> & values, const double target_value)
 {
+  if (values.size() < 2U) {
+    throw std::invalid_argument("values must contain at least two elements");
+  }
+
+  if (!std::isfinite(target_value)) {
+    throw std::invalid_argument("target_value must be finite");
+  }
+
   size_t lower_idx = 0;
   size_t upper_idx = 1;
   double ratio = 0.0;
@@ -403,11 +411,6 @@ InterpolatedState TrajectoryInterpolator::interpolate_state_from_time(
     return InterpolatedState{0.0, point.pose, point.longitudinal_velocity_mps};
   }
 
-  if (time_from_refs_.empty()) {
-    throw std::invalid_argument(
-      "reference_time_ must be set before calling interpolate_state_from_time");
-  }
-
   const double target_time_from_ref = (target_time - reference_time_).seconds();
   const auto [lower_idx, upper_idx, ratio] =
     resolve_interpolation(time_from_refs_, target_time_from_ref);
@@ -431,11 +434,6 @@ InterpolatedState TrajectoryInterpolator::interpolate_state_from_dist(
   if (trajectory_points_.size() == 1) {
     const auto & point = trajectory_points_.front();
     return InterpolatedState{0.0, point.pose, point.longitudinal_velocity_mps};
-  }
-
-  if (dist_from_fronts_.empty()) {
-    throw std::invalid_argument(
-      "dist_from_fronts_ must be set before calling interpolate_state_from_dist");
   }
 
   const auto [lower_idx, upper_idx, ratio] = resolve_interpolation(dist_from_fronts_, target_dist);

--- a/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/trajectory_utils.hpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/trajectory_utils.hpp
@@ -31,10 +31,12 @@
 
 #include <algorithm>
 #include <array>
+#include <cmath>
 #include <cstdint>
 #include <iterator>
 #include <map>
 #include <optional>
+#include <stdexcept>
 #include <string>
 #include <unordered_map>
 #include <utility>
@@ -399,7 +401,27 @@ public:
     if (trajectory_points_.empty()) {
       throw std::invalid_argument("points must not be empty");
     }
-  };
+    if (
+      trajectory_points_.size() != time_from_refs_.size() ||
+      trajectory_points_.size() != dist_from_fronts_.size()) {
+      throw std::logic_error("trajectory points, times, and distances must have the same size");
+    }
+
+    const auto is_finite = [](const double value) { return std::isfinite(value); };
+    if (!std::all_of(time_from_refs_.begin(), time_from_refs_.end(), is_finite)) {
+      throw std::invalid_argument("time_from_refs must contain only finite values");
+    }
+    if (!std::all_of(dist_from_fronts_.begin(), dist_from_fronts_.end(), is_finite)) {
+      throw std::invalid_argument("dist_from_fronts must contain only finite values");
+    }
+
+    if (!std::is_sorted(time_from_refs_.begin(), time_from_refs_.end())) {
+      throw std::invalid_argument("time_from_refs must be in non-decreasing order");
+    }
+    if (!std::is_sorted(dist_from_fronts_.begin(), dist_from_fronts_.end())) {
+      throw std::invalid_argument("dist_from_fronts must be in non-decreasing order");
+    }
+  }
   InterpolatedState interpolate_state_from_time(const rclcpp::Time & target_time) const;
   InterpolatedState interpolate_state_from_dist(const double target_dist) const;
 };


### PR DESCRIPTION
TrajectoryInterpolator周辺においてノード死が発生したため、今後の発生の防止と発生時の原因究明のために、ガードを追加します。

なお、ノード死課題自体は、https://github.com/tier4/autoware_universe/pull/3183 による`motion_utils::calcSignedArcLength` の使用停止により解決しています。

psimで物体を配置するなどして、新たな例外をはかずに判定が行われることを確認しました。

https://tier4.atlassian.net/browse/PDDP-442



