### PR TITLE
feat(minimum_rule_based_planner): add earlystop enable_flag

### DIFF
--- a/planning/autoware_minimum_rule_based_planner/README.md
+++ b/planning/autoware_minimum_rule_based_planner/README.md
@@ -7,7 +7,7 @@ A minimum rule-based trajectory planner that generates safe and feasible traject
 ## Features
 
 - **Centerline-based path planning**: Generates paths along lanelet centerline from the HD map, extending backward and forward from the ego vehicle's position
-- **Smooth goal connection**: Refines the path near the goal pose for smooth stopping
+- **Goal handling**: Selected by `path_planning.early_stop.enable`. When disabled (default), the path is refined near the goal pose so that ego reaches the goal itself (smooth goal connection). When enabled, the path is instead cut short before the goal so that ego stops in front of it without pulling over to the side of the road
 - **Path shifting**: Shifts the centerline path to start from the ego vehicle's current pose, using curvature-aware shift distance calculation based on ego velocity and lateral acceleration limits
 - **Trajectory smoothing**: Applies an Elastic Band smoother for geometric smoothing via a plugin interface
 - **Trajectory modification**: Applies modifier plugins (e.g., obstacle stop) for safety modifications

--- a/planning/autoware_minimum_rule_based_planner/config/minimum_rule_based_planner.param.yaml
+++ b/planning/autoware_minimum_rule_based_planner/config/minimum_rule_based_planner.param.yaml
@@ -12,10 +12,16 @@
         forward: 300.0
 
       early_stop:
+        enable: false
         expected_ego_speed_parking: 2.8
         max_lat_accel_parking: 0.8
         max_decel_parking: 1.0
         max_jerk_parking: 1.0
+
+      # Used only when early_stop.enable is false
+      smooth_goal_connection:
+        search_radius_range: 7.5
+        pre_goal_offset: 1.0
 
       lane_change_failure_stop_margin: 0.0
 

--- a/planning/autoware_minimum_rule_based_planner/param/minimum_rule_based_planner_parameters.yaml
+++ b/planning/autoware_minimum_rule_based_planner/param/minimum_rule_based_planner_parameters.yaml
@@ -25,6 +25,11 @@ minimum_rule_based_planner:
         description: ratio to expand interval bound of group according to lateral distance
 
     early_stop:
+      enable:
+        type: bool
+        default_value: false
+        description: if true, stop in front of the goal instead of connecting the path to the goal pose
+
       expected_ego_speed_parking:
         type: double
         default_value: 2.8
@@ -52,6 +57,18 @@ minimum_rule_based_planner:
         validation:
           gt<>: [0.1]
         description: max longitudinal jerk used to compute the stopping distance during pull over [m/s^3]
+
+    # Used only when early_stop.enable is false
+    smooth_goal_connection:
+      search_radius_range:
+        type: double
+        default_value: 7.5
+        description: search radius range for smooth goal connection [m]
+
+      pre_goal_offset:
+        type: double
+        default_value: 1.0
+        description: offset before goal for smooth connection [m]
 
     # Parameters for lanelet matching (different from EB smoother's ego_nearest_* params)
     ego_nearest_lanelet:

--- a/planning/autoware_minimum_rule_based_planner/schema/minimum_rule_based_planner.schema.json
+++ b/planning/autoware_minimum_rule_based_planner/schema/minimum_rule_based_planner.schema.json
@@ -54,6 +54,11 @@
             "early_stop": {
               "type": "object",
               "properties": {
+                "enable": {
+                  "type": "boolean",
+                  "description": "If true, stop in front of the goal instead of connecting the path to the goal pose",
+                  "default": false
+                },
                 "expected_ego_speed_parking": {
                   "type": "number",
                   "description": "expected ego speed during pull over to the side of the road [m/s]",
@@ -77,6 +82,25 @@
                   "description": "max longitudinal jerk used to compute the stopping distance during pull over [m/s^3]",
                   "default": 1.0,
                   "minimum": 0.1
+                }
+              },
+              "required": [],
+              "additionalProperties": false
+            },
+            "smooth_goal_connection": {
+              "type": "object",
+              "properties": {
+                "search_radius_range": {
+                  "type": "number",
+                  "description": "Search radius for goal connection, used only when early_stop.enable is false [m]",
+                  "default": 7.5,
+                  "minimum": 0.0
+                },
+                "pre_goal_offset": {
+                  "type": "number",
+                  "description": "Offset before goal for smooth connection, used only when early_stop.enable is false [m]",
+                  "default": 1.0,
+                  "minimum": 0.0
                 }
               },
               "required": [],

--- a/planning/autoware_minimum_rule_based_planner/src/path_planner.cpp
+++ b/planning/autoware_minimum_rule_based_planner/src/path_planner.cpp
@@ -864,6 +864,64 @@ PathRange<std::optional<double>> get_arc_length_on_centerline(
     s_right_centerline ? s_right_centerline : s_right_bound};
 }
 
