### PR TITLE
fix(autoware_system_monitor): add missing dependency to edac_utils

### DIFF
--- a/system/autoware_system_monitor/package.xml
+++ b/system/autoware_system_monitor/package.xml
@@ -28,6 +28,7 @@
   <depend>tier4_external_api_msgs</depend>
 
   <exec_depend>chrony</exec_depend>
+  <exec_depend>edac-utils</exec_depend>
   <exec_depend>sysstat</exec_depend>
 
   <test_depend>ament_cmake_ros</test_depend>


### PR DESCRIPTION
This will backport https://github.com/autowarefoundation/autoware_universe/pull/13127 to beta/x2/v4.4.1