### PR TITLE
feat(MPPI): smoother nominal steering computation with min chord length

### DIFF
--- a/planning/autoware_mppi_optimizer/src/first_order_dubins/first_order_dubins_mppi_interface.cu
+++ b/planning/autoware_mppi_optimizer/src/first_order_dubins/first_order_dubins_mppi_interface.cu
@@ -550,10 +550,38 @@ struct FirstOrderDubinsMppiInterface::Impl
       const auto & point = reference.points[idx];
       u_nom(accel_idx, t) = std::clamp(point.acceleration_mps2, min_accel, max_accel);
 
-      // Only use an explicit steer command if the reference provides one. Do NOT derive steer
-      // from path curvature: that pre-solves lateral tracking inside u_nom, so MPPI δ_cmd
-      // barely moves when track/heading costs are retuned (samples stay glued to the seed).
-      u_nom(steer_idx, t) = std::clamp(point.front_wheel_angle_rad, -max_steer, max_steer);
+      float steer = point.front_wheel_angle_rad;
+      if (std::abs(steer) <= 1.0E-6F && idx + 1U < reference.points.size()) {
+        size_t lookahead_idx = idx + 1U;
+        float ds = 0.0F;
+        float dx = 0.0F;
+        float dy = 0.0F;
+
+        const float min_chord_length = std::max(1.5F, vehicle_params.wheel_base * 0.5F);
+
+        // Search ahead for a point far enough away to safely calculate curvature
+        while (lookahead_idx < reference.points.size()) {
+          const auto & next = reference.points[lookahead_idx];
+          dx = static_cast<float>(next.pose.position.x - point.pose.position.x);
+          dy = static_cast<float>(next.pose.position.y - point.pose.position.y);
+          ds = std::hypot(dx, dy);
+
+          if (ds >= min_chord_length) {
+            break;
+          }
+          lookahead_idx++;
+        }
+
+        if (ds >= min_chord_length) {
+          const auto & next = reference.points[lookahead_idx];
+          const float yaw0 = static_cast<float>(tf2::getYaw(point.pose.orientation));
+          const float yaw1 = static_cast<float>(tf2::getYaw(next.pose.orientation));
+          const float dyaw = std::atan2(std::sin(yaw1 - yaw0), std::cos(yaw1 - yaw0));
+
+          steer = std::atan(vehicle_params.wheel_base * (dyaw / ds));
+        }
+      }
+      u_nom(steer_idx, t) = std::clamp(steer, -max_steer, max_steer);
     }
   }
 


### PR DESCRIPTION
Estimating the reference steering using successive points can be very noisy.
This PR smoothes the nominal control commands by using a minimum arc length between points when to estimate the reference steering.