+PathPointTrajectory refine_path_for_goal(
+  const PathPointTrajectory & input, const geometry_msgs::msg::Pose & goal_pose,
+  const lanelet::Id goal_lane_id, const double search_radius_range, const double pre_goal_offset)
+{
+  auto contain_goal_lane_id = [&](const PathPointWithLaneId & point) {
+    const auto & ids = point.lane_ids;
+    return std::find(ids.begin(), ids.end(), goal_lane_id) != ids.end();
+  };
+
+  auto outside_circle = [&](const PathPointWithLaneId & point) {
+    return autoware_utils::calc_distance2d(point.point.pose, goal_pose) > search_radius_range;
+  };
+
+  auto closest_to_goal = autoware::experimental::trajectory::closest_with_constraint(
+    input, goal_pose, contain_goal_lane_id);
+
+  // If no point with the goal lane ID exists in the trajectory (e.g. goal is on an adjacent lane),
+  // fall back to the geometrically closest point so the goal connection still applies.
+  if (!closest_to_goal) {
+    closest_to_goal = autoware::experimental::trajectory::closest(input, goal_pose);
+  }
+
+  auto cropped_path = autoware::experimental::trajectory::crop(input, 0, *closest_to_goal);
+
+  auto intervals =
+    autoware::experimental::trajectory::find_intervals(cropped_path, outside_circle, 10);
+
+  std::vector<PathPointWithLaneId> goal_connected_trajectory_points;
+
+  if (!intervals.empty()) {
+    auto cropped = autoware::experimental::trajectory::crop(cropped_path, 0, intervals.back().end);
+    goal_connected_trajectory_points = cropped.restore();
+  } else if (cropped_path.length() > pre_goal_offset) {
+    // If distance from start to goal is smaller than refine_goal_search_radius_range and start is
+    // farther from goal than pre_goal, we just connect start, pre_goal, and goal.
+    goal_connected_trajectory_points = {cropped_path.compute(0)};
+  }
+
+  auto goal = input.compute(autoware::experimental::trajectory::closest(input, goal_pose));
+  goal.point.pose = goal_pose;
+  goal.point.longitudinal_velocity_mps = 0.0;
+
+  const auto pre_goal_pose =
+    autoware_utils::calc_offset_pose(goal_pose, -pre_goal_offset, 0.0, 0.0);
+  auto pre_goal = input.compute(autoware::experimental::trajectory::closest(input, pre_goal_pose));
+  pre_goal.point.pose = pre_goal_pose;
+
+  goal_connected_trajectory_points.push_back(pre_goal);
+  goal_connected_trajectory_points.push_back(goal);
+
+  if (
+    const auto output =
+      autoware::experimental::trajectory::pretty_build(goal_connected_trajectory_points)) {
+    return *output;
+  }
+  return input;
+}
+
 lanelet::ConstLanelets extract_lanelets_from_trajectory(
   const PathPointTrajectory & trajectory, const RouteContext & planner_data)
 {
@@ -891,6 +949,50 @@ bool is_trajectory_inside_lanelets(
   return std::none_of(points.begin(), points.end(), [&](const auto & point) {
     return !is_in_lanelets(point.point.pose, lanelets);
   });
+}
+
+std::optional<PathPointTrajectory> modify_path_for_smooth_goal_connection(
+  const PathPointTrajectory & trajectory, const RouteContext & planner_data,
+  const double search_radius_range, const double pre_goal_offset)
+{
+  if (planner_data.preferred_lanelets.empty()) {
+    return std::nullopt;
+  }
+  // Build the set of lanelets valid for the refined path.
+  // Include goal lanelets so that a path connecting to an adjacent goal lane passes validation.
+  auto lanelets = extract_lanelets_from_trajectory(trajectory, planner_data);
+  for (const auto & goal_ll : planner_data.goal_lanelets) {
+    if (std::find(lanelets.begin(), lanelets.end(), goal_ll) == lanelets.end()) {
+      lanelets.push_back(goal_ll);
+    }
+  }
+
+  // Include lanelets that contain the goal pose (e.g., shoulder lanelets) so that
+  // the trajectory connecting to an off-lane goal passes the inside-lanelets check.
+  const auto goal_point_2d =
+    lanelet::BasicPoint2d(planner_data.goal_pose.position.x, planner_data.goal_pose.position.y);
+  const auto nearest_lanelets =
+    lanelet::geometry::findNearest(planner_data.lanelet_map_ptr->laneletLayer, goal_point_2d, 5);
+  for (const auto & [dist, ll] : nearest_lanelets) {
+    if (
+      lanelet::geometry::inside(ll, goal_point_2d) &&
+      std::find(lanelets.begin(), lanelets.end(), ll) == lanelets.end()) {
+      lanelets.push_back(ll);
+    }
+  }
+
+  // This process is to fit the trajectory inside the lanelets. By reducing
+  // refine_goal_search_radius_range, we can fit the trajectory inside lanelets even if the
+  // trajectory has a high curvature.
+  for (double s = search_radius_range; s > 0; s -= 0.1) {
+    const auto refined_trajectory = refine_path_for_goal(
+      trajectory, planner_data.goal_pose, planner_data.preferred_lanelets.back().id(), s,
+      pre_goal_offset);
+    if (is_trajectory_inside_lanelets(refined_trajectory, lanelets)) {
+      return refined_trajectory;
+    }
+  }
+  return std::nullopt;
 }
 
 }  // namespace utils
