### PR TITLE
fix(MPPI): clamp steer rate and check collision at terminal point

### DIFF
--- a/planning/autoware_mppi_optimizer/include/mppi/cost_functions/dubins/first_order_dubins_bicycle_cost.cu
+++ b/planning/autoware_mppi_optimizer/include/mppi/cost_functions/dubins/first_order_dubins_bicycle_cost.cu
@@ -684,8 +684,13 @@ FirstOrderDubinsBicycleCostImpl<CLASS_T, NUM_TIMESTEPS, PARAMS_T, DYN_PARAMS_T>:
   const float drivable_area_cost = egoCrossesDrivableAreaBoundary(x_pos, y_pos, yaw)
                                      ? this->params_.drivable_area_crossing_coeff
                                      : 0.0F;
+  int terminal_crash_status = 0;
+  const float crash_cost =
+    detectAndLatchCrash(x_pos, y_pos, yaw, NUM_TIMESTEPS - 1, &terminal_crash_status)
+      ? latchedCrashCost(&terminal_crash_status)
+      : 0.0F;
   return track_cost + heading_cost + lateral_distance_cost + lateral_yaw_error_cost +
-         drivable_area_cost;
+         drivable_area_cost + crash_cost;
 }
 
 template <class CLASS_T, int NUM_TIMESTEPS, class PARAMS_T, class DYN_PARAMS_T>

--- a/planning/autoware_mppi_optimizer/include/mppi/cost_functions/dubins/first_order_dubins_bicycle_cost.cu
+++ b/planning/autoware_mppi_optimizer/include/mppi/cost_functions/dubins/first_order_dubins_bicycle_cost.cu
@@ -54,7 +54,7 @@ __host__ __device__ void comfortTerms(
 
   longitudinal_jerk = (accel_cmd - accel) / accel_tau;
 
-  steer_rate = (steer_cmd - steer) / steer_tau;
+  steer_rate = clampSteerRate(params, (steer_cmd - steer) / steer_tau);
   const float curvature = tanf(steer) / wheel_base;
 #ifdef __CUDA_ARCH__
   const float sec_sq = 1.0F / fmaxf(cosf(steer) * cosf(steer), 1.0E-6F);

--- a/planning/autoware_mppi_optimizer/include/mppi/cost_functions/dubins/first_order_dubins_bicycle_cost.cuh
+++ b/planning/autoware_mppi_optimizer/include/mppi/cost_functions/dubins/first_order_dubins_bicycle_cost.cuh
@@ -43,6 +43,8 @@ struct FirstOrderDubinsBicycleCostParams : public CostParams<2>
   float wheel_base = 0.32F;
   float accel_time_constant = 0.15F;
   float steer_time_constant = 0.08F;
+  /** Must match the dynamics limit so comfort terms price the steering rate actually executed. */
+  float max_steer_rate = 3.0F;
   /** Ego OBB for parked-car collision (rear axle at pose; box center offset forward). */
   float ego_length = 0.55F * 1.5F;
   float ego_width = 0.28F * 1.5F;

--- a/planning/autoware_mppi_optimizer/include/mppi/cost_functions/dubins/first_order_dubins_bicycle_cost_bridge.hpp
+++ b/planning/autoware_mppi_optimizer/include/mppi/cost_functions/dubins/first_order_dubins_bicycle_cost_bridge.hpp
@@ -39,6 +39,7 @@ inline void fillFirstOrderDubinsBicycleCostGeometry(
   cost_params.wheel_base = dyn.wheel_base;
   cost_params.accel_time_constant = dyn.accel_time_constant;
   cost_params.steer_time_constant = dyn.steer_time_constant;
+  cost_params.max_steer_rate = dyn.max_steer_rate;
 }
 
 template <int NUM_TIMESTEPS>

--- a/planning/autoware_mppi_optimizer/include/mppi/dynamics/dubins/first_order_dubins_bicycle.cu
+++ b/planning/autoware_mppi_optimizer/include/mppi/dynamics/dubins/first_order_dubins_bicycle.cu
@@ -7,12 +7,6 @@ namespace
 using S = FirstOrderDubinsBicycleParams::StateIndex;
 using C = FirstOrderDubinsBicycleParams::ControlIndex;
 
-__host__ __device__ float clampSteerRate(
-  const FirstOrderDubinsBicycleParams & p, const float steer_dot)
-{
-  return fmaxf(fminf(steer_dot, p.max_steer_rate), -p.max_steer_rate);
-}
-
 __host__ __device__ void firstOrderDubinsBicycleDeriv(
   const FirstOrderDubinsBicycleParams & p, const float * state, const float * control,
   float * state_der)

--- a/planning/autoware_mppi_optimizer/include/mppi/dynamics/dubins/first_order_dubins_bicycle.cuh
+++ b/planning/autoware_mppi_optimizer/include/mppi/dynamics/dubins/first_order_dubins_bicycle.cuh
@@ -18,6 +18,8 @@
 #include <mppi/dynamics/dynamics.cuh>
 #include <mppi/utils/angle_utils.cuh>
 
+#include <cmath>
+
 struct FirstOrderDubinsBicycleParams : public DynamicsParams
 {
   enum class StateIndex : int {
@@ -60,6 +62,13 @@ struct FirstOrderDubinsBicycleParams : public DynamicsParams
   float min_accel = -6.0F;
   float max_accel = 4.0F;
 };
+
+/** Apply the steering-rate limit shared by the dynamics and comfort-cost models. */
+template <class PARAMS_T>
+__host__ __device__ inline float clampSteerRate(const PARAMS_T & params, const float steer_rate)
+{
+  return fmaxf(fminf(steer_rate, params.max_steer_rate), -params.max_steer_rate);
+}
 
 using namespace MPPI_internal;
 


### PR DESCRIPTION
Minor bugfixes:
- use the clamped steering when evaluating the steer rate cost.
- check collision at the terminal point.