### PR TITLE
fix(autoware_traffic_light_selector): change to genIoU, check inside by center (#12220)

### DIFF
--- a/perception/autoware_traffic_light_selector/src/traffic_light_selector_node.cpp
+++ b/perception/autoware_traffic_light_selector/src/traffic_light_selector_node.cpp
@@ -80,7 +80,7 @@ void TrafficLightSelectorNode::objectsCallback(
     const auto & expect_roi = expected_rois_msg_rois.roi;
 
     for (const auto & detected_roi : detected_rois) {
-      if (!utils::isInsideRoughRoi(detected_roi, rough_roi)) {
+      if (!utils::isCenterInsideRoughRoi(detected_roi, rough_roi)) {
         continue;
       }
 
@@ -155,7 +155,7 @@ void TrafficLightSelectorNode::evaluateWholeRois(
     double max_iou = 0.0;
     RegionOfInterest max_iou_roi;
     for (const auto & detected_roi : detected_rois) {
-      const double iou = utils::getIoU(expect_roi_shifted.second, detected_roi);
+      const double iou = utils::getGenIoU(expect_roi_shifted.second, detected_roi);
       if (iou > max_iou) {
         max_iou = iou;
         max_iou_roi = detected_roi;

--- a/perception/autoware_traffic_light_selector/src/traffic_light_selector_utils.cpp
+++ b/perception/autoware_traffic_light_selector/src/traffic_light_selector_utils.cpp
@@ -44,6 +44,16 @@ bool isInsideRoughRoi(const RegionOfInterest & detected_roi, const RegionOfInter
   return true;
 }
 
+bool isCenterInsideRoughRoi(
+  const RegionOfInterest & detected_roi, const RegionOfInterest & rough_roi)
+{
+  const auto center_x = detected_roi.x_offset + detected_roi.width / 2;
+  const auto center_y = detected_roi.y_offset + detected_roi.height / 2;
+
+  return rough_roi.x_offset < center_x && center_x < rough_roi.x_offset + rough_roi.width &&
+         rough_roi.y_offset < center_y && center_y < rough_roi.y_offset + rough_roi.height;
+}
+
 void computeCenterOffset(
   const RegionOfInterest & source, const RegionOfInterest & target, int32_t & shift_x,
   int32_t & shift_y)

--- a/perception/autoware_traffic_light_selector/src/traffic_light_selector_utils.hpp
+++ b/perception/autoware_traffic_light_selector/src/traffic_light_selector_utils.hpp
@@ -27,6 +27,9 @@ using sensor_msgs::msg::RegionOfInterest;
 
 bool isInsideRoughRoi(const RegionOfInterest & detected_roi, const RegionOfInterest & rough_roi);
 
+bool isCenterInsideRoughRoi(
+  const RegionOfInterest & detected_roi, const RegionOfInterest & rough_roi);
+
 void computeCenterOffset(
   const RegionOfInterest & source, const RegionOfInterest & target, int32_t & shift_x,
   int32_t & shift_y);


### PR DESCRIPTION
Cherry-pick：https://github.com/autowarefoundation/autoware_universe/pull/12220　for using GIOU in traffic_light_selector