@@ -1511,22 +1613,55 @@ std::optional<PathWithLaneId> PathPlanner::generate_path(
   // Adjust s_path_end relative to the new trajectory origin
   const auto adjusted_s_path_end = s_path_end - s_path_start;
 
-  // Offset end point to stop before goal
-  const auto early_stop_dist = cal_early_stop(
-    *trajectory, route_context_, params_.path_planning.early_stop.expected_ego_speed_parking,
-    params_.path_planning.early_stop.max_lat_accel_parking,
-    params_.path_planning.early_stop.max_decel_parking,
-    params_.path_planning.early_stop.max_jerk_parking);
-  if (!early_stop_dist.has_value()) {
-    RCLCPP_ERROR(logger_, "Failed to calculate early stop distance");
-    return std::nullopt;
-  }
-  const double adjusted_s_path_end_earlystop =
-    std::max(0.0, adjusted_s_path_end - *early_stop_dist);
+  if (params_.path_planning.early_stop.enable) {
+    // Offset end point to stop before goal
+    const auto early_stop_dist = cal_early_stop(
+      *trajectory, route_context_, params_.path_planning.early_stop.expected_ego_speed_parking,
+      params_.path_planning.early_stop.max_lat_accel_parking,
+      params_.path_planning.early_stop.max_decel_parking,
+      params_.path_planning.early_stop.max_jerk_parking);
+    if (!early_stop_dist.has_value()) {
+      RCLCPP_ERROR(logger_, "Failed to calculate early stop distance");
+      return std::nullopt;
+    }
+    const double adjusted_s_path_end_earlystop =
+      std::max(0.0, adjusted_s_path_end - *early_stop_dist);
 
-  // Crop end
-  if (trajectory->length() > adjusted_s_path_end_earlystop) {
-    trajectory->crop(0., adjusted_s_path_end_earlystop);
+    // Crop end
+    if (trajectory->length() > adjusted_s_path_end_earlystop) {
+      trajectory->crop(0., adjusted_s_path_end_earlystop);
+    }
+  } else {
+    // Connect the path to the goal pose so that ego reaches the goal itself.
+    // Check if the goal point is in the search range
+    // Note: We only see if the goal is approaching the tail of the path.
+    const auto s_path_end_clamped = std::min(trajectory->length(), adjusted_s_path_end);
+    const auto distance_to_goal = autoware_utils::calc_distance2d(
+      trajectory->compute(s_path_end_clamped), route_context_.goal_pose);
+
+    bool goal_connection_applied = false;
+    if (distance_to_goal < params_.path_planning.smooth_goal_connection.search_radius_range) {
+      auto refined_path = utils::modify_path_for_smooth_goal_connection(
+        *trajectory, route_context_,
+        params_.path_planning.smooth_goal_connection.search_radius_range,
+        params_.path_planning.smooth_goal_connection.pre_goal_offset);
+
+      if (refined_path) {
+        refined_path->align_orientation_with_trajectory_direction();
+        *trajectory = *refined_path;
+        goal_connection_applied = true;
+      }
+    }
+
+    // Crop end
+    if (!goal_connection_applied && trajectory->length() > adjusted_s_path_end) {
+      trajectory->crop(0., adjusted_s_path_end);
+    }
+
+    if (trajectory->length() < 1e-3) {
+      RCLCPP_WARN(logger_, "Trajectory length too short after cropping: %f", trajectory->length());
+      return std::nullopt;
+    }
   }
 
   // Compose the polished path

--- a/planning/autoware_minimum_rule_based_planner/src/path_planner.hpp
+++ b/planning/autoware_minimum_rule_based_planner/src/path_planner.hpp
@@ -251,6 +251,13 @@ PathRange<std::optional<double>> get_arc_length_on_centerline(
   const std::optional<double> & s_right_bound);
 
 /**
+ * @brief Recreate the path with a given goal pose
+ */
+PathPointTrajectory refine_path_for_goal(
+  const PathPointTrajectory & input, const geometry_msgs::msg::Pose & goal_pose,
+  const lanelet::Id goal_lane_id, const double search_radius_range, const double pre_goal_offset);
+
+/**
  * @brief Extract lanelets from the trajectory
  */
 lanelet::ConstLanelets extract_lanelets_from_trajectory(
@@ -266,6 +273,13 @@ bool is_in_lanelets(const geometry_msgs::msg::Pose & pose, const lanelet::ConstL
  */
 bool is_trajectory_inside_lanelets(
   const PathPointTrajectory & refined_path, const lanelet::ConstLanelets & lanelets);
+
+/**
+ * @brief Modify path for smooth goal connection
+ */
+std::optional<PathPointTrajectory> modify_path_for_smooth_goal_connection(
+  const PathPointTrajectory & trajectory, const RouteContext & planner_data,
+  const double search_radius_range, const double pre_goal_offset);
 
 }  // namespace utils
 }  // namespace autoware::minimum_rule_based_planner

--- a/planning/autoware_minimum_rule_based_planner/test/test_path_planner.cpp
+++ b/planning/autoware_minimum_rule_based_planner/test/test_path_planner.cpp
@@ -43,6 +43,9 @@ Params make_default_params()
   params.path_planning.output.delta_arc_length = 1.0;
   params.path_planning.waypoint_group.separation_threshold = 1.0;
   params.path_planning.waypoint_group.interval_margin_ratio = 0.5;
+  params.path_planning.early_stop.enable = false;
+  params.path_planning.smooth_goal_connection.search_radius_range = 15.0;
+  params.path_planning.smooth_goal_connection.pre_goal_offset = 3.0;
   params.path_planning.path_shift.enable = false;
   params.path_planning.path_shift.minimum_shift_length = 0.1;
   params.path_planning.path_shift.minimum_shift_yaw = 0.1;


### PR DESCRIPTION
## Description

Add a flag to enable/disable the early stop in front of the goal introduced in https://github.com/tier4/autoware_universe/pull/3193, and make it **disabled by default** so that the previous goal-reaching behavior is restored.

## Related links

- https://github.com/tier4/autoware_launch.x2/pull/2811 (sets `enable: false` in the operational config)
- https://github.com/tier4/autoware_universe/pull/3193 (the PR this flag gates)

**Parent Issue:**

- Link

<!-- ⬇️🟢
**Private Links:**

- [CompanyName internal link]()
⬆️🟢 -->

## How was this PR tested?
- psim

## Notes for reviewers

- `refine_path_for_goal()` and `modify_path_for_smooth_goal_connection()` are restored exactly as they were before #3193, so they can be reviewed as a pure revert.

## Interface changes

No topic changes.

### ROS Parameter Changes

#### Additions and removals

| Change type | Parameter Name                                             | Type     | Default Value | Description                                                                                                                    |
| :---------- | :--------------------------------------------------------- | :------- | :------------ | :----------------------------------------------------------------------------------------------------------------------------- |
| Added       | `path_planning.early_stop.enable`                          | `bool`   | `false`       | If true, stop in front of the goal instead of connecting the path to the goal pose                                              |
| Added       | `path_planning.smooth_goal_connection.search_radius_range` | `double` | `7.5`         | Search radius for goal connection, used only when `early_stop.enable` is false [m]. Re-added (it was removed in #3193)          |
| Added       | `path_planning.smooth_goal_connection.pre_goal_offset`     | `double` | `1.0`         | Offset before the goal for smooth connection, used only when `early_stop.enable` is false [m]. Re-added (it was removed in #3193) |

## Effects on system behavior

With the default `early_stop.enable: false`, the minimum rule based planner reaches the goal via smooth goal connection again, exactly as it did before #3193. The early stop in front of the goal is performed only when the flag is explicitly set to `true`.
