### PR TITLE
feat(collison_check_filter): change risk level for abandon case

### DIFF
--- a/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/assessment.cpp
+++ b/planning/autoware_trajectory_validator/src/filters/safety/collision_check_filter/assessment.cpp
@@ -145,7 +145,7 @@ RiskLevel::_level_type identify_risk_level(
   const DracParams::EgoDracAcceleration & acceleration_params)
 {
   if (!required_acceleration.has_value()) {
-    return acceleration_params.enable_abandon ? RiskLevel::HIGH_CAUTION : RiskLevel::FATAL;
+    return acceleration_params.enable_abandon ? RiskLevel::LOW_CAUTION : RiskLevel::FATAL;
   }
 
   if (required_acceleration >= acceleration_params.safe_limit) {


### PR DESCRIPTION
停止したところで衝突を避けられないケースにおいて出力するriskレベルを他の機能や評価基盤との整合性を加味して、`HIGH_CAUTION`から`LOW_CAUTION`に変更